### PR TITLE
Corrected interoperability with GNU stack and MKL

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -165,12 +165,12 @@ ELSE()
 ENDIF()
 
 # Check that the gfortran version is >= 4.8
-# IF(${CMAKE_Fortran_COMPILER_ID} MATCHES "GNU")
-#   INCLUDE(testGFortranVersion)
-#   IF(NOT CMAKE_Fortran_COMPILER_GNU_VERSION_OK)
-#     MESSAGE(FATAL_ERROR "GNU Fortran version is too old, should be at least 4.8")
-#   ENDIF()
-# ENDIF()
+IF(${CMAKE_Fortran_COMPILER_ID} MATCHES "GNU")
+  INCLUDE(testGFortranVersion)
+  IF(NOT CMAKE_Fortran_COMPILER_GNU_VERSION_OK)
+    MESSAGE(FATAL_ERROR "GNU Fortran version is too old, should be at least 4.8")
+  ENDIF()
+ENDIF()
 
 # Check if this is mingw toolchain. 
 IF(MINGW)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -150,6 +150,12 @@ IF(Hypre_FOUND)
   # LINK_DIRECTORIES(${Hypre_LIBRARIES})
 ENDIF()
 
+# Check if Fortran compiler supports procedure pointer
+INCLUDE(testProcedurePointer)
+IF(NOT CMAKE_Fortran_COMPILER_SUPPORTS_PROCEDUREPOINTER)
+  MESSAGE(FATAL_ERROR "Fortran compiler does not seem to support the PROCEDURE statement.")
+ENDIF()
+
 # Check if Fortran compiler supports contiguous keyword
 INCLUDE(testContiguous)
 IF(CMAKE_Fortran_COMPILER_SUPPORTS_CONTIGUOUS)
@@ -159,12 +165,12 @@ ELSE()
 ENDIF()
 
 # Check that the gfortran version is >= 4.8
-IF(${CMAKE_Fortran_COMPILER_ID} MATCHES "GNU")
-  INCLUDE(testGFortranVersion)
-  IF(NOT CMAKE_Fortran_COMPILER_GNU_VERSION_OK)
-    MESSAGE(FATAL_ERROR "GNU Fortran version is too old, should be at least 4.8")
-  ENDIF()
-ENDIF()
+# IF(${CMAKE_Fortran_COMPILER_ID} MATCHES "GNU")
+#   INCLUDE(testGFortranVersion)
+#   IF(NOT CMAKE_Fortran_COMPILER_GNU_VERSION_OK)
+#     MESSAGE(FATAL_ERROR "GNU Fortran version is too old, should be at least 4.8")
+#   ENDIF()
+# ENDIF()
 
 # Check if this is mingw toolchain. 
 IF(MINGW)

--- a/cmake/Modules/testGFortranVersion.cmake
+++ b/cmake/Modules/testGFortranVersion.cmake
@@ -1,6 +1,7 @@
 
 # Quick hack to test if the GNU Fortran version is >= 4.8
 
