### PR TITLE
Further improvements to computation of basis functions

### DIFF
--- a/fem/src/H1Basis.F90
+++ b/fem/src/H1Basis.F90
@@ -13,14 +13,19 @@ MODULE H1Basis
 #define LINEAR_REF(var)
 #endif
 
+  INTEGER, PARAMETER :: H1Basis_MaxPElementEdgeNodes=2, &
+          H1Basis_MaxPElementEdges = 12, &
+          H1Basis_MaxPElementFaceNodes = 4, &
+          H1Basis_MaxPElementFaces = 6
 CONTAINS
 
   SUBROUTINE H1Basis_GetEdgeDirection(ecode, nedges, globalind, direction)
     IMPLICIT NONE
     INTEGER, INTENT(IN) :: ecode, nedges
     INTEGER, DIMENSION(:), POINTER CONTIG, INTENT(IN) :: globalind
-    INTEGER, DIMENSION(:,:) CONTIG, INTENT(INOUT) :: direction
-    INTEGER :: i, ekey, tmp
+    INTEGER, DIMENSION(H1Basis_MaxPElementEdgeNodes, &
+                       H1Basis_MaxPElementEdges), INTENT(INOUT) :: direction
+    INTEGER :: i, tmp
 
     CALL H1Basis_GetEdgeMap(ecode, direction)
 
@@ -35,40 +40,257 @@ CONTAINS
     END DO
   END SUBROUTINE H1Basis_GetEdgeDirection
   
-  PURE SUBROUTINE H1Basis_GetEdgeMap(ecode, map)
+  SUBROUTINE H1Basis_GetTetraEdgeDirection(ttype, direction)
+    IMPLICIT NONE
+    INTEGER, INTENT(IN) :: ttype
+    INTEGER, DIMENSION(H1Basis_MaxPElementEdgeNodes, &
+                       H1Basis_MaxPElementEdges), TARGET, INTENT(INOUT) :: direction
+    ! Local variables
+    INTEGER, DIMENSION(:), POINTER CONTIG :: flatdir
+
+    ! Remap array bounds
+    flatdir(1:H1Basis_MaxPElementEdgeNodes*H1Basis_MaxPElementEdges) => direction
+    SELECT CASE (ttype)
+    CASE (1)
+      flatdir(1:12) = [ 1,2, &
+                        2,3, &
+                        1,3, &
+                        1,4, &
+                        2,4, &
+                        3,4 ]
+    CASE (2)
+      flatdir(1:12) = [ 1,2, &
+                        3,2, &
+                        1,3, &
+                        1,4, &
+                        2,4, &
+                        3,4 ]      
+    CASE DEFAULT
+      CALL Fatal('H1Basis_GetTetraEdgeDirection','Unknown tetra type')
+    END SELECT
+  END SUBROUTINE H1Basis_GetTetraEdgeDirection
+  
+  SUBROUTINE H1Basis_GetFaceDirection(ecode, nfaces, globalind, direction)
+    IMPLICIT NONE
+    INTEGER, INTENT(IN) :: ecode, nfaces
+    INTEGER, DIMENSION(:), POINTER CONTIG, INTENT(IN) :: globalind
+    INTEGER, DIMENSION(H1Basis_MaxPElementFaceNodes, &
+                       H1Basis_MaxPElementFaces), INTENT(INOUT) :: direction
+    INTEGER :: face, tmp, tmp1, tmp2, i, minI
+
+    CALL H1Basis_GetFaceMap(ecode, direction)
+
+!DIR$ LOOP COUNT MAX=6
+    DO face=1,nfaces
+      IF (direction(H1Basis_MaxPElementFaceNodes, face) == 0) THEN
+        ! Triangle face (last local index 0)
+        
+        ! Global face direction is consistent when the local indices are chosen such 
+        ! that the global index is sorted
+
+        ! Sort globalind(direction(:,face))
+        ! (1,2) -> (1,2) or (2,1)
+        IF (globalind(direction(1,face))>globalind(direction(2,face))) THEN
+          tmp = direction(1,face)
+          direction(1,face)=direction(2,face)
+          direction(2,face)=tmp
+        END IF
+        ! (1,3) -> (1,3) or (3,1)
+        IF (globalind(direction(1,face))>globalind(direction(3,face))) THEN
+          tmp = direction(1,face)
+          direction(1,face)=direction(3,face)
+          direction(3,face)=tmp
+        END IF
+        ! (2,3) -> (2,3) or (3,2)
+        IF (globalind(direction(2,face))>globalind(direction(3,face))) THEN
+          tmp = direction(2,face)
+          direction(2,face)=direction(3,face)
+          direction(3,face)=tmp
+        END IF
+      ELSE
+        ! Square face
+        ! Find index of minimum global index (A)
+        minI = 1
+        DO i=2,4
+          IF (globalind(direction(i,face))<globalind(direction(minI,face))) minI=i
+        END DO
+        
+        ! In place rotate face to left or right cyclically to move minI as first element
+        ! sqface(1:4)=cshift(direction(1:4,face),minI-1)
+        SELECT CASE(minI-1)
+        CASE(0)
+          ! Nothing to do!
+        CASE(1)
+          tmp = direction(1,face)
+          ! arr(i) -> arr(i+1)
+          DO i=1,3
+            direction(i,face)=direction(i+1,face)
+          END DO
+          direction(4,face)=tmp
+        CASE(2)
+          ! (1,3)->(3,1)
+          tmp1 = direction(1,face)
+          direction(1,face)=direction(3,face)
+          direction(3,face)=tmp1
+          ! (2,4)->(4,2)
+          tmp2 = direction(2,face)
+          direction(2,face)=direction(4,face)
+          direction(4,face)=tmp2
+        CASE(3)
+          tmp = direction(4,face)
+          ! arr(i+1) -> arr(i)
+          DO i=3,1,-1
+            direction(i+1,face)=direction(i,face)
+          END DO
+          direction(1,face)=tmp
+        END SELECT
+
+        ! Find second smallest index B next to global minimum (either 2 or 4)
+        IF (globalind(direction(2,face))>globalind(direction(4,face))) THEN
+          tmp=direction(2,face)
+          direction(2,face)=direction(4,face)
+          direction(4,face)=tmp
+        END IF
+
+        ! Let C be the remaining index next to the global minimum A and 
+        ! D the index opposite of A -> [A,B,D,C] forms a globally consistent ordering
+      END IF
+    END DO
+  END SUBROUTINE H1Basis_GetFaceDirection
+
+  SUBROUTINE H1Basis_GetTetraFaceDirection(ttype, direction)
+    IMPLICIT NONE
+    INTEGER, INTENT(IN) :: ttype
+    INTEGER, DIMENSION(H1Basis_MaxPElementFaceNodes, &
+                       H1Basis_MaxPElementFaces), TARGET, INTENT(INOUT) :: direction
+    ! Local variables
+    INTEGER, DIMENSION(:), POINTER CONTIG :: flatdir
+
+    ! Remap array bounds
+    flatdir(1:H1Basis_MaxPElementFaceNodes*H1Basis_MaxPElementFaces) => direction
+    SELECT CASE (ttype)
+    CASE (1)
+      flatdir(1:16) = [ 1,2,3,0, & 
+                        1,2,4,0, &
+                        2,3,4,0, &
+                        1,3,4,0 ]
+    CASE (2)
+      flatdir(1:16) = [ 1,3,2,0, &
+                        1,2,4,0, &
+                        3,2,4,0, &
+                        1,3,4,0 ]
+    CASE DEFAULT
+      CALL Fatal('H1Basis_GetTetraFaceDirection','Unknown tetra type')
+    END SELECT
+  END SUBROUTINE H1Basis_GetTetraFaceDirection
+
+  SUBROUTINE H1Basis_GetEdgeMap(ecode, map)
     IMPLICIT NONE
 
     INTEGER, INTENT(IN) :: ecode
-    INTEGER, DIMENSION(:,:) CONTIG, INTENT(INOUT) :: map
-    
+    INTEGER, DIMENSION(H1Basis_MaxPElementEdgeNodes, &
+                       H1Basis_MaxPElementEdges), TARGET, INTENT(OUT) :: map
+    ! Local variables
+    INTEGER, DIMENSION(:), POINTER CONTIG :: flatmap
+
+    ! Remap array bounds
+    flatmap(1:H1Basis_MaxPElementEdgeNodes*H1Basis_MaxPElementEdges) => map
+
     SELECT CASE (ecode)
     CASE(202)
       ! Line edge mappings
-      map(:,1) = [ 1,2 ]
+      flatmap(1:2) = [ 1,2 ]
     CASE(303)
       ! Triangle edge mappings
-      map(:,1) = [ 1,2 ]
-      map(:,2) = [ 2,3 ]
-      map(:,3) = [ 3,1 ]
+      flatmap(1:6) = [ 1,2, &
+                       2,3, &
+                       3,1 ]
     CASE(404)
       ! Quad edge mappings
-      map(:,1) = [ 1,2 ]
-      map(:,2) = [ 2,3 ]
-      map(:,3) = [ 4,3 ]
-      map(:,4) = [ 1,4 ]
+      flatmap(1:8) = [ 1,2,&
+                       2,3,&
+                       4,3,&
+                       1,4 ]
+    CASE(504)
+      ! Tetra edge mapping (for completeness, not needed for enforcing parity)
+      CALL H1Basis_GetTetraEdgeDirection(1, map)
+    CASE(706)
+      flatmap(1:18) = [ 1,2,&
+                        2,3,&
+                        3,1,&
+                        4,5,&
+                        5,6,&
+                        6,4,&
+                        1,4,&
+                        2,5,&
+                        3,6 ]
+    CASE(808)
+      flatmap(1:24) = [ 1,2,&
+                        2,3,&
+                        4,3,&
+                        1,4,&
+                        5,6,&
+                        6,7,&
+                        8,7,&
+                        5,8,&
+                        1,5,&
+                        2,6,&
+                        3,7,&
+                        4,8 ]
+
     CASE DEFAULT
-      ! WRITE (*,*) 'H1Basis_InitEdgeMap: Not fully implemented yet!'
-      ! STOP
+      CALL Fatal('H1Basis_GetEdgeMap','Not fully implemented yet!')
     END SELECT
   END SUBROUTINE H1Basis_GetEdgeMap
 
-  SUBROUTINE H1Basis_LineNodal(nvec, u, fval)
+  SUBROUTINE H1Basis_GetFaceMap(ecode, map)
+    IMPLICIT NONE
+
+    INTEGER, INTENT(IN) :: ecode
+    INTEGER, DIMENSION(H1Basis_MaxPElementFaceNodes, &
+                       H1Basis_MaxPElementFaces), TARGET, INTENT(OUT) :: map
+    ! Local variables
+    INTEGER, DIMENSION(:), POINTER CONTIG :: flatmap
+
+    ! Remap array bounds
+    flatmap(1:H1Basis_MaxPElementFaceNodes*H1Basis_MaxPElementFaces) => map
+
+    SELECT CASE (ecode)
+    CASE(303)
+      ! 2D boundary element in a 3D mesh
+      flatmap(1:4) = [ 1,2,3,0 ]
+    CASE(404)
+      ! 2D boundary element in a 3D mesh
+      flatmap(1:4) = [ 1,2,3,4 ]
+    CASE(504)
+      ! Tetra face mapping (for completeness, not needed for enforcing parity)
+      CALL H1Basis_GetTetraFaceDirection(1, map)
+    CASE(706)
+      flatmap(1:20) = [ 1,2,3,0, &
+                        4,5,6,0, &
+                        1,2,5,4, &
+                        2,3,6,5, &
+                        3,1,4,6 ]
+    CASE(808)
+      flatmap(1:24) = [ 1,2,3,4, &
+                        5,6,7,8, &
+                        1,2,6,5, &
+                        2,3,7,6, &
+                        4,3,7,8, &
+                        1,4,8,5 ]
+    CASE DEFAULT
+      CALL Fatal('H1Basis_GetFaceMap','Not fully implemented yet!')
+    END SELECT
+  END SUBROUTINE H1Basis_GetFaceMap
+  
+  SUBROUTINE H1Basis_LineNodal(nvec, u, nbasis, fval)
     IMPLICIT NONE
 
     ! Parameters
     INTEGER, INTENT(IN) :: nvec
     REAL(Kind=dp), DIMENSION(:) CONTIG, INTENT(IN) :: u
     ! Variables
+    INTEGER, INTENT(INOUT) :: nbasis
     REAL(Kind=dp), DIMENSION(:,:) CONTIG, INTENT(INOUT) :: fval
     REAL(Kind=dp), PARAMETER :: c = 1D0/2D0
     INTEGER :: j
@@ -77,20 +299,22 @@ CONTAINS
     !$OMP SIMD
     DO j=1,nvec
       ! Node 1
-      fval(j,1) = c*(1-u(j))
+      fval(j,nbasis+1) = c*(1-u(j))
       ! Node 2
-      fval(j,2) = c*(1+u(j))
+      fval(j,nbasis+2) = c*(1+u(j))
     END DO
     !$END OMP SIMD
+    nbasis = nbasis + 2
   END SUBROUTINE H1Basis_LineNodal
 
-  SUBROUTINE H1Basis_dLineNodal(nvec, u, grad)
+  SUBROUTINE H1Basis_dLineNodal(nvec, u, nbasis, grad)
     IMPLICIT NONE
 
     ! Parameters
     INTEGER, INTENT(IN) :: nvec
     REAL(Kind=dp), DIMENSION(:) CONTIG, INTENT(IN) :: u
     ! Variables
+    INTEGER, INTENT(INOUT) :: nbasis
     REAL(Kind=dp), DIMENSION(:,:,:) CONTIG, INTENT(INOUT) :: grad
     REAL(Kind=dp), PARAMETER :: c = 1D0/2D0
     INTEGER :: j
@@ -99,10 +323,11 @@ CONTAINS
     ! First coordinate (xi)
     !$OMP SIMD
     DO j=1,nvec
-      grad(j,1,1) = -c
-      grad(j,2,1) = c
+      grad(j,nbasis+1,1) = -c
+      grad(j,nbasis+2,1) = c
     END DO
     !$END OMP SIMD
+    nbasis = nbasis + 2
   END SUBROUTINE H1Basis_dLineNodal
 
   SUBROUTINE H1Basis_LineBubbleP(nvec, u, pmax, nbasis, fval, invertEdge)
@@ -189,13 +414,14 @@ CONTAINS
     nbasis = nbasis+pmax-1
   END SUBROUTINE H1Basis_dLineBubbleP
 
-  SUBROUTINE H1Basis_TriangleNodalP(nvec, u, v, fval)
+  SUBROUTINE H1Basis_TriangleNodalP(nvec, u, v, nbasis, fval)
     IMPLICIT NONE
 
     ! Parameters
     INTEGER, INTENT(IN) :: nvec
     REAL(Kind=dp), DIMENSION(:) CONTIG, INTENT(IN) :: u,v
     ! Variables
+    INTEGER, INTENT(INOUT) :: nbasis
     REAL(Kind=dp), DIMENSION(:,:) CONTIG, INTENT(INOUT) :: fval
 
     INTEGER :: j
@@ -204,11 +430,12 @@ CONTAINS
 
     !$OMP SIMD
     DO j=1,nvec
-      fval(j,1) = c*(1-u(j)-d*v(j))
-      fval(j,2) = c*(1+u(j)-d*v(j))
-      fval(j,3) = d*v(j)
+      fval(j,nbasis+1) = c*(1-u(j)-d*v(j))
+      fval(j,nbasis+2) = c*(1+u(j)-d*v(j))
+      fval(j,nbasis+3) = d*v(j)
     END DO
     !$END OMP SIMD
+    nbasis = nbasis + 3
   END SUBROUTINE H1Basis_TriangleNodalP
 
   FUNCTION H1Basis_TriangleL(node, u, v) RESULT(fval)
@@ -233,13 +460,14 @@ CONTAINS
     END SELECT
   END FUNCTION H1Basis_TriangleL
 
-  SUBROUTINE H1Basis_dTriangleNodalP(nvec, u, v, grad)
+  SUBROUTINE H1Basis_dTriangleNodalP(nvec, u, v, nbasis, grad)
     IMPLICIT NONE
 
     ! Parameters
     INTEGER, INTENT(IN) :: nvec
     REAL(Kind=dp), DIMENSION(:) CONTIG, INTENT(IN) :: u,v
     ! Variables
+    INTEGER, INTENT(INOUT) :: nbasis
     REAL(Kind=dp), DIMENSION(:,:,:) CONTIG, INTENT(INOUT) :: grad
     INTEGER :: j
 !DIR$ ASSUME_ALIGNED u:64, v:64, grad:64
@@ -247,34 +475,35 @@ CONTAINS
     ! First coordinate (xi)
     !$OMP SIMD
     DO j=1,nvec
-      grad(j,1,1) = -1d0/2
+      grad(j,nbasis+1,1) = -1d0/2
     END DO
     !$END OMP SIMD
     !$OMP SIMD
     DO j=1,nvec
-      grad(j,2,1) = 1d0/2
+      grad(j,nbasis+2,1) = 1d0/2
     END DO
     !$END OMP SIMD
     !$OMP SIMD
     DO j=1,nvec
-      grad(j,3,1) = REAL(0,dp)
+      grad(j,nbasis+3,1) = REAL(0,dp)
     END DO
     !$END OMP SIMD
     ! Second coordinate (eta)
     !$OMP SIMD
     DO j=1,nvec
-      grad(j,1,2) = -SQRT(3d0)/6
+      grad(j,nbasis+1,2) = -SQRT(3d0)/6
     END DO
     !$END OMP SIMD
     DO j=1,nvec
-      grad(j,2,2) = -SQRT(3d0)/6
+      grad(j,nbasis+2,2) = -SQRT(3d0)/6
     END DO
     !$END OMP SIMD
     !$OMP SIMD
     DO j=1,nvec
-      grad(j,3,2) = SQRT(3d0)/3
+      grad(j,nbasis+3,2) = SQRT(3d0)/3
     END DO
     !$END OMP SIMD
+    nbasis = nbasis + 3
   END SUBROUTINE H1Basis_dTriangleNodalP
   
   FUNCTION H1Basis_dTriangleL(node) RESULT(grad)
@@ -350,7 +579,7 @@ CONTAINS
       dLb = H1Basis_dTriangleL(edgedir(2,i))
 
       DO j=2,pmax(i)
-        !$OMP SIMD PRIVATE(La, Lb, vPhi)
+        !$OMP SIMD PRIVATE(La, Lb, vPhi, dVPhi)
         DO k=1,nvec
           La = H1Basis_TriangleL(edgedir(1,i),u(k),v(k))
           Lb = H1Basis_TriangleL(edgedir(2,i),u(k),v(k))
@@ -372,7 +601,7 @@ CONTAINS
 
   END SUBROUTINE H1Basis_dTriangleEdgeP
 
-  SUBROUTINE H1Basis_TriangleBubbleP(nvec, u, v, pmax, nbasis, fval)
+  SUBROUTINE H1Basis_TriangleBubbleP(nvec, u, v, pmax, nbasis, fval, localnumbers)
     IMPLICIT NONE
 
     INTEGER, INTENT(IN) :: nvec
@@ -380,31 +609,52 @@ CONTAINS
     INTEGER, INTENT(IN) :: pmax
     INTEGER, INTENT(INOUT) :: nbasis
     REAL(KIND=dp), DIMENSION(:,:) CONTIG, INTENT(INOUT) :: fval
+    INTEGER, INTENT(IN), DIMENSION(3), OPTIONAL :: localnumbers
       
     ! Variables
     INTEGER :: i,j,k
     REAL (KIND=dp) :: La, Lb, Lc
 !DIR$ ASSUME_ALIGNED u:64, v:64, fval:64
 
-    DO i = 0,pmax-3
-      DO j = 0,pmax-i-3
-        !$OMP SIMD PRIVATE(La, Lb, Lc)
-        DO k=1,nvec
-          La = H1Basis_TriangleL(1,u(k),v(k))
-          Lb = H1Basis_TriangleL(2,u(k),v(k))
-          Lc = H1Basis_TriangleL(3,u(k),v(k))
+    IF (.NOT. PRESENT(localnumbers)) THEN
+      ! Triangle bubble basis
+      DO i = 0,pmax-3
+        DO j = 0,pmax-i-3
+          !$OMP SIMD PRIVATE(La, Lb, Lc)
+          DO k=1,nvec
+            La = H1Basis_TriangleL(1,u(k),v(k))
+            Lb = H1Basis_TriangleL(2,u(k),v(k))
+            Lc = H1Basis_TriangleL(3,u(k),v(k))
           
-          fval(k,nbasis+j+1) = La*Lb*Lc*(H1Basis_PowInt((Lb-La),i))*&
-                  H1Basis_PowInt((2D0*Lc-1),j)
+            fval(k,nbasis+j+1) = La*Lb*Lc*(H1Basis_PowInt((Lb-La),i))*&
+                    H1Basis_PowInt((2D0*Lc-1),j)
+          END DO
+          !$OMP END SIMD
         END DO
-        !$OMP END SIMD
+        ! nbasis = nbasis + (pmax-i-3) + 1
+        nbasis = nbasis + MAX(pmax-i-2,0)
       END DO
-      ! nbasis = nbasis + (pmax-i-3) + 1
-      nbasis = nbasis + pmax-i-2
-    END DO
+    ELSE
+      ! Triangular face basis
+      DO i=0,pmax-3
+        DO j=0,pmax-i-3
+          !$OMP SIMD PRIVATE(La, Lb, Lc)
+          DO k=1,nvec
+            La=H1Basis_TriangleL(localnumbers(1),u(k),v(k))
+            Lb=H1Basis_TriangleL(localnumbers(2),u(k),v(k))
+            Lc=H1Basis_TriangleL(localnumbers(3),u(k),v(k))
+            
+            fval(k,nbasis+j+1) = La*Lb*Lc*H1Basis_LegendreP(i,Lb-La)* &
+                                          H1Basis_LegendreP(j,2*Lc-1)
+          END DO
+        END DO
+        ! nbasis = nbasis + (pmax-i-3 + 1)
+        nbasis = nbasis + MAX(pmax-i-2,0)
+      END DO
+    END IF
   END SUBROUTINE H1Basis_TriangleBubbleP
 
-  SUBROUTINE H1Basis_dTriangleBubbleP(nvec, u, v, pmax, nbasis, grad)
+  SUBROUTINE H1Basis_dTriangleBubbleP(nvec, u, v, pmax, nbasis, grad, localnumbers)
     IMPLICIT NONE
 
     INTEGER, INTENT(IN) :: nvec
@@ -412,36 +662,73 @@ CONTAINS
     INTEGER, INTENT(IN) :: pmax
     INTEGER, INTENT(INOUT) :: nbasis
     REAL(KIND=dp), DIMENSION(:,:,:) CONTIG, INTENT(INOUT) :: grad
+    INTEGER, INTENT(IN), DIMENSION(3), OPTIONAL :: localnumbers
 
     ! Variables
-    REAL (KIND=dp) :: La, Lb, Lc, Lc_1, Lb_Lai, Lc_1n
+    REAL (KIND=dp) :: La, Lb, Lc, Lc_1, Lb_Lai, Lc_1n, a, b, Lb_La,&
+            dLa(2), dLb(2), dLc(2)
     INTEGER :: i,j,k
     REAL(KIND=dp), PARAMETER :: c = 1D0/2D0, d = -SQRT(3D0)/6, e = SQRT(3D0)/3
 !DIR$ ASSUME_ALIGNED u:64, v:64, grad:64
 
-    DO i = 0,pmax-3
-      DO j = 0,pmax-i-3
-        !$OMP SIMD PRIVATE(La, Lb, Lc, Lb_Lai, Lc_1n)
-        DO k=1,nvec
-          La = H1Basis_TriangleL(1,u(k),v(k))
-          Lb = H1Basis_TriangleL(2,u(k),v(k))
-          Lc = H1Basis_TriangleL(3,u(k),v(k))
-    
-          Lb_Lai = H1Basis_PowInt((Lb-La), i)
-          Lc_1n = H1Basis_PowInt((2D0*Lc-1), j)
-
-          ! Calculate value of function from general form
-          grad(k,nbasis+j+1,1) = -c*Lb*Lc*Lb_Lai*Lc_1n + La*c*Lc*Lb_Lai*Lc_1n + &
-                  La*Lb*Lc*i*(H1Basis_PowInt((Lb-La),i-1))*Lc_1n
-          grad(k,nbasis+j+1,2) = d*Lb*Lc*Lb_Lai*Lc_1n + La*d*Lc*Lb_Lai*Lc_1n + &
-                  La*Lb*e*Lb_Lai*Lc_1n + &
-                  La*Lb*Lc*Lb_Lai*j*(H1Basis_PowInt((2D0*Lc-1),j-1))*2D0*e
+    IF (.NOT. PRESENT(localnumbers)) THEN
+      ! Triangle bubble basis
+      DO i = 0,pmax-3
+        DO j = 0,pmax-i-3
+          !$OMP SIMD PRIVATE(La, Lb, Lc, Lb_Lai, Lc_1n)
+          DO k=1,nvec
+            La = H1Basis_TriangleL(1,u(k),v(k))
+            Lb = H1Basis_TriangleL(2,u(k),v(k))
+            Lc = H1Basis_TriangleL(3,u(k),v(k))
+            
+            Lb_Lai = H1Basis_PowInt((Lb-La), i)
+            Lc_1n = H1Basis_PowInt((2D0*Lc-1), j)
+            
+            ! Calculate value of function from general form
+            grad(k,nbasis+j+1,1) = -c*Lb*Lc*Lb_Lai*Lc_1n + La*c*Lc*Lb_Lai*Lc_1n + &
+                    La*Lb*Lc*i*(H1Basis_PowInt((Lb-La),i-1))*Lc_1n
+            grad(k,nbasis+j+1,2) = d*Lb*Lc*Lb_Lai*Lc_1n + La*d*Lc*Lb_Lai*Lc_1n + &
+                    La*Lb*e*Lb_Lai*Lc_1n + &
+                    La*Lb*Lc*Lb_Lai*j*(H1Basis_PowInt((2D0*Lc-1),j-1))*2D0*e
+          END DO
+          !$OMP END SIMD
         END DO
-        !$OMP END SIMD
+        ! nbasis = nbasis + (pmax-i-3) + 1
+        nbasis = nbasis + MAX(pmax-i-2,0)
       END DO
-      ! nbasis = nbasis + (pmax-i-3) + 1
-      nbasis = nbasis + pmax-i-2
-    END DO
+    ELSE
+      ! Triangular face basis
+      dLa = H1Basis_dTriangleL(localnumbers(1))
+      dLb = H1Basis_dTriangleL(localnumbers(2))
+      dLc = H1Basis_dTriangleL(localnumbers(3))
+
+      DO i=0,pmax-3
+        DO j=0,pmax-i-3
+          !$OMP SIMD PRIVATE(La, Lb, Lc, Lb_La, Lc_1, a, b)
+          DO k=1,nvec
+            La=H1Basis_TriangleL(localnumbers(1),u(k),v(k))
+            Lb=H1Basis_TriangleL(localnumbers(2),u(k),v(k))
+            Lc=H1Basis_TriangleL(localnumbers(3),u(k),v(k))
+            Lb_La=Lb-La
+            Lc_1=2*Lc-1
+            a=H1Basis_LegendreP(i,Lb_La)
+            b=H1Basis_LegendreP(j,Lc_1)
+
+            grad(k,nbasis+j+1,1) = dLa(1)*Lb*Lc*a*b + La*dLb(1)*Lc*a*b + &
+                    La*Lb*dLc(1)*a*b + &
+                    La*Lb*Lc*H1Basis_dLegendreP(i,Lb_La)*(dLb(1)-dLa(1))*b + &
+                    La*Lb*Lc*a*H1Basis_dLegendreP(j,Lc_1)*2*dLc(1)
+            grad(k,nbasis+j+1,2) = dLa(2)*Lb*Lc*a*b + La*dLb(2)*Lc*a*b + &
+                    La*Lb*dLc(2)*a*b + &
+                    La*Lb*Lc*H1Basis_dLegendreP(i,Lb_La)*(dLb(2)-dLa(2))*b + &
+                    La*Lb*Lc*a*H1Basis_dLegendreP(j,Lc_1)*2*dLc(2)
+          END DO
+        END DO
+        ! nbasis = nbasis + (pmax-i-3 + 1)
+        nbasis = nbasis + MAX(pmax-i-2,0)
+      END DO
+    END IF
+
   END SUBROUTINE H1Basis_dTriangleBubbleP
 
   FUNCTION H1Basis_PowInt(x,j) RESULT(powi)
