### PR TITLE
cmake: remove oneline c-comments from fem/config.h

### DIFF
--- a/fem/CMakeLists.txt
+++ b/fem/CMakeLists.txt
@@ -3,6 +3,19 @@ INCLUDE(CheckIncludeFiles)
 
 CHECK_INCLUDE_FILES(inttypes.h HAVE_INTTYPES_H)
 
+
+FUNCTION(FORTRANIZE infile outfile)
+  SET(RESULT "")
+  FILE(STRINGS "${infile}" lines)
+  FOREACH(i IN LISTS lines)
+    STRING(REGEX REPLACE "/\\*.*\\*/" "" i "${i}")
+    IF(i)
+      SET(RESULT "${RESULT}${i}\n")
+    ENDIF(i)
+  ENDFOREACH()
+  FILE(WRITE "${outfile}" "${RESULT}")
+ENDFUNCTION(FORTRANIZE infile outfile)
+
 #TODO: is this proper way of choosing shared library API?
 IF(WIN32)
   UNSET(HAVE_DLOPEN_API)
@@ -49,7 +62,8 @@ IF(APPLE)
   SET(SHL_EXTENSION ".dylib")
 ENDIF()
 
-CONFIGURE_FILE(config.h.cmake config.h)
+CONFIGURE_FILE(config.h.cmake config.h.commented)
+FORTRANIZE(${CMAKE_BINARY_DIR}/fem/config.h.commented ${CMAKE_BINARY_DIR}/fem/config.h)
 
 INCLUDE_DIRECTORIES("${PROJECT_BINARY_DIR}")
 ADD_SUBDIRECTORY(src)

--- a/fem/config.h.cmake
+++ b/fem/config.h.cmake
@@ -1,3 +1,5 @@
+/* Don't use multiline c-style comments */
+
 #ifndef CONFIG_H_FEM
 #define CONFIG_H_FEM
 
@@ -31,8 +33,8 @@
 /* Define to 1 if you have the `dlopen' function. */
 #define HAVE_DLOPEN
 
-/* Define if your system has dlopen, dlsym, dlerror, and dlclose for dynamic
-   linking */
+/* Define if your system has dlopen, dlsym, dlerror, and dlclose for dynamic */
+/* linking */
 #cmakedefine HAVE_DLOPEN_API
 
 /* Define if your system has LoadLibrary API (e.g. WIN32)*/


### PR DESCRIPTION
Because Fortran preprocessors do not and should not necessarily support them.