+IF (NOT(CMAKE_CROSSCOMPILING))
 FILE(WRITE ${CMAKE_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/CMakeTmp/testGFortranVersion.F90
 "
 program versiontest
@@ -36,6 +37,33 @@ ELSE()
   MESSAGE(STATUS "Could not determine the Fortran compiler version")
   MESSAGE(STATUS "${COMPILE_RESULT}")
   MESSAGE(STATUS "${RUN_RESULT}")
+ENDIF()
+ELSE()
+  # Handle cross-compilation without user intervention
+  FILE(WRITE ${CMAKE_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/CMakeTmp/testGFortranVersion.F90
+"
+program versiontest
+#if defined(__GFORTRAN__) && defined(__GNUC__) && defined(__GNUC_MINOR__)
+#if __GNUC__<5
+#if __GNUC_MINOR__<8
+#error "Gfortran versions <4.8 known not to fully work with Elmer"
+#endif
+#endif
+#endif
+end program versiontest
+")
+
+  TRY_COMPILE(GFORTRAN_VERSIONTEST_COMPILE_RESULT ${CMAKE_BINARY_DIR}
+    ${CMAKE_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/CMakeTmp/testGFortranVersion.F90
+    OUTPUT_VARIABLE OUTPUT)
+
+  IF(GFORTRAN_VERSIONTEST_COMPILE_RESULT)
+    MESSAGE(STATUS "Checking whether GFortran version >= 4.8 -- yes")
+    SET(CMAKE_Fortran_COMPILER_GNU_VERSION_OK 1 CACHE BOOL "")
+  ELSE()
+    MESSAGE(STATUS "Checking whether GFortran version >= 4.8 -- no")
+    SET(CMAKE_Fortran_COMPILER_GNU_VERSION_OK 0 CACHE BOOL "")
+  ENDIF()
 ENDIF()
 
 MARK_AS_ADVANCED(CMAKE_Fortran_COMPILER_GNU_VERSION_OK)

--- a/cmake/Modules/testProcedurePointer.cmake
+++ b/cmake/Modules/testProcedurePointer.cmake
@@ -1,0 +1,73 @@
+# Quick hack to test if the Fortran compiler supports procedure pointer
+
+message(STATUS "Checking whether ${CMAKE_Fortran_COMPILER} supports PROCEDURE POINTER")
+file(WRITE ${CMAKE_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/CMakeTmp/testFortranProcedurePointer.f90
+"
+FUNCTION addrof(fn) RESULT(faddr)
+    USE ISO_C_BINDING
+    IMPLICIT NONE
+    INTERFACE
+        SUBROUTINE dummysubr(x,y) bind(C)
+          IMPORT
+          IMPLICIT NONE
+          REAL(KIND=C_FLOAT) :: x, y
+        END SUBROUTINE dummysubr
+    END INTERFACE
+    PROCEDURE(dummysubr) :: fn  
+    INTEGER(KIND=8) :: faddr
+    TYPE(C_FUNPTR) :: cptr
+    cptr = C_FUNLOC(fn)
+    faddr = TRANSFER(cptr, faddr)
+END FUNCTION addrof
+SUBROUTINE mysin(x,y) BIND(C)
+  USE ISO_C_BINDING
+  IMPLICIT NONE
+  REAL(KIND=C_FLOAT) :: x, y
+  INTRINSIC SIN
+  y=SIN(x)
+END SUBROUTINE mysin
+PROGRAM TESTFortranProcPtr
+  USE ISO_C_BINDING
+  IMPLICIT NONE
+  ABSTRACT INTERFACE
+    SUBROUTINE trig(x,y) BIND(C)
+      IMPORT
+      IMPLICIT NONE
+      REAL(KIND=C_FLOAT) :: x, y
+    END SUBROUTINE trig
+  END INTERFACE
+  INTERFACE
+    SUBROUTINE mysin(x,y) BIND(C)
+      IMPORT
+      IMPLICIT NONE
+      REAL(KIND=C_FLOAT) :: x, y
+    END SUBROUTINE mysin
+  END INTERFACE
+  TYPE(C_FUNPTR) :: cfptr
+  PROCEDURE(trig), POINTER :: trigf
+  REAL(KIND=C_FLOAT) :: x, y, yc
+  INTEGER(KIND=8) :: addrof, addr
+  EXTERNAL :: addrof
+  ! Mimic Elmer behaviour by transferring a function pointer to a 
+  ! C pointer with TRANSFER, transfer back to Fortran pointer and 
+  ! then call the function
+  addr = addrof(mysin)
+  cfptr = TRANSFER(addr,cfptr) 
+  CALL C_F_PROCPOINTER(cfptr, trigf)
+  x = real(3.14/2,C_FLOAT)
+  CALL trigf(x,y)
+  CALL mysin(x,yc)
+  write (*,*) y, yc
+END PROGRAM TESTFortranProcPtr
+  ")
+try_compile(FC_HAS_PROCEDUREPOINTER ${CMAKE_BINARY_DIR}
+  ${CMAKE_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/CMakeTmp/testFortranProcedurePointer.f90
+  OUTPUT_VARIABLE OUTPUT)
+if(FC_HAS_PROCEDUREPOINTER)
+  message(STATUS "Checking whether ${CMAKE_Fortran_COMPILER} supports PROCEDURE POINTER -- yes")
+  set(CMAKE_Fortran_COMPILER_SUPPORTS_PROCEDUREPOINTER 1 CACHE BOOL "")
+else()
+  message(STATUS "Checking whether ${CMAKE_Fortran_COMPILER} supports PROCEDURE POINTER -- no")
+  set(CMAKE_Fortran_COMPILER_SUPPORTS_PROCEDUREPOINTER 0 CACHE BOOL "")
+endif()
+MARK_AS_ADVANCED(CMAKE_Fortran_COMPILER_SUPPORTS_PROCEDUREPOINTER)

--- a/cmake/Toolchains/Elmer-linux-taito-gcc-hsw.cmake
+++ b/cmake/Toolchains/Elmer-linux-taito-gcc-hsw.cmake
@@ -1,28 +1,30 @@
-# CMake toolchain file for building on taito-mic.csc.fi
+# CMake toolchain file for building on taito.csc.fi
+# with the GNU toolchain and Intel MKL for the Haswell nodes
 #
 # Author: Mikko Byckling, CSC - IT Center for Science Ltd.
-# Version: 0.1
+# Version: 0.2
 
+# Cross-compile for Haswell nodes on taito.csc.fi
 SET(CMAKE_SYSTEM_NAME Linux)
-SET(CMAKE_SYSTEM_PROCESSOR x86_64)
+SET(CMAKE_SYSTEM_PROCESSOR k1om)
 SET(CMAKE_SYSTEM_VERSION 1)
 
 # Specify the cross compilers (serial)
-SET(CMAKE_C_COMPILER icc)
-SET(CMAKE_Fortran_COMPILER ifort)
-SET(CMAKE_CXX_COMPILER icpc)
+SET(CMAKE_C_COMPILER gcc)
+SET(CMAKE_Fortran_COMPILER gfortran)
+SET(CMAKE_CXX_COMPILER g++)
 
 # Specify the cross compilers (parallel)
-SET(MPI_C_COMPILER mpiicc)
-SET(MPI_CXX_COMPILER mpiicpc)
-SET(MPI_Fortran_COMPILER mpiifort)
+SET(MPI_C_COMPILER mpicc)
+SET(MPI_CXX_COMPILER mpicxx)
+SET(MPI_Fortran_COMPILER mpif90)
 
 # Compilation flags (i.e. with optimization)
-SET(CMAKE_C_FLAGS "-O3 -g" CACHE STRING "")
-SET(CMAKE_CXX_FLAGS "-O3 -g" CACHE STRING "")
-SET(CMAKE_Fortran_FLAGS "-O3 -g -fma -align all -align array64byte" CACHE STRING "")
+SET(CMAKE_C_FLAGS "-O2 -g -m64 -ftree-vectorize -funroll-loops -mavx2 -march=core-avx2" CACHE STRING "")
+SET(CMAKE_CXX_FLAGS "-O2 -g -m64 -ftree-vectorize -funroll-loops -mavx2 -march=core-avx2" CACHE STRING "")
+SET(CMAKE_Fortran_FLAGS "-O2 -g -m64 -ftree-vectorize -funroll-loops -mavx2 -march=core-avx2" CACHE STRING "")
 
-# BLAS and LAPACK (from MKL), no threading
+# BLAS and LAPACK (from MKL), no threading as MPI_INIT is used
 SET(BLAS_LIBRARIES $ENV{MKLROOT}/lib/intel64/libmkl_scalapack_lp64.so
 		   $ENV{MKLROOT}/lib/intel64/libmkl_intel_lp64.so
 		   $ENV{MKLROOT}/lib/intel64/libmkl_core.so
@@ -48,5 +50,4 @@ SET(SCALAPACK_LIBRARIES $ENV{MKLROOT}/lib/intel64/libmkl_scalapack_lp64.so
 		   /usr/lib64/libm.so
 		   CACHE STRING "")
 
-ADD_DEFINITIONS(-I$ENV{MKLROOT}/include)
-
+ADD_DEFINITIONS(-m64 -I$ENV{MKLROOT}/include -Wl,--no-as-needed)

--- a/cmake/Toolchains/Elmer-linux-taito-gcc-hsw.cmake
+++ b/cmake/Toolchains/Elmer-linux-taito-gcc-hsw.cmake
@@ -25,24 +25,20 @@ SET(CMAKE_CXX_FLAGS "-O2 -g -m64 -ftree-vectorize -funroll-loops -mavx2 -march=c
 SET(CMAKE_Fortran_FLAGS "-O2 -g -m64 -ftree-vectorize -funroll-loops -mavx2 -march=core-avx2" CACHE STRING "")
 
 # BLAS and LAPACK (from MKL), no threading as MPI_INIT is used
-SET(BLAS_LIBRARIES $ENV{MKLROOT}/lib/intel64/libmkl_scalapack_lp64.so
-		   $ENV{MKLROOT}/lib/intel64/libmkl_intel_lp64.so
+SET(BLAS_LIBRARIES $ENV{MKLROOT}/lib/intel64/libmkl_gf_lp64.so
 		   $ENV{MKLROOT}/lib/intel64/libmkl_core.so
 		   $ENV{MKLROOT}/lib/intel64/libmkl_sequential.so
-		   $ENV{MKLROOT}/lib/intel64/libmkl_blacs_intelmpi_lp64.so
 		   /usr/lib64/libpthread.so
 		   /usr/lib64/libm.so
 		   CACHE STRING "")
-SET(LAPACK_LIBRARIES $ENV{MKLROOT}/lib/intel64/libmkl_scalapack_lp64.so
-		   $ENV{MKLROOT}/lib/intel64/libmkl_intel_lp64.so
+SET(LAPACK_LIBRARIES $ENV{MKLROOT}/lib/intel64/libmkl_gf_lp64.so
 		   $ENV{MKLROOT}/lib/intel64/libmkl_core.so
 		   $ENV{MKLROOT}/lib/intel64/libmkl_sequential.so
-		   $ENV{MKLROOT}/lib/intel64/libmkl_blacs_intelmpi_lp64.so
 		   /usr/lib64/libpthread.so
 		   /usr/lib64/libm.so
 		   CACHE STRING "")
 SET(SCALAPACK_LIBRARIES $ENV{MKLROOT}/lib/intel64/libmkl_scalapack_lp64.so
-		   $ENV{MKLROOT}/lib/intel64/libmkl_intel_lp64.so
+		   $ENV{MKLROOT}/lib/intel64/libmkl_gf_lp64.so
 		   $ENV{MKLROOT}/lib/intel64/libmkl_core.so
 		   $ENV{MKLROOT}/lib/intel64/libmkl_sequential.so
 		   $ENV{MKLROOT}/lib/intel64/libmkl_blacs_intelmpi_lp64.so

--- a/cmake/Toolchains/Elmer-linux-taito-gcc-hsw.cmake
+++ b/cmake/Toolchains/Elmer-linux-taito-gcc-hsw.cmake
@@ -6,7 +6,7 @@
 
 # Cross-compile for Haswell nodes on taito.csc.fi
 SET(CMAKE_SYSTEM_NAME Linux)
-SET(CMAKE_SYSTEM_PROCESSOR k1om)
+SET(CMAKE_SYSTEM_PROCESSOR x86_64)
 SET(CMAKE_SYSTEM_VERSION 1)
 
 # Specify the cross compilers (serial)

--- a/cmake/Toolchains/Elmer-linux-taito-gcc-snb.cmake
+++ b/cmake/Toolchains/Elmer-linux-taito-gcc-snb.cmake
@@ -1,0 +1,51 @@
+# CMake toolchain file for building on taito.csc.fi
+# with the GNU toolchain and Intel MKL
+#
+# Author: Mikko Byckling, CSC - IT Center for Science Ltd.
+# Version: 0.2
+
+# No need to cross-compile for SNB nodes on taito.csc.fi,
+# i.e., do NOT set CMAKE_SYSTEM_NAME etc. here 
+
+# Specify the cross compilers (serial)
+SET(CMAKE_C_COMPILER gcc)
+SET(CMAKE_Fortran_COMPILER gfortran)
+SET(CMAKE_CXX_COMPILER g++)
+
+# Specify the cross compilers (parallel)
+SET(MPI_C_COMPILER mpicc)
+SET(MPI_CXX_COMPILER mpicxx)
+SET(MPI_Fortran_COMPILER mpif90)
+
+# Compilation flags (i.e. with optimization)
+SET(CMAKE_C_FLAGS "-O2 -g" CACHE STRING "")
+SET(CMAKE_CXX_FLAGS "-O2 -g" CACHE STRING "")
+SET(CMAKE_Fortran_FLAGS "-O2 -g" CACHE STRING "")
+
+# BLAS and LAPACK (from MKL), no threading as MPI_INIT is used
+SET(BLAS_LIBRARIES $ENV{MKLROOT}/lib/intel64/libmkl_scalapack_lp64.so
+		   $ENV{MKLROOT}/lib/intel64/libmkl_intel_lp64.so
+		   $ENV{MKLROOT}/lib/intel64/libmkl_core.so
+		   $ENV{MKLROOT}/lib/intel64/libmkl_sequential.so
+		   $ENV{MKLROOT}/lib/intel64/libmkl_blacs_intelmpi_lp64.so
+		   /usr/lib64/libpthread.so
+		   /usr/lib64/libm.so
+		   CACHE STRING "")
+SET(LAPACK_LIBRARIES $ENV{MKLROOT}/lib/intel64/libmkl_scalapack_lp64.so
+		   $ENV{MKLROOT}/lib/intel64/libmkl_intel_lp64.so
+		   $ENV{MKLROOT}/lib/intel64/libmkl_core.so
+		   $ENV{MKLROOT}/lib/intel64/libmkl_sequential.so
+		   $ENV{MKLROOT}/lib/intel64/libmkl_blacs_intelmpi_lp64.so
+		   /usr/lib64/libpthread.so
+		   /usr/lib64/libm.so
+		   CACHE STRING "")
+SET(SCALAPACK_LIBRARIES $ENV{MKLROOT}/lib/intel64/libmkl_scalapack_lp64.so
+		   $ENV{MKLROOT}/lib/intel64/libmkl_intel_lp64.so
+		   $ENV{MKLROOT}/lib/intel64/libmkl_core.so
+		   $ENV{MKLROOT}/lib/intel64/libmkl_sequential.so
+		   $ENV{MKLROOT}/lib/intel64/libmkl_blacs_intelmpi_lp64.so
+		   /usr/lib64/libpthread.so
+		   /usr/lib64/libm.so
+		   CACHE STRING "")
+
+ADD_DEFINITIONS(-m64 -I$ENV{MKLROOT}/include -Wl,--no-as-needed)

--- a/cmake/Toolchains/Elmer-linux-taito-gcc-snb.cmake
+++ b/cmake/Toolchains/Elmer-linux-taito-gcc-snb.cmake
@@ -23,24 +23,20 @@ SET(CMAKE_CXX_FLAGS "-O2 -g" CACHE STRING "")
 SET(CMAKE_Fortran_FLAGS "-O2 -g" CACHE STRING "")
 
 # BLAS and LAPACK (from MKL), no threading as MPI_INIT is used
-SET(BLAS_LIBRARIES $ENV{MKLROOT}/lib/intel64/libmkl_scalapack_lp64.so
-		   $ENV{MKLROOT}/lib/intel64/libmkl_intel_lp64.so
+SET(BLAS_LIBRARIES $ENV{MKLROOT}/lib/intel64/libmkl_gf_lp64.so
 		   $ENV{MKLROOT}/lib/intel64/libmkl_core.so
 		   $ENV{MKLROOT}/lib/intel64/libmkl_sequential.so
-		   $ENV{MKLROOT}/lib/intel64/libmkl_blacs_intelmpi_lp64.so
 		   /usr/lib64/libpthread.so
 		   /usr/lib64/libm.so
 		   CACHE STRING "")
-SET(LAPACK_LIBRARIES $ENV{MKLROOT}/lib/intel64/libmkl_scalapack_lp64.so
-		   $ENV{MKLROOT}/lib/intel64/libmkl_intel_lp64.so
+SET(LAPACK_LIBRARIES $ENV{MKLROOT}/lib/intel64/libmkl_gf_lp64.so
 		   $ENV{MKLROOT}/lib/intel64/libmkl_core.so
 		   $ENV{MKLROOT}/lib/intel64/libmkl_sequential.so
-		   $ENV{MKLROOT}/lib/intel64/libmkl_blacs_intelmpi_lp64.so
 		   /usr/lib64/libpthread.so
 		   /usr/lib64/libm.so
 		   CACHE STRING "")
 SET(SCALAPACK_LIBRARIES $ENV{MKLROOT}/lib/intel64/libmkl_scalapack_lp64.so
-		   $ENV{MKLROOT}/lib/intel64/libmkl_intel_lp64.so
+		   $ENV{MKLROOT}/lib/intel64/libmkl_gf_lp64.so
 		   $ENV{MKLROOT}/lib/intel64/libmkl_core.so
 		   $ENV{MKLROOT}/lib/intel64/libmkl_sequential.so
 		   $ENV{MKLROOT}/lib/intel64/libmkl_blacs_intelmpi_lp64.so

--- a/fem/src/IterSolve.F90
+++ b/fem/src/IterSolve.F90
@@ -812,8 +812,10 @@ CONTAINS
       IF (astat /= 0) THEN
         CALL Fatal('IterSolve','Unable to allocate memory for complex arrays')
       END IF
-      ! Initialize xC and copy bC
-      xC = cmplx(0,dp)
+      ! Initialize xC and bC
+      DO i=1,HUTI_NDIM
+        xC(i) = cmplx(x(2*i-1),x(2*i),dp)
+      END DO
       DO i=1,HUTI_NDIM
         bC(i) = cmplx(b(2*i-1),b(2*i),dp)
       END DO

--- a/fem/src/LoadMod.F90
+++ b/fem/src/LoadMod.F90
@@ -668,8 +668,8 @@ MODULE LoadMod
 
             INTEGER(KIND=AddrInt) :: fptr
             REAL(KIND=dp), DIMENSION(:) CONTIG :: x,b
-            INTEGER :: ipar(50)
-            REAL(KIND=dp) :: dpar(50)
+            INTEGER :: ipar(HUTI_IPAR_DFLTSIZE)
+            REAL(KIND=dp) :: dpar(HUTI_DPAR_DFLTSIZE)
             REAL(KIND=dp) :: work(:,:)
             INTEGER(KIND=Addrint) :: mvptr, pcondptr, pcondrptr, &
                                      dotptr, normptr, stopcptr
@@ -724,8 +724,8 @@ MODULE LoadMod
 
             INTEGER(KIND=AddrInt) :: fptr
             COMPLEX(KIND=dp), DIMENSION(:) CONTIG :: x,b
-            INTEGER :: ipar(50)
-            REAL(KIND=dp) :: dpar(50)
+            INTEGER :: ipar(HUTI_IPAR_DFLTSIZE)
+            REAL(KIND=dp) :: dpar(HUTI_DPAR_DFLTSIZE)
             COMPLEX(KIND=dp) :: work(:,:)
             INTEGER(KIND=Addrint) :: mvptr, pcondptr, pcondrptr, &
                                      dotptr, normptr, stopcptr
@@ -766,7 +766,7 @@ MODULE LoadMod
             ! Stopping criterion operator
             cfptr = TRANSFER(stopcptr, cfptr)
             IF (C_ASSOCIATED(cfptr)) CALL C_F_PROCPOINTER(cfptr, stopcfun)
-
+            
             ! Finally, do the itercall
             cfptr = TRANSFER(fptr, cfptr)
             CALL C_F_PROCPOINTER(cfptr, iterfun)

--- a/fhutiter/src/huti_sfe.F90
+++ b/fhutiter/src/huti_sfe.F90
@@ -16,56 +16,66 @@ MODULE huti_sfe
   INTERFACE
   
      FUNCTION zdotc(n, x, xinc, y, yinc) RESULT(res)
+       IMPLICIT NONE
        INTEGER :: n, xinc, yinc
        DOUBLE COMPLEX :: x(*), y(*)
        DOUBLE COMPLEX :: res
      END FUNCTION zdotc
 
      FUNCTION zdotu(n, x, xinc, y, yinc) RESULT(res)
+       IMPLICIT NONE
        INTEGER :: n, xinc, yinc
        DOUBLE COMPLEX :: x(*), y(*)
        DOUBLE COMPLEX :: res
      END FUNCTION zdotu
 
      FUNCTION cdotc(n, x, xinc, y, yinc) RESULT(res)
+       IMPLICIT NONE
        INTEGER :: n, xinc, yinc
        COMPLEX :: x(*), y(*)
        COMPLEX :: res
      END FUNCTION cdotc
 
      FUNCTION cdotu(n, x, xinc, y, yinc) RESULT(res)
+       IMPLICIT NONE
        INTEGER :: n, xinc, yinc
        COMPLEX :: x(*), y(*)
        COMPLEX :: res
      END FUNCTION cdotu
 
      FUNCTION sdot(n, x, xinc, y, yinc) RESULT(res)
+       IMPLICIT NONE
        INTEGER :: n, xinc, yinc
        REAL :: x(*), y(*), res
      END FUNCTION sdot
 
      FUNCTION ddot(n, x, xinc, y, yinc) RESULT(res)
+       IMPLICIT NONE
        INTEGER :: n, xinc, yinc
        DOUBLE PRECISION :: x(*), y(*), res
      END FUNCTION ddot
 
      FUNCTION dnrm2(n, x, xinc) RESULT(res)
+       IMPLICIT NONE
        INTEGER :: n, xinc
        DOUBLE PRECISION :: x(*), res
      END FUNCTION dnrm2
 
      FUNCTION snrm2(n, x, xinc) RESULT(res)
+       IMPLICIT NONE
        INTEGER :: n, xinc
        REAL :: x(*), res
      END FUNCTION snrm2
 
      FUNCTION dznrm2(n, x, xinc) RESULT(res)
+       IMPLICIT NONE
        INTEGER :: n, xinc
        DOUBLE COMPLEX :: x(*)
        DOUBLE PRECISION :: res
      END FUNCTION dznrm2
 
      FUNCTION scnrm2(n, x, xinc) RESULT(res)
+       IMPLICIT NONE
        INTEGER :: n, xinc
        COMPLEX :: x(*)
        REAL :: res
@@ -77,7 +87,7 @@ CONTAINS
   
   SUBROUTINE huti_s_cg(xvec, rhsvec, ipar, dpar, work, matvecsubr, &
        & pcondlsubr, pcondrsubr, dotprodfun, normfun, mstopfun)
-    
+    IMPLICIT NONE
     PROCEDURE( mv_iface_s ), POINTER :: matvecsubr
     PROCEDURE( pc_iface_s ), POINTER :: pcondlsubr
     PROCEDURE( pc_iface_s ), POINTER :: pcondrsubr
@@ -111,7 +121,7 @@ CONTAINS
 
   SUBROUTINE huti_s_tfqmr(xvec, rhsvec, ipar, dpar, work, matvecsubr, &
        & pcondlsubr, pcondrsubr, dotprodfun, normfun, mstopfun)
-    
+    IMPLICIT NONE
     PROCEDURE( mv_iface_s ), POINTER :: matvecsubr
     PROCEDURE( pc_iface_s ), POINTER :: pcondlsubr
     PROCEDURE( pc_iface_s ), POINTER :: pcondrsubr
@@ -145,7 +155,7 @@ CONTAINS
 
   SUBROUTINE huti_s_cgs(xvec, rhsvec, ipar, dpar, work, matvecsubr, &
        & pcondlsubr, pcondrsubr, dotprodfun, normfun, mstopfun)
-    
+    IMPLICIT NONE
     PROCEDURE( mv_iface_s ), POINTER :: matvecsubr
     PROCEDURE( pc_iface_s ), POINTER :: pcondlsubr
     PROCEDURE( pc_iface_s ), POINTER :: pcondrsubr
@@ -179,7 +189,7 @@ CONTAINS
 
   SUBROUTINE huti_s_qmr(xvec, rhsvec, ipar, dpar, work, matvecsubr, &
        & pcondlsubr, pcondrsubr, dotprodfun, normfun, mstopfun)
-    
+    IMPLICIT NONE
     PROCEDURE( mv_iface_s ), POINTER :: matvecsubr
     PROCEDURE( pc_iface_s ), POINTER :: pcondlsubr
     PROCEDURE( pc_iface_s ), POINTER :: pcondrsubr
@@ -213,7 +223,7 @@ CONTAINS
 
   SUBROUTINE huti_s_bicgstab(xvec, rhsvec, ipar, dpar, work, matvecsubr, &
        & pcondlsubr, pcondrsubr, dotprodfun, normfun, mstopfun)
-    
+    IMPLICIT NONE
     PROCEDURE( mv_iface_s ), POINTER :: matvecsubr
     PROCEDURE( pc_iface_s ), POINTER :: pcondlsubr
     PROCEDURE( pc_iface_s ), POINTER :: pcondrsubr
@@ -247,7 +257,7 @@ CONTAINS
 
   SUBROUTINE huti_s_gmres(xvec, rhsvec, ipar, dpar, work, matvecsubr, &
        & pcondlsubr, pcondrsubr, dotprodfun, normfun, mstopfun)
-    
+    IMPLICIT NONE
     PROCEDURE( mv_iface_s ), POINTER :: matvecsubr
     PROCEDURE( pc_iface_s ), POINTER :: pcondlsubr
     PROCEDURE( pc_iface_s ), POINTER :: pcondrsubr
@@ -281,7 +291,7 @@ CONTAINS
 
   SUBROUTINE huti_s_bicgstab_2(xvec, rhsvec, ipar, dpar, work, matvecsubr, &
        & pcondlsubr, pcondrsubr, dotprodfun, normfun, mstopfun)
-    
+    IMPLICIT NONE
     PROCEDURE( mv_iface_s ), POINTER :: matvecsubr
     PROCEDURE( pc_iface_s ), POINTER :: pcondlsubr
     PROCEDURE( pc_iface_s ), POINTER :: pcondrsubr
@@ -315,7 +325,7 @@ CONTAINS
 
   SUBROUTINE huti_d_cg(xvec, rhsvec, ipar, dpar, work, matvecsubr, &
        & pcondlsubr, pcondrsubr, dotprodfun, normfun, mstopfun)
-    
+    IMPLICIT NONE
     PROCEDURE( mv_iface_d ), POINTER :: matvecsubr
     PROCEDURE( pc_iface_d ), POINTER :: pcondlsubr
     PROCEDURE( pc_iface_d ), POINTER :: pcondrsubr
@@ -349,7 +359,7 @@ CONTAINS
 
   SUBROUTINE huti_d_cgs(xvec, rhsvec, ipar, dpar, work, matvecsubr, &
        & pcondlsubr, pcondrsubr, dotprodfun, normfun, mstopfun)
-    
+    IMPLICIT NONE
     PROCEDURE( mv_iface_d ), POINTER :: matvecsubr
     PROCEDURE( pc_iface_d ), POINTER :: pcondlsubr
     PROCEDURE( pc_iface_d ), POINTER :: pcondrsubr
@@ -383,7 +393,7 @@ CONTAINS
 
   SUBROUTINE huti_d_bicgstab(xvec, rhsvec, ipar, dpar, work, matvecsubr, &
        & pcondlsubr, pcondrsubr, dotprodfun, normfun, mstopfun)
-    
+    IMPLICIT NONE
     PROCEDURE( mv_iface_d ), POINTER :: matvecsubr
     PROCEDURE( pc_iface_d ), POINTER :: pcondlsubr
     PROCEDURE( pc_iface_d ), POINTER :: pcondrsubr
@@ -417,7 +427,7 @@ CONTAINS
 
   SUBROUTINE huti_d_tfqmr(xvec, rhsvec, ipar, dpar, work, matvecsubr, &
        & pcondlsubr, pcondrsubr, dotprodfun, normfun, mstopfun)
-    
+    IMPLICIT NONE
     PROCEDURE( mv_iface_d ), POINTER :: matvecsubr
     PROCEDURE( pc_iface_d ), POINTER :: pcondlsubr
     PROCEDURE( pc_iface_d ), POINTER :: pcondrsubr
@@ -451,7 +461,7 @@ CONTAINS
 
   SUBROUTINE huti_d_qmr(xvec, rhsvec, ipar, dpar, work, matvecsubr, &
        & pcondlsubr, pcondrsubr, dotprodfun, normfun, mstopfun)
-    
+    IMPLICIT NONE
     PROCEDURE( mv_iface_d ), POINTER :: matvecsubr
     PROCEDURE( pc_iface_d ), POINTER :: pcondlsubr
     PROCEDURE( pc_iface_d ), POINTER :: pcondrsubr
@@ -485,7 +495,7 @@ CONTAINS
 
   SUBROUTINE huti_d_gmres(xvec, rhsvec, ipar, dpar, work, matvecsubr, &
        & pcondlsubr, pcondrsubr, dotprodfun, normfun, mstopfun)
-    
+    IMPLICIT NONE
     PROCEDURE( mv_iface_d ), POINTER :: matvecsubr
     PROCEDURE( pc_iface_d ), POINTER :: pcondlsubr
     PROCEDURE( pc_iface_d ), POINTER :: pcondrsubr
@@ -519,7 +529,7 @@ CONTAINS
 
   SUBROUTINE huti_d_bicgstab_2(xvec, rhsvec, ipar, dpar, work, matvecsubr, &
        & pcondlsubr, pcondrsubr, dotprodfun, normfun, mstopfun)
-    
+    IMPLICIT NONE
     PROCEDURE( mv_iface_d ), POINTER :: matvecsubr
     PROCEDURE( pc_iface_d ), POINTER :: pcondlsubr
     PROCEDURE( pc_iface_d ), POINTER :: pcondrsubr
@@ -553,7 +563,7 @@ CONTAINS
 
   SUBROUTINE huti_c_cg(xvec, rhsvec, ipar, dpar, work, matvecsubr, &
        & pcondlsubr, pcondrsubr, dotprodfun, normfun, mstopfun)
-    
+    IMPLICIT NONE
     PROCEDURE( mv_iface_c ), POINTER :: matvecsubr
     PROCEDURE( pc_iface_c ), POINTER :: pcondlsubr
     PROCEDURE( pc_iface_c ), POINTER :: pcondrsubr
@@ -587,7 +597,7 @@ CONTAINS
 
   SUBROUTINE huti_c_cgs(xvec, rhsvec, ipar, dpar, work, matvecsubr, &
        & pcondlsubr, pcondrsubr, dotprodfun, normfun, mstopfun)
-    
+    IMPLICIT NONE
     PROCEDURE( mv_iface_c ), POINTER :: matvecsubr
     PROCEDURE( pc_iface_c ), POINTER :: pcondlsubr
     PROCEDURE( pc_iface_c ), POINTER :: pcondrsubr
@@ -621,7 +631,7 @@ CONTAINS
 
   SUBROUTINE huti_c_bicgstab(xvec, rhsvec, ipar, dpar, work, matvecsubr, &
        & pcondlsubr, pcondrsubr, dotprodfun, normfun, mstopfun)
-    
+    IMPLICIT NONE
     PROCEDURE( mv_iface_c ), POINTER :: matvecsubr
     PROCEDURE( pc_iface_c ), POINTER :: pcondlsubr
     PROCEDURE( pc_iface_c ), POINTER :: pcondrsubr
@@ -655,7 +665,7 @@ CONTAINS
 
   SUBROUTINE huti_c_qmr(xvec, rhsvec, ipar, dpar, work, matvecsubr, &
        & pcondlsubr, pcondrsubr, dotprodfun, normfun, mstopfun)
-    
+    IMPLICIT NONE
     PROCEDURE( mv_iface_c ), POINTER :: matvecsubr
     PROCEDURE( pc_iface_c ), POINTER :: pcondlsubr
     PROCEDURE( pc_iface_c ), POINTER :: pcondrsubr
@@ -689,7 +699,7 @@ CONTAINS
 
   SUBROUTINE huti_c_tfqmr(xvec, rhsvec, ipar, dpar, work, matvecsubr, &
        & pcondlsubr, pcondrsubr, dotprodfun, normfun, mstopfun)
-    
+    IMPLICIT NONE
     PROCEDURE( mv_iface_c ), POINTER :: matvecsubr
     PROCEDURE( pc_iface_c ), POINTER :: pcondlsubr
     PROCEDURE( pc_iface_c ), POINTER :: pcondrsubr
@@ -701,7 +711,7 @@ CONTAINS
     COMPLEX, DIMENSION(HUTI_NDIM) :: xvec, rhsvec
     DOUBLE PRECISION, DIMENSION(HUTI_DPAR_DFLTSIZE) :: dpar
     COMPLEX, DIMENSION(HUTI_WRKDIM,HUTI_NDIM) :: work
-
+ 
     IF(.NOT. ASSOCIATED(pcondrsubr) ) THEN
        pcondrsubr => huti_cdummy_pcondfun
     END IF
@@ -723,7 +733,7 @@ CONTAINS
 
   SUBROUTINE huti_c_gmres(xvec, rhsvec, ipar, dpar, work, matvecsubr, &
        & pcondlsubr, pcondrsubr, dotprodfun, normfun, mstopfun)
-    
+    IMPLICIT NONE    
     PROCEDURE( mv_iface_c ), POINTER :: matvecsubr
     PROCEDURE( pc_iface_c ), POINTER :: pcondlsubr
     PROCEDURE( pc_iface_c ), POINTER :: pcondrsubr
@@ -757,7 +767,7 @@ CONTAINS
 
   SUBROUTINE huti_c_bicgstab_2(xvec, rhsvec, ipar, dpar, work, matvecsubr, &
        & pcondlsubr, pcondrsubr, dotprodfun, normfun, mstopfun)
-    
+    IMPLICIT NONE
     PROCEDURE( mv_iface_c ), POINTER :: matvecsubr
     PROCEDURE( pc_iface_c ), POINTER :: pcondlsubr
     PROCEDURE( pc_iface_c ), POINTER :: pcondrsubr
@@ -791,7 +801,7 @@ CONTAINS
   
   SUBROUTINE huti_z_cg(xvec, rhsvec, ipar, dpar, work, matvecsubr, &
        & pcondlsubr, pcondrsubr, dotprodfun, normfun, mstopfun)
-    
+    IMPLICIT NONE
     PROCEDURE( mv_iface_z ), POINTER :: matvecsubr
     PROCEDURE( pc_iface_z ), POINTER :: pcondlsubr
     PROCEDURE( pc_iface_z ), POINTER :: pcondrsubr


### PR DESCRIPTION
Complex linear solvers should work now with GNU+MKL. Also, added modifications to avoid cross-compilation problems due to TRY_RUN when detecting the GNU compiler. 