@@ -460,13 +747,14 @@ CONTAINS
 
   END FUNCTION H1Basis_PowInt
 
-  SUBROUTINE H1Basis_QuadNodal(nvec, u, v, fval)
+  SUBROUTINE H1Basis_QuadNodal(nvec, u, v, nbasis, fval)
     IMPLICIT NONE
 
     ! Parameters
     INTEGER, INTENT(IN) :: nvec
     REAL(Kind=dp), DIMENSION(:) CONTIG, INTENT(IN) :: u,v
     ! Variables
+    INTEGER, INTENT(INOUT) :: nbasis
     REAL(Kind=dp), DIMENSION(:,:) CONTIG, INTENT(INOUT) :: fval
     REAL(Kind=dp), PARAMETER :: c = 1D0/4D0
     INTEGER :: j
@@ -484,15 +772,17 @@ CONTAINS
       fval(j,4) = c*(1-u(j))*(1+v(j))
     END DO
     !$END OMP SIMD
+    nbasis = nbasis + 4
   END SUBROUTINE H1Basis_QuadNodal
 
-  SUBROUTINE H1Basis_dQuadNodal(nvec, u, v, grad)
+  SUBROUTINE H1Basis_dQuadNodal(nvec, u, v, nbasis, grad)
     IMPLICIT NONE
 
     ! Parameters
     INTEGER, INTENT(IN) :: nvec
     REAL(Kind=dp), DIMENSION(:) CONTIG, INTENT(IN) :: u,v
     ! Variables
+    INTEGER, INTENT(INOUT) :: nbasis
     REAL(Kind=dp), DIMENSION(:,:,:) CONTIG, INTENT(INOUT) :: grad
     REAL(Kind=dp), PARAMETER :: c = 1D0/4D0
     INTEGER :: j
@@ -501,22 +791,24 @@ CONTAINS
     ! First coordinate (xi)
     !$OMP SIMD
     DO j=1,nvec
-      grad(j,1,1) = -c*(1-v(j))
-      grad(j,2,1) = c*(1-v(j))
-      grad(j,3,1) = c*(1+v(j))
-      grad(j,4,1) = -c*(1+v(j))
+      grad(j,nbasis+1,1) = -c*(1-v(j))
+      grad(j,nbasis+2,1) = c*(1-v(j))
+      grad(j,nbasis+3,1) = c*(1+v(j))
+      grad(j,nbasis+4,1) = -c*(1+v(j))
     END DO
     !$END OMP SIMD
 
     ! Second coordinate (eta)
     !$OMP SIMD
     DO j=1,nvec
-      grad(j,1,2) = -c*(1-u(j))
-      grad(j,2,2) = -c*(1+u(j))
-      grad(j,3,2) = c*(1+u(j))
-      grad(j,4,2) = c*(1-u(j))
+      grad(j,nbasis+1,2) = -c*(1-u(j))
+      grad(j,nbasis+2,2) = -c*(1+u(j))
+      grad(j,nbasis+3,2) = c*(1+u(j))
+      grad(j,nbasis+4,2) = c*(1-u(j))
     END DO
     !$END OMP SIMD
+
+    nbasis = nbasis + 4
   END SUBROUTINE H1Basis_dQuadNodal
 
   SUBROUTINE H1Basis_QuadEdgeP(nvec, u, v, pmax, nbasis, fval, edgedir)
@@ -617,7 +909,7 @@ CONTAINS
           END DO
           !$END OMP SIMD
         END DO
-        nbasis = nbasis+pmax-i-1
+        nbasis = nbasis+MAX(pmax-i-1,0)
       END DO
     ELSE
       DO i=2,(pmax-2)
@@ -634,7 +926,7 @@ CONTAINS
           END DO
           !$END OMP SIMD
         END DO
-        nbasis = nbasis+pmax-i-1
+        nbasis = nbasis+MAX(pmax-i-1,0)
       END DO
     END IF
   END SUBROUTINE H1Basis_QuadBubbleP
@@ -667,7 +959,7 @@ CONTAINS
           END DO
           !$END OMP SIMD
         END DO
-        nbasis = nbasis+(pmax-i)-1
+        nbasis = nbasis+MAX((pmax-i)-1,0)
       END DO
     ELSE
       ! Numbering present, so use it
@@ -693,7 +985,7 @@ CONTAINS
           END DO
           !$END OMP SIMD
         END DO
-        nbasis = nbasis+(pmax-i)-1
+        nbasis = nbasis+MAX((pmax-i)-1,0)
       END DO
     END IF
   END SUBROUTINE H1Basis_dQuadBubbleP
@@ -741,13 +1033,14 @@ CONTAINS
     END SELECT
   END FUNCTION H1Basis_dQuadL
 
-  SUBROUTINE H1Basis_TetraNodalP(nvec, u, v, w, fval)
+  SUBROUTINE H1Basis_TetraNodalP(nvec, u, v, w, nbasis, fval)
     IMPLICIT NONE
 
     ! Parameters
     INTEGER, INTENT(IN) :: nvec
     REAL(Kind=dp), DIMENSION(:) CONTIG, INTENT(IN) :: u,v,w
     ! Variables
+    INTEGER, INTENT(INOUT) :: nbasis
     REAL(Kind=dp), DIMENSION(:,:) CONTIG, INTENT(INOUT) :: fval
     INTEGER :: j
 
@@ -758,94 +1051,17 @@ CONTAINS
     !$OMP SIMD
     DO j=1,nvec
       ! Node 1
-      fval(j,1) = c*(1-u(j)-d*v(j)-e*w(j))
+      fval(j,nbasis+1) = c*(1-u(j)-d*v(j)-e*w(j))
       ! Node 2
-      fval(j,2) = c*(1+u(j)-d*v(j)-e*w(j))
+      fval(j,nbasis+2) = c*(1+u(j)-d*v(j)-e*w(j))
       ! Node 3
-      fval(j,3) = SQRT(3d0)/3*(v(j)-f*w(j))
+      fval(j,nbasis+3) = SQRT(3d0)/3*(v(j)-f*w(j))
       ! Node 4
-      fval(j,4) = SQRT(3d0/8d0)*w(j)
+      fval(j,nbasis+4) = SQRT(3d0/8d0)*w(j)
     END DO
     !$END OMP SIMD
+    nbasis = nbasis + 4
   END SUBROUTINE H1Basis_TetraNodalP
-
-  SUBROUTINE H1Basis_dTetraNodalP(nvec, u, v, w, grad)
-    IMPLICIT NONE
-
-    ! Parameters
-    INTEGER, INTENT(IN) :: nvec
-    REAL(Kind=dp), DIMENSION(:) CONTIG, INTENT(IN) :: u,v,w
-    ! Variables
-    REAL(Kind=dp), DIMENSION(:,:,:) CONTIG, INTENT(INOUT) :: grad
-    INTEGER :: j
-!DIR$ ASSUME_ALIGNED u:64, v:64, w:64, grad:64
-
-    ! First coordinate (xi)
-    !$OMP SIMD
-    DO j=1,nvec
-      grad(j,1,1)=-1d0/2
-    END DO
-    !$END OMP SIMD
-    !$OMP SIMD
-    DO j=1,nvec
-      grad(j,2,1)=1d0/2
-    END DO
-    !$END OMP SIMD
-    !$OMP SIMD
-    DO j=1,nvec
-      grad(j,3,1)=REAL(0,dp)
-    END DO
-    !$END OMP SIMD
-    !$OMP SIMD
-    DO j=1,nvec
-      grad(j,4,1)=REAL(0,dp)
-    END DO
-    !$END OMP SIMD
-
-    ! Second coordinate (eta)
-    !$OMP SIMD
-    DO j=1,nvec
-      grad(j,1,2)=-SQRT(3d0)/6
-    END DO
-    !$END OMP SIMD
-    !$OMP SIMD
-    DO j=1,nvec
-      grad(j,2,2)=-SQRT(3d0)/6
-    END DO
-    !$END OMP SIMD  
-    !$OMP SIMD
-    DO j=1,nvec
-      grad(j,3,2)=SQRT(3d0)/3
-    END DO
-    !$END OMP SIMD
-    !$OMP SIMD
-    DO j=1,nvec
-      grad(j,4,2)=REAL(0,dp)
-    END DO
-    !$END OMP SIMD
-
-    ! Third coordinate (zeta)
-    !$OMP SIMD
-    DO j=1,nvec
-      grad(j,1,3)=-SQRT(6d0)/12
-    END DO
-    !$END OMP SIMD
-    !$OMP SIMD
-    DO j=1,nvec
-      grad(j,2,3)=-SQRT(6d0)/12
-    END DO
-    !$END OMP SIMD
-    !$OMP SIMD
-    DO j=1,nvec
-      grad(j,3,3)=-SQRT(6d0)/12
-    END DO
-    !$END OMP SIMD
-    !$OMP SIMD
-    DO j=1,nvec
-      grad(j,4,3)=SQRT(6d0)/4
-    END DO
-    !$END OMP SIMD
-  END SUBROUTINE H1Basis_dTetraNodalP
 
   FUNCTION H1Basis_TetraL(node, u, v, w) RESULT(fval)
     IMPLICIT NONE
@@ -871,7 +1087,271 @@ CONTAINS
       fval = SQRT(3d0/8d0)*w      
     END SELECT
   END FUNCTION H1Basis_TetraL
+  
+  SUBROUTINE H1Basis_dTetraNodalP(nvec, u, v, w, nbasis, grad)
+    IMPLICIT NONE
 
+    ! Parameters
+    INTEGER, INTENT(IN) :: nvec
+    REAL(Kind=dp), DIMENSION(:) CONTIG, INTENT(IN) :: u,v,w
+    ! Variables
+    INTEGER, INTENT(INOUT) :: nbasis
+    REAL(Kind=dp), DIMENSION(:,:,:) CONTIG, INTENT(INOUT) :: grad
+    INTEGER :: j
+!DIR$ ASSUME_ALIGNED u:64, v:64, w:64, grad:64
+
+    ! First coordinate (xi)
+    !$OMP SIMD
+    DO j=1,nvec
+      grad(j,nbasis+1,1)=-1d0/2
+    END DO
+    !$END OMP SIMD
+    !$OMP SIMD
+    DO j=1,nvec
+      grad(j,nbasis+2,1)=1d0/2
+    END DO
+    !$END OMP SIMD
+    !$OMP SIMD
+    DO j=1,nvec
+      grad(j,nbasis+3,1)=REAL(0,dp)
+    END DO
+    !$END OMP SIMD
+    !$OMP SIMD
+    DO j=1,nvec
+      grad(j,nbasis+4,1)=REAL(0,dp)
+    END DO
+    !$END OMP SIMD
+
+    ! Second coordinate (eta)
+    !$OMP SIMD
+    DO j=1,nvec
+      grad(j,nbasis+1,2)=-SQRT(3d0)/6
+    END DO
+    !$END OMP SIMD
+    !$OMP SIMD
+    DO j=1,nvec
+      grad(j,nbasis+2,2)=-SQRT(3d0)/6
+    END DO
+    !$END OMP SIMD  
+    !$OMP SIMD
+    DO j=1,nvec
+      grad(j,nbasis+3,2)=SQRT(3d0)/3
+    END DO
+    !$END OMP SIMD
+    !$OMP SIMD
+    DO j=1,nvec
+      grad(j,nbasis+4,2)=REAL(0,dp)
+    END DO
+    !$END OMP SIMD
+
+    ! Third coordinate (zeta)
+    !$OMP SIMD
+    DO j=1,nvec
+      grad(j,nbasis+1,3)=-SQRT(6d0)/12
+    END DO
+    !$END OMP SIMD
+    !$OMP SIMD
+    DO j=1,nvec
+      grad(j,nbasis+2,3)=-SQRT(6d0)/12
+    END DO
+    !$END OMP SIMD
+    !$OMP SIMD
+    DO j=1,nvec
+      grad(j,nbasis+3,3)=-SQRT(6d0)/12
+    END DO
+    !$END OMP SIMD
+    !$OMP SIMD
+    DO j=1,nvec
+      grad(j,nbasis+4,3)=SQRT(6d0)/4
+    END DO
+    !$END OMP SIMD
+    nbasis = nbasis + 4
+  END SUBROUTINE H1Basis_dTetraNodalP
+  
+  FUNCTION H1Basis_dTetraL(node) RESULT(grad)
+    IMPLICIT NONE
+
+    ! Parameters 
+    INTEGER, INTENT(IN) :: node
+    ! Result
+    REAL(KIND=dp) :: grad(3)
+    REAL(KIND=dp), PARAMETER :: c = 1D0/2D0, d = 1D0/SQRT(3D0), &
+            e = 1D0/SQRT(6D0), f = 1D0/SQRT(8D0)
+    !$OMP DECLARE SIMD(H1Basis_dTetraL) UNIFORM(node) NOTINBRANCH
+
+    SELECT CASE(node)
+    CASE(1)
+      grad = c*[-1D0, -d, -e]
+    CASE(2)
+      grad = c*[1D0, -d, -e]
+    CASE(3)
+      grad = d*[0D0, 1D0, -f]
+    CASE(4)
+      grad = [0D0, 0D0, SQRT(3d0/8d0)]
+    END SELECT
+  END FUNCTION H1Basis_dTetraL
+
+  SUBROUTINE H1Basis_TetraEdgeP(nvec, u, v, w, pmax, nbasis, fval, edgedir)
+    IMPLICIT NONE
+
+    INTEGER, INTENT(IN) :: nvec
+    REAL(KIND=dp), DIMENSION(:) CONTIG, INTENT(IN) :: u, v, w
+    INTEGER, DIMENSION(:) CONTIG, INTENT(IN) :: pmax
+    INTEGER, INTENT(INOUT) :: nbasis
+    REAL(KIND=dp), DIMENSION(:,:) CONTIG, INTENT(INOUT) :: fval
+    INTEGER, DIMENSION(:,:) CONTIG, INTENT(IN) :: edgedir
+
+    REAL(KIND=dp) :: La, Lb
+    INTEGER :: i,j,k
+!DIR$ ASSUME_ALIGNED u:64, v:64, w:64, fval:64
+
+    ! For each edge
+    DO i=1,6
+      DO j=2,pmax(i)
+        !$OMP SIMD PRIVATE(La, Lb)
+        DO k=1,nvec
+          La = H1Basis_TetraL(edgedir(1,i), u(k), v(k), w(k))
+          Lb = H1Basis_TetraL(edgedir(2,i), u(k), v(k), w(k))
+
+          fval(k, nbasis+j-1) = La*Lb*H1Basis_varPhi(j,Lb-La)
+        END DO
+        !$OMP END SIMD
+      END DO
+      ! nbasis = nbasis + (pmax(i)-2) + 1
+      nbasis = nbasis + pmax(i) - 1
+    END DO
+  END SUBROUTINE H1Basis_TetraEdgeP
+  
+  SUBROUTINE H1Basis_dTetraEdgeP(nvec, u, v, w, pmax, nbasis, grad, edgedir)
+    IMPLICIT NONE
+
+    INTEGER, INTENT(IN) :: nvec
+    REAL(KIND=dp), DIMENSION(:) CONTIG, INTENT(IN) :: u, v, w
+    INTEGER, DIMENSION(:) CONTIG, INTENT(IN) :: pmax
+    INTEGER, INTENT(INOUT) :: nbasis
+    REAL(KIND=dp), DIMENSION(:,:,:) CONTIG, INTENT(INOUT) :: grad
+    INTEGER, DIMENSION(:,:) CONTIG, INTENT(IN) :: edgedir
+
+    REAL(KIND=dp) :: La, Lb, vPhi, dVPhi, dLa(3), dLb(3)
+    INTEGER :: i,j,k
+!DIR$ ASSUME_ALIGNED u:64, v:64, w:64, grad:64
+
+    ! For each edge
+    DO i=1,6
+      dLa = H1Basis_dTetraL(edgedir(1,i))
+      dLb = H1Basis_dTetraL(edgedir(2,i))
+
+      DO j=2,pmax(i)
+        !$OMP SIMD PRIVATE(La, Lb, vPhi, dVPhi)
+        DO k=1,nvec
+          La = H1Basis_TetraL(edgedir(1,i),u(k),v(k),w(k))
+          Lb = H1Basis_TetraL(edgedir(2,i),u(k),v(k),w(k))
+          vPhi = H1Basis_varPhi(j,Lb-La)
+          dVPhi = H1Basis_dVarPhi(j,Lb-La)
+
+          grad(k, nbasis+j-1, 1) = dLa(1)*Lb*vPhi+ &
+                  La*dLb(1)*vPhi +&
+                  La*Lb*dVPhi*(dLb(1)-dLa(1))
+          grad(k, nbasis+j-1, 2) = dLa(2)*Lb*vPhi+ &
+                  La*dLb(2)*vPhi +&
+                  La*Lb*dVPhi*(dLb(2)-dLa(2))
+          grad(k, nbasis+j-1, 3) = dLa(3)*Lb*vPhi+ &
+                  La*dLb(3)*vPhi +&
+                  La*Lb*dVPhi*(dLb(3)-dLa(3))
+        END DO
+        !$OMP END SIMD
+      END DO
+      ! nbasis = nbasis + (pmax(i)-2) + 1
+      nbasis = nbasis + pmax(i) - 1
+    END DO
+  END SUBROUTINE H1Basis_dTetraEdgeP
+
+  SUBROUTINE H1Basis_TetraFaceP(nvec, u, v, w, pmax, nbasis, fval, facedir)
+    IMPLICIT NONE
+
+    INTEGER, INTENT(IN) :: nvec
+    REAL(KIND=dp), DIMENSION(:) CONTIG, INTENT(IN) :: u, v, w
+    INTEGER, DIMENSION(:) CONTIG, INTENT(IN) :: pmax
+    INTEGER, INTENT(INOUT) :: nbasis
+    REAL(KIND=dp), DIMENSION(:,:) CONTIG, INTENT(INOUT) :: fval
+    INTEGER, DIMENSION(:,:) CONTIG, INTENT(IN) :: facedir
+
+    REAL(KIND=dp) :: La, Lb, Lc
+    INTEGER :: i,j,k,l
+!DIR$ ASSUME_ALIGNED u:64, v:64, w:64, fval:64
+
+    ! For each face
+    DO i=1,4
+      DO j=0,pmax(i)-3
+        DO k=0,pmax(i)-j-3
+          !$OMP SIMD PRIVATE(La, Lb, Lc)
+          DO l=1,nvec
+            La=H1Basis_TetraL(facedir(1,i),u(l),v(l),w(l))
+            Lb=H1Basis_TetraL(facedir(2,i),u(l),v(l),w(l))
+            Lc=H1Basis_TetraL(facedir(3,i),u(l),v(l),w(l))
+    
+            fval(l,nbasis+k+1) = La*Lb*Lc*H1Basis_LegendreP(j,Lb-La)* &
+                                        H1Basis_LegendreP(k,2*Lc-1)
+          END DO
+        END DO
+        ! nbasis = nbasis + (pmax(i)-j-3 + 1)
+        nbasis = nbasis + MAX(pmax(i)-j-2,0)
+      END DO
+    END DO
+  END SUBROUTINE H1Basis_TetraFaceP
+  
+  SUBROUTINE H1Basis_dTetraFaceP(nvec, u, v, w, pmax, nbasis, grad, facedir)
+    IMPLICIT NONE
+
+    INTEGER, INTENT(IN) :: nvec
+    REAL(KIND=dp), DIMENSION(:) CONTIG, INTENT(IN) :: u, v, w
+    INTEGER, DIMENSION(:) CONTIG, INTENT(IN) :: pmax
+    INTEGER, INTENT(INOUT) :: nbasis
+    REAL(KIND=dp), DIMENSION(:,:,:) CONTIG, INTENT(INOUT) :: grad
+    INTEGER, DIMENSION(:,:) CONTIG, INTENT(IN) :: facedir
+
+    REAL(KIND=dp) :: La, Lb, Lc, dLa(3), dLb(3), dLc(3), Lb_La, Lc_1, a, b
+    INTEGER :: i,j,k,l
+!DIR$ ASSUME_ALIGNED u:64, v:64, w:64, grad:64
+
+    ! For each face
+    DO i=1,4
+      dLa = H1Basis_dTetraL(facedir(1,i))
+      dLb = H1Basis_dTetraL(facedir(2,i))
+      dLc = H1Basis_dTetraL(facedir(3,i))
+
+      DO j=0,pmax(i)-3
+        DO k=0,pmax(i)-j-3
+          !$OMP SIMD PRIVATE(La, Lb, Lc, Lb_La, Lc_1, a, b)
+          DO l=1,nvec
+            La=H1Basis_TetraL(facedir(1,i),u(l),v(l),w(l))
+            Lb=H1Basis_TetraL(facedir(2,i),u(l),v(l),w(l))
+            Lc=H1Basis_TetraL(facedir(3,i),u(l),v(l),w(l))
+            Lb_La=Lb-La
+            Lc_1=2*Lc-1
+            a=H1Basis_LegendreP(j,Lb_La)
+            b=H1Basis_LegendreP(k,Lc_1)
+
+            grad(l,nbasis+k+1,1) = dLa(1)*Lb*Lc*a*b + La*dLb(1)*Lc*a*b + &
+                    La*Lb*dLc(1)*a*b + &
+                    La*Lb*Lc*H1Basis_dLegendreP(j,Lb_La)*(dLb(1)-dLa(1))*b + &
+                    La*Lb*Lc*a*H1Basis_dLegendreP(k,Lc_1)*2*dLc(1)
+            grad(l,nbasis+k+1,2) = dLa(2)*Lb*Lc*a*b + La*dLb(2)*Lc*a*b + &
+                    La*Lb*dLc(2)*a*b + &
+                    La*Lb*Lc*H1Basis_dLegendreP(j,Lb_La)*(dLb(2)-dLa(2))*b + &
+                    La*Lb*Lc*a*H1Basis_dLegendreP(k,Lc_1)*2*dLc(2)
+            grad(l,nbasis+k+1,3) = dLa(3)*Lb*Lc*a*b + La*dLb(3)*Lc*a*b + &
+                    La*Lb*dLc(3)*a*b + &
+                    La*Lb*Lc*H1Basis_dLegendreP(j,Lb_La)*(dLb(3)-dLa(3))*b + &
+                    La*Lb*Lc*a*H1Basis_dLegendreP(k,Lc_1)*2*dLc(3)
+          END DO
+        END DO
+        ! nbasis = nbasis + (pmax(i)-j-3 + 1)
+        nbasis = nbasis + MAX(pmax(i)-j-2,0)
+      END DO
+    END DO
+  END SUBROUTINE H1Basis_dTetraFaceP
+  
   SUBROUTINE H1Basis_TetraBubbleP(nvec, u, v, w, pmax, nbasis, fval)
     IMPLICIT NONE
 
@@ -908,7 +1388,7 @@ CONTAINS
           !$END OMP SIMD
         END DO
         ! nbasis = nbasis + (pmax-i-j-4) + 1
-        nbasis = nbasis + pmax-i-j-3
+        nbasis = nbasis + MAX(pmax-i-j-3,0)
       END DO
     END DO
   END SUBROUTINE H1Basis_TetraBubbleP
@@ -961,18 +1441,19 @@ CONTAINS
           !$END OMP SIMD
         END DO
         ! nbasis = nbasis + (pmax-i-j-4) + 1
-        nbasis = nbasis + pmax-i-j-3
+        nbasis = nbasis + MAX(pmax-i-j-3,0)
       END DO
     END DO
   END SUBROUTINE H1Basis_dTetraBubbleP
 
-  SUBROUTINE H1Basis_WedgeNodalP(nvec, u, v, w, fval)
+  SUBROUTINE H1Basis_WedgeNodalP(nvec, u, v, w, nbasis, fval)
     IMPLICIT NONE
 
     ! Parameters
     INTEGER, INTENT(IN) :: nvec
     REAL(KIND=dp), DIMENSION(:) CONTIG, INTENT(IN) :: u,v,w
     ! Result
+    INTEGER, INTENT(INOUT) :: nbasis
     REAL(KIND=dp), DIMENSION(:,:) CONTIG, INTENT(INOUT) :: fval 
     INTEGER :: j
 
@@ -983,27 +1464,29 @@ CONTAINS
     !$OMP SIMD
     DO j=1,nvec
       ! Node 1
-      fval(j,1) = c*(1d0-u(j)-d*v(j))*(1d0-w(j))
+      fval(j,nbasis+1) = c*(1d0-u(j)-d*v(j))*(1d0-w(j))
       ! Node 2
-      fval(j,2) = c*(1d0+u(j)-d*v(j))*(1d0-w(j))
+      fval(j,nbasis+2) = c*(1d0+u(j)-d*v(j))*(1d0-w(j))
       ! Node 3
-      fval(j,3) = e*v(j)*(1-w(j))
+      fval(j,nbasis+3) = e*v(j)*(1-w(j))
       ! Node 4
-      fval(j,4) = c*(1d0-u(j)-d*v(j))*(1d0+w(j))
+      fval(j,nbasis+4) = c*(1d0-u(j)-d*v(j))*(1d0+w(j))
       ! Node 5
-      fval(j,5) = c*(1d0+u(j)-d*v(j))*(1d0+w(j))
+      fval(j,nbasis+5) = c*(1d0+u(j)-d*v(j))*(1d0+w(j))
       ! Node 6
-      fval(j,6) = e*v(j)*(1+w(j))
+      fval(j,nbasis+6) = e*v(j)*(1+w(j))
     END DO
     !$END OMP SIMD
+    nbasis = nbasis + 6
   END SUBROUTINE H1Basis_WedgeNodalP
 
-  SUBROUTINE H1Basis_dWedgeNodalP(nvec, u, v, w, grad)
+  SUBROUTINE H1Basis_dWedgeNodalP(nvec, u, v, w, nbasis, grad)
     IMPLICIT NONE
 
     ! Parameters
     INTEGER, INTENT(IN) :: nvec
     REAL(KIND=dp), DIMENSION(:) CONTIG, INTENT(IN) :: u,v,w
+    INTEGER, INTENT(INOUT) :: nbasis
     REAL(KIND=dp), DIMENSION(:,:,:) CONTIG, INTENT(INOUT) :: grad
 
     ! Variables
@@ -1015,38 +1498,39 @@ CONTAINS
     ! First coordinate (xi)
     !$OMP SIMD
     DO j=1,nvec
-      grad(j,1,1) = -c*(1-w(j))
-      grad(j,2,1) = c*(1-w(j))  
-      grad(j,3,1) = REAL(0, dp)
-      grad(j,4,1) = -c*(1+w(j))
-      grad(j,5,1) = c*(1+w(j))
-      grad(j,6,1) = REAL(0, dp)
+      grad(j,nbasis+1,1) = -c*(1-w(j))
+      grad(j,nbasis+2,1) = c*(1-w(j))  
+      grad(j,nbasis+3,1) = REAL(0, dp)
+      grad(j,nbasis+4,1) = -c*(1+w(j))
+      grad(j,nbasis+5,1) = c*(1+w(j))
+      grad(j,nbasis+6,1) = REAL(0, dp)
     END DO
     !$END OMP SIMD
 
     ! Second coordinate (eta)
     !$OMP SIMD
     DO j=1,nvec
