### PR TITLE
elmersolver: C_PTR field to Solver_t

### DIFF
--- a/fem/src/Types.F90
+++ b/fem/src/Types.F90
@@ -788,6 +788,9 @@ END INTERFACE
       INTEGER :: CurrentColour = 0
       INTEGER :: DirectMethod = DIRECT_NORMAL
       LOGICAL :: GlobalBubbles = .FALSE., DG = .FALSE.
+#ifdef USE_ISO_C_BINDINGS
+      TYPE(C_PTR) :: CWrap = C_NULL_PTR
+#endif
     END TYPE Solver_t
 
 !------------------------------------------------------------------------------


### PR DESCRIPTION
For calling external solvers and storing wrapper data between timesteps.

Fields to Solver_t should not be added lightly but I think this might have future use as well.