### PR TITLE
fix: traverse constraint matrices properly

### DIFF
--- a/fem/src/SolverUtils.F90
+++ b/fem/src/SolverUtils.F90
@@ -13581,6 +13581,7 @@ CONTAINS
        DO WHILE(ASSOCIATED(Ctmp))
          mcount = mcount + 1
          row = row + Ctmp % NumberOfRows
+         Ctmp => Ctmp % ConstraintMatrix
        END DO
      END IF
 


### PR DESCRIPTION
Fixed an endless loop bug in `fem/src/SolverUtils.F90` where constraint
matrices weren't traversed  properly