-      grad(j,1,2)= -f*(1-w(j))
-      grad(j,2,2) = -f*(1-w(j))
-      grad(j,3,2) = e*(1-w(j))
-      grad(j,4,2) = -f*(1+w(j))
-      grad(j,5,2) = -f*(1+w(j))
-      grad(j,6,2) = e*(1+w(j))
+      grad(j,nbasis+1,2)= -f*(1-w(j))
+      grad(j,nbasis+2,2) = -f*(1-w(j))
+      grad(j,nbasis+3,2) = e*(1-w(j))
+      grad(j,nbasis+4,2) = -f*(1+w(j))
+      grad(j,nbasis+5,2) = -f*(1+w(j))
+      grad(j,nbasis+6,2) = e*(1+w(j))
     END DO
     !$END OMP SIMD
 
     ! Third coordinate (zeta)
     !$OMP SIMD
     DO j=1,nvec
-      grad(j,1,3) = -c*(1d0-u(j)-d*v(j))
-      grad(j,2,3) = -c*(1d0+u(j)-d*v(j))
-      grad(j,3,3) = -e*v(j)
-      grad(j,4,3) = c*(1d0-u(j)-d*v(j))
-      grad(j,5,3) = c*(1d0+u(j)-d*v(j))
-      grad(j,6,3) = e*v(j)
+      grad(j,nbasis+1,3) = -c*(1d0-u(j)-d*v(j))
+      grad(j,nbasis+2,3) = -c*(1d0+u(j)-d*v(j))
+      grad(j,nbasis+3,3) = -e*v(j)
+      grad(j,nbasis+4,3) = c*(1d0-u(j)-d*v(j))
+      grad(j,nbasis+5,3) = c*(1d0+u(j)-d*v(j))
+      grad(j,nbasis+6,3) = e*v(j)
     END DO
     !$END OMP SIMD
+    nbasis = nbasis + 6
   END SUBROUTINE H1Basis_dWedgeNodalP
 
   FUNCTION H1Basis_WedgeL(node, u, v) RESULT(fval)
@@ -1069,6 +1553,414 @@ CONTAINS
       fval = SQRT(3d0)/3*v
     END SELECT
   END FUNCTION H1Basis_WedgeL
+
+  FUNCTION H1Basis_dWedgeL(node) RESULT(grad)
+    IMPLICIT NONE
+
+    ! Parameters
+    INTEGER, INTENT(IN) :: node
+    ! Result
+    REAL(KIND=dp) :: grad(3)
+    REAL(KIND=dp), PARAMETER :: c = 1D0/2D0, d = 1D0/SQRT(3D0)
+    !$OMP DECLARE SIMD(H1Basis_dWedgeL) UNIFORM(node) NOTINBRANCH
+
+    SELECT CASE(node)
+    CASE(1,4)
+      grad = c*[REAL(-1,dp), REAL(-d,dp), 0D0]
+    CASE(2,5)
+      grad = c*[REAL(1,dp), REAL(-d,dp), 0D0]
+    CASE(3,6)
+      grad = [REAL(0,dp), REAL(d,dp), 0D0]
+    END SELECT    
+  END FUNCTION H1Basis_dWedgeL
+
+  FUNCTION H1Basis_WedgeH(node, w) RESULT(fval)
+    IMPLICIT NONE
+
+    ! Parameters
+    INTEGER, INTENT(IN) :: node
+    REAL(KIND=dp), INTENT(IN) :: w
+    ! Result
+    REAL(KIND=dp) :: fval
+    !$OMP DECLARE SIMD(H1Basis_WedgeH) UNIFORM(node) &
+    !$OMP LINEAR_REF(w) NOTINBRANCH
+    
+    SELECT CASE(node)
+    CASE (1,2,3)
+      fval = -w/2d0
+    CASE (4,5,6)
+      fval = w/2d0
+    END SELECT
+  END FUNCTION H1Basis_WedgeH
+
+  FUNCTION H1Basis_dWedgeH(node) RESULT(grad)
+    IMPLICIT NONE
+
+    ! Parameters
+    INTEGER, INTENT(IN) :: node
+    ! Result
+    REAL(KIND=dp) :: grad(3)
+    REAL(KIND=dp), PARAMETER :: c = 1D0/2D0
+    !$OMP DECLARE SIMD(H1Basis_dWedgeH) UNIFORM(node) NOTINBRANCH
+    
+    SELECT CASE(node)
+    CASE (1,2,3)
+      grad = [0D0, 0D0, -c]
+    CASE (4,5,6)
+      grad = [0D0, 0D0, c]
+    END SELECT
+  END FUNCTION H1Basis_dWedgeH
+  
+  SUBROUTINE H1Basis_WedgeEdgeP(nvec, u, v, w, pmax, nbasis, fval, edgedir)
+    IMPLICIT NONE
+
+    INTEGER, INTENT(IN) :: nvec
+    REAL(KIND=dp), DIMENSION(:) CONTIG, INTENT(IN) :: u, v, w
+    INTEGER, DIMENSION(:) CONTIG, INTENT(IN) :: pmax
+    INTEGER, INTENT(INOUT) :: nbasis
+    REAL(KIND=dp), DIMENSION(:,:) CONTIG, INTENT(INOUT) :: fval
+    INTEGER, DIMENSION(:,:) CONTIG, INTENT(IN) :: edgedir
+
+    REAL(KIND=dp) :: La, Lb, Na, Nb
+    REAL(KIND=dp), PARAMETER :: c = 1D0/2D0
+    INTEGER :: i,j,k,l
+!DIR$ ASSUME_ALIGNED u:64, v:64, w:64, fval:64
+
+    ! For each triangle face edge
+    DO i=1,6
+      DO j=2,pmax(i)
+        !$OMP SIMD PRIVATE(La, Lb, Na, Nb)
+        DO k=1,nvec
+          La = H1Basis_WedgeL(edgedir(1,i), u(k), v(k))
+          Lb = H1Basis_WedgeL(edgedir(2,i), u(k), v(k))
+          Na = H1Basis_WedgeH(edgedir(1,i), w(k))
+          Nb = H1Basis_WedgeH(edgedir(2,i), w(k))
+          fval(k, nbasis+j-1) = c*La*Lb*H1Basis_varPhi(j,Lb-La)*(1+Na+Nb)
+        END DO
+        !$OMP END SIMD
+      END DO
+      ! nbasis = nbasis + (pmax(i)-2) + 1
+      nbasis = nbasis + pmax(i) - 1
+    END DO
+      
+    ! For each square face edge
+    DO i=7,9
+      DO j=2,pmax(i)
+        !$OMP SIMD PRIVATE(La, Na, Nb)
+        DO k=1,nvec
+          La = H1Basis_WedgeL(edgedir(1,i), u(k), v(k))
+          Na = H1Basis_WedgeH(edgedir(1,i), w(k))
+          Nb = H1Basis_WedgeH(edgedir(2,i), w(k))
+          fval(k, nbasis+j-1) = La*H1Basis_Phi(j, Nb-Na)
+        END DO
+        !$OMP END SIMD
+      END DO
+      ! nbasis = nbasis + (pmax(i)-2) + 1
+      nbasis = nbasis + pmax(i) - 1
+    END DO
+  END SUBROUTINE H1Basis_WedgeEdgeP
+  
+  SUBROUTINE H1Basis_dWedgeEdgeP(nvec, u, v, w, pmax, nbasis, grad, edgedir)
+    IMPLICIT NONE
+
+    INTEGER, INTENT(IN) :: nvec
+    REAL(KIND=dp), DIMENSION(:) CONTIG, INTENT(IN) :: u, v, w
+    INTEGER, DIMENSION(:) CONTIG, INTENT(IN) :: pmax
+    INTEGER, INTENT(INOUT) :: nbasis
+    REAL(KIND=dp), DIMENSION(:,:,:) CONTIG, INTENT(INOUT) :: grad
+    INTEGER, DIMENSION(:,:) CONTIG, INTENT(IN) :: edgedir
+
+    REAL(KIND=dp) :: La, Lb, Na, Nb, Phi, dPhi, vPhi, dVPhi, &
+          dLa(3), dLb(3), dNa(3), dNb(3), NaNb
+    REAL(KIND=dp), PARAMETER :: c = 1D0/2D0
+    INTEGER :: i,j,k
+!DIR$ ASSUME_ALIGNED u:64, v:64, w:64, grad:64
+
+    ! For each triangle face edge
+    DO i=1,6
+      dLa = H1Basis_dWedgeL(edgedir(1,i))
+      dLb = H1Basis_dWedgeL(edgedir(2,i))
+      dNa = H1Basis_dWedgeH(edgedir(1,i))
+      dNb = H1Basis_dWedgeH(edgedir(2,i))
+      DO j=2,pmax(i)
+        !$OMP SIMD PRIVATE(La, Lb, Na, Nb, vPhi, dVPhi, NaNb)
+        DO k=1,nvec
+          La = H1Basis_WedgeL(edgedir(1,i), u(k), v(k))
+          Lb = H1Basis_WedgeL(edgedir(2,i), u(k), v(k))
+          Na = H1Basis_WedgeH(edgedir(1,i), w(k))
+          Nb = H1Basis_WedgeH(edgedir(2,i), w(k))
+          vPhi=H1Basis_varPhi(j,Lb-La)
+          dVPhi=H1Basis_dVarPhi(j,Lb-La)
+          NaNb=1+Na+Nb
+          ! fval(k, nbasis+j-1) = c*La*Lb*H1Basis_varPhi(j,Lb-La)*(1+Na+Nb)
+          grad(k, nbasis+j-1,1) = c*dLa(1)*Lb*vPhi*NaNb + &
+                c*La*dLb(1)*vPhi*NaNb + c*La*Lb*dVPhi*(dLb(1)-dLa(1))*NaNb
+                ! + c*La*Lb*vPhi*(dNb(1)+dNa(1)) ! Last term zero
+          grad(k, nbasis+j-1,2) = c*dLa(2)*Lb*vPhi*NaNb + &
+                c*La*dLb(2)*vPhi*NaNb + c*La*Lb*dVPhi*(dLb(2)-dLa(2))*NaNb
+                ! c*La*Lb*vPhi*(dNb(2)+dNa(2)) ! Last term zero
+          grad(k, nbasis+j-1,3) = c*La*Lb*vPhi*(dNb(3)+dNa(3))
+                ! c*dLa(3)*Lb*vPhi*NaNb + ! First term zero
+                ! c*La*dLb(3)*vPhi*NaNb + ! Second term zero
+                ! c*La*Lb*dVPhi*(dLb(3)-dLa(3))*NaNb ! Third term zero
+        END DO
+        !$OMP END SIMD
+      END DO
+      ! nbasis = nbasis + (pmax(i)-2) + 1
+      nbasis = nbasis + pmax(i) - 1
+    END DO
+      
+    ! For each square face edge
+    DO i=7,9
+      dLa = H1Basis_dWedgeL(edgedir(1,i))
+      dNa = H1Basis_dWedgeH(edgedir(1,i))
+      dNb = H1Basis_dWedgeH(edgedir(2,i))
+      DO j=2,pmax(i)
+        !$OMP SIMD PRIVATE(La, Na, Nb, Phi, dPhi)
+        DO k=1,nvec
+          La = H1Basis_WedgeL(edgedir(1,i), u(k), v(k))
+          Na = H1Basis_WedgeH(edgedir(1,i), w(k))
+          Nb = H1Basis_WedgeH(edgedir(2,i), w(k))
+          Phi = H1Basis_Phi(j, Nb-Na)
+          dPhi = H1Basis_dPhi(j,Nb-Na)
+          
+          grad(k, nbasis+j-1,1) = dLa(1)*Phi+La*dPhi*(dNb(1)-dNa(1))
+          grad(k, nbasis+j-1,2) = dLa(2)*Phi+La*dPhi*(dNb(2)-dNa(2))
+          grad(k, nbasis+j-1,3) = dLa(3)*Phi+La*dPhi*(dNb(3)-dNa(3)) 
+        END DO
+        !$OMP END SIMD
+      END DO
+      ! nbasis = nbasis + (pmax(i)-2) + 1
+      nbasis = nbasis + pmax(i) - 1
+    END DO
+  END SUBROUTINE H1Basis_dWedgeEdgeP
+  
+  SUBROUTINE H1Basis_WedgeFaceP(nvec, u, v, w, pmax, nbasis, fval, facedir)
+    IMPLICIT NONE
+
+    INTEGER, INTENT(IN) :: nvec
+    REAL(KIND=dp), DIMENSION(:) CONTIG, INTENT(IN) :: u, v, w
+    INTEGER, DIMENSION(:) CONTIG, INTENT(IN) :: pmax
+    INTEGER, INTENT(INOUT) :: nbasis
+    REAL(KIND=dp), DIMENSION(:,:) CONTIG, INTENT(INOUT) :: fval
+    INTEGER, DIMENSION(:,:) CONTIG, INTENT(IN) :: facedir
+
+    REAL(KIND=dp) :: La, Lb, Lc, Na, Nc
+    REAL(KIND=dp), PARAMETER :: c = 1D0/2D0
+    INTEGER :: i,j,k,l
+    LOGICAL :: nonpermuted
+!DIR$ ASSUME_ALIGNED u:64, v:64, w:64, fval:64
+
+    ! Triangle faces
+    DO i=1,2      
+      DO j=0,pmax(i)-3
+        DO k=0,pmax(i)-j-3
+          !$OMP SIMD PRIVATE(La, Lb, Lc, Na)
+          DO l=1,nvec
+            La = H1Basis_WedgeL(facedir(1,i), u(l), v(l))
+            Lb = H1Basis_WedgeL(facedir(2,i), u(l), v(l))
+            Lc = H1Basis_WedgeL(facedir(3,i), u(l), v(l))
+            Na = H1Basis_WedgeH(facedir(1,i), w(l))
+
+            fval(l,nbasis+k+1) = c*(1+2*Na)*La*Lb*Lc* &
+                                            H1Basis_LegendreP(j, Lb-La)* &
+                                            H1Basis_LegendreP(k, 2*Lc-1)
+          END DO
+          !$OMP END SIMD
+        END DO
+        ! nbasis = nbasis + (p-j-3) + 1
+        nbasis = nbasis + MAX(pmax(i)-j-2,0)
+      END DO
+    END DO
+    ! Square faces
+    DO i=3,5
+      ! First and second node must form an edge in upper or lower triangle
+      nonpermuted = (facedir(1,i) >= 1 .AND. facedir(1,i) <= 3 .AND.&
+                     facedir(2,i) >= 1 .AND. facedir(2,i) <= 3) .OR. &
+                    (facedir(1,i) >= 4 .AND. facedir(1,i) <= 6 .AND.&
+                     facedir(2,i) >= 4 .AND. facedir(2,i) <= 6)
+      
+      DO j=2,pmax(i)-2
+        DO k=2,pmax(i)-j          
+          IF (nonpermuted) THEN
+            !$OMP SIMD PRIVATE(La,Lb,Na,Nc)
+            DO l=1,nvec
+              La = H1Basis_WedgeL(facedir(1,i), u(l), v(l))
+              Lb = H1Basis_WedgeL(facedir(2,i), u(l), v(l))
+              Na = H1Basis_WedgeH(facedir(1,i), w(l))
+              Nc = H1Basis_WedgeH(facedir(4,i), w(l))
+              fval(l,nbasis+k-1) = La*Lb*H1Basis_varPhi(j, Lb-La)* &
+                                         H1Basis_Phi(k, Nc-Na)
+            END DO
+            !$OMP END SIMD
+          ELSE
+            !$OMP SIMD PRIVATE(La,Lb,Na,Nc)
+            DO l=1,nvec
+              ! Numbering permuted, switch indices j,k and nodes 2 and 4
+              La = H1Basis_WedgeL(facedir(1,i), u(l), v(l))
+              Lb = H1Basis_WedgeL(facedir(4,i), u(l), v(l))
+              Na = H1Basis_WedgeH(facedir(1,i), w(l))
+              Nc = H1Basis_WedgeH(facedir(2,i), w(l))
+              fval(l,nbasis+k-1) = La*Lb*H1Basis_varPhi(k, Lb-La)* &
+                                         H1Basis_Phi(j, Nc-Na)
+            END DO
+            !$OMP END SIMD
+          END IF
+        END DO
+        ! nbasis = nbasis + (pmax(i)-j-2) + 1
+        nbasis = nbasis + MAX(pmax(i)-j-1,0)
+      END DO
+    END DO
+  END SUBROUTINE H1Basis_WedgeFaceP
+  
+  SUBROUTINE H1Basis_dWedgeFaceP(nvec, u, v, w, pmax, nbasis, grad, facedir)
+    IMPLICIT NONE
+
+    INTEGER, INTENT(IN) :: nvec
+    REAL(KIND=dp), DIMENSION(:) CONTIG, INTENT(IN) :: u, v, w
+    INTEGER, DIMENSION(:) CONTIG, INTENT(IN) :: pmax
+    INTEGER, INTENT(INOUT) :: nbasis
+    REAL(KIND=dp), DIMENSION(:,:,:) CONTIG, INTENT(INOUT) :: grad
+    INTEGER, DIMENSION(:,:) CONTIG, INTENT(IN) :: facedir
+
+    REAL(KIND=dp) :: La, Lb, Lc, Na, Nc, LegPLbLa, LegP2Lc1, &
+            cNa, vPhi, Phi, dLa(3), dLb(3), dLc(3), dNa(3), dNc(3)
+    REAL(KIND=dp), PARAMETER :: c = 1D0/2D0
+    INTEGER :: i,j,k,l
+    LOGICAL :: nonpermuted
+!DIR$ ASSUME_ALIGNED u:64, v:64, w:64, grad:64
+
+    ! Triangle faces
+    DO i=1,2
+      dLa = H1Basis_dWedgeL(facedir(1,i))
+      dLb = H1Basis_dWedgeL(facedir(2,i))
+      dLc = H1Basis_dWedgeL(facedir(3,i))
+      dNa = H1Basis_dWedgeH(facedir(1,i))
+      DO j=0,pmax(i)-3
+        DO k=0,pmax(i)-j-3
+          !$OMP SIMD PRIVATE(La, Lb, Lc, Na, LegPLbLa, LegP2Lc1, cNa)
+          DO l=1,nvec
+            La = H1Basis_WedgeL(facedir(1,i), u(l), v(l))
+            Lb = H1Basis_WedgeL(facedir(2,i), u(l), v(l))
+            Lc = H1Basis_WedgeL(facedir(3,i), u(l), v(l))
+            Na = H1Basis_WedgeH(facedir(1,i), w(l))
+
+            LegPLbLa = H1Basis_LegendreP(j, Lb-La)
+            LegP2Lc1 = H1Basis_LegendreP(k, 2*Lc-1)
+            cNa = c*(1+2*Na)
+
+            grad(l,nbasis+k+1,1) = cNa*dLa(1)*Lb*Lc*LegPLbLa*LegP2Lc1 + &
+                    cNa*La*dLb(1)*Lc*LegPLbLa*LegP2Lc1 + &
+                    cNa*La*Lb*dLc(1)*LegPLbLa*LegP2Lc1 + &
+                    cNa*La*Lb*Lc*H1Basis_dLegendreP(j, Lb-La)*(dLb(1)-dLa(1))*LegP2Lc1 + &
+                    cNa*La*Lb*Lc*LegPLbLa*H1Basis_dLegendreP(k, 2*Lc-1)*(2*dLc(1))
+            ! + 2*c*dNa(1)*La*Lb*Lc*LegPLbLa*LegP2Lc1 ! Term always zero
+            grad(l,nbasis+k+1,2) = cNa*dLa(2)*Lb*Lc*LegPLbLa*LegP2Lc1 + &
+                    cNa*La*dLb(2)*Lc*LegPLbLa*LegP2Lc1 + &
+                    cNa*La*Lb*dLc(2)*LegPLbLa*LegP2Lc1 + &
+                    cNa*La*Lb*Lc*H1Basis_dLegendreP(j, Lb-La)*(dLb(2)-dLa(2))*LegP2Lc1 + &
+                    cNa*La*Lb*Lc*LegPLbLa*H1Basis_dLegendreP(k, 2*Lc-1)*(2*dLc(2))
+            ! + 2*c*dNa(2)*La*Lb*Lc*LegPLbLa*LegP2Lc1 ! Term always zero
+            grad(l,nbasis+k+1,3) = 2*c*dNa(3)*La*Lb*Lc*LegPLbLa*LegP2Lc1
+            ! Rest of the terms always zero
+            ! cNa*dLa(3)*Lb*Lc*LegPLbLa*LegP2Lc1 + &
+            ! cNa*La*dLb(3)*Lc*LegPLbLa*LegP2Lc1 + &
+            ! cNa*La*Lb*dLc(3)*LegPLbLa*LegP2Lc1 + &
+            ! cNa*La*Lb*Lc*H1Basis_dLegendreP(j, Lb-La)*(dLb(3)-dLa(3))*LegP2Lc1 + &
+            ! cNa*La*Lb*Lc*LegPLbLa*H1Basis_dLegendreP(k, 2*Lc-1)*(2*dLc(3))
+          END DO
+          !$OMP END SIMD
+        END DO
+        ! nbasis = nbasis + (p-j-3) + 1
+        nbasis = nbasis + MAX(pmax(i)-j-2,0)
+      END DO
+    END DO
+    ! Square faces
+    DO i=3,5
+      ! First and second node must form an edge in upper or lower triangle
+      nonpermuted = (facedir(1,i) >= 1 .AND. facedir(1,i) <= 3 .AND.&
+                     facedir(2,i) >= 1 .AND. facedir(2,i) <= 3) .OR. &
+                    (facedir(1,i) >= 4 .AND. facedir(1,i) <= 6 .AND.&
+                     facedir(2,i) >= 4 .AND. facedir(2,i) <= 6)
+      
+      IF (nonpermuted) THEN
+        dLa = H1Basis_dWedgeL(facedir(1,i))
+        dLb = H1Basis_dWedgeL(facedir(2,i))
+        dNa = H1Basis_dWedgeH(facedir(1,i))
+        dNc = H1Basis_dWedgeH(facedir(4,i))
+      ELSE
+        dLa = H1Basis_dWedgeL(facedir(1,i))
+        dLb = H1Basis_dWedgeL(facedir(4,i))
+        dNa = H1Basis_dWedgeH(facedir(1,i))
+        dNc = H1Basis_dWedgeH(facedir(2,i))
+      END IF
+
+      DO j=2,pmax(i)-2
+        DO k=2,pmax(i)-j          
+          IF (nonpermuted) THEN
+            !$OMP SIMD PRIVATE(La,Lb,Na,Nc,vPhi,Phi)
+            DO l=1,nvec
+              La = H1Basis_WedgeL(facedir(1,i), u(l), v(l))
+              Lb = H1Basis_WedgeL(facedir(2,i), u(l), v(l))
+              Na = H1Basis_WedgeH(facedir(1,i), w(l))
+              Nc = H1Basis_WedgeH(facedir(4,i), w(l))
+              
+              vPhi = H1Basis_varPhi(j, Lb-La)
+              Phi = H1Basis_Phi(k, Nc-Na)
+
+              ! fval(l,nbasis+k-1) = La*Lb*H1Basis_varPhi(j, Lb-La)* &
+              !                            H1Basis_Phi(k, Nc-Na)
+              grad(l,nbasis+k-1,1) = dLa(1)*Lb*vPhi*Phi+ &
+                      La*dLb(1)*vPhi*Phi + &
+                      La*Lb*H1Basis_dVarPhi(j, Lb-La)*(dLb(1)-dLa(1))*Phi
+              ! La*Lb*vPhi*H1Basis_dPhi(k, Nc-Na)*(dNc(1)-dNa(1)) ! Term always zero
+              grad(l,nbasis+k-1,2) = dLa(2)*Lb*vPhi*Phi+ &
+                      La*dLb(2)*vPhi*Phi + &
+                      La*Lb*H1Basis_dVarPhi(j, Lb-La)*(dLb(2)-dLa(2))*Phi
+              ! La*Lb*vPhi*H1Basis_dPhi(k, Nc-Na)*(dNc(2)-dNa(2)) ! Term always zero
+              grad(l,nbasis+k-1,3) = La*Lb*vPhi*H1Basis_dPhi(k, Nc-Na)*(dNc(3)-dNa(3))
+              ! Rest of the terms always zero
+              ! dLa(3)*Lb*vPhi*Phi+ &
+              ! La*dLb(3)*vPhi*Phi + &
+              ! La*Lb*H1Basis_dVarPhi(j, Lb-La)*(dLb(3)-dLa(3))*Phi
+            END DO
+            !$OMP END SIMD
+          ELSE
+            !$OMP SIMD PRIVATE(La,Lb,Na,Nc)
+            DO l=1,nvec
+              ! Numbering permuted, switch indices j,k and nodes 2 and 4
+              La = H1Basis_WedgeL(facedir(1,i), u(l), v(l))
+              Lb = H1Basis_WedgeL(facedir(4,i), u(l), v(l))
+              Na = H1Basis_WedgeH(facedir(1,i), w(l))
+              Nc = H1Basis_WedgeH(facedir(2,i), w(l))
+              
+              vPhi = H1Basis_varPhi(k, Lb-La)
+              Phi = H1Basis_Phi(j, Nc-Na)
+
+              ! fval(l,nbasis+k-1) = La*Lb*H1Basis_varPhi(k, Lb-La)* &
+              !                            H1Basis_Phi(j, Nc-Na)
+              grad(l,nbasis+k-1,1) = dLa(1)*Lb*vPhi*Phi+ &
+                      La*dLb(1)*vPhi*Phi + &
+                      La*Lb*H1Basis_dVarPhi(k, Lb-La)*(dLb(1)-dLa(1))*Phi
+              ! La*Lb*vPhi*H1Basis_dPhi(j, Nc-Na)*(dNc(1)-dNa(1)) ! Term always zero
+              grad(l,nbasis+k-1,2) = dLa(2)*Lb*vPhi*Phi+ &
+                      La*dLb(2)*vPhi*Phi + &
+                      La*Lb*H1Basis_dVarPhi(k, Lb-La)*(dLb(2)-dLa(2))*Phi
+              ! La*Lb*vPhi*H1Basis_dPhi(j, Nc-Na)*(dNc(2)-dNa(2)) ! Term always zero
+              grad(l,nbasis+k-1,3) = La*Lb*vPhi*H1Basis_dPhi(j, Nc-Na)*(dNc(3)-dNa(3))
+              ! Rest of the terms always zero
+              ! dLa(3)*Lb*vPhi*Phi+ &
+              ! La*dLb(3)*vPhi*Phi + &
+              ! La*Lb*H1Basis_dVarPhi(k, Lb-La)*(dLb(3)-dLa(3))*Phi
+            END DO
+            !$OMP END SIMD
+          END IF
+        END DO
+        ! nbasis = nbasis + (pmax(i)-j-2) + 1
+        nbasis = nbasis + MAX(pmax(i)-j-1,0)
+      END DO
+    END DO
+  END SUBROUTINE H1Basis_dWedgeFaceP
   
   SUBROUTINE H1Basis_WedgeBubbleP(nvec, u, v, w, pmax, nbasis, fval)
     IMPLICIT NONE
@@ -1100,7 +1992,7 @@ CONTAINS
           END DO
         END DO
         ! nbasis = nbasis + (pmax-3-i-j)-2+1
-        nbasis = nbasis + pmax-4-i-j
+        nbasis = nbasis + MAX(pmax-4-i-j,0)
       END DO
     END DO
   END SUBROUTINE H1Basis_WedgeBubbleP
@@ -1149,18 +2041,19 @@ CONTAINS
           END DO
         END DO
         ! nbasis = nbasis + (pmax-3-i-j)-2+1
