### PR TITLE
Sisu crosscompilation changes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 # 
-# Experimental CMake configuration script for Elmer
+# CMake configuration script for Elmer
 # 
 # Authors:
 #  Sami Ilvonen, CSC - IT Center for Science, Ltd.
@@ -9,10 +9,10 @@
 #
 # First public beta release 11th of October, 2013
 #
-# Note that this version is highly experimental and includes
-# only a very limited subset of features that are supported
-# by the original autotools scripts.
-#
+
+IF(NOT CMAKE_BUILD_TYPE)
+  SET(CMAKE_BUILD_TYPE "RelWithDebInfo" CACHE STRING "Build type (Release, Debug, RelWithDebugInfo, MinSizeRel)")
+ENDIF()
 
 PROJECT(Elmer Fortran C CXX)
 CMAKE_MINIMUM_REQUIRED(VERSION 2.8.9)
@@ -36,10 +36,6 @@ SET(ELMER_INSTALL_LIB_DIR "lib/elmersolver" CACHE PATH "Location of elmer shared
 SET(WITH_Trilinos FALSE CACHE BOOL "Use Trilinos")
 SET(WITH_ELMERPOST FALSE CACHE BOOL "Include ElmerPost (DEPRECATED)")
 
-IF(NOT CMAKE_BUILD_TYPE)
-  SET(CMAKE_BUILD_TYPE "RelWithDebInfo" CACHE STRING "Build type (Release, Debug, RelWithDebInfo, MinSizeRel)" FORCE)
-  SET_PROPERTY(CACHE CMAKE_BUILD_TYPE PROPERTY STRINGS "Debug" "Release" "MinSizeRel" "RelWithDebInfo")
-ENDIF(NOT CMAKE_BUILD_TYPE)
 
 MARK_AS_ADVANCED(WITH_ELMERPOST)
 
@@ -212,15 +208,18 @@ ENDIF()
 MARK_AS_ADVANCED(USE_EIO)
 
 ADD_SUBDIRECTORY(matc)
+
 IF(WITH_EIO)
   ADD_SUBDIRECTORY(eio)
   SET(HAVE_EIO TRUE)
   MARK_AS_ADVANCED(HAVE_EIO)
-ENDIF()
+ENDIF(WITH_EIO)
+
 IF(WITH_ElmerIce)
   MESSAGE(STATUS "Adding optional package ElmerIce")
   ADD_SUBDIRECTORY(elmerice)
-ENDIF()
+ENDIF(WITH_ElmerIce)
+
 ADD_SUBDIRECTORY(umfpack)
 ADD_SUBDIRECTORY(fhutiter)
 ADD_SUBDIRECTORY(meshgen2d)
@@ -233,7 +232,7 @@ IF(WITH_ELMERGUI)
     MESSAGE(STATUS "  Building ElmerGUI")
     MESSAGE(STATUS "------------------------------------------------")
     ADD_SUBDIRECTORY(ElmerGUI)
-ENDIF()
+ENDIF(WITH_ELMERGUI)
 
 IF(WITH_ELMERGUITESTER)
   ADD_SUBDIRECTORY(ElmerGUItester)
@@ -252,7 +251,6 @@ ENDIF(WITH_ELMERGUILOGGER)
 
 # 
 
-
 MESSAGE(STATUS "------------------------------------------------")
 MESSAGE(STATUS "  BLAS library:   " "${BLAS_LIBRARIES}")
 MESSAGE(STATUS "  LAPACK library: " "${LAPACK_LIBRARIES}")
@@ -263,66 +261,62 @@ MESSAGE(STATUS "------------------------------------------------")
 MESSAGE(STATUS "  C compiler:              " "${CMAKE_C_COMPILER}")
 MESSAGE(STATUS "  C flags:                 " "${CMAKE_C_FLAGS}")
 MESSAGE(STATUS "------------------------------------------------")
+MESSAGE(STATUS "  CXX compiler:            " "${CMAKE_CXX_COMPILER}")
+MESSAGE(STATUS "  CXX flags:               " "${CMAKE_CXX_FLAGS}")
+MESSAGE(STATUS "------------------------------------------------")
 IF(WITH_MPI)
-MESSAGE(STATUS "  MPI Fortran:             " "${MPI_Fortran_FOUND}")
-MESSAGE(STATUS "  MPI Fortran compiler:    " "${MPI_Fortran_COMPILER}")
-MESSAGE(STATUS "  MPI Fortran flags:       " "${MPI_Fortran_COMPILE_FLAGS}")
-MESSAGE(STATUS "  MPI Fortran include dir: " "${MPI_Fortran_INCLUDE_PATH}")
-MESSAGE(STATUS "  MPI Fortran libraries:   " "${MPI_Fortran_LIBRARIES}")
-MESSAGE(STATUS "  MPI Fortran link flags:  " "${MPI_Fortran_LINK_FLAGS}")
-MESSAGE(STATUS "------------------------------------------------")
-MESSAGE(STATUS "  MPI C:             " "${MPI_C_FOUND}")
-MESSAGE(STATUS "  MPI C compiler:    " "${MPI_C_COMPILER}")
-MESSAGE(STATUS "  MPI C flags:       " "${MPI_C_COMPILE_FLAGS}")
-MESSAGE(STATUS "  MPI C include dir: " "${MPI_C_INCLUDE_PATH}")
-MESSAGE(STATUS "  MPI C libraries:   " "${MPI_C_LIBRARIES}")
-MESSAGE(STATUS "  MPI C flags:       " "${MPI_C_LINK_FLAGS}")
-MESSAGE(STATUS "------------------------------------------------")
-IF(WITH_Mumps)
-MESSAGE(STATUS "  Mumps:             " "${Mumps_FOUND}")
-MESSAGE(STATUS "  Mumps include:     " "${Mumps_INCLUDE_DIR}")
-MESSAGE(STATUS "  Mumps libraries:   " "${Mumps_LIBRARIES}")
-MESSAGE(STATUS "------------------------------------------------")
-ENDIF()
-IF(WITH_Hypre)
-MESSAGE(STATUS "  Hypre:             " "${Hypre_FOUND}")
-MESSAGE(STATUS "  Hypre include:     " "${Hypre_INCLUDE_DIR}")
-MESSAGE(STATUS "  Hypre libraries:   " "${Hypre_LIBRARIES}")
-MESSAGE(STATUS "------------------------------------------------")
-ENDIF()
-ELSE()
-MESSAGE(STATUS "  Fortran compiler:  " "${CMAKE_Fortran_COMPILER}")
-MESSAGE(STATUS "------------------------------------------------")
-MESSAGE(STATUS "  C compiler:        " "${CMAKE_C_COMPILER}")
-MESSAGE(STATUS "------------------------------------------------")
-MESSAGE(STATUS "  C++ compiler:      " "${CMAKE_CXX_COMPILER}")
-MESSAGE(STATUS "------------------------------------------------")
-ENDIF()
+  MESSAGE(STATUS "  MPI Fortran:             " "${MPI_Fortran_FOUND}")
+  MESSAGE(STATUS "  MPI Fortran compiler:    " "${MPI_Fortran_COMPILER}")
+  MESSAGE(STATUS "  MPI Fortran flags:       " "${MPI_Fortran_COMPILE_FLAGS}")
+  MESSAGE(STATUS "  MPI Fortran include dir: " "${MPI_Fortran_INCLUDE_PATH}")
+  MESSAGE(STATUS "  MPI Fortran libraries:   " "${MPI_Fortran_LIBRARIES}")
+  MESSAGE(STATUS "  MPI Fortran link flags:  " "${MPI_Fortran_LINK_FLAGS}")
+  MESSAGE(STATUS "------------------------------------------------")
+  MESSAGE(STATUS "  MPI C:             " "${MPI_C_FOUND}")
+  MESSAGE(STATUS "  MPI C compiler:    " "${MPI_C_COMPILER}")
+  MESSAGE(STATUS "  MPI C flags:       " "${MPI_C_COMPILE_FLAGS}")
+  MESSAGE(STATUS "  MPI C include dir: " "${MPI_C_INCLUDE_PATH}")
+  MESSAGE(STATUS "  MPI C libraries:   " "${MPI_C_LIBRARIES}")
+  MESSAGE(STATUS "  MPI C flags:       " "${MPI_C_LINK_FLAGS}")
+  MESSAGE(STATUS "------------------------------------------------")
+  IF(WITH_Mumps)
+    MESSAGE(STATUS "  Mumps:             " "${Mumps_FOUND}")
+    MESSAGE(STATUS "  Mumps include:     " "${Mumps_INCLUDE_DIR}")
+    MESSAGE(STATUS "  Mumps libraries:   " "${Mumps_LIBRARIES}")
+    MESSAGE(STATUS "------------------------------------------------")
+  ENDIF(WITH_Mumps)
+  IF(WITH_Hypre)
+    MESSAGE(STATUS "  Hypre:             " "${Hypre_FOUND}")
+    MESSAGE(STATUS "  Hypre include:     " "${Hypre_INCLUDE_DIR}")
+    MESSAGE(STATUS "  Hypre libraries:   " "${Hypre_LIBRARIES}")
+    MESSAGE(STATUS "------------------------------------------------")
+  ENDIF(WITH_Hypre)
+ENDIF(WITH_MPI)
 
 IF(WITH_Trilinos)
-MESSAGE(STATUS "  Trilinos:           " "${Trilinos_FOUND}")
-MESSAGE(STATUS "  Trilinos_DIR:       " "${Trilinos_DIR}")
-MESSAGE(STATUS "  Trilinos_LIBRARIES: " "${Trilinos_LIBRARIES}")
-MESSAGE(STATUS "------------------------------------------------")
-ENDIF()
+  MESSAGE(STATUS "  Trilinos:           " "${Trilinos_FOUND}")
+  MESSAGE(STATUS "  Trilinos_DIR:       " "${Trilinos_DIR}")
+  MESSAGE(STATUS "  Trilinos_LIBRARIES: " "${Trilinos_LIBRARIES}")
+  MESSAGE(STATUS "------------------------------------------------")
+ENDIF(WITH_Trilinos)
 
 IF(WITH_ELMERGUITESTER)
   MESSAGE(STATUS "  Building ElmerGUI tester")
   MESSAGE(STATUS "------------------------------------------------")
-ENDIF()
+ENDIF(WITH_ELMERGUITESTER)
 
 IF(WITH_ELMERGUILOGGER)
   MESSAGE(STATUS "  Building ElmerGUI logger")
   MESSAGE(STATUS "------------------------------------------------")
-ENDIF()
+ENDIF(WITH_ELMERGUILOGGER)
 
 IF(WITH_ELMERPOST)
   MESSAGE(WARNING "  Building ElmerPost")
   MESSAGE(STATUS "------------------------------------------------")
   ADD_SUBDIRECTORY(post)
-ENDIF()
+ENDIF(WITH_ELMERPOST)
 
 # Packaging
 if(NOT BYPASS_CPACK)
   INCLUDE(${CMAKE_CURRENT_SOURCE_DIR}/cpack/ElmerCPack.cmake)
-endif()
+endif(NOT BYPASS_CPACK)

--- a/cmake/Toolchains/Elmer-CNL-sisu.cmake
+++ b/cmake/Toolchains/Elmer-CNL-sisu.cmake
@@ -22,6 +22,14 @@ SET(CMAKE_C_FLAGS "-g -fPIC" CACHE STRING "")
 SET(CMAKE_CXX_FLAGS "-g -fPIC" CACHE STRING "")
 SET(CMAKE_Fortran_FLAGS "-g -fPIC" CACHE STRING "")
 
+# Reset the default build type flags, all flags should be set above
+SET(CMAKE_C_FLAGS_RELWITHDEBINFO "" CACHE STRING "")
+SET(CMAKE_CXX_FLAGS_RELWITHDEBINFO "" CACHE STRING "")
+SET(CMAKE_Fortran_FLAGS_RELWITHDEBINFO "" CACHE STRING "")
+
+# Compilation flags for native build using C compiler, used for ElmerGrid
+SET(NATIVE_BUILD_FLAGS "-g -fPIC -target-cpu=sandybridge" CACHE STRING "")
+
 # BLAS and LAPACK libraries are included in the wrappers,
 # so we just link in libm to make cmake happy
 SET(BLAS_LIBRARIES "m" CACHE STRING "")

--- a/elmergrid/src/CMakeLists.txt
+++ b/elmergrid/src/CMakeLists.txt
@@ -1,4 +1,17 @@
 
+IF(CMAKE_CROSSCOMPILING)
+  IF(NATIVE_BUILD_FLAGS)
+    IF(CMAKE_BUILD_TYPE)
+      STRING(TOUPPER _${CMAKE_BUILD_TYPE} _build_type)
+      SET(CMAKE_C_FLAGS${_build_type} "")
+    ENDIF()
+    SET(CMAKE_C_FLAGS ${NATIVE_BUILD_FLAGS})
+    MESSAGE(STATUS "Resetting build flags for Elmergrid: ${NATIVE_BUILD_FLAGS}")
+  ELSE()
+    MESSAGE(WARNING "Crosscompiling ElmerGrid, no native build flags set")
+  ENDIF()
+ENDIF()
+
 ADD_SUBDIRECTORY(metis)
 
 SET(elmergrid_SRCS common.h femdef.h femelmer.h femfilein.h
@@ -10,12 +23,13 @@ SET(elmergrid_SRCS common.h femdef.h femelmer.h femfilein.h
 INCLUDE_DIRECTORIES(${CMAKE_SOURCE_DIR}/elmergrid/src/metis)
 INCLUDE_DIRECTORIES(${CMAKE_BINARY_DIR}/elmergrid/src)
 
+ADD_DEFINITIONS(-DDISABLE_MATC)
+
 ADD_EXECUTABLE(ElmerGrid ${elmergrid_SRCS})
 
-TARGET_LINK_LIBRARIES(ElmerGrid matc metis)
+TARGET_LINK_LIBRARIES(ElmerGrid metis m)
 IF(NOT(WIN32))
   SET_TARGET_PROPERTIES(ElmerGrid PROPERTIES INSTALL_RPATH ${ELMERSOLVER_RPATH_STRING})
 ENDIF()
 
-#INSTALL(PROGRAMS ${CMAKE_BINARY_DIR}/elmergrid/src/ElmerGrid DESTINATION "bin")
 INSTALL(TARGETS ElmerGrid RUNTIME DESTINATION "bin")


### PR DESCRIPTION
- If WITH_MPI is defined the tests are executed
  using MPIEXEC
- Removed matc dependency from ElmerGrid and enabled
  native build when crosscompiling (see the toolchain file)
- Moved the default build type setting to beginning,
  now the FORCE setting for cache variable shouldn't
  be needed
