### PR TITLE
feature: MagnetoDynamics option for harmonic average power

### DIFF
--- a/fem/tests/mgdyn_harmonic_wire/case.sif
+++ b/fem/tests/mgdyn_harmonic_wire/case.sif
@@ -55,7 +55,7 @@ Material 2
 End 
 
 Equation 1
-  Active Solvers(2) = 1 2 
+  Active Solvers(3) = 1 2 3
 End
 
 
@@ -102,6 +102,7 @@ Solver 2
   Impose Body Force Current = Logical True
 
   Discontinuous Bodies = True
+  calculate harmonic peak power = logical true
 End
 
 


### PR DESCRIPTION
- Power in harmonic case is now conj( E) . sigma E / 2
- Added option for having "peak" harmonic power with keyword
  `Calculate peak harmonic power = logical TRUE`. Default
  is `FALSE`.  If this is `TRUE` then the 1/2 is dropped out from the
  formula for power.
- Edited test `mgdyn_harmonic_wire` to have
  `calculate peak harmonic power = logical TRUE`