-        nbasis = nbasis + pmax-4-i-j
+        nbasis = nbasis + MAX(pmax-4-i-j,0)
       END DO
     END DO
   END SUBROUTINE H1Basis_dWedgeBubbleP
 
-  SUBROUTINE H1Basis_BrickNodal(nvec, u, v, w, fval)
+  SUBROUTINE H1Basis_BrickNodal(nvec, u, v, w, nbasis, fval)
     IMPLICIT NONE
 
     ! Parameters
     INTEGER, INTENT(IN) :: nvec
     REAL(Kind=dp), DIMENSION(:) CONTIG, INTENT(IN) :: u,v,w
     ! Variables
+    INTEGER, INTENT(INOUT) :: nbasis
     REAL(Kind=dp), DIMENSION(:,:) CONTIG, INTENT(INOUT) :: fval
     REAL(Kind=dp), PARAMETER :: c = 1D0/8D0
     INTEGER :: j
@@ -1169,32 +2062,34 @@ CONTAINS
     !$OMP SIMD
     DO j=1,nvec
       ! Node 1
-      fval(j,1) = c*(1-u(j))*(1-v(j))*(1-w(j))
+      fval(j,nbasis+1) = c*(1-u(j))*(1-v(j))*(1-w(j))
       ! Node 2
-      fval(j,2) = c*(1+u(j))*(1-v(j))*(1-w(j))
+      fval(j,nbasis+2) = c*(1+u(j))*(1-v(j))*(1-w(j))
       ! Node 3
-      fval(j,3) = c*(1+u(j))*(1+v(j))*(1-w(j))
+      fval(j,nbasis+3) = c*(1+u(j))*(1+v(j))*(1-w(j))
       ! Node 4
-      fval(j,4) = c*(1-u(j))*(1+v(j))*(1-w(j))
+      fval(j,nbasis+4) = c*(1-u(j))*(1+v(j))*(1-w(j))
       ! Node 5
-      fval(j,5) = c*(1-u(j))*(1-v(j))*(1+w(j))
+      fval(j,nbasis+5) = c*(1-u(j))*(1-v(j))*(1+w(j))
       ! Node 6
-      fval(j,6) = c*(1+u(j))*(1-v(j))*(1+w(j))
+      fval(j,nbasis+6) = c*(1+u(j))*(1-v(j))*(1+w(j))
       ! Node 7
-      fval(j,7) = c*(1+u(j))*(1+v(j))*(1+w(j))
+      fval(j,nbasis+7) = c*(1+u(j))*(1+v(j))*(1+w(j))
       ! Node 8
-      fval(j,8) = c*(1-u(j))*(1+v(j))*(1+w(j))
+      fval(j,nbasis+8) = c*(1-u(j))*(1+v(j))*(1+w(j))
     END DO
     !$END OMP SIMD
+    nbasis = nbasis + 8
   END SUBROUTINE H1Basis_BrickNodal
 
-  SUBROUTINE H1Basis_dBrickNodal(nvec, u, v, w, grad)
+  SUBROUTINE H1Basis_dBrickNodal(nvec, u, v, w, nbasis, grad)
     IMPLICIT NONE
 
     ! Parameters
     INTEGER, INTENT(IN) :: nvec
     REAL(Kind=dp), DIMENSION(:) CONTIG, INTENT(IN) :: u,v,w
     ! Variables
+    INTEGER, INTENT(INOUT) :: nbasis
     REAL(Kind=dp), DIMENSION(:,:,:) CONTIG, INTENT(INOUT) :: grad
     REAL(Kind=dp), PARAMETER :: c = 1D0/8D0
     INTEGER :: j
@@ -1203,46 +2098,379 @@ CONTAINS
     ! First coordinate (xi)
     !$OMP SIMD
     DO j=1,nvec
-      grad(j,1,1) = -c*(1-v(j))*(1-w(j))
-      grad(j,2,1) = c*(1-v(j))*(1-w(j))
-      grad(j,3,1) = c*(1+v(j))*(1-w(j))
-      grad(j,4,1) = -c*(1+v(j))*(1-w(j))
-      grad(j,5,1) = -c*(1-v(j))*(1+w(j))
-      grad(j,6,1) = c*(1-v(j))*(1+w(j))
-      grad(j,7,1) = c*(1+v(j))*(1+w(j))
-      grad(j,8,1) = -c*(1+v(j))*(1+w(j))
+      grad(j,nbasis+1,1) = -c*(1-v(j))*(1-w(j))
+      grad(j,nbasis+2,1) = c*(1-v(j))*(1-w(j))
+      grad(j,nbasis+3,1) = c*(1+v(j))*(1-w(j))
+      grad(j,nbasis+4,1) = -c*(1+v(j))*(1-w(j))
+      grad(j,nbasis+5,1) = -c*(1-v(j))*(1+w(j))
+      grad(j,nbasis+6,1) = c*(1-v(j))*(1+w(j))
+      grad(j,nbasis+7,1) = c*(1+v(j))*(1+w(j))
+      grad(j,nbasis+8,1) = -c*(1+v(j))*(1+w(j))
     END DO
     !$END OMP SIMD
 
     ! Second coordinate (eta)
     !$OMP SIMD
     DO j=1,nvec
-      grad(j,1,2) = -c*(1-u(j))*(1-w(j))
-      grad(j,2,2) = -c*(1+u(j))*(1-w(j))
-      grad(j,3,2) = c*(1+u(j))*(1-w(j))
-      grad(j,4,2) = c*(1-u(j))*(1-w(j))
-      grad(j,5,2) = -c*(1-u(j))*(1+w(j))
-      grad(j,6,2) = -c*(1+u(j))*(1+w(j))
-      grad(j,7,2) = c*(1+u(j))*(1+w(j))
-      grad(j,8,2) = c*(1-u(j))*(1+w(j))
+      grad(j,nbasis+1,2) = -c*(1-u(j))*(1-w(j))
+      grad(j,nbasis+2,2) = -c*(1+u(j))*(1-w(j))
+      grad(j,nbasis+3,2) = c*(1+u(j))*(1-w(j))
+      grad(j,nbasis+4,2) = c*(1-u(j))*(1-w(j))
+      grad(j,nbasis+5,2) = -c*(1-u(j))*(1+w(j))
+      grad(j,nbasis+6,2) = -c*(1+u(j))*(1+w(j))
+      grad(j,nbasis+7,2) = c*(1+u(j))*(1+w(j))
+      grad(j,nbasis+8,2) = c*(1-u(j))*(1+w(j))
     END DO
     !$END OMP SIMD
 
     ! Third coordinate (zeta)
     !$OMP SIMD
     DO j=1,nvec
-      grad(j,1,3) = -c*(1-u(j))*(1-v(j))
-      grad(j,2,3) = -c*(1+u(j))*(1-v(j))
-      grad(j,3,3) = -c*(1+u(j))*(1+v(j))
-      grad(j,4,3) = -c*(1-u(j))*(1+v(j))
-      grad(j,5,3) = c*(1-u(j))*(1-v(j))
-      grad(j,6,3) = c*(1+u(j))*(1-v(j))
-      grad(j,7,3) = c*(1+u(j))*(1+v(j))
-      grad(j,8,3) = c*(1-u(j))*(1+v(j))
+      grad(j,nbasis+1,3) = -c*(1-u(j))*(1-v(j))
+      grad(j,nbasis+2,3) = -c*(1+u(j))*(1-v(j))
+      grad(j,nbasis+3,3) = -c*(1+u(j))*(1+v(j))
+      grad(j,nbasis+4,3) = -c*(1-u(j))*(1+v(j))
+      grad(j,nbasis+5,3) = c*(1-u(j))*(1-v(j))
+      grad(j,nbasis+6,3) = c*(1+u(j))*(1-v(j))
+      grad(j,nbasis+7,3) = c*(1+u(j))*(1+v(j))
+      grad(j,nbasis+8,3) = c*(1-u(j))*(1+v(j))
     END DO
     !$END OMP SIMD
+    nbasis = nbasis + 8
   END SUBROUTINE H1Basis_dBrickNodal
 
+  FUNCTION H1Basis_BrickL(node, u, v, w) RESULT(fval)
+    IMPLICIT NONE
+
+    INTEGER, INTENT(IN) :: node
+    REAL(KIND=dp), INTENT(IN) :: u, v, w
+    REAL(KIND=dp) :: fval
+    REAL(KIND=dp), PARAMETER :: c = 1/2D0
+    !$OMP DECLARE SIMD(H1Basis_BrickL) UNIFORM(node) &
+    !$OMP LINEAR_REF(u) LINEAR_REF(v) LINEAR_REF(w) NOTINBRANCH
+
+    SELECT CASE (node)
+    CASE (1)
+      fval = c*(3D0-u-v-w)
+    CASE (2)
+      fval = c*(3D0+u-v-w)
+    CASE (3)
+      fval = c*(3D0+u+v-w)
+    CASE (4)
+      fval = c*(3D0-u+v-w)
+    CASE (5)
+      fval = c*(3D0-u-v+w)
+    CASE (6)
+      fval = c*(3D0+u-v+w)
+    CASE (7)
+      fval = c*(3D0+u+v+w)
+    CASE (8)
+      fval = c*(3D0-u+v+w)
+    END SELECT
+  END FUNCTION H1Basis_BrickL
+
+  FUNCTION H1Basis_dBrickL(node) RESULT(grad)
+    IMPLICIT NONE
+
+    INTEGER, INTENT(IN) :: node
+    ! REAL(KIND=dp), INTENT(IN) :: u, v
+    REAL(KIND=dp) :: grad(3)
+    REAL(KIND=dp), PARAMETER :: c = 1/2D0
+    !$OMP DECLARE SIMD(H1Basis_dBrickL) UNIFORM(node) NOTINBRANCH
+
+    SELECT CASE(node)
+    CASE (1)
+      grad(1:3) = c*[-1,-1,-1 ]
+    CASE (2)
+      grad(1:3) = c*[ 1,-1,-1 ]
+    CASE (3)
+      grad(1:3) = c*[ 1, 1,-1 ]
+    CASE (4)
+      grad(1:3) = c*[-1, 1,-1 ]
+    CASE (5)
+      grad(1:3) = c*[-1,-1, 1 ]
+    CASE (6)
+      grad(1:3) = c*[ 1,-1, 1 ]
+    CASE (7)
+      grad(1:3) = c*[ 1, 1, 1 ]
+    CASE (8)
+      grad(1:3) = c*[-1, 1, 1 ]
+    END SELECT
+  END FUNCTION H1Basis_dBrickL
+
+  SUBROUTINE H1Basis_BrickEdgeL(edge, u, v, w, La, Lb)
+    IMPLICIT NONE
+
+    INTEGER, INTENT(IN) :: edge
+    REAL(KIND=dp), INTENT(IN) :: u, v, w
+    REAL(KIND=dp), INTENT(OUT) :: La, Lb
+#ifndef __GFORTRAN__
+    !$OMP DECLARE SIMD (H1Basis_BrickEdgeL) UNIFORM(edge) &
+    !$OMP& LINEAR_REF(u) LINEAR_REF(v) &
+    !$OMP& LINEAR_REF(w) LINEAR_REF(La) LINEAR_REF(Lb) NOTINBRANCH
+#endif
+
+    SELECT CASE(edge)
+    CASE (1)
+      La=1-v
+      Lb=1-w
+    CASE (2)
+      La=1+u
+      Lb=1-w
+    CASE (3)
+      La=1+v
+      Lb=1-w
+    CASE (4)
+      La=1-u
+      Lb=1-w
+    CASE (5)
+      La=1-v
+      Lb=1+w
+    CASE (6)
+      La=1+u
+      Lb=1+w
+    CASE (7)
+      La=1+v
+      Lb=1+w
+    CASE (8)
+      La=1-u
+      Lb=1+w
+    CASE (9)
+      La=1-u
+      Lb=1-v
+    CASE (10)
+      La=1+u
+      Lb=1-v
+    CASE (11)
+      La=1+u
+      Lb=1+v
+    CASE (12)
+      La=1-u
+      Lb=1+v
+    END SELECT
+  END SUBROUTINE H1Basis_BrickEdgeL
+
+  SUBROUTINE H1Basis_dBrickEdgeL(edge, dLa, dLb)
+    IMPLICIT NONE
+
+    INTEGER, INTENT(IN) :: edge
+    REAL(KIND=dp), INTENT(OUT) :: dLa(3), dLb(3)
+#ifndef __GFORTRAN__
+    !$OMP DECLARE SIMD(H1Basis_dBrickEdgeL) UNIFORM(edge) NOTINBRANCH
+#endif
+
+    SELECT CASE(edge)
+    CASE (1)
+      dLa=[ 0,-1, 0 ] ! 1-v
+      dLb=[ 0, 0,-1 ] ! 1-w
+    CASE (2)
+      dLa=[ 1, 0, 0 ] ! 1+u
+      dLb=[ 0, 0,-1 ] ! 1-w
+    CASE (3)
+      dLa=[ 0, 1, 0 ] ! 1+v
+      dLb=[ 0, 0,-1 ] ! 1-w
+    CASE (4)
+      dLa=[-1, 0, 0 ] ! 1-u
+      dLb=[ 0, 0,-1 ] ! 1-w
+    CASE (5)
+      dLa=[ 0,-1, 0 ] ! 1-v
+      dLb=[ 0, 0, 1 ] ! 1+w
+    CASE (6)
+      dLa=[ 1, 0, 0 ] ! 1+u
+      dLb=[ 0, 0, 1 ] ! 1+w
+    CASE (7)
+      dLa=[ 0, 1, 0 ] ! 1+v
+      dLb=[ 0, 0, 1 ] ! 1+w
+    CASE (8)
+      dLa=[-1, 0, 0 ] ! 1-u
+      dLb=[ 0, 0, 1 ] ! 1+w
+    CASE (9)
+      dLa=[-1, 0, 0 ] ! 1-u
+      dLb=[ 0,-1, 0 ] ! 1-v
+    CASE (10)
+      dLa=[ 1, 0, 0 ] ! 1+u
+      dLb=[ 0,-1, 0 ] ! 1-v
+    CASE (11)
+      dLa=[ 1, 0, 0 ] ! 1+u
+      dLb=[ 0, 1, 0 ] ! 1+v
+    CASE (12)
+      dLa=[-1, 0, 0 ] ! 1-u
+      dLb=[ 0, 1, 0 ] ! 1+v
+    END SELECT
+  END SUBROUTINE H1Basis_dBrickEdgeL
+  
+  SUBROUTINE H1Basis_BrickEdgeP(nvec, u, v, w, pmax, nbasis, fval, edgedir)
+    IMPLICIT NONE
+
+    INTEGER, INTENT(IN) :: nvec
+    REAL(KIND=dp), DIMENSION(:) CONTIG, INTENT(IN) :: u, v, w
+    INTEGER, DIMENSION(:) CONTIG, INTENT(IN) :: pmax
+    INTEGER, INTENT(INOUT) :: nbasis
+    REAL(KIND=dp), DIMENSION(:,:) CONTIG, INTENT(INOUT) :: fval
+    INTEGER, DIMENSION(:,:) CONTIG, INTENT(IN) :: edgedir
+
+    REAL(KIND=dp), PARAMETER :: c = 1/4D0
+    REAL(KIND=dp) :: La, Lb, Aa, Ba
+    INTEGER :: i,j,k,l
+!DIR$ ASSUME_ALIGNED u:64, v:64, w:64, fval:64
+
+    ! For each edge
+    DO i=1,12
+      DO j=2,pmax(i)
+        !$OMP SIMD PRIVATE(La, Lb, Aa, Ba)
+        DO k=1,nvec
+          La=H1Basis_BrickL(edgedir(1,i), u(k), v(k), w(k))
+          Lb=H1Basis_BrickL(edgedir(2,i), u(k), v(k), w(k))
+          CALL H1Basis_BrickEdgeL(i, u(k), v(k), w(k), Aa, Ba)
+          
+          fval(k, nbasis+j-1) = c*H1Basis_Phi(j, Lb-La)*Aa*Ba
+        END DO
+        !$OMP END SIMD
+      END DO
+      ! nbasis = nbasis + (pmax(i)-2) + 1
+      nbasis = nbasis + pmax(i) - 1
+    END DO
+  END SUBROUTINE H1Basis_BrickEdgeP
+  
+  SUBROUTINE H1Basis_dBrickEdgeP(nvec, u, v, w, pmax, nbasis, grad, edgedir)
+    IMPLICIT NONE
+
+    INTEGER, INTENT(IN) :: nvec
+    REAL(KIND=dp), DIMENSION(:) CONTIG, INTENT(IN) :: u, v, w
+    INTEGER, DIMENSION(:) CONTIG, INTENT(IN) :: pmax
+    INTEGER, INTENT(INOUT) :: nbasis
+    REAL(KIND=dp), DIMENSION(:,:,:) CONTIG, INTENT(INOUT) :: grad
+    INTEGER, DIMENSION(:,:) CONTIG, INTENT(IN) :: edgedir
+
+    REAL(KIND=dp), PARAMETER :: c = 1/4D0
+    REAL(KIND=dp) :: La, Lb, Aa, Ba, Phi, dPhi, dLa(3), &
+            dLb(3), dAa(3), dBa(3)
+    INTEGER :: i,j,k
+!DIR$ ASSUME_ALIGNED u:64, v:64, w:64, grad:64
+
+    ! For each edge
+    DO i=1,12
+      dLa = H1Basis_dBrickL(edgedir(1,i))
+      dLb = H1Basis_dBrickL(edgedir(2,i))
+      CALL H1Basis_dBrickEdgeL(i, dAa, dBa)
+
+      DO j=2,pmax(i)
+        !$OMP SIMD PRIVATE(La, Lb, Aa, Ba, Phi, dPhi)
+        DO k=1,nvec
+          La=H1Basis_BrickL(edgedir(1,i), u(k), v(k), w(k))
+          Lb=H1Basis_BrickL(edgedir(2,i), u(k), v(k), w(k))
+          CALL H1Basis_BrickEdgeL(i, u(k), v(k), w(k), Aa, Ba)
+
+          Phi = H1Basis_Phi(j, Lb-La)
+          dPhi = H1Basis_dPhi(j, Lb-La)
+
+          grad(k,nbasis+j-1,1) = c*dPhi*(dLb(1)-dLa(1))*Aa*Ba +&
+                  c*Phi*dAa(1)*Ba +&
+                  c*Phi*Aa*dBa(1)
+          grad(k,nbasis+j-1,2) = c*dPhi*(dLb(2)-dLa(2))*Aa*Ba +&
+                  c*Phi*dAa(2)*Ba +&
+                  c*Phi*Aa*dBa(2)
+          grad(k,nbasis+j-1,3) = c*dPhi*(dLb(3)-dLa(3))*Aa*Ba +&
+                  c*Phi*dAa(3)*Ba +&
+                  c*Phi*Aa*dBa(3)
+        END DO
+        !$OMP END SIMD
+      END DO
+      ! nbasis = nbasis + (pmax(i)-2) + 1
+      nbasis = nbasis + pmax(i) - 1
+    END DO
+  END SUBROUTINE H1Basis_dBrickEdgeP
+  
+  SUBROUTINE H1Basis_BrickFaceP(nvec, u, v, w, pmax, nbasis, fval, facedir)
+    IMPLICIT NONE
+
+    INTEGER, INTENT(IN) :: nvec
+    REAL(KIND=dp), DIMENSION(:) CONTIG, INTENT(IN) :: u, v, w
+    INTEGER, DIMENSION(:) CONTIG, INTENT(IN) :: pmax
+    INTEGER, INTENT(INOUT) :: nbasis
+    REAL(KIND=dp), DIMENSION(:,:) CONTIG, INTENT(INOUT) :: fval
+    INTEGER, DIMENSION(:,:) CONTIG, INTENT(IN) :: facedir
+
+    REAL(KIND=dp) :: La, Lb, Lc, Ld
+    REAL(KIND=dp), PARAMETER :: a=1D0/4D0
+    INTEGER :: i,j,k,l
+!DIR$ ASSUME_ALIGNED u:64, v:64, w:64, fval:64
+
+    ! For each face
+    DO i=1,6
+      DO j=2,pmax(i)
+        DO k=2,pmax(i)-j
+          !$OMP SIMD PRIVATE(La, Lb, Lc, Ld)
+          DO l=1,nvec
+            La=H1Basis_BrickL(facedir(1,i), u(l), v(l), w(l))
+            Lb=H1Basis_BrickL(facedir(2,i), u(l), v(l), w(l))
+            Lc=H1Basis_BrickL(facedir(3,i), u(l), v(l), w(l))
+            Ld=H1Basis_BrickL(facedir(4,i), u(l), v(l), w(l))
+            
+            fval(l, nbasis+k-1) = (a*(La+Lb+Lc+Ld)-1)*H1Basis_Phi(j, Lb-La) &
+                                                     *H1Basis_Phi(k, Ld-La)
+          END DO
+          !$OMP END SIMD
+        END DO
+        ! nbasis = nbasis + (pmax(i)-j-2) + 1
+        nbasis = nbasis + MAX(pmax(i)-j-1,0)
+      END DO
+    END DO
+  END SUBROUTINE H1Basis_BrickFaceP
+  
+  SUBROUTINE H1Basis_dBrickFaceP(nvec, u, v, w, pmax, nbasis, grad, facedir)
+    IMPLICIT NONE
+
+    INTEGER, INTENT(IN) :: nvec
+    REAL(KIND=dp), DIMENSION(:) CONTIG, INTENT(IN) :: u, v, w
+    INTEGER, DIMENSION(:) CONTIG, INTENT(IN) :: pmax
+    INTEGER, INTENT(INOUT) :: nbasis
+    REAL(KIND=dp), DIMENSION(:,:,:) CONTIG, INTENT(INOUT) :: grad
+    INTEGER, DIMENSION(:,:) CONTIG, INTENT(IN) :: facedir
+
+    REAL(KIND=dp) :: La, Lb, Lc, Ld, dLa(3), dLb(3), dLc(3), dLd(3), &
+          PhiLbLa, PhiLdLa, LaLbLcLd
+    REAL(KIND=dp), PARAMETER :: a=1D0/4D0
+    INTEGER :: i,j,k,l
+!DIR$ ASSUME_ALIGNED u:64, v:64, w:64, grad:64
+
+    ! For each face
+    DO i=1,6
+      dLa=H1Basis_dBrickL(facedir(1,i))
+      dLb=H1Basis_dBrickL(facedir(2,i))
+      dLc=H1Basis_dBrickL(facedir(3,i))
+      dLd=H1Basis_dBrickL(facedir(4,i))
+      DO j=2,pmax(i)
+        DO k=2,pmax(i)-j
+          !$OMP SIMD PRIVATE(La, Lb, Lc, Ld, PhiLbLa, PhiLdLa, LaLbLcLd)
+          DO l=1,nvec
+            La=H1Basis_BrickL(facedir(1,i), u(l), v(l), w(l))
+            Lb=H1Basis_BrickL(facedir(2,i), u(l), v(l), w(l))
+            Lc=H1Basis_BrickL(facedir(3,i), u(l), v(l), w(l))
+            Ld=H1Basis_BrickL(facedir(4,i), u(l), v(l), w(l))
+            
+            PhiLbLa=H1Basis_Phi(j, Lb-La)
+            PhiLdLa=H1Basis_Phi(k, Ld-La)
+            LaLbLcLd=a*(La+Lb+Lc+Ld)-1
+
+            grad(l, nbasis+k-1, 1)=a*(dLa(1)+dLb(1)+dLc(1)+dLd(1))*PhiLbLa*PhiLdLa + &
+                  LaLbLcLd*H1Basis_dPhi(j,Lb-La)*(dLb(1)-dLa(1))*PhiLdLa + &
+                  LaLbLcLd*PhiLbLa*H1Basis_dPhi(k, Ld-La)*(dLd(1)-dLa(1))
+            grad(l, nbasis+k-1, 2)=a*(dLa(2)+dLb(2)+dLc(2)+dLd(2))*PhiLbLa*PhiLdLa + &
+                  LaLbLcLd*H1Basis_dPhi(j,Lb-La)*(dLb(2)-dLa(2))*PhiLdLa + &
+                  LaLbLcLd*PhiLbLa*H1Basis_dPhi(k, Ld-La)*(dLd(2)-dLa(2))
+            grad(l, nbasis+k-1, 3)=a*(dLa(3)+dLb(3)+dLc(3)+dLd(3))*PhiLbLa*PhiLdLa + &
+                  LaLbLcLd*H1Basis_dPhi(j,Lb-La)*(dLb(3)-dLa(3))*PhiLdLa + &
+                  LaLbLcLd*PhiLbLa*H1Basis_dPhi(k, Ld-La)*(dLd(3)-dLa(3))
+          END DO
+          !$OMP END SIMD
+        END DO
+        ! nbasis = nbasis + (pmax(i)-j-2) + 1
+        nbasis = nbasis + MAX(pmax(i)-j-1,0)
+      END DO
+    END DO
+  END SUBROUTINE H1Basis_dBrickFaceP
+  
   SUBROUTINE H1Basis_BrickBubbleP(nvec, u, v, w, pmax, nbasis, fval)
     IMPLICIT NONE
 
@@ -1266,7 +2494,7 @@ CONTAINS
           END DO
           !$END OMP SIMD
         END DO
-        nbasis = nbasis+pmax-i-j-1
+        nbasis = nbasis+MAX(pmax-i-j-1,0)
       END DO
     END DO
   END SUBROUTINE H1Basis_BrickBubbleP
@@ -1301,7 +2529,7 @@ CONTAINS
           END DO
           !$END OMP SIMD
         END DO
-        nbasis = nbasis+pmax-i-j-1
+        nbasis = nbasis+MAX(pmax-i-j-1,0)
       END DO
     END DO
   END SUBROUTINE H1Basis_dBrickBubbleP
@@ -1319,58 +2547,58 @@ CONTAINS
     ! Phi function values (autogenerated to Horner form)
     SELECT CASE(k)
     CASE(2)
-      fval = -sqrt(0.6D1) / 0.4D1 + sqrt(0.6D1) * x ** 2 / 0.4D1
+      fval = -SQRT(0.6D1) / 0.4D1 + SQRT(0.6D1) * x ** 2 / 0.4D1
     CASE(3)
-      fval = (-sqrt(0.10D2) / 0.4D1 + sqrt(0.10D2) * x ** 2 / 0.4D1) * x
+      fval = (-SQRT(0.10D2) / 0.4D1 + SQRT(0.10D2) * x ** 2 / 0.4D1) * x
     CASE(4)
-      fval = sqrt(0.14D2) / 0.16D2 + (-0.3D1 / 0.8D1 * sqrt(0.14D2) &
-              + 0.5D1 / 0.16D2 * sqrt(0.14D2) * x ** 2) * x ** 2
+      fval = SQRT(0.14D2) / 0.16D2 + (-0.3D1 / 0.8D1 * SQRT(0.14D2) &
+              + 0.5D1 / 0.16D2 * SQRT(0.14D2) * x ** 2) * x ** 2
     CASE(5)
-      fval = (0.9D1 / 0.16D2 * sqrt(0.2D1) + (-0.15D2 / 0.8D1 * sqrt(0.2D1)&
-              + 0.21D2 / 0.16D2 * sqrt(0.2D1) * x ** 2) * x ** 2) * x
+      fval = (0.9D1 / 0.16D2 * SQRT(0.2D1) + (-0.15D2 / 0.8D1 * SQRT(0.2D1)&
+              + 0.21D2 / 0.16D2 * SQRT(0.2D1) * x ** 2) * x ** 2) * x
     CASE(6)
-      fval = -sqrt(0.22D2) / 0.32D2 + (0.15D2 / 0.32D2 * sqrt(0.22D2) + &
-              (-0.35D2 / 0.32D2 * sqrt(0.22D2) + 0.21D2 / 0.32D2 * &
-              sqrt(0.22D2) * x ** 2) * x ** 2) * x ** 2
+      fval = -SQRT(0.22D2) / 0.32D2 + (0.15D2 / 0.32D2 * SQRT(0.22D2) + &
+              (-0.35D2 / 0.32D2 * SQRT(0.22D2) + 0.21D2 / 0.32D2 * &
+              SQRT(0.22D2) * x ** 2) * x ** 2) * x ** 2
     CASE(7)
-      fval = (-0.5D1 / 0.32D2 * sqrt(0.26D2) + (0.35D2 / 0.32D2 * sqrt(0.26D2) &
-              + (-0.63D2 / 0.32D2 * sqrt(0.26D2) + 0.33D2 / 0.32D2 * &
-              sqrt(0.26D2) * x ** 2) * x ** 2) * x ** 2) * x
+      fval = (-0.5D1 / 0.32D2 * SQRT(0.26D2) + (0.35D2 / 0.32D2 * SQRT(0.26D2) &
+              + (-0.63D2 / 0.32D2 * SQRT(0.26D2) + 0.33D2 / 0.32D2 * &
+              SQRT(0.26D2) * x ** 2) * x ** 2) * x ** 2) * x
     CASE(8)
-      fval = 0.5D1 / 0.256D3 * sqrt(0.30D2) + (-0.35D2 / 0.64D2 * sqrt(0.30D2) &
-              + (0.315D3 / 0.128D3 * sqrt(0.30D2) + (-0.231D3 / 0.64D2 * sqrt(0.30D2) &
-              + 0.429D3 / 0.256D3 * sqrt(0.30D2) * x ** 2) * x ** 2) * x ** 2) * x ** 2
+      fval = 0.5D1 / 0.256D3 * SQRT(0.30D2) + (-0.35D2 / 0.64D2 * SQRT(0.30D2) &
+              + (0.315D3 / 0.128D3 * SQRT(0.30D2) + (-0.231D3 / 0.64D2 * SQRT(0.30D2) &
+              + 0.429D3 / 0.256D3 * SQRT(0.30D2) * x ** 2) * x ** 2) * x ** 2) * x ** 2
     CASE(9)
-      fval = (0.35D2 / 0.256D3 * sqrt(0.34D2) + (-0.105D3 / 0.64D2 * sqrt(0.34D2) +&
-              (0.693D3 / 0.128D3 * sqrt(0.34D2) + (-0.429D3 / 0.64D2 * sqrt(0.34D2) +&
-              0.715D3 / 0.256D3 * sqrt(0.34D2) * x ** 2) * x ** 2) * x ** 2) * x ** 2) * x
+      fval = (0.35D2 / 0.256D3 * SQRT(0.34D2) + (-0.105D3 / 0.64D2 * SQRT(0.34D2) +&
+              (0.693D3 / 0.128D3 * SQRT(0.34D2) + (-0.429D3 / 0.64D2 * SQRT(0.34D2) +&
+              0.715D3 / 0.256D3 * SQRT(0.34D2) * x ** 2) * x ** 2) * x ** 2) * x ** 2) * x
     CASE(10)
-      fval = -0.7D1 / 0.512D3 * sqrt(0.38D2) + (0.315D3 / 0.512D3 * sqrt(0.38D2) + &
-              (-0.1155D4 / 0.256D3 * sqrt(0.38D2) + (0.3003D4 / 0.256D3 * sqrt(0.38D2) +&
-              (-0.6435D4 / 0.512D3 * sqrt(0.38D2) + 0.2431D4 / 0.512D3 * sqrt(0.38D2) &
+      fval = -0.7D1 / 0.512D3 * SQRT(0.38D2) + (0.315D3 / 0.512D3 * SQRT(0.38D2) + &
+              (-0.1155D4 / 0.256D3 * SQRT(0.38D2) + (0.3003D4 / 0.256D3 * SQRT(0.38D2) +&
+              (-0.6435D4 / 0.512D3 * SQRT(0.38D2) + 0.2431D4 / 0.512D3 * SQRT(0.38D2) &
               * x ** 2) * x ** 2) * x ** 2) * x ** 2) * x ** 2
     CASE(11)
-      fval = (-0.63D2 / 0.512D3 * sqrt(0.42D2) + (0.1155D4 / 0.512D3 * sqrt(0.42D2) + &
-              (-0.3003D4 / 0.256D3 * sqrt(0.42D2) + (0.6435D4 / 0.256D3 * sqrt(0.42D2) +&
-              (-0.12155D5 / 0.512D3 * sqrt(0.42D2) + 0.4199D4 / 0.512D3 * &
-              sqrt(0.42D2) * x ** 2) * x ** 2) * x ** 2) * x ** 2) * x ** 2) * x
+      fval = (-0.63D2 / 0.512D3 * SQRT(0.42D2) + (0.1155D4 / 0.512D3 * SQRT(0.42D2) + &
+              (-0.3003D4 / 0.256D3 * SQRT(0.42D2) + (0.6435D4 / 0.256D3 * SQRT(0.42D2) +&
+              (-0.12155D5 / 0.512D3 * SQRT(0.42D2) + 0.4199D4 / 0.512D3 * &
+              SQRT(0.42D2) * x ** 2) * x ** 2) * x ** 2) * x ** 2) * x ** 2) * x
     CASE(12)
-      fval = 0.21D2 / 0.2048D4 * sqrt(0.46D2) + (-0.693D3 / 0.1024D4 * sqrt(0.46D2) + &
-              (0.15015D5 / 0.2048D4 * sqrt(0.46D2) + (-0.15015D5 / 0.512D3 * sqrt(0.46D2) +&
-              (0.109395D6 / 0.2048D4 * sqrt(0.46D2) + (-0.46189D5 / 0.1024D4 * sqrt(0.46D2) +&
-              0.29393D5 / 0.2048D4 * sqrt(0.46D2) * x ** 2) * x ** 2) * x ** 2) * x ** 2) &
+      fval = 0.21D2 / 0.2048D4 * SQRT(0.46D2) + (-0.693D3 / 0.1024D4 * SQRT(0.46D2) + &
+              (0.15015D5 / 0.2048D4 * SQRT(0.46D2) + (-0.15015D5 / 0.512D3 * SQRT(0.46D2) +&
+              (0.109395D6 / 0.2048D4 * SQRT(0.46D2) + (-0.46189D5 / 0.1024D4 * SQRT(0.46D2) +&
+              0.29393D5 / 0.2048D4 * SQRT(0.46D2) * x ** 2) * x ** 2) * x ** 2) * x ** 2) &
               * x ** 2) * x ** 2
     CASE(13)
-      fval = (0.1155D4 / 0.2048D4 * sqrt(0.2D1) + (-0.15015D5 / 0.1024D4 * sqrt(0.2D1) +&
-              (0.225225D6 / 0.2048D4 * sqrt(0.2D1) + (-0.182325D6 / 0.512D3 * sqrt(0.2D1) +&
-              (0.1154725D7 / 0.2048D4 * sqrt(0.2D1) + (-0.440895D6 / 0.1024D4 * sqrt(0.2D1) +&
-              0.260015D6 / 0.2048D4 * sqrt(0.2D1) * x ** 2) * x ** 2) * x ** 2) * x ** 2) &
+      fval = (0.1155D4 / 0.2048D4 * SQRT(0.2D1) + (-0.15015D5 / 0.1024D4 * SQRT(0.2D1) +&
+              (0.225225D6 / 0.2048D4 * SQRT(0.2D1) + (-0.182325D6 / 0.512D3 * SQRT(0.2D1) +&
+              (0.1154725D7 / 0.2048D4 * SQRT(0.2D1) + (-0.440895D6 / 0.1024D4 * SQRT(0.2D1) +&
+              0.260015D6 / 0.2048D4 * SQRT(0.2D1) * x ** 2) * x ** 2) * x ** 2) * x ** 2) &
               * x ** 2) * x ** 2) * x
     CASE(14)
-      fval = -0.99D2 / 0.4096D4 * sqrt(0.6D1) + (0.9009D4 / 0.4096D4 * sqrt(0.6D1) + &
-              (-0.135135D6 / 0.4096D4 * sqrt(0.6D1) + (0.765765D6 / 0.4096D4 * sqrt(0.6D1) + &
-              (-0.2078505D7 / 0.4096D4 * sqrt(0.6D1) + (0.2909907D7 / 0.4096D4 * sqrt(0.6D1) +&
-              (-0.2028117D7 / 0.4096D4 * sqrt(0.6D1) + 0.557175D6 / 0.4096D4 * sqrt(0.6D1) &
+      fval = -0.99D2 / 0.4096D4 * SQRT(0.6D1) + (0.9009D4 / 0.4096D4 * SQRT(0.6D1) + &
+              (-0.135135D6 / 0.4096D4 * SQRT(0.6D1) + (0.765765D6 / 0.4096D4 * SQRT(0.6D1) + &
+              (-0.2078505D7 / 0.4096D4 * SQRT(0.6D1) + (0.2909907D7 / 0.4096D4 * SQRT(0.6D1) +&
+              (-0.2028117D7 / 0.4096D4 * SQRT(0.6D1) + 0.557175D6 / 0.4096D4 * SQRT(0.6D1) &
               * x ** 2) * x ** 2) * x ** 2) * x ** 2) * x ** 2) * x ** 2) * x ** 2
 !!!      CASE(15)
 !!!        fval = (-0.429D3 / 0.4096D4 * sqrt(0.58D2) + (0.15015D5 / 0.4096D4 * sqrt(0.58D2) +&
@@ -1436,41 +2664,41 @@ CONTAINS
     ! Phi function values (autogenerated to Horner form)
     SELECT CASE(k)
     CASE(2)
-      fval = x * sqrt(0.6D1) / 0.2D1
+      fval = x * SQRT(0.6D1) / 0.2D1
     CASE(3)
-      fval = dble(3 * x ** 2 - 1) * sqrt(0.10D2) / 0.4D1
+      fval = DBLE(3 * x ** 2 - 1) * SQRT(0.10D2) / 0.4D1
     CASE(4)
-      fval = dble(5 * x ** 2 - 3) * dble(x) * sqrt(0.14D2) / 0.4D1
+      fval = DBLE(5 * x ** 2 - 3) * DBLE(x) * SQRT(0.14D2) / 0.4D1
     CASE(5)
-      fval = 0.3D1 / 0.16D2 * dble(3 + (35 * x ** 2 - 30) * x ** 2) * sqrt(0.2D1)
+      fval = 0.3D1 / 0.16D2 * DBLE(3 + (35 * x ** 2 - 30) * x ** 2) * SQRT(0.2D1)
     CASE(6)
-      fval = dble(15 + (63 * x ** 2 - 70) * x ** 2) * dble(x) * sqrt(0.22D2) / 0.16D2
+      fval = DBLE(15 + (63 * x ** 2 - 70) * x ** 2) * DBLE(x) * SQRT(0.22D2) / 0.16D2
     CASE(7)
-      fval = dble(-5 + (105 + (231 * x ** 2 - 315) * x ** 2) * x ** 2) * &
-              sqrt(0.26D2) / 0.32D2
+      fval = DBLE(-5 + (105 + (231 * x ** 2 - 315) * x ** 2) * x ** 2) * &
+              SQRT(0.26D2) / 0.32D2
     CASE(8)
-      fval = dble(-35 + (315 + (429 * x ** 2 - 693) * x ** 2) * x ** 2) * &
-              dble(x) * sqrt(0.30D2) / 0.32D2
+      fval = DBLE(-35 + (315 + (429 * x ** 2 - 693) * x ** 2) * x ** 2) * &
+              DBLE(x) * SQRT(0.30D2) / 0.32D2
     CASE(9)
-      fval = dble(35 + (-1260 + (6930 + (6435 * x ** 2 - 12012) * x ** 2) &
-              * x ** 2) * x ** 2) * sqrt(0.34D2) / 0.256D3
+      fval = DBLE(35 + (-1260 + (6930 + (6435 * x ** 2 - 12012) * x ** 2) &
+              * x ** 2) * x ** 2) * SQRT(0.34D2) / 0.256D3
     CASE(10)
-      fval = dble(315 + (-4620 + (18018 + (12155 * x ** 2 - 25740) * x ** 2) * &
-              x ** 2) * x ** 2) * dble(x) * sqrt(0.38D2) / 0.256D3
+      fval = DBLE(315 + (-4620 + (18018 + (12155 * x ** 2 - 25740) * x ** 2) * &
+              x ** 2) * x ** 2) * DBLE(x) * SQRT(0.38D2) / 0.256D3
     CASE(11)
-      fval = dble(-63 + (3465 + (-30030 + (90090 + (46189 * x ** 2 - 109395) * &
-              x ** 2) * x ** 2) * x ** 2) * x ** 2) * sqrt(0.42D2) / 0.512D3
+      fval = DBLE(-63 + (3465 + (-30030 + (90090 + (46189 * x ** 2 - 109395) * &
+              x ** 2) * x ** 2) * x ** 2) * x ** 2) * SQRT(0.42D2) / 0.512D3
     CASE(12)
-      fval = dble(-693 + (15015 + (-90090 + (218790 + (88179 * x ** 2 - 230945) *&
-              x ** 2) * x ** 2) * x ** 2) * x ** 2) * dble(x) * sqrt(0.46D2) / 0.512D3
+      fval = DBLE(-693 + (15015 + (-90090 + (218790 + (88179 * x ** 2 - 230945) *&
+              x ** 2) * x ** 2) * x ** 2) * x ** 2) * DBLE(x) * SQRT(0.46D2) / 0.512D3
     CASE(13)
-      fval = 0.5D1 / 0.2048D4 * dble(231 + (-18018 + (225225 + (-1021020 + &
+      fval = 0.5D1 / 0.2048D4 * DBLE(231 + (-18018 + (225225 + (-1021020 + &
               (2078505 + (676039 * x ** 2 - 1939938) * x ** 2) * x ** 2) * &
-              x ** 2) * x ** 2) * x ** 2) * sqrt(0.2D1)
+              x ** 2) * x ** 2) * x ** 2) * SQRT(0.2D1)
     CASE(14)
-      fval = 0.3D1 / 0.2048D4 * dble(3003 + (-90090 + (765765 + (-2771340 + &
+      fval = 0.3D1 / 0.2048D4 * DBLE(3003 + (-90090 + (765765 + (-2771340 + &
               (4849845 + (1300075 * x ** 2 - 4056234) * x ** 2) * x ** 2) * &
-              x ** 2) * x ** 2) * x ** 2) * dble(x) * sqrt(0.6D1)
+              x ** 2) * x ** 2) * x ** 2) * DBLE(x) * SQRT(0.6D1)
 !!!      CASE(15)
 !!!        fval = dble(-429 + (45045 + (-765765 + (4849845 + (-14549535 + &
 !!!                (22309287 + (5014575 * x ** 2 - 16900975) * x ** 2) * &
@@ -1516,41 +2744,41 @@ CONTAINS
 
     SELECT CASE(k)
     CASE(2)
-      fval = -sqrt(0.6D1)
+      fval = -SQRT(0.6D1)
     CASE(3)
-      fval = -x * sqrt(0.10D2)
+      fval = -x * SQRT(0.10D2)
     CASE(4)
-      fval = -dble(5 * x ** 2 - 1) * sqrt(0.14D2) / 0.4D1
+      fval = -DBLE(5 * x ** 2 - 1) * SQRT(0.14D2) / 0.4D1
     CASE(5)
-      fval = -0.3D1 / 0.4D1 * dble(7 * x ** 2 - 3) * dble(x) * sqrt(0.2D1)
+      fval = -0.3D1 / 0.4D1 * DBLE(7 * x ** 2 - 3) * DBLE(x) * SQRT(0.2D1)
     CASE(6)
-      fval = -dble(1 + (21 * x ** 2 - 14) * x ** 2) * sqrt(0.22D2) / 0.8D1
+      fval = -DBLE(1 + (21 * x ** 2 - 14) * x ** 2) * SQRT(0.22D2) / 0.8D1
     CASE(7)
-      fval = -dble(5 + (33 * x ** 2 - 30) * x ** 2) * dble(x) * &
-              sqrt(0.26D2) / 0.8D1
+      fval = -DBLE(5 + (33 * x ** 2 - 30) * x ** 2) * DBLE(x) * &
+              SQRT(0.26D2) / 0.8D1
     CASE(8)
-      fval = -dble(-5 + (135 + (429 * x ** 2 - 495) * x ** 2) * x ** 2) *&
-              sqrt(0.30D2) / 0.64D2
+      fval = -DBLE(-5 + (135 + (429 * x ** 2 - 495) * x ** 2) * x ** 2) *&
+              SQRT(0.30D2) / 0.64D2
     CASE(9)
-      fval = -dble(-35 + (385 + (715 * x ** 2 - 1001) * x ** 2) * x ** 2) * &
-              dble(x) * sqrt(0.34D2) / 0.64D2
+      fval = -DBLE(-35 + (385 + (715 * x ** 2 - 1001) * x ** 2) * x ** 2) * &
+              DBLE(x) * SQRT(0.34D2) / 0.64D2
     CASE(10)
-      fval = -dble(7 + (-308 + (2002 + (2431 * x ** 2 - 4004) * x ** 2) * &
-              x ** 2) * x ** 2) * sqrt(0.38D2) / 0.128D3
+      fval = -DBLE(7 + (-308 + (2002 + (2431 * x ** 2 - 4004) * x ** 2) * &
+              x ** 2) * x ** 2) * SQRT(0.38D2) / 0.128D3
     CASE(11)
-      fval = -dble(63 + (-1092 + (4914 + (4199 * x ** 2 - 7956) * x ** 2) *&
-              x ** 2) * x ** 2) * dble(x) * sqrt(0.42D2) / 0.128D3
+      fval = -DBLE(63 + (-1092 + (4914 + (4199 * x ** 2 - 7956) * x ** 2) *&
+              x ** 2) * x ** 2) * DBLE(x) * SQRT(0.42D2) / 0.128D3
     CASE(12)
-      fval = -dble(-21 + (1365 + (-13650 + (46410 + (29393 * x ** 2 - 62985) *&
-              x ** 2) * x ** 2) * x ** 2) * x ** 2) * sqrt(0.46D2) / 0.512D3
+      fval = -DBLE(-21 + (1365 + (-13650 + (46410 + (29393 * x ** 2 - 62985) *&
+              x ** 2) * x ** 2) * x ** 2) * x ** 2) * SQRT(0.46D2) / 0.512D3
     CASE(13)
-      fval = -0.5D1 / 0.512D3 * dble(-231 + (5775 + (-39270 + (106590 + &
+      fval = -0.5D1 / 0.512D3 * DBLE(-231 + (5775 + (-39270 + (106590 + &
               (52003 * x ** 2 - 124355) * x ** 2) * x ** 2) * x ** 2) * &
-              x ** 2) * dble(x) * sqrt(0.2D1)
+              x ** 2) * DBLE(x) * SQRT(0.2D1)
     CASE(14)
-      fval = -0.3D1 / 0.1024D4 * dble(33 + (-2970 + (42075 + (-213180 + &
+      fval = -0.3D1 / 0.1024D4 * DBLE(33 + (-2970 + (42075 + (-213180 + &
               (479655 + (185725 * x ** 2 - 490314) * x ** 2) * x ** 2) *&
-              x ** 2) * x ** 2) * x ** 2) * sqrt(0.6D1)
+              x ** 2) * x ** 2) * x ** 2) * SQRT(0.6D1)
 !!!      CASE(15)
 !!!        fval = -dble(429 + (-14586 + (138567 + (-554268 + (1062347 + (334305 *&
 !!!                x ** 2 - 965770) * x ** 2) * x ** 2) * x ** 2) * x ** 2) * &
@@ -1597,36 +2825,36 @@ CONTAINS
     CASE(2)
       fval = 0
     CASE(3)
-      fval = -sqrt(0.10D2)
+      fval = -SQRT(0.10D2)
     CASE(4)
-      fval = -0.5D1 / 0.2D1 * sqrt(0.14D2) * x
+      fval = -0.5D1 / 0.2D1 * SQRT(0.14D2) * x
     CASE(5)
-      fval = -0.9D1 / 0.4D1 * sqrt(0.2D1) * dble(7 * x ** 2 - 1)
+      fval = -0.9D1 / 0.4D1 * SQRT(0.2D1) * DBLE(7 * x ** 2 - 1)
     CASE(6)
-      fval = -0.7D1 / 0.2D1 * sqrt(0.22D2) * dble(x) * dble(3 * x ** 2 - 1)
+      fval = -0.7D1 / 0.2D1 * SQRT(0.22D2) * DBLE(x) * DBLE(3 * x ** 2 - 1)
     CASE(7)
-      fval = -0.5D1 / 0.8D1 * sqrt(0.26D2) * dble(1 + (33 * x ** 2 - 18) * &
+      fval = -0.5D1 / 0.8D1 * SQRT(0.26D2) * DBLE(1 + (33 * x ** 2 - 18) * &
               x ** 2)
     CASE(8)
-      fval = -0.9D1 / 0.32D2 * sqrt(0.30D2) * dble(x) * dble(15 + (143 * x ** 2 -&
+      fval = -0.9D1 / 0.32D2 * SQRT(0.30D2) * DBLE(x) * DBLE(15 + (143 * x ** 2 -&
               110) * x ** 2)
     CASE(9)
-      fval = -0.35D2 / 0.64D2 * sqrt(0.34D2) * dble(-1 + (33 + (143 * x ** 2 - 143) &
+      fval = -0.35D2 / 0.64D2 * SQRT(0.34D2) * DBLE(-1 + (33 + (143 * x ** 2 - 143) &
               * x ** 2) * x ** 2)
     CASE(10)
-      fval = -0.11D2 / 0.16D2 * sqrt(0.38D2) * dble(x) * dble(-7 + (91 + (221 * &
+      fval = -0.11D2 / 0.16D2 * SQRT(0.38D2) * DBLE(x) * DBLE(-7 + (91 + (221 * &
               x ** 2 - 273) * x ** 2) * x ** 2)
     CASE(11)
-      fval = -0.9D1 / 0.128D3 * sqrt(0.42D2) * dble(7 + (-364 + (2730 + (4199 * &
+      fval = -0.9D1 / 0.128D3 * SQRT(0.42D2) * DBLE(7 + (-364 + (2730 + (4199 * &
               x ** 2 - 6188) * x ** 2) * x ** 2) * x ** 2)
     CASE(12)
-      fval = -0.65D2 / 0.256D3 * sqrt(0.46D2) * dble(x) * dble(21 + (-420 + (2142 +&
+      fval = -0.65D2 / 0.256D3 * SQRT(0.46D2) * DBLE(x) * DBLE(21 + (-420 + (2142 +&
               (2261 * x ** 2 - 3876) * x ** 2) * x ** 2) * x ** 2)
     CASE(13)
-      fval = -0.385D3 / 0.512D3 * sqrt(0.2D1) * dble(-3 + (225 + (-2550 + (9690 + &
+      fval = -0.385D3 / 0.512D3 * SQRT(0.2D1) * DBLE(-3 + (225 + (-2550 + (9690 + &
               (7429 * x ** 2 - 14535) * x ** 2) * x ** 2) * x ** 2) * x ** 2)
     CASE(14)
-      fval = -0.45D2 / 0.256D3 * dble(x) * sqrt(0.6D1) * dble(-99 + (2805 + (-21318 + &
+      fval = -0.45D2 / 0.256D3 * DBLE(x) * SQRT(0.6D1) * DBLE(-99 + (2805 + (-21318 + &
               (63954 + (37145 * x ** 2 - 81719) * x ** 2) * x ** 2) * x ** 2) * x ** 2)
 !!!      CASE(15)
 !!!        fval = -0.13D2 / 0.1024D4 * sqrt(0.58D2) * dble(33 + (-3366 + (53295 + &
@@ -1789,38 +3017,38 @@ CONTAINS
     CASE(3)
       fval = 0.15D2 / 0.2D1 * x ** 2 - 0.3D1 / 0.2D1
     CASE(4)
-      fval = 0.5D1 / 0.2D1 * dble(7 * x ** 2 - 3) * dble(x)
+      fval = 0.5D1 / 0.2D1 * DBLE(7 * x ** 2 - 3) * DBLE(x)
     CASE(5)
       fval = 0.15D2 / 0.8D1 + (-0.105D3 / 0.4D1 + 0.315D3 / 0.8D1 * x ** 2) *&
               x ** 2
     CASE(6)
-      fval = 0.21D2 / 0.8D1 * dble(5 + (33 * x ** 2 - 30) * x ** 2) * dble(x)
+      fval = 0.21D2 / 0.8D1 * DBLE(5 + (33 * x ** 2 - 30) * x ** 2) * DBLE(x)
     CASE(7)
       fval = -0.35D2 / 0.16D2 + (0.945D3 / 0.16D2 + (-0.3465D4 / 0.16D2 + 0.3003D4 / &
               0.16D2 * x ** 2) * x ** 2) * x ** 2
     CASE(8)
-      fval = 0.9D1 / 0.16D2 * dble(-35 + (385 + (715 * x ** 2 - 1001) * x ** 2) * x ** 2) *&
-              dble(x)
+      fval = 0.9D1 / 0.16D2 * DBLE(-35 + (385 + (715 * x ** 2 - 1001) * x ** 2) * x ** 2) *&
+              DBLE(x)
     CASE(9)
       fval = 0.315D3 / 0.128D3 + (-0.3465D4 / 0.32D2 + (0.45045D5 / 0.64D2 + (-0.45045D5 / &
               0.32D2 + 0.109395D6 / 0.128D3 * x ** 2) * x ** 2) * x ** 2) * x ** 2
     CASE(10)
-      fval = 0.55D2 / 0.128D3 * dble(63 + (-1092 + (4914 + (4199 * x ** 2 - 7956) * x ** 2) * &
-              x ** 2) * x ** 2) * dble(x)
+      fval = 0.55D2 / 0.128D3 * DBLE(63 + (-1092 + (4914 + (4199 * x ** 2 - 7956) * x ** 2) * &
+              x ** 2) * x ** 2) * DBLE(x)
     CASE(11)
       fval = -0.693D3 / 0.256D3 + (0.45045D5 / 0.256D3 + (-0.225225D6 / 0.128D3 + &
               (0.765765D6 / 0.128D3 + (-0.2078505D7 / 0.256D3 + 0.969969D6 / 0.256D3 *&
               x ** 2) * x ** 2) * x ** 2) * x ** 2) * x ** 2
     CASE(12)
-      fval = 0.39D2 / 0.256D3 * dble(-231 + (5775 + (-39270 + (106590 + (52003 * x ** 2 - &
-              124355) * x ** 2) * x ** 2) * x ** 2) * x ** 2) * dble(x)
+      fval = 0.39D2 / 0.256D3 * DBLE(-231 + (5775 + (-39270 + (106590 + (52003 * x ** 2 - &
+              124355) * x ** 2) * x ** 2) * x ** 2) * x ** 2) * DBLE(x)
     CASE(13)
       fval = 0.3003D4 / 0.1024D4 + (-0.135135D6 / 0.512D3 + (0.3828825D7 / 0.1024D4 + &
               (-0.4849845D7 / 0.256D3 + (0.43648605D8 / 0.1024D4 + (-0.22309287D8 / 0.512D3 + &
               0.16900975D8 / 0.1024D4 * x ** 2) * x ** 2) * x ** 2) * x ** 2) * x ** 2) * x ** 2
     CASE(14)
-      fval = 0.105D3 / 0.1024D4 * dble(429 + (-14586 + (138567 + (-554268 + (1062347 + (334305 *&
-              x ** 2 - 965770) * x ** 2) * x ** 2) * x ** 2) * x ** 2) * x ** 2) * dble(x)
+      fval = 0.105D3 / 0.1024D4 * DBLE(429 + (-14586 + (138567 + (-554268 + (1062347 + (334305 *&
+              x ** 2 - 965770) * x ** 2) * x ** 2) * x ** 2) * x ** 2) * x ** 2) * DBLE(x)
 !!!      CASE(15)
 !!!        fval = -0.6435D4 / 0.2048D4 + (0.765765D6 / 0.2048D4 + (-0.14549535D8 / 0.2048D4 +&
 !!!                (0.101846745D9 / 0.2048D4 + (-0.334639305D9 / 0.2048D4 + (0.557732175D9 / &

--- a/fem/src/Types.F90
+++ b/fem/src/Types.F90
@@ -579,6 +579,7 @@ END INTERFACE
          NodeIndexes => NULL(), EdgeIndexes   => NULL(), &
          FaceIndexes => NULL(), BubbleIndexes => NULL(), &
          DGIndexes   => NULL()
+!DIR$ ATTRIBUTES ALIGN:64::NodeIndexes, EdgeIndexes, FaceIndexes, BubbleIndexes, DGIndexes
 
      TYPE(PElementDefs_t), POINTER :: PDefs=>NULL()
      TYPE(ElementData_t),  POINTER :: PropertyData=>NULL()

--- a/fem/tests/H1BasisEvaluation/CMakeLists.txt
+++ b/fem/tests/H1BasisEvaluation/CMakeLists.txt
@@ -7,4 +7,4 @@ ADD_ELMERTEST_MODULE(H1BasisEvaluation H1BasisEvaluation H1BasisEvaluation.F90)
 file(COPY H1BasisEvaluation.F90 cube.grd ELMERSOLVER_STARTINFO DESTINATION "${CMAKE_CURRENT_BINARY_DIR}/")
 
 ADD_ELMER_TEST(H1BasisEvaluation)
-ADD_ELMER_LABEL(H1BasisEvaluation quick)
+ADD_ELMER_LABEL(H1BasisEvaluation LABELS benchmark serial)

--- a/fem/tests/H1BasisEvaluation/H1BasisEvaluation.F90
+++ b/fem/tests/H1BasisEvaluation/H1BasisEvaluation.F90
@@ -45,15 +45,29 @@ SUBROUTINE H1BasisEvaluation( Model,Solver,dt,TransientSimulation )
     nerror = nerror + netest
     
     ! 2D tests 
-    netest = TestTriangleElement(Solver, tol1d)
+    netest = TestTriangleElement(Solver, tol1d, .FALSE.)
     IF (netest /= 0) THEN
       CALL Warn('H1BasisEvaluation','Triangle element contained errors')
     END IF
     nerror = nerror + netest
 
-    netest = TestQuadElement(Solver, tol1d)
+    ! 2D element in a 3D mesh
+    netest = TestTriangleElement(Solver, tol1d, .TRUE.)
+    IF (netest /= 0) THEN
+      CALL Warn('H1BasisEvaluation','Triangle face element contained errors')
+    END IF
+    nerror = nerror + netest
+
+    netest = TestQuadElement(Solver, tol1d, .FALSE.)
     IF (netest /= 0) THEN
       CALL Warn('H1BasisEvaluation','Quad element contained errors')
+    END IF
+    nerror = nerror + netest
+
+    ! 2D element in a 3D mesh
+    netest = TestQuadElement(Solver, tol1d, .TRUE.)
+    IF (netest /= 0) THEN
+      CALL Warn('H1BasisEvaluation','Quad face element contained errors')
     END IF
     nerror = nerror + netest
 
@@ -90,19 +104,26 @@ CONTAINS
     TYPE(Element_t), POINTER :: Element
     TYPE( GaussIntegrationPoints_t ) :: GP
     REAL(KIND=dp), ALLOCATABLE :: Basis(:,:), dBasisdx(:,:,:), &
-            BasisVec(:,:), dBasisdxVec(:,:,:)
+            BasisVec(:,:), dBasisdxVec(:,:,:), UWrk(:), VWrk(:), WWrk(:)
 
     INTEGER :: i, j, ngp, nerror, nbasis, nndof, nbdof, allocstat, &
-            nbasisvec, ndbasisdxvec, rep, dim, perm, q
+            nbasisvec, ndbasisdxvec, rep, dim, perm, q, tag
     INTEGER, PARAMETER :: P = 6, NREP = 100, BubblePerm = 2
     REAL(kind=dp) :: t_start, t_end, t_startvec, t_endvec, &
             t_start_tmp, t_tot_n, t_totvec_n, &
             t_tot_b, t_totvec_b
     LOGICAL :: Invert(BubblePerm)
 !DIR$ ATTRIBUTES ALIGN:64 :: Basis, dBasisdx, BasisVec, dBasisdxVec
+!DIR$ ATTRIBUTES ALIGN:64 :: UWrk, VWrk, WWrk
 
     nerror = 0
     Element => AllocatePElement(Solver % Mesh, 202, P)
+    ! Insert P element definitions to Solver mapping (sets P elements as "active")
+    IF (ALLOCATED(Solver % Def_Dofs)) THEN
+      tag = Element % Type % ElementCode / 100
+      Solver % Def_Dofs(tag,1,6) = P
+    END IF
+
     GP = GaussPoints(Element)
 
     nndof = Element % Type % NumberOfNodes
@@ -113,11 +134,17 @@ CONTAINS
     ! Reserve workspace for finite element basis
     ALLOCATE(Basis(ngp,nbasis), dBasisdx(ngp,nbasis,3), &
             BasisVec(ngp,nbasis), dBasisdxVec(ngp,nbasis,3), &
+            UWrk(ngp), VWrk(ngp), WWrk(ngp), &
             STAT=allocstat)
     IF (allocstat /= 0) THEN
       CALL Fatal('H1BasisEvaluation',&
               'Storage allocation for local element basis failed')
     END IF
+
+    ! Copy Gauss points to local arrays
+    UWrk(1:ngp) = GP % U(1:ngp)
+    VWrk(1:ngp) = GP % V(1:ngp)
+    WWrk(1:ngp) = GP % W(1:ngp)
 
     ! Initialize arrays
     Basis = 0
@@ -131,8 +158,8 @@ CONTAINS
       ! Nodal basis 
       t_start_tmp=ftimer()
       DO i=1,ngp
-        CALL NodalBasisFunctions1D( Basis(i,1:nndof), Element, GP % U(i))
-        CALL NodalFirstDerivatives1D( dBasisdx(i,1:nndof,1:3), Element, GP % U(i))
+        CALL NodalBasisFunctions1D( Basis(i,1:nndof), Element, UWrk(i))
+        CALL NodalFirstDerivatives1D( dBasisdx(i,1:nndof,1:3), Element, UWrk(i))
       END DO
       t_tot_n=t_tot_n+(ftimer()-t_start_tmp)
 
@@ -143,8 +170,8 @@ CONTAINS
         DO j=1, Element % BDOFs
           q = q + 1
           DO i=1,ngp
-            Basis(i,q) = LineBubblePBasis(j+1, GP % U(i),Invert(perm))
-            dBasisdx(i,q,1) = dLineBubblePBasis(j+1, GP % U(i), Invert(perm))
+            Basis(i,q) = LineBubblePBasis(j+1, UWrk(i),Invert(perm))
+            dBasisdx(i,q,1) = dLineBubblePBasis(j+1, UWrk(i), Invert(perm))
           END DO
         END DO
       END DO
@@ -160,23 +187,23 @@ CONTAINS
     t_totvec_b = REAL(0,dp)
     t_startvec = ftimer()
     DO rep=1,NREP
+      nbasisvec = 0
+      ndbasisdxvec = 0
       t_start_tmp=ftimer()
-      CALL H1Basis_LineNodal(ngp, GP % U, BasisVec)
-      CALL H1Basis_dLineNodal(ngp, GP % U, dBasisdxVec)
+      CALL H1Basis_LineNodal(ngp, UWrk, nbasisvec, BasisVec)
+      CALL H1Basis_dLineNodal(ngp, UWrk, ndbasisdxvec, dBasisdxVec)
       t_totvec_n=t_totvec_n+(ftimer()-t_start_tmp)
       t_start_tmp=ftimer()
-      nbasisvec = 2
-      ndbasisdxvec = 2
       DO perm=1,BubblePerm
-        CALL H1Basis_LineBubbleP(ngp, GP % U, P, nbasisvec, BasisVec, Invert(perm))
-        CALL H1Basis_dLineBubbleP(ngp, GP % U, P, ndbasisdxvec, dBasisdxVec, &
+        CALL H1Basis_LineBubbleP(ngp, UWrk, P, nbasisvec, BasisVec, Invert(perm))
+        CALL H1Basis_dLineBubbleP(ngp, UWrk, P, ndbasisdxvec, dBasisdxVec, &
               Invert(perm))
       END DO
       t_totvec_b=t_totvec_b+(ftimer()-t_start_tmp)
     END DO
     t_endvec = ftimer()
 
-    CALL PrintTestData(Element, ngp, nrep, &
+    CALL PrintTestData(Element, ngp, nrep, nbdof, &
             t_tot_n, t_tot_b, t_end-t_start, &
             t_totvec_n, t_totvec_b, t_endvec-t_startvec)
 
@@ -184,47 +211,70 @@ CONTAINS
             dBasisdx, dBasisdxVec, tol)
 
     CALL DeallocatePElement(Element)
-    DEALLOCATE(Basis, dBasisdx, BasisVec, dBasisdxVec)
+    DEALLOCATE(Basis, dBasisdx, BasisVec, dBasisdxVec, UWrk, VWrk, WWrk)
   END FUNCTION TestLineElement
 
-  FUNCTION TestTriangleElement(Solver, tol) RESULT(nerror)
+  FUNCTION TestTriangleElement(Solver, tol, isEdge) RESULT(nerror)
     IMPLICIT NONE
     
     TYPE(Solver_t) :: Solver
     REAL(kind=dp), INTENT(IN) :: tol
+    LOGICAL :: isEdge
+
     TYPE(Element_t), POINTER :: Element
     TYPE( GaussIntegrationPoints_t ) :: GP
     REAL(KIND=dp), ALLOCATABLE :: Basis(:,:), dBasisdx(:,:,:), &
-            BasisVec(:,:), dBasisdxVec(:,:,:)
+            BasisVec(:,:), dBasisdxVec(:,:,:), UWrk(:), VWrk(:), WWrk(:)
 
-    INTEGER :: i, j, k, l, q, ndof, ngp, nerror, nbasis, nndof, nedof, nbdof, allocstat, &
-            nbasisvec, ndbasisdxvec, rep, dim, perm
-    INTEGER, PARAMETER :: P = 6, NREP = 100, EdgePerm = 2
+    INTEGER :: i, j, k, l, q, ndof, ngp, nerror, nbasis, nndof, nedof, nfdof, &
+            nbdof, allocstat, nbasisvec, ndbasisdxvec, rep, dim, perm, tag
+    INTEGER, PARAMETER :: P = 6, NREP = 100, EdgePerm = 2, BubblePerm=3
     REAL(kind=dp) :: t_start, t_end, t_startvec, t_endvec, &
             t_start_tmp, t_tot_n, t_totvec_n, t_tot_e, t_totvec_e, &
-            t_tot_b, t_totvec_b
-    INTEGER :: EdgeDir(2,3,EdgePerm), EdgeP(3)
+            t_tot_f, t_totvec_f, t_tot_b, t_totvec_b
+    
+    INTEGER :: EdgeDir(H1Basis_MaxPElementEdgeNodes,&
+                       H1Basis_MaxPElementEdges,&
+                       EdgePerm), EdgeP(H1Basis_MaxPElementEdges), &
+               BubbleDir(H1Basis_MaxPElementFaceNodes, &
+                       BubblePerm)
     LOGICAL :: InvertEdge(3, EdgePerm)
 !DIR$ ATTRIBUTES ALIGN:64 :: Basis, dBasisdx, BasisVec, dBasisdxVec
+!DIR$ ATTRIBUTES ALIGN:64 :: UWrk, VWrk, WWrk
 
     nerror = 0
     Element => AllocatePElement(Solver % Mesh, 303, P)
-    GP = GaussPoints(Element)
+    ! Insert P element definitions to Solver mapping (sets P elements as "active")
+    IF (ALLOCATED(Solver % Def_Dofs)) THEN
+      tag = Element % Type % ElementCode / 100
+      Solver % Def_Dofs(tag,1,6) = P
+    END IF
+    GP = GaussPoints(Element,4)
     
     nndof = Element % Type % NumberOfNodes
     nedof = GetEdgeDOFs( Element, P )
-    nbdof = Element % BDofs
+    IF (isEdge) THEN
+      nbdof = Element % BDofs*BubblePerm
+    ELSE
+      nbdof = Element % BDofs
+    END IF
     nbasis = nndof + 3*nedof*EdgePerm + nbdof
     ngp = GP % N
 
     ! Reserve workspace for finite element basis
     ALLOCATE(Basis(ngp,nbasis), dBasisdx(ngp,nbasis,3), &
             BasisVec(ngp,nbasis), dBasisdxVec(ngp,nbasis,3), &
+            UWrk(ngp), VWrk(ngp), WWrk(ngp), &
             STAT=allocstat)
     IF (allocstat /= 0) THEN
       CALL Fatal('H1BasisEvaluation',&
               'Storage allocation for local element basis failed')
     END IF
+    
+    ! Copy Gauss points to local arrays
+    UWrk(1:ngp) = GP % U(1:ngp)
+    VWrk(1:ngp) = GP % V(1:ngp)
+    WWrk(1:ngp) = GP % W(1:ngp)
 
     ! Initialize arrays
     Basis = 0
@@ -238,6 +288,15 @@ CONTAINS
     END DO
     InvertEdge(:,1) = .FALSE.
     InvertEdge(:,2) = .TRUE.
+
+    ! Initialize bubble mappings if needed
+    IF (isEdge) THEN
+      BubbleDir(1:3,1)=[ 1,2,3 ]
+      DO i=2,BubblePerm
+        BubbleDir(1:3,i)=CSHIFT(BubbleDir(1:3,1),i-1)
+      END DO
+    END IF
+
     EdgeP = P
 
     t_tot_n = REAL(0,dp)
@@ -249,12 +308,13 @@ CONTAINS
       t_start_tmp=ftimer()
       DO ndof=1,nndof
         DO i=1,ngp
-          Basis(i,ndof) = TriangleNodalPBasis(ndof, GP % U(i), GP % V(i))
-          dBasisdx(i,ndof,1:2) = dTriangleNodalPBasis(ndof, GP % U(i), GP % V(i))
+          Basis(i,ndof) = TriangleNodalPBasis(ndof, UWrk(i), VWrk(i))
+          dBasisdx(i,ndof,1:2) = dTriangleNodalPBasis(ndof, UWrk(i), VWrk(i))
         END DO
       END Do
       t_tot_n=t_tot_n+(ftimer()-t_start_tmp)
 
+      ! Edge basis
       t_start_tmp=ftimer()
       q = 3
       DO perm=1,EdgePerm
@@ -262,27 +322,46 @@ CONTAINS
           DO ndof=1,nedof
             q=q+1
             DO k=1,ngp
-              Basis(k,q) = TriangleEdgePBasis(i, ndof+1, GP % U(k), GP % V(k), InvertEdge(i,perm))
-              dBasisdx(k,q,1:2) = dTriangleEdgePBasis(i, ndof+1, GP % U(k), GP % V(k), InvertEdge(i,perm))
+              Basis(k,q) = TriangleEdgePBasis(i, ndof+1, UWrk(k), VWrk(k), &
+                                              InvertEdge(i,perm))
+              dBasisdx(k,q,1:2) = dTriangleEdgePBasis(i, ndof+1, UWrk(k), VWrk(k), &
+                                              InvertEdge(i,perm))
             END DO
           END DO
         END DO
       END DO
       t_tot_e=t_tot_e+(ftimer()-t_start_tmp)
         
-      ! Bubble basis 
-      t_start_tmp=ftimer()
-      q = 3 + nedof * 3 * EdgePerm
-      DO i = 0,p-3
-        DO j = 0,p-i-3
-          q = q + 1
-          DO k = 1, ngp
-            Basis(k, q) = TriangleBubblePBasis(i,j,GP % U(k), GP % v(k))
-            dBasisdx(k, q, 1:2) = dTriangleBubblePBasis(i,j,GP % u(k), GP % v(k))  
+      ! Bubble basis
+      IF (.NOT. isEdge) THEN
+        t_start_tmp=ftimer()
+        DO i = 0,p-3
+          DO j = 0,p-i-3
+            q = q + 1
+            DO k = 1, ngp
+              Basis(k, q) = TriangleBubblePBasis(i,j,UWrk(k), GP % v(k))
+              dBasisdx(k, q, 1:2) = dTriangleBubblePBasis(i,j,GP % u(k), GP % v(k))  
+            END DO
           END DO
         END DO
-      END DO
-      t_tot_b=t_tot_b+(ftimer()-t_start_tmp)
+        t_tot_b=t_tot_b+(ftimer()-t_start_tmp)
+      ELSE
+        t_start_tmp=ftimer()
+        DO perm=1,BubblePerm
+          DO i = 0,p-3
+            DO j = 0,p-i-3
+              q = q + 1
+              DO k = 1, ngp
+                Basis(k, q) = TriangleEBubblePBasis(i,j,UWrk(k), GP % v(k), &
+                        BubbleDir(1:3,perm))
+                dBasisdx(k, q, 1:2) = dTriangleEBubblePBasis(i,j,GP % u(k), GP % v(k), &
+                        BubbleDir(1:3,perm))  
+              END DO
+            END DO
+          END DO
+        END DO
+        t_tot_b=t_tot_b+(ftimer()-t_start_tmp)
+      END IF
     END DO ! NREP
     t_end = ftimer()
     
@@ -295,30 +374,43 @@ CONTAINS
     t_totvec_b = REAL(0,dp)
     t_startvec = ftimer()
     DO rep=1,NREP
+      nbasisvec = 0
+      ndbasisdxvec = 0
       t_start_tmp=ftimer()
-      CALL H1Basis_TriangleNodalP(ngp, GP % U, GP % V, BasisVec)
-      CALL H1Basis_dTriangleNodalP(ngp, GP % U, GP % V, dBasisdxVec)
+      CALL H1Basis_TriangleNodalP(ngp, UWrk, VWrk, nbasisvec, BasisVec)
+      CALL H1Basis_dTriangleNodalP(ngp, UWrk, VWrk, ndbasisdxvec, dBasisdxVec)
       t_totvec_n=t_totvec_n+(ftimer()-t_start_tmp)
-      nbasisvec = 3
-      ndbasisdxvec = 3
       t_start_tmp=ftimer()
       DO perm=1,EdgePerm
-        CALL H1Basis_TriangleEdgeP(ngp, GP % U, GP % V, EdgeP, &
+        CALL H1Basis_TriangleEdgeP(ngp, UWrk, VWrk, EdgeP, &
                 nbasisvec, BasisVec, EdgeDir(:,:,perm))
-        CALL H1Basis_dTriangleEdgeP(ngp, GP % U, GP % V, EdgeP, &
+        CALL H1Basis_dTriangleEdgeP(ngp, UWrk, VWrk, EdgeP, &
                 ndbasisdxvec, dBasisdxVec, EdgeDir(:,:,perm))
       END DO
       t_totvec_e=t_totvec_e+(ftimer()-t_start_tmp)
-      t_start_tmp=ftimer()
-      CALL H1Basis_TriangleBubbleP(ngp, GP % U, GP % V, P, &
-              nbasisvec, BasisVec)
-      CALL H1Basis_dTriangleBubbleP(ngp, GP % U, GP % V, P, &
-              ndbasisdxvec, dBasisdxVec)
-      t_totvec_b=t_totvec_b+(ftimer()-t_start_tmp)
+      
+      IF (.NOT. isEdge) THEN
+        t_start_tmp=ftimer()
+        CALL H1Basis_TriangleBubbleP(ngp, UWrk, VWrk, P, &
+                nbasisvec, BasisVec)
+        CALL H1Basis_dTriangleBubbleP(ngp, UWrk, VWrk, P, &
+                ndbasisdxvec, dBasisdxVec)
+        t_totvec_b=t_totvec_b+(ftimer()-t_start_tmp)
+      ELSE
+        t_start_tmp=ftimer()
+        DO perm=1,BubblePerm
+          CALL H1Basis_TriangleBubbleP(ngp, UWrk, VWrk, P, &
+                  nbasisvec, BasisVec, BubbleDir(1:3,perm))
+          CALL H1Basis_dTriangleBubbleP(ngp, UWrk, VWrk, P, &
+                  ndbasisdxvec, dBasisdxVec, BubbleDir(1:3,perm))
+        END DO
+        t_totvec_b=t_totvec_b+(ftimer()-t_start_tmp)
+      END IF
+
     END DO
     t_endvec = ftimer()
-    
-    CALL PrintTestData(Element, ngp, nrep, &
+
+    CALL PrintTestData(Element, ngp, nrep, 3*nedof+nbdof, &
             t_tot_n, t_tot_e+t_tot_b, t_end-t_start, &
             t_totvec_n, t_totvec_e+t_totvec_b, t_endvec-t_startvec)
 
@@ -326,47 +418,69 @@ CONTAINS
             dBasisdx, dBasisdxVec, tol)
 
     CALL DeallocatePElement(Element)
-    DEALLOCATE(Basis, dBasisdx, BasisVec, dBasisdxVec)
+    DEALLOCATE(Basis, dBasisdx, BasisVec, dBasisdxVec, UWrk, VWrk, WWrk)
   END FUNCTION TestTriangleElement
   
-  FUNCTION TestQuadElement(Solver, tol) RESULT(nerror)
+  FUNCTION TestQuadElement(Solver, tol, isEdge) RESULT(nerror)
     IMPLICIT NONE
     
     TYPE(Solver_t) :: Solver
     REAL(kind=dp), INTENT(IN) :: tol
+    LOGICAL :: isEdge
+
     TYPE(Element_t), POINTER :: Element
     TYPE( GaussIntegrationPoints_t ) :: GP
     REAL(KIND=dp), ALLOCATABLE :: Basis(:,:), dBasisdx(:,:,:), &
-            BasisVec(:,:), dBasisdxVec(:,:,:)
+            BasisVec(:,:), dBasisdxVec(:,:,:), UWrk(:), VWrk(:), WWrk(:)
 
     INTEGER :: i, j, k, l, q, ndof, ngp, nerror, nbasis, nndof, nedof, nbdof, allocstat, &
-            nbasisvec, ndbasisdxvec, rep, dim, perm
-    INTEGER, PARAMETER :: P = 6, NREP = 100, EdgePerm = 2
+            nbasisvec, ndbasisdxvec, rep, dim, perm, tag
+    INTEGER, PARAMETER :: P = 6, NREP = 100, EdgePerm = 2, BubblePerm = 4
     REAL(kind=dp) :: t_start, t_end, t_startvec, t_endvec, &
             t_start_tmp, t_tot_n, t_totvec_n, &
             t_tot_e, t_totvec_e, t_tot_b, t_totvec_b
-    INTEGER :: EdgeDir(2,4,EdgePerm), EdgeP(4)
+    INTEGER :: EdgeDir(H1Basis_MaxPElementEdgeNodes,&
+                       H1Basis_MaxPElementEdges,&
+                       EdgePerm), EdgeP(H1Basis_MaxPElementEdges),&
+               BubbleDir(H1Basis_MaxPElementFaceNodes,BubblePerm)
     LOGICAL :: InvertEdge(4, EdgePerm)
-!DIR$ ATTRIBUTES ALIGN:64 :: Basis, dBasisdx, BasisVec, dBasisdxVec
+!DIR$ ATTRIBUTES ALIGN:64 :: Basis, dBasisdx, BasisVec, dBasisdxVec, EdgeDir
+!DIR$ ATTRIBUTES ALIGN:64 :: UWrk, VWrk, WWrk
 
     nerror = 0
     Element => AllocatePElement(Solver % Mesh, 404, P)
+    ! Insert P element definitions to Solver mapping (sets P elements as "active")
+    IF (ALLOCATED(Solver % Def_Dofs)) THEN
+      tag = Element % Type % ElementCode / 100
+      Solver % Def_Dofs(tag,1,6) = P
+    END IF
+
     GP = GaussPoints(Element)
     
     nndof = Element % Type % NumberOfNodes
     nedof = getEdgeDOFs( Element, P )
-    nbdof = Element % BDofs
+    IF (isEdge) THEN
+      nbdof = Element % BDofs*BubblePerm
+    ELSE
+      nbdof = Element % BDofs
+    END IF
     nbasis = nndof + 4*nedof*EdgePerm + nbdof
     ngp = GP % N
 
     ! Reserve workspace for finite element basis
     ALLOCATE(Basis(ngp,nbasis), dBasisdx(ngp,nbasis,3), &
             BasisVec(ngp,nbasis), dBasisdxVec(ngp,nbasis,3), &
+            UWrk(ngp), VWrk(ngp), WWrk(ngp), &
             STAT=allocstat)
     IF (allocstat /= 0) THEN
       CALL Fatal('H1BasisEvaluation',&
               'Storage allocation for local element basis failed')
     END IF
+    
+    ! Copy Gauss points to local arrays
+    UWrk(1:ngp) = GP % U(1:ngp)
+    VWrk(1:ngp) = GP % V(1:ngp)
+    WWrk(1:ngp) = GP % W(1:ngp)
 
     ! Initialize arrays
     Basis = 0
@@ -380,8 +494,16 @@ CONTAINS
     END DO
     InvertEdge(:,1) = .FALSE.
     InvertEdge(:,2) = .TRUE.
-    EdgeP = P
 
+    ! Initialize face mappings if needed
+    IF (isEdge) THEN
+      BubbleDir(1:4,1)=[ 1,2,3,4 ]
+      DO i=2,BubblePerm
+        BubbleDir(1:4,i)=CSHIFT(BubbleDir(1:4,1),i-1)
+      END DO
+    END IF
+
+    EdgeP = P
     
     t_tot_n = REAL(0,dp)
     t_tot_e = REAL(0,dp)
@@ -391,8 +513,8 @@ CONTAINS
       ! Nodal basis 
       t_start_tmp=ftimer()
       DO i=1,ngp
-        CALL NodalBasisFunctions2D( Basis(i,1:nndof), Element, GP % U(i), GP % V(i))
-        CALL NodalFirstDerivatives2D( dBasisdx(i,1:nndof,1:3), Element, GP % U(i), GP % V(i))
+        CALL NodalBasisFunctions2D( Basis(i,1:nndof), Element, UWrk(i), VWrk(i))
+        CALL NodalFirstDerivatives2D( dBasisdx(i,1:nndof,1:3), Element, UWrk(i), VWrk(i))
       END DO
       t_tot_n=t_tot_n+(ftimer()-t_start_tmp)
 
@@ -404,8 +526,8 @@ CONTAINS
           DO ndof=1,nedof
             q=q+1
             DO k=1,ngp
-              Basis(k,q) = QuadEdgePBasis(i, ndof+1, GP % U(k), GP % V(k), InvertEdge(i,perm))
-              dBasisdx(k,q,1:2) = dQuadEdgePBasis(i, ndof+1, GP % U(k), GP % V(k), InvertEdge(i,perm))
+              Basis(k,q) = QuadEdgePBasis(i, ndof+1, UWrk(k), VWrk(k), InvertEdge(i,perm))
+              dBasisdx(k,q,1:2) = dQuadEdgePBasis(i, ndof+1, UWrk(k), VWrk(k), InvertEdge(i,perm))
             END DO
           END DO
         END DO
@@ -413,13 +535,480 @@ CONTAINS
       t_tot_e=t_tot_e+(ftimer()-t_start_tmp)
 
       ! Bubble basis 
+      IF (.NOT. isEdge) THEN
+        t_start_tmp=ftimer()
+        DO i=2,(p-2)
+          DO j=2,(p-i)
+            q = q + 1
+            DO k = 1, ngp
+              Basis(k, q) = QuadBubblePBasis(i,j,UWrk(k),VWrk(k))
+              dBasisdx(k, q, 1:2) = dQuadBubblePBasis(i,j,UWrk(k),VWrk(k))
+            END DO
+          END DO
+        END DO
+        t_tot_b=t_tot_b+(ftimer()-t_start_tmp)
+      ELSE
+        t_start_tmp=ftimer()
+        DO perm=1,BubblePerm
+          DO i=2,(p-2)
+            DO j=2,(p-i)
+              q = q + 1
+              DO k = 1, ngp
+                Basis(k, q) = QuadBubblePBasis(i,j,UWrk(k),VWrk(k),&
+                                               BubbleDir(1:4,perm))
+                dBasisdx(k, q, 1:2) = dQuadBubblePBasis(i,j,UWrk(k),VWrk(k),&
+                                               BubbleDir(1:4,perm))
+              END DO
+            END DO
+          END DO
+        END DO
+        t_tot_b=t_tot_b+(ftimer()-t_start_tmp)
+      END IF
+    END DO
+    t_end = ftimer()
+    
+    ! Initialize arrays
+    BasisVec = 0
+    dBasisdxVec = 0
+
+    t_totvec_n = REAL(0,dp)
+    t_totvec_e = REAL(0,dp)
+    t_totvec_b = REAL(0,dp)
+    t_startvec = ftimer()
+    DO rep=1,NREP
+      nbasisvec = 0
+      ndbasisdxvec = 0
       t_start_tmp=ftimer()
-      DO i=2,(p-2)
-        DO j=2,(p-i)
-          q = q + 1
-          DO k = 1, ngp
-            Basis(k, q) = QuadBubblePBasis(i,j,GP % U(k),GP % V(k))
-            dBasisdx(k, q, 1:2) = dQuadBubblePBasis(i,j,GP % U(k),GP % V(k))
+      CALL H1Basis_QuadNodal(ngp, UWrk, VWrk, nbasisvec, BasisVec)
+      CALL H1Basis_dQuadNodal(ngp, UWrk, VWrk, ndbasisdxvec, dBasisdxVec)
+      t_totvec_n=t_totvec_n+(ftimer()-t_start_tmp)
+      
+      ! Edge basis
+      t_start_tmp=ftimer()
+      DO perm=1,EdgePerm
+        CALL H1Basis_QuadEdgeP(ngp, UWrk, VWrk, EdgeP, &
+                nbasisvec, BasisVec, EdgeDir(:,:,perm))
+        CALL H1Basis_dQuadEdgeP(ngp, UWrk, VWrk, EdgeP, &
+                ndbasisdxvec, dBasisdxVec, EdgeDir(:,:,perm))
+      END DO
+      t_totvec_e=t_totvec_e+(ftimer()-t_start_tmp)
+
+      IF (.NOT. isEdge) THEN
+        t_start_tmp=ftimer()
+        CALL H1Basis_QuadBubbleP(ngp, UWrk, VWrk, P, &
+                nbasisvec, BasisVec)
+        
+        CALL H1Basis_dQuadBubbleP(ngp, UWrk, VWrk, P, &
+                ndbasisdxvec, dBasisdxVec)
+        t_totvec_b=t_totvec_b+(ftimer()-t_start_tmp)
+      ELSE
+        t_start_tmp=ftimer()
+        DO perm=1,BubblePerm
+          CALL H1Basis_QuadBubbleP(ngp, UWrk, VWrk, P, &
+                  nbasisvec, BasisVec, BubbleDir(1:4,perm))
+          
+          CALL H1Basis_dQuadBubbleP(ngp, UWrk, VWrk, P, &
+                  ndbasisdxvec, dBasisdxVec, BubbleDir(1:4,perm))
+        END DO
+        t_totvec_b=t_totvec_b+(ftimer()-t_start_tmp)
+      END IF
+    END DO
+    t_endvec = ftimer()
+    
+    CALL PrintTestData(Element, ngp, nrep, 4*nedof+nbdof,&
+            t_tot_n, t_tot_e+t_tot_b, t_end-t_start, &
+            t_totvec_n, t_totvec_e+t_totvec_b, t_endvec-t_startvec)
+
+    nerror = TestBasis(ngp, nbasis, Element % TYPE % DIMENSION, Basis, BasisVec, &
+            dBasisdx, dBasisdxVec, tol)
+
+    CALL DeallocatePElement(Element)
+    DEALLOCATE(Basis, dBasisdx, BasisVec, dBasisdxVec, UWrk, VWrk, WWrk)
+  END FUNCTION TestQuadElement
+
+  FUNCTION TestTetraElement(Solver, tol) RESULT(nerror)
+    IMPLICIT NONE
+    
+    TYPE(Solver_t) :: Solver
+    REAL(kind=dp), INTENT(IN) :: tol
+    TYPE(Element_t), POINTER :: Element
+    TYPE( GaussIntegrationPoints_t ) :: GP
+    REAL(KIND=dp), ALLOCATABLE :: Basis(:,:), dBasisdx(:,:,:), &
+            BasisVec(:,:), dBasisdxVec(:,:,:), UWrk(:), VWrk(:), WWrk(:)
+
+    INTEGER :: i, j, k, l, q, ndof, nedof, nfdof, ngp, nerror, nbasis, nndof, nbdof, allocstat, &
+            nbasisvec, ndbasisdxvec, rep, dim, tag, perm
+    INTEGER, PARAMETER :: P = 6, NREP = 100, EdgePerm=2, FacePerm=2
+    REAL(kind=dp) :: t_start, t_end, t_startvec, t_endvec, &
+          t_start_tmp, t_tot_n, t_totvec_n, &
+          t_tot_e, t_totvec_e, t_tot_f, t_totvec_f, t_tot_b, t_totvec_b
+    INTEGER :: EdgeDir(H1Basis_MaxPElementEdgeNodes,&
+                       H1Basis_MaxPElementEdges,&
+                       EdgePerm), EdgeP(H1Basis_MaxPElementEdges), &
+               FaceDir(H1Basis_MaxPElementFaceNodes, &
+                       H1Basis_MaxPElementFaces, &
+                       FacePerm), FaceP(H1Basis_MaxPElementFaces), &
+               TetraType(H1Basis_MaxPElementEdges, EdgePerm)
+!DIR$ ATTRIBUTES ALIGN:64 :: Basis, dBasisdx, BasisVec, dBasisdxVec, EdgeDir, FaceDir
+!DIR$ ATTRIBUTES ALIGN:64 :: UWrk, VWrk, WWrk
+
+    nerror = 0
+    Element => AllocatePElement(Solver % Mesh, 504, P)
+    ! Insert P element definitions to Solver mapping (sets P elements as "active")
+    IF (ALLOCATED(Solver % Def_Dofs)) THEN
+      tag = Element % Type % ElementCode / 100
+      Solver % Def_Dofs(tag,1,6) = P
+    END IF
+
+    GP = GaussPoints(Element)
+    
+    nndof = Element % Type % NumberOfNodes
+    nedof = getEdgeDOFs( Element, P )
+    nfdof = getFaceDOFs( Element, P )
+    nbdof = Element % BDofs
+    nbasis = nndof + 6*nedof*EdgePerm + 4*nfdof*FacePerm + nbdof 
+    ngp = GP % N
+
+    ! Reserve workspace for finite element basis
+    ALLOCATE(Basis(ngp,nbasis), dBasisdx(ngp,nbasis,3), &
+            BasisVec(ngp,nbasis), dBasisdxVec(ngp,nbasis,3), &
+            UWrk(ngp), VWrk(ngp), WWrk(ngp), &
+            STAT=allocstat)
+    IF (allocstat /= 0) THEN
+      CALL Fatal('H1BasisEvaluation',&
+              'Storage allocation for local element basis failed')
+    END IF
+    
+    ! Copy Gauss points to local arrays
+    UWrk(1:ngp) = GP % U(1:ngp)
+    VWrk(1:ngp) = GP % V(1:ngp)
+    WWrk(1:ngp) = GP % W(1:ngp)
+
+    ! Initialize arrays
+    Basis = 0
+    dBasisdx = 0
+    ! Tetra type 1 and 2
+    DO perm=1,EdgePerm
+      DO i=1,6
+        EdgeDir(1:2,i,perm)=getTetraEdgeMap(i,perm)
+      END DO
+    END DO
+    FaceDir = 0
+    DO perm=1,FacePerm
+      DO i=1,4
+        FaceDir(1:3,i,perm)=getTetraFaceMap(i,perm)
+      END DO
+    END DO
+    TetraType(:,1) = 1
+    TetraType(:,2) = 2
+    EdgeP = P
+    FaceP = P
+    
+    t_tot_n = REAL(0,dp)
+    t_tot_e = REAL(0,dp)
+    t_tot_f = REAL(0,dp)
+    t_tot_b = REAL(0,dp)
+    t_start = ftimer()
+    DO rep=1,NREP
+      ! Nodal basis 
+      t_start_tmp=ftimer()
+      DO ndof=1,nndof
+        DO i=1,ngp
+          Basis(i,ndof) = TetraNodalPBasis(ndof, UWrk(i), VWrk(i), WWrk(i))
+          dBasisdx(i,ndof,1:3) = dTetraNodalPBasis(ndof, UWrk(i), VWrk(i), WWrk(i))
+        END DO
+      END Do
+      t_tot_n=t_tot_n+(ftimer()-t_start_tmp)
+
+      ! Edge basis
+      t_start_tmp=ftimer()
+      q = 4
+      DO perm=1,EdgePerm
+        DO i=1,6
+          DO ndof=1,nedof
+            q= q + 1
+            DO k=1,ngp
+              Basis(k,q) = TetraEdgePBasis(i, ndof+1, UWrk(k), VWrk(k), WWrk(k), TetraType(i,perm))
+              dBasisdx(k,q,1:3) = dTetraEdgePBasis(i, ndof+1, UWrk(k), VWrk(k), WWrk(k), TetraType(i,perm))
+            END DO
+          END DO
+        END DO
+      END DO
+      t_tot_e=t_tot_e+(ftimer()-t_start_tmp)
+      
+      ! Face basis
+      t_start_tmp=ftimer()
+      DO perm=1,FacePerm
+        DO i=1,4
+          DO j=0,p-3
+            DO k=0,p-j-3
+              q= q + 1
+              DO l=1,ngp
+                Basis(l,q) = TetraFacePBasis(i, j, k, UWrk(l), VWrk(l), WWrk(l), TetraType(i,perm))
+                dBasisdx(l,q,1:3) = dTetraFacePBasis(i, j, k, UWrk(l), VWrk(l), WWrk(l), TetraType(i,perm))
+              END DO
+            END DO
+          END DO
+        END DO
+      END DO
+      t_tot_f=t_tot_e+(ftimer()-t_start_tmp)
+      
+      ! Bubble basis 
+      t_start_tmp=ftimer()
+      DO i=0,p-4
+        DO j=0,p-i-4
+          DO k=0,p-i-j-4
+            q = q + 1
+            DO l = 1, ngp
+              Basis(l, q) = TetraBubblePBasis(i,j,k,UWrk(l), VWrk(l), WWrk(l))
+              dBasisdx(l, q, 1:3) = dTetraBubblePBasis(i,j,k,UWrk(l), VWrk(l), WWrk(l))  
+            END DO
+          END DO
+        END DO
+      END DO
+      t_tot_b=t_tot_b+(ftimer()-t_start_tmp)
+    END DO
+    t_end = ftimer()
+
+    ! Initialize arrays
+    BasisVec = 0
+    dBasisdxVec = 0
+
+    t_totvec_n = REAL(0,dp)
+    t_totvec_e = REAL(0,dp)
+    t_totvec_f = REAL(0,dp)
+    t_totvec_b = REAL(0,dp)
+    t_startvec = ftimer()
+    DO rep=1,NREP
+      nbasisvec = 0
+      ndbasisdxvec = 0
+      t_start_tmp=ftimer()
+      CALL H1Basis_TetraNodalP(ngp, UWrk, VWrk, WWrk, nbasisvec, BasisVec)
+      CALL H1Basis_dTetraNodalP(ngp, UWrk, VWrk, WWrk, ndbasisdxvec, dBasisdxVec)
+      t_totvec_n=t_totvec_n+(ftimer()-t_start_tmp)
+      t_start_tmp=ftimer()
+      DO perm=1,EdgePerm
+        CALL H1Basis_TetraEdgeP(ngp, UWrk, VWrk, WWrk, EdgeP, &
+              nbasisvec, BasisVec, EdgeDir(:,:,perm))
+        CALL H1Basis_dTetraEdgeP(ngp, UWrk, VWrk, WWrk, EdgeP, &
+              ndbasisdxvec, dBasisdxVec, EdgeDir(:,:,perm))
+      END DO
+      t_totvec_e=t_totvec_e+(ftimer()-t_start_tmp)
+      t_start_tmp=ftimer()
+      DO perm=1,FacePerm
+        CALL H1Basis_TetraFaceP(ngp, UWrk, VWrk, WWrk, FaceP, &
+              nbasisvec, BasisVec, FaceDir(:,:,perm))
+        CALL H1Basis_dTetraFaceP(ngp, UWrk, VWrk, WWrk, FaceP, &
+              ndbasisdxvec, dBasisdxVec, FaceDir(:,:,perm))
+      END DO
+      t_totvec_f=t_totvec_f+(ftimer()-t_start_tmp)
+      t_start_tmp=ftimer()
+      CALL H1Basis_TetraBubbleP(ngp, UWrk, VWrk, WWrk, P, &
+              nbasisvec, BasisVec)
+      CALL H1Basis_dTetraBubbleP(ngp, UWrk, VWrk, WWrk, P, &
+              ndbasisdxvec, dBasisdxVec)
+      t_totvec_b=t_totvec_b+(ftimer()-t_start_tmp)
+    END DO
+    t_endvec = ftimer()
+
+    CALL PrintTestData(Element, ngp, nrep, 6*nedof+4*nfdof+nbdof, &
+            t_tot_n, t_tot_e+t_tot_f+t_tot_b, t_end-t_start, &
+            t_totvec_n, t_totvec_e+t_totvec_f+t_totvec_b, t_endvec-t_startvec)
+
+    nerror = TestBasis(ngp, nbasis, Element % TYPE % DIMENSION, Basis, BasisVec, &
+            dBasisdx, dBasisdxVec, tol)
+
+    CALL DeallocatePElement(Element)
+    DEALLOCATE(Basis, dBasisdx, BasisVec, dBasisdxVec, UWrk, VWrk, WWrk)
+  END FUNCTION TestTetraElement
+
+  
+  FUNCTION TestWedgeElement(Solver, tol) RESULT(nerror)
+    IMPLICIT NONE
+    
+    TYPE(Solver_t) :: Solver
+    REAL(kind=dp), INTENT(IN) :: tol
+    TYPE(Element_t), POINTER :: Element
+    TYPE( GaussIntegrationPoints_t ) :: GP
+    REAL(KIND=dp), ALLOCATABLE :: Basis(:,:), dBasisdx(:,:,:), &
+            BasisVec(:,:), dBasisdxVec(:,:,:), UWrk(:), VWrk(:), WWrk(:)
+
+    INTEGER :: i, j, k, l, q, ngp, nerror, nbasis, nndof, nedof, &
+          nfdof, nbdof, allocstat, perm, &
+          nbasisvec, ndbasisdxvec, rep, dim, tag, ndof
+    INTEGER, PARAMETER :: P = 6, NREP = 100, EdgePerm=2, FacePerm=4
+    REAL(kind=dp) :: t_start, t_end, t_startvec, t_endvec, &
+            t_start_tmp, t_tot_n, t_totvec_n, &
+            t_tot_e, t_totvec_e, t_tot_f, t_totvec_f, t_tot_b, t_totvec_b
+    INTEGER :: EdgeDir(H1Basis_MaxPElementEdgeNodes,&
+                       H1Basis_MaxPElementEdges,&
+                       EdgePerm), EdgeP(H1Basis_MaxPElementEdges), &
+               FaceDir(H1Basis_MaxPElementFaceNodes, &
+                       H1Basis_MaxPElementFaces, &
+                       FacePerm), FaceP(H1Basis_MaxPElementFaces)
+    INTEGER :: direction(H1Basis_MaxPElementFaceNodes), tmp
+    LOGICAL :: InvertEdge(9, EdgePerm), invert
+!DIR$ ATTRIBUTES ALIGN:64 :: Basis, dBasisdx, BasisVec, dBasisdxVec, EdgeDir, FaceDir
+!DIR$ ATTRIBUTES ALIGN:64 :: UWrk, VWrk, WWrk
+
+    nerror = 0
+    Element => AllocatePElement(Solver % Mesh, 706, P)
+    ! Insert P element definitions to Solver mapping (sets P elements as "active")
+    IF (ALLOCATED(Solver % Def_Dofs)) THEN
+      tag = Element % Type % ElementCode / 100
+      Solver % Def_Dofs(tag,1,6) = P
+    END IF
+
+    GP = GaussPoints(Element)
+    
+    nndof = Element % Type % NumberOfNodes
+    nedof = getEdgeDOFs( Element, P )
+    nfdof = 2*getFaceDofs( Element, P, 1)+3*getFaceDOFs( Element, P, 3 )
+    nbdof = Element % BDofs
+    nbasis = nndof + 9*nedof*EdgePerm + nfdof*FacePerm + nbdof
+    ngp = GP % N
+
+    ! Reserve workspace for finite element basis
+    ALLOCATE(Basis(ngp,nbasis), dBasisdx(ngp,nbasis,3), &
+            BasisVec(ngp,nbasis), dBasisdxVec(ngp,nbasis,3), &
+            UWrk(ngp), VWrk(ngp), WWrk(ngp), &
+            STAT=allocstat)
+    IF (allocstat /= 0) THEN
+      CALL Fatal('H1BasisEvaluation',&
+              'Storage allocation for local element basis failed')
+    END IF
+    
+    ! Copy Gauss points to local arrays
+    UWrk(1:ngp) = GP % U(1:ngp)
+    VWrk(1:ngp) = GP % V(1:ngp)
+    WWrk(1:ngp) = GP % W(1:ngp)
+
+    ! Initialize arrays
+    Basis = 0
+    dBasisdx = 0
+    DO i=1,9
+      EdgeDir(1:2,i,1)=getWedgeEdgeMap(i)
+    END DO
+    ! Invert direction
+    DO i=1,9
+      EdgeDir(2:1:-1,i,2)=EdgeDir(1:2,i,1)
+    END DO
+    InvertEdge(:,1) = .FALSE.
+    InvertEdge(:,2) = .TRUE.
+
+    DO i=1,5
+      FaceDir(1:4,i,1)=getWedgeFaceMap(i)
+    END DO
+    DO j=2,FacePerm
+      DO i=1,2
+        FaceDir(1:3,i,j)=CSHIFT(FaceDir(1:3,i,1), j-1)
+      END DO
+      DO i=3,5
+        FaceDir(1:4,i,j)=CSHIFT(FaceDir(1:4,i,1), j-1)
+      END DO
+    END DO
+
+    EdgeP = P
+    FaceP = P
+
+    t_tot_n = REAL(0,dp)
+    t_tot_e = REAL(0,dp)
+    t_tot_f = REAL(0,dp)
+    t_tot_b = REAL(0,dp)
+    
+    t_start = ftimer()
+    DO rep=1,NREP
+      ! Nodal basis 
+      t_start_tmp=ftimer()
+      DO ndof=1,nndof
+        DO i=1,ngp
+          Basis(i,ndof) = WedgeNodalPBasis(ndof, UWrk(i), VWrk(i), WWrk(i))
+          dBasisdx(i,ndof,1:3) = dWedgeNodalPBasis(ndof, UWrk(i), VWrk(i), WWrk(i))
+        END DO
+      END Do
+      t_tot_n=t_tot_n+(ftimer()-t_start_tmp)
+
+      ! Edge basis
+      t_start_tmp=ftimer()
+      q = 6
+      DO perm=1,EdgePerm
+        DO i=1,9
+          DO ndof=1,nedof
+            q=q+1
+            DO k=1,ngp
+              Basis(k,q) = WedgeEdgePBasis(i, ndof+1, UWrk(k), VWrk(k), WWrk(k), &
+                      InvertEdge(i,perm))
+              dBasisdx(k,q,1:3) = dWedgeEdgePBasis(i, ndof+1, UWrk(k), VWrk(k), WWrk(k), &
+                      InvertEdge(i,perm))
+            END DO
+          END DO
+        END DO
+      END DO
+      t_tot_e=t_tot_e+(ftimer()-t_start_tmp)
+
+      ! Face basis
+      t_start_tmp=ftimer()
+      DO perm=1,FacePerm
+        ! Triangle faces
+        DO i=1,2
+          DO j=0,p-3
+            DO k=0,p-j-3
+              q = q + 1
+              DO l=1,ngp
+                Basis(l,q) = WedgeFacePBasis(i,j,k,UWrk(l), VWrk(l), WWrk(l), &
+                        FaceDir(1:4,i,perm))
+                dBasisdx(l,q,1:3) = dWedgeFacePBasis(i,j,k,UWrk(l), VWrk(l), WWrk(l), &
+                        FaceDir(1:4,i,perm))
+              END DO
+            END DO
+          END DO
+        END DO
+        ! Square faces
+        DO i=3,5
+          ! First and second node must form an edge in the upper or lower triangle
+          direction(1:4) = FaceDir(1:4,i,perm)
+          invert=.FALSE. 
+          IF (.NOT. wedgeOrdering(direction)) THEN
+            invert = .TRUE.
+            tmp = direction(2)
+            direction(2) = direction(4)
+            direction(4) = tmp
+          END IF
+
+          DO j=2,p-2
+            DO k=2,p-j
+              q = q + 1
+              IF (.NOT. invert) THEN
+                DO l=1,ngp
+                  Basis(l,q) = WedgeFacePBasis(i,j,k,UWrk(l), VWrk(l), WWrk(l), &
+                          direction)
+                  dBasisdx(l,q,1:3) = dWedgeFacePBasis(i,j,k,UWrk(l), VWrk(l), WWrk(l), &
+                          direction)
+                END DO
+              ELSE
+                DO l=1,ngp
+                  Basis(l,q) = WedgeFacePBasis(i,k,j,UWrk(l), VWrk(l), WWrk(l), &
+                          direction)
+                  dBasisdx(l,q,1:3) = dWedgeFacePBasis(i,k,j,UWrk(l), VWrk(l), WWrk(l), &
+                          direction)
+                END DO
+              END IF
+            END DO
+          END DO
+        END DO
+      END DO
+      t_tot_f=t_tot_f+(ftimer()-t_start_tmp)
+      
+      ! Bubble basis 
+      t_start_tmp=ftimer()
+      DO i=0,p-5
+        DO j=0,p-5-i
+          DO k=2,p-3-i-j
+            q = q + 1
+            DO l = 1, ngp
+              Basis(l, q) = WedgeBubblePBasis(i,j,k,UWrk(l), VWrk(l), WWrk(l))
+              dBasisdx(l, q, 1:3) = dWedgeBubblePBasis(i,j,k,UWrk(l), VWrk(l), WWrk(l))  
+            END DO
           END DO
         END DO
       END DO
@@ -433,260 +1022,52 @@ CONTAINS
 
     t_totvec_n = REAL(0,dp)
     t_totvec_e = REAL(0,dp)
-    t_totvec_b = REAL(0,dp)
+    t_totvec_f = REAL(0,dp)
+    t_totvec_b = REAL(0,dp)    
     t_startvec = ftimer()
     DO rep=1,NREP
+      nbasisvec = 0
+      ndbasisdxvec = 0
       t_start_tmp=ftimer()
-      CALL H1Basis_QuadNodal(ngp, GP % U, GP % V, BasisVec)
-      CALL H1Basis_dQuadNodal(ngp, GP % U, GP % V, dBasisdxVec)
+      CALL H1Basis_WedgeNodalP(ngp, UWrk, VWrk, WWrk, nbasisvec, BasisVec)
+      CALL H1Basis_dWedgeNodalP(ngp, UWrk, VWrk, WWrk, ndbasisdxvec, dBasisdxVec)
       t_totvec_n=t_totvec_n+(ftimer()-t_start_tmp)
-      nbasisvec = 4
-      ndbasisdxvec = 4
-      
-      ! Edge basis
       t_start_tmp=ftimer()
       DO perm=1,EdgePerm
-        CALL H1Basis_QuadEdgeP(ngp, GP % U, GP % V, EdgeP, &
-                nbasisvec, BasisVec, EdgeDir(:,:,perm))
-        CALL H1Basis_dQuadEdgeP(ngp, GP % U, GP % V, EdgeP, &
-                ndbasisdxvec, dBasisdxVec, EdgeDir(:,:,perm))
+        CALL H1Basis_WedgeEdgeP(ngp, UWrk, VWrk, WWrk, EdgeP, &
+              nbasisvec, BasisVec, EdgeDir(:,:,perm))
+        CALL H1Basis_dWedgeEdgeP(ngp, UWrk, VWrk, WWrk, EdgeP, &
+              ndbasisdxvec, dBasisdxVec, EdgeDir(:,:,perm))
       END DO
-      t_totvec_e=t_totvec_e+(ftimer()-t_start_tmp)
-    
+      t_totvec_e=t_totvec_e+(ftimer()-t_start_tmp)    
       t_start_tmp=ftimer()
-      CALL H1Basis_QuadBubbleP(ngp, GP % U, GP % V, P, &
+      DO perm=1,FacePerm
+        CALL H1Basis_WedgeFaceP(ngp, UWrk, VWrk, WWrk, FaceP, &
+              nbasisvec, BasisVec, FaceDir(:,:,perm))
+        CALL H1Basis_dWedgeFaceP(ngp, UWrk, VWrk, WWrk, FaceP, &
+              ndbasisdxvec, dBasisdxVec, FaceDir(:,:,perm))
+      END DO
+      t_totvec_f=t_totvec_f+(ftimer()-t_start_tmp)    
+      t_start_tmp=ftimer()
+      CALL H1Basis_WedgeBubbleP(ngp, UWrk, VWrk, WWrk, P, &
               nbasisvec, BasisVec)
-    
-      CALL H1Basis_dQuadBubbleP(ngp, GP % U, GP % V, P, &
+      CALL H1Basis_dWedgeBubbleP(ngp, UWrk, VWrk, WWrk, P, &
               ndbasisdxvec, dBasisdxVec)
       t_totvec_b=t_totvec_b+(ftimer()-t_start_tmp)
     END DO
     t_endvec = ftimer()
     
-    CALL PrintTestData(Element, ngp, nrep, &
-            t_tot_n, t_tot_e+t_tot_b, t_end-t_start, &
-            t_totvec_n, t_totvec_e+t_totvec_b, t_endvec-t_startvec)
+    CALL PrintTestData(Element, ngp, nrep, 9*nedof+nfdof+nbdof, &
+          t_tot_n, t_tot_e+t_tot_f+t_tot_b, t_end-t_start, &
+          t_totvec_n, t_totvec_e+t_totvec_f+t_totvec_b, t_endvec-t_startvec)
 
     nerror = TestBasis(ngp, nbasis, Element % TYPE % DIMENSION, Basis, BasisVec, &
             dBasisdx, dBasisdxVec, tol)
 
     CALL DeallocatePElement(Element)
-    DEALLOCATE(Basis, dBasisdx, BasisVec, dBasisdxVec)
-  END FUNCTION TestQuadElement
-
-  FUNCTION TestTetraElement(Solver, tol) RESULT(nerror)
-    IMPLICIT NONE
-    
-    TYPE(Solver_t) :: Solver
-    REAL(kind=dp), INTENT(IN) :: tol
-    TYPE(Element_t), POINTER :: Element
-    TYPE( GaussIntegrationPoints_t ) :: GP
-    REAL(KIND=dp), ALLOCATABLE :: Basis(:,:), dBasisdx(:,:,:), &
-            BasisVec(:,:), dBasisdxVec(:,:,:)
-
-    INTEGER :: i, j, k, l, q, ndof, ngp, nerror, nbasis, nndof, nbdof, allocstat, &
-            nbasisvec, ndbasisdxvec, rep, dim
-    INTEGER, PARAMETER :: P = 6, NREP = 100
-    REAL(kind=dp) :: t_start, t_end, t_startvec, t_endvec, &
-            t_start_tmp, t_tot_n, t_totvec_n, &
-            t_tot_b, t_totvec_b
-!DIR$ ATTRIBUTES ALIGN:64 :: Basis, dBasisdx, BasisVec, dBasisdxVec
-
-    nerror = 0
-    Element => AllocatePElement(Solver % Mesh, 504, P)
-    GP = GaussPoints(Element)
-    
-    nndof = Element % Type % NumberOfNodes
-    nbdof = Element % BDofs
-    nbasis = nndof + nbdof 
-    ngp = GP % N
-
-    ! Reserve workspace for finite element basis
-    ALLOCATE(Basis(ngp,nbasis), dBasisdx(ngp,nbasis,3), &
-            BasisVec(ngp,nbasis), dBasisdxVec(ngp,nbasis,3), &
-            STAT=allocstat)
-    IF (allocstat /= 0) THEN
-      CALL Fatal('H1BasisEvaluation',&
-              'Storage allocation for local element basis failed')
-    END IF
-
-    ! Initialize arrays
-    Basis = 0
-    dBasisdx = 0
-    
-    t_tot_n = REAL(0,dp)
-    t_tot_b = REAL(0,dp)
-    t_start = ftimer()
-    DO rep=1,NREP
-      ! Nodal basis 
-      t_start_tmp=ftimer()
-      DO ndof=1,nndof
-        DO i=1,ngp
-          Basis(i,ndof) = TetraNodalPBasis(ndof, GP % U(i), GP % V(i), GP % W(i))
-          dBasisdx(i,ndof,1:3) = dTetraNodalPBasis(ndof, GP % U(i), GP % V(i), GP % W(i))
-        END DO
-      END Do
-      t_tot_n=t_tot_n+(ftimer()-t_start_tmp)
-
-      ! Bubble basis 
-      t_start_tmp=ftimer()
-      q = 4
-      DO i=0,p-4
-        DO j=0,p-i-4
-          DO k=0,p-i-j-4
-            q = q + 1
-            DO l = 1, ngp
-              Basis(l, q) = TetraBubblePBasis(i,j,k,GP % U(l), GP % V(l), GP % W(l))
-              dBasisdx(l, q, 1:3) = dTetraBubblePBasis(i,j,k,GP % U(l), GP % V(l), GP % W(l))  
-            END DO
-          END DO
-        END DO
-      END DO
-      t_tot_b=t_tot_b+(ftimer()-t_start_tmp)
-    END DO
-    t_end = ftimer()
-    
-    ! Initialize arrays
-    BasisVec = 0
-    dBasisdxVec = 0
-
-    t_totvec_n = REAL(0,dp)
-    t_totvec_b = REAL(0,dp)
-    t_startvec = ftimer()
-    DO rep=1,NREP
-      t_start_tmp=ftimer()
-      CALL H1Basis_TetraNodalP(ngp, GP % U, GP % V, GP % W, BasisVec)
-      CALL H1Basis_dTetraNodalP(ngp, GP % U, GP % V, GP % W, dBasisdxVec)
-      t_totvec_n=t_totvec_n+(ftimer()-t_start_tmp)
-      nbasisvec = 4
-      t_start_tmp=ftimer()
-      CALL H1Basis_TetraBubbleP(ngp, GP % U, GP % V, GP % W, P, &
-              nbasisvec, BasisVec)
-      ndbasisdxvec = 4
-      CALL H1Basis_dTetraBubbleP(ngp, GP % U, GP % V, GP % W, P, &
-              ndbasisdxvec, dBasisdxVec)
-      t_totvec_b=t_totvec_b+(ftimer()-t_start_tmp)
-    END DO
-    t_endvec = ftimer()
-    
-    CALL PrintTestData(Element, ngp, nrep, &
-            t_tot_n, t_tot_b, t_end-t_start, &
-            t_totvec_n, t_totvec_b, t_endvec-t_startvec)
-
-    nerror = TestBasis(ngp, nbasis, Element % TYPE % DIMENSION, Basis, BasisVec, &
-            dBasisdx, dBasisdxVec, tol)
-
-    CALL DeallocatePElement(Element)
-    DEALLOCATE(Basis, dBasisdx, BasisVec, dBasisdxVec)
-  END FUNCTION TestTetraElement
-
+    DEALLOCATE(Basis, dBasisdx, BasisVec, dBasisdxVec, UWrk, VWrk, WWrk)
+  END FUNCTION TestWedgeElement  
   
-  FUNCTION TestWedgeElement(Solver, tol) RESULT(nerror)
-    IMPLICIT NONE
-    
-    TYPE(Solver_t) :: Solver
-    REAL(kind=dp), INTENT(IN) :: tol
-    TYPE(Element_t), POINTER :: Element
-    TYPE( GaussIntegrationPoints_t ) :: GP
-    REAL(KIND=dp), ALLOCATABLE :: Basis(:,:), dBasisdx(:,:,:), &
-            BasisVec(:,:), dBasisdxVec(:,:,:)
-
-    INTEGER :: i, j, k, l, q, ndof, ngp, nerror, nbasis, nndof, nbdof, allocstat, &
-            nbasisvec, ndbasisdxvec, rep, dim
-    INTEGER, PARAMETER :: P = 6, NREP = 100
-    REAL(kind=dp) :: t_start, t_end, t_startvec, t_endvec, &
-            t_start_tmp, t_tot_n, t_totvec_n, &
-            t_tot_b, t_totvec_b
-!DIR$ ATTRIBUTES ALIGN:64 :: Basis, dBasisdx, BasisVec, dBasisdxVec
-
-    nerror = 0
-    Element => AllocatePElement(Solver % Mesh, 706, P)
-    GP = GaussPoints(Element)
-    
-    nndof = Element % Type % NumberOfNodes
-    nbdof = Element % BDofs
-    nbasis = nndof + nbdof 
-    ngp = GP % N
-
-    ! Reserve workspace for finite element basis
-    ALLOCATE(Basis(ngp,nbasis), dBasisdx(ngp,nbasis,3), &
-            BasisVec(ngp,nbasis), dBasisdxVec(ngp,nbasis,3), &
-            STAT=allocstat)
-    IF (allocstat /= 0) THEN
-      CALL Fatal('H1BasisEvaluation',&
-              'Storage allocation for local element basis failed')
-    END IF
-
-    ! Initialize arrays
-    Basis = 0
-    dBasisdx = 0
-    
-    t_tot_n = REAL(0,dp)
-    t_tot_b = REAL(0,dp)
-    t_start = ftimer()
-    DO rep=1,NREP
-      ! Nodal basis 
-      t_start_tmp=ftimer()
-      DO ndof=1,nndof
-        DO i=1,ngp
-          Basis(i,ndof) = WedgeNodalPBasis(ndof, GP % U(i), GP % V(i), GP % W(i))
-          dBasisdx(i,ndof,1:3) = dWedgeNodalPBasis(ndof, GP % U(i), GP % V(i), GP % W(i))
-        END DO
-      END Do
-      t_tot_n=t_tot_n+(ftimer()-t_start_tmp)
-
-      ! Bubble basis 
-      t_start_tmp=ftimer()
-      q = 6
-      DO i=0,p-5
-        DO j=0,p-5-i
-          DO k=2,p-3-i-j
-            q = q + 1
-            DO l = 1, ngp
-              Basis(l, q) = WedgeBubblePBasis(i,j,k,GP % U(l), GP % V(l), GP % W(l))
-              dBasisdx(l, q, 1:3) = dWedgeBubblePBasis(i,j,k,GP % U(l), GP % V(l), GP % W(l))  
-            END DO
-          END DO
-        END DO
-      END DO
-      t_tot_b=t_tot_b+(ftimer()-t_start_tmp)
-    END DO
-    t_end = ftimer()
-    
-    ! Initialize arrays
-    BasisVec = 0
-    dBasisdxVec = 0
-
-    t_totvec_n = REAL(0,dp)
-    t_totvec_b = REAL(0,dp)
-    t_startvec = ftimer()
-    DO rep=1,NREP
-      t_start_tmp=ftimer()
-      CALL H1Basis_WedgeNodalP(ngp, GP % U, GP % V, GP % W, BasisVec)
-      CALL H1Basis_dWedgeNodalP(ngp, GP % U, GP % V, GP % W, dBasisdxVec)
-      t_totvec_n=t_totvec_n+(ftimer()-t_start_tmp)
-      nbasisvec = 6
-      t_start_tmp=ftimer()
-      CALL H1Basis_WedgeBubbleP(ngp, GP % U, GP % V, GP % W, P, &
-              nbasisvec, BasisVec)
-      ndbasisdxvec = 6
-      CALL H1Basis_dWedgeBubbleP(ngp, GP % U, GP % V, GP % W, P, &
-              ndbasisdxvec, dBasisdxVec)
-      t_totvec_b=t_totvec_b+(ftimer()-t_start_tmp)
-    END DO
-    t_endvec = ftimer()
-    
-    CALL PrintTestData(Element, ngp, nrep, &
-            t_tot_n, t_tot_b, t_end-t_start, &
-            t_totvec_n, t_totvec_b, t_endvec-t_startvec)
-
-    nerror = TestBasis(ngp, nbasis, Element % TYPE % DIMENSION, Basis, BasisVec, &
-            dBasisdx, dBasisdxVec, tol)
-
-    CALL DeallocatePElement(Element)
-    DEALLOCATE(Basis, dBasisdx, BasisVec, dBasisdxVec)
-  END FUNCTION TestWedgeElement
-
   FUNCTION TestBrickElement(Solver, tol) RESULT(nerror)
     IMPLICIT NONE
     
@@ -695,39 +1076,85 @@ CONTAINS
     TYPE(Element_t), POINTER :: Element
     TYPE( GaussIntegrationPoints_t ) :: GP
     REAL(KIND=dp), ALLOCATABLE :: Basis(:,:), dBasisdx(:,:,:), &
-            BasisVec(:,:), dBasisdxVec(:,:,:)
+            BasisVec(:,:), dBasisdxVec(:,:,:), UWrk(:), VWrk(:), WWrk(:)
 
-    INTEGER :: i, j, k, l, q, ngp, nerror, nbasis, nndof, nbdof, allocstat, &
-            nbasisvec, ndbasisdxvec, rep, dim
-    INTEGER, PARAMETER :: P = 6, NREP = 100
+    INTEGER :: i, j, k, l, q, ngp, nerror, nbasis, nndof, nedof, &
+            nfdof, nbdof, allocstat, perm, &
+            nbasisvec, ndbasisdxvec, rep, dim, tag, ndof
+    INTEGER, PARAMETER :: P = 6, NREP = 100, EdgePerm=2, FacePerm=4
     REAL(kind=dp) :: t_start, t_end, t_startvec, t_endvec, &
             t_start_tmp, t_tot_n, t_totvec_n, &
-            t_tot_b, t_totvec_b
-!DIR$ ATTRIBUTES ALIGN:64 :: Basis, dBasisdx, BasisVec, dBasisdxVec
+            t_tot_e, t_totvec_e, t_tot_f, t_totvec_f, t_tot_b, t_totvec_b
+    INTEGER :: EdgeDir(H1Basis_MaxPElementEdgeNodes,&
+                       H1Basis_MaxPElementEdges,&
+                       EdgePerm), EdgeP(H1Basis_MaxPElementEdges), &
+               FaceDir(H1Basis_MaxPElementFaceNodes, &
+                       H1Basis_MaxPElementFaces, &
+                       FacePerm), FaceP(H1Basis_MaxPElementFaces)
+    LOGICAL :: InvertEdge(12, EdgePerm)
+!DIR$ ATTRIBUTES ALIGN:64 :: Basis, dBasisdx, BasisVec, dBasisdxVec, EdgeDir, FaceDir
+!DIR$ ATTRIBUTES ALIGN:64 :: UWrk, VWrk, WWrk
 
     nerror = 0
     Element => AllocatePElement(Solver % Mesh, 808, P)
+    ! Insert P element definitions to Solver mapping (sets P elements as "active")
+    IF (ALLOCATED(Solver % Def_Dofs)) THEN
+      tag = Element % Type % ElementCode / 100
+      Solver % Def_Dofs(tag,1,6) = P
+    END IF
+
     GP = GaussPoints(Element)
     
     nndof = Element % Type % NumberOfNodes
+    nedof = getEdgeDOFs( Element, P )
+    nfdof = getFaceDOFs( Element, P )
     nbdof = Element % BDofs
-    nbasis = nndof + nbdof 
+    nbasis = nndof + 12*nedof*EdgePerm + 6*nfdof*FacePerm + nbdof
     ngp = GP % N
 
     ! Reserve workspace for finite element basis
     ALLOCATE(Basis(ngp,nbasis), dBasisdx(ngp,nbasis,3), &
             BasisVec(ngp,nbasis), dBasisdxVec(ngp,nbasis,3), &
+            UWrk(ngp), VWrk(ngp), WWrk(ngp), &
             STAT=allocstat)
     IF (allocstat /= 0) THEN
       CALL Fatal('H1BasisEvaluation',&
               'Storage allocation for local element basis failed')
     END IF
+    
+    ! Copy Gauss points to local arrays
+    UWrk(1:ngp) = GP % U(1:ngp)
+    VWrk(1:ngp) = GP % V(1:ngp)
+    WWrk(1:ngp) = GP % W(1:ngp)
 
     ! Initialize arrays
     Basis = 0
     dBasisdx = 0
-    
+    DO i=1,12
+      EdgeDir(1:2,i,1)=getBrickEdgeMap(i)
+    END DO
+    ! Invert direction
+    DO i=1,12
+      EdgeDir(2:1:-1,i,2)=EdgeDir(1:2,i,1)
+    END DO
+    InvertEdge(:,1) = .FALSE.
+    InvertEdge(:,2) = .TRUE.
+
+    DO i=1,6
+      FaceDir(1:4,i,1)=getBrickFaceMap(i)
+    END DO
+    DO j=2,FacePerm
+      DO i=1,6
+        FaceDir(1:4,i,j)=CSHIFT(FaceDir(1:4,i,1), j-1)
+      END DO
+    END DO
+
+    EdgeP = P
+    FaceP = P
+
     t_tot_n = REAL(0,dp)
+    t_tot_e = REAL(0,dp)
+    t_tot_f = REAL(0,dp)
     t_tot_b = REAL(0,dp)
     t_start = ftimer()
     DO rep=1,NREP
@@ -735,24 +1162,60 @@ CONTAINS
       t_start_tmp=ftimer()
       DO i=1,ngp
         CALL NodalBasisFunctions3D( Basis(i,1:nndof), Element, &
-                GP % U(i), GP % V(i), GP % W(i))
+                UWrk(i), VWrk(i), WWrk(i))
         CALL NodalFirstDerivatives3D( dBasisdx(i,1:nndof,1:3), Element, &
-                GP % U(i), GP % V(i), GP % W(i))
+                UWrk(i), VWrk(i), WWrk(i))
       END DO
       t_tot_n=t_tot_n+(ftimer()-t_start_tmp)
 
-      ! Bubble basis 
+      ! Edge basis
       t_start_tmp=ftimer()
       q = 8
+      DO perm=1,EdgePerm
+        DO i=1,12
+          DO ndof=1,nedof
+            q=q+1
+            DO k=1,ngp
+              Basis(k,q) = BrickEdgePBasis(i, ndof+1, UWrk(k), VWrk(k), WWrk(k), &
+                      InvertEdge(i,perm))
+              dBasisdx(k,q,1:3) = dBrickEdgePBasis(i, ndof+1, UWrk(k), VWrk(k), WWrk(k), &
+                      InvertEdge(i,perm))
+            END DO
+          END DO
+        END DO
+      END DO
+      t_tot_e=t_tot_e+(ftimer()-t_start_tmp)
+
+      ! Face basis
+      t_start_tmp=ftimer()
+      DO perm=1,FacePerm
+        DO i=1,6
+          DO j=2,FaceP(i)-2
+            DO k=2,FaceP(i)-j
+              q = q + 1
+              DO l=1,ngp
+                Basis(l,q) = BrickFacePBasis(i,j,k,UWrk(l), VWrk(l), WWrk(l), &
+                        FaceDir(1:4,i,perm))
+                dBasisdx(l,q,1:3) = dBrickFacePBasis(i,j,k,UWrk(l), VWrk(l), WWrk(l), &
+                        FaceDir(1:4,i,perm))
+              END DO
+            END DO
+          END DO
+        END DO
+      END DO
+      t_tot_f=t_tot_f+(ftimer()-t_start_tmp)
+
+      ! Bubble basis 
+      t_start_tmp=ftimer()
       DO i=2,p-4
         DO j=2,p-i-2
           DO k=2,p-i-j
             q = q + 1
             DO l=1,ngp
               Basis(l,q) = BrickBubblePBasis(i,j,k, &
-                      GP % U(l), GP % V(l), GP % W(l))
+                      UWrk(l), VWrk(l), WWrk(l))
               dBasisdx(l,q,:) = dBrickBubblePBasis(i,j,k, &
-                      GP % U(l), GP % V(l), GP % W(l))
+                      UWrk(l), VWrk(l), WWrk(l))
             END DO
           END DO
         END DO
@@ -766,33 +1229,54 @@ CONTAINS
     dBasisdxVec = 0
 
     t_totvec_n = REAL(0,dp)
+    t_totvec_e = REAL(0,dp)
+    t_totvec_f = REAL(0,dp)
     t_totvec_b = REAL(0,dp)
     t_startvec = ftimer()
     DO rep=1,NREP
+      nbasisvec = 0
+      ndbasisdxvec = 0
       t_start_tmp=ftimer()
-      CALL H1Basis_BrickNodal(ngp, GP % U, GP % V, GP % W, BasisVec)
-      CALL H1Basis_dBrickNodal(ngp, GP % U, GP % V, GP % W, dBasisdxVec)
+      CALL H1Basis_BrickNodal(ngp, UWrk, VWrk, WWrk, nbasisvec, BasisVec)
+      CALL H1Basis_dBrickNodal(ngp, UWrk, VWrk, WWrk, ndbasisdxvec, dBasisdxVec)
       t_totvec_n=t_totvec_n+(ftimer()-t_start_tmp)
-      nbasisvec = 8
+
       t_start_tmp=ftimer()
-      CALL H1Basis_BrickBubbleP(ngp, GP % U, GP % V, GP % W, P, &
+      DO perm=1,EdgePerm
+        CALL H1Basis_BrickEdgeP(ngp, UWrk, VWrk, WWrk, EdgeP, &
+              nbasisvec, BasisVec, EdgeDir(:,:,perm))
+        CALL H1Basis_dBrickEdgeP(ngp, UWrk, VWrk, WWrk, EdgeP, &
+              ndbasisdxvec, dBasisdxVec, EdgeDir(:,:,perm))
+      END DO
+      t_totvec_e=t_totvec_e+(ftimer()-t_start_tmp)
+
+      t_start_tmp=ftimer()
+      DO perm=1,FacePerm
+        CALL H1Basis_BrickFaceP(ngp, UWrk, VWrk, WWrk, FaceP, &
+              nbasisvec, BasisVec, FaceDir(:,:,perm))
+        CALL H1Basis_dBrickFaceP(ngp, UWrk, VWrk, WWrk, FaceP, &
+              ndbasisdxvec, dBasisdxVec, FaceDir(:,:,perm))
+      END DO
+      t_totvec_f=t_totvec_f+(ftimer()-t_start_tmp)
+
+      t_start_tmp=ftimer()
+      CALL H1Basis_BrickBubbleP(ngp, UWrk, VWrk, WWrk, P, &
               nbasisvec, BasisVec)
-      ndbasisdxvec = 8
-      CALL H1Basis_dBrickBubbleP(ngp, GP % U, GP % V, GP % W, P, &
+      CALL H1Basis_dBrickBubbleP(ngp, UWrk, VWrk, WWrk, P, &
               ndbasisdxvec, dBasisdxVec)
       t_totvec_b=t_totvec_b+(ftimer()-t_start_tmp)
     END DO
     t_endvec = ftimer()
-    
-    CALL PrintTestData(Element, ngp, nrep, &
-            t_tot_n, t_tot_b, t_end-t_start, &
-            t_totvec_n, t_totvec_b, t_endvec-t_startvec)
+
+    CALL PrintTestData(Element, ngp, nrep, 12*nedof+6*nfdof+nbdof, &
+            t_tot_n, t_tot_e+t_tot_f+t_tot_b, t_end-t_start, &
+            t_totvec_n, t_totvec_e+t_totvec_f+t_totvec_b, t_endvec-t_startvec)
 
     nerror = TestBasis(ngp, nbasis, Element % TYPE % DIMENSION, Basis, BasisVec, &
             dBasisdx, dBasisdxVec, tol)
 
     CALL DeallocatePElement(Element)
-    DEALLOCATE(Basis, dBasisdx, BasisVec, dBasisdxVec)
+    DEALLOCATE(Basis, dBasisdx, BasisVec, dBasisdxVec, UWrk, VWrk, WWrk)
   END FUNCTION TestBrickElement
 
   FUNCTION TestBasis(ngp, nbasis, ndim, Basis1, Basis2, dBasisdx1, dBasisdx2, tol) RESULT(nerror)
@@ -839,12 +1323,12 @@ CONTAINS
     END IF
   END FUNCTION TestBasis
 
-  SUBROUTINE PrintTestData(Element, ngp, nrep, t_n1, t_b1, t_tot1, &
+  SUBROUTINE PrintTestData(Element, ngp, nrep, nndofs, t_n1, t_b1, t_tot1, &
           t_n2, t_b2, t_tot2)
   
     IMPLICIT NONE
     TYPE(Element_t) :: Element
-    INTEGER, INTENT(IN) :: ngp, nrep
+    INTEGER, INTENT(IN) :: ngp, nrep, nndofs
     REAL(kind=dp), INTENT(IN) :: t_n1, t_b1, t_tot1, t_n2, t_b2, t_tot2
 
     WRITE (*,'(A,I0)') 'Element type=', Element % TYPE % ElementCode
@@ -852,7 +1336,7 @@ CONTAINS
       WRITE (*,'(A,I0)') 'Element polynomial degree=', Element % PDefs % P
     END IF
     WRITE (*,'(A,I0)') 'Element number of nodes=', Element % TYPE % NumberOfNodes
-    WRITE (*,'(A,I0)') 'Element number of nonnodal dofs=', GetElementNOFDOFs(Element)
+    WRITE (*,'(A,I0)') 'Element number of nonnodal dofs=', nndofs
     WRITE (*,'(A,I0)') 'Element number of bubble dofs=', GetElementNOFBDOFs()
     WRITE (*,'(A,I0)') 'Number of Gauss points=', ngp
     WRITE (*,'(A,I0)') 'Number of repetitions=', nrep

--- a/fem/tests/LinearFormsAssembly/LinearFormsAssembly.F90
+++ b/fem/tests/LinearFormsAssembly/LinearFormsAssembly.F90
@@ -248,7 +248,7 @@ CONTAINS
 
     ! Normalize the times / thread
     nthr = 1
-    !$ omp_get_max_threads()
+    !$ nthr = omp_get_max_threads()
     t_tot = t_tot / nthr
     t_tot_vec = t_tot_vec / nthr
     CALL PrintTestData(SingleElement, NumGP, t_tot, lm_eval, &

--- a/fem/tests/LinearFormsAssembly/LinearFormsAssembly.F90
+++ b/fem/tests/LinearFormsAssembly/LinearFormsAssembly.F90
@@ -159,7 +159,7 @@ CONTAINS
     REAL(KIND=dp), ALLOCATABLE :: STIFF(:,:), LOAD(:), FORCE(:), &
             STIFFvec(:,:), FORCEvec(:)
 
-    INTEGER :: i, j, k, l, q, nerror, nbasis, nndof, allocstat, tag, &
+    INTEGER :: i, j, k, l, q, nerror, nbasis, nndof, allocstat, tag, nthr, &
             nbasisvec, ndbasisdxvec, rep, dim, lm_eval, lm_eval_vec, NumGP
 
     INTEGER, PARAMETER :: P = 6, NREP = 100, NumGP1D = 8
@@ -247,6 +247,10 @@ CONTAINS
     !$OMP END PARALLEL
 
     ! Normalize the times / thread
+    nthr = 1
+    !$ omp_get_max_threads()
+    t_tot = t_tot / nthr
+    t_tot_vec = t_tot_vec / nthr
     CALL PrintTestData(SingleElement, NumGP, t_tot, lm_eval, &
             t_tot_vec, lm_eval_vec)
 
@@ -510,8 +514,7 @@ CONTAINS
     END IF
     PElement % NodeIndexes(:) = [(node, node=1,PElement % Type % NumberOfNodes)]
 
-    ! Temporarily disable creation of edges for 3D elements (not implemented yet)
-    IF (PElement % Type % Dimension < 3) THEN
+    IF (PElement % Type % Dimension > 1) THEN
       ! Add element edge indexes to element
       ALLOCATE(PElement % EdgeIndexes(PElement % Type % NumberOfEdges), STAT=astat)
       IF (astat /= 0) THEN
@@ -538,7 +541,9 @@ CONTAINS
         Mesh % Edges(edge) % BDOFs = GetBubbleDofs(Mesh % Edges(edge), P)
         Mesh % MaxEdgeDofs = MAX(Mesh % MaxEdgeDofs, Mesh % Edges(edge) % BDOFs)
       END DO
-      
+    END IF
+
+    IF (PElement % Type % Dimension > 2) THEN
       ! Add element face indexes to element
       ALLOCATE(PElement % FaceIndexes(PElement % Type % NumberOfFaces))
       IF (astat /= 0) THEN
@@ -584,10 +589,16 @@ CONTAINS
         Mesh % Faces(face) % BDOFs = GetBubbleDofs(Mesh % Faces(face), P)
         Mesh % MaxFaceDofs = MAX(Mesh % MaxFaceDofs, Mesh % Faces(face) % BDOFs)
       END DO
-    END IF ! Dimensionality check
+    END IF 
 
     PElement % BDofs = GetBubbleDofs( PElement, P )
     PElement % PDefs % P = P
+    IF (ElementCode == 504) THEN
+      PElement % PDefs % TetraType = 1
+    ELSE
+      PElement % PDefs % TetraType = 0
+    END IF
+    PElement % PDefs % isEdge = .FALSE.
     ! Set max element dofs to mesh
     Mesh % MaxElementDOFs = PElement % Type % NumberOfNodes + &
            PElement % Type % NumberOfEdges * Mesh % MaxEdgeDOFs + &


### PR DESCRIPTION
A complete vectorized implementation of hierarchical H^1 basis functions.

New functionality:

- OpenMP SIMD implementation of high-order edge and face modes for
  Tetras, Wedges and Bricks (all feature complete vs. scalar implementation).
- OpenMP SIMD implementation of directed high-order bubble modes for Lines,
  Triangles and Quadrilaterals (all feature complete vs. scalar implementation).
- Enabled placing of the computed function values according to a given offset
  to H1Basis module.
- Added routines for computing edge and face directivity to H1Basis module.
- Added evaluation of edge and face modes to H1BasisEvaluation and
  LinearFormsAssembly tests.
- Added evaluation of directed bubble modes to H1BasisEvaluation test.
- Added normalization of thread timings to LinearFormsAssembly test.

Performance improvements:

- Removed copyin/copyout of basis function arguments from the
  H1BasisEvaluation test to better reflect the real usage pattern present in
  ElementInfoVec.

NOTE: Enforcing parity has been implemented for both 2D and 3D elements within
ElementInfoVec, but has not been yet tested very thoroughly.