### PR TITLE
Collection of multithreading improvements.

### DIFF
--- a/elmergrid/src/femelmer.c
+++ b/elmergrid/src/femelmer.c
@@ -5116,7 +5116,8 @@ int SaveElmerInputPartitioned(struct FemType *data,struct BoundaryType *bound,
   int *bcnodesaved[MAXBCS],maxbcnodesaved,*bcelemsaved,*bcnode;
   int *bcnodedummy,*elementhalo,*neededtimes2;
   int partstart,partfin,filesetsize,nofile,nofile2,nobcnodes;
-  int halobulkelems,halobcs,savethis,fail,cdstat;
+  int halobulkelems,halobcs,savethis,fail=0,cdstat;
+
   FILE *out,*outfiles[MAXPARTITIONS+1];
   int sumelementsinpart,sumownnodes,sumsharednodes,sumsidesinpart,sumindirect;
 
@@ -5209,7 +5210,7 @@ int SaveElmerInputPartitioned(struct FemType *data,struct BoundaryType *bound,
 #ifdef MINGW32
   mkdir(directoryname);
 #else
-  mkdir(directoryname,0700);
+  fail = mkdir(directoryname,0700);
 #endif
   if(info && !fail) printf("Created mesh directory: %s\n",directoryname);
   fail = chdir(directoryname);

--- a/fem/src/BandwidthOptimize.F90
+++ b/fem/src/BandwidthOptimize.F90
@@ -80,6 +80,11 @@ CONTAINS
      TYPE(ListMatrixEntry_t), POINTER :: CList
 !-------------------------------------------------------------------------------
      HalfBandWidth = 0
+     !$OMP PARALLEL DO &
+     !$OMP SHARED(List, Reorder, InvInitialReorder, N) & 
+     !$OMP PRIVATE(Clist, j, k) & 
+     !$OMP REDUCTION(max:HalfBandWidth) &
+     !$OMP DEFAULT(NONE)
      DO i=1,n
         CList => List(i) % Head
         j = i
@@ -95,6 +100,7 @@ CONTAINS
            Clist => Clist % Next
         END DO
      END DO
+     !$OMP END PARALLEL DO
 !-------------------------------------------------------------------------------
    END FUNCTION ComputeBandwidth
 !-------------------------------------------------------------------------------

--- a/fem/src/CMakeLists.txt
+++ b/fem/src/CMakeLists.txt
@@ -20,7 +20,7 @@ SET(solverlib_SOURCES AddrFunc.F90 NavierStokes.F90 NavierStokesGeneral.F90
   NavierStokesCylindrical.F90 Lists.F90
   DiffuseConvectiveAnisotropic.F90 LoadMod.F90
   DiffuseConvectiveGeneralAnisotropic.F90 PElementMaps.F90
-  PElementBase.F90 ElementDescription.F90 Integration.F90
+  PElementBase.F90 ElementDescription.F90 Integration.F90 ListMatrixArray.F90
   ModelDescription.F90 GeneralUtils.F90 Stress.F90 StressGeneral.F90
   LinearAlgebra.F90 CoordinateSystems.F90 ListMatrix.F90 CRSMatrix.F90
   BandMatrix.F90 BandwidthOptimize.F90 BlockSolve.F90

--- a/fem/src/ElmerSolver.F90
+++ b/fem/src/ElmerSolver.F90
@@ -1470,6 +1470,7 @@ END INTERFACE
 !------------------------------------------------------------------------------
    SUBROUTINE ExecSimulation(TimeIntervals,  CoupledMinIter, &
               CoupledMaxIter, OutputIntervals, Transient, Scanning)
+     IMPLICIT NONE
       INTEGER :: TimeIntervals,CoupledMinIter, CoupledMaxIter,OutputIntervals(:)
       LOGICAL :: Transient,Scanning
 !------------------------------------------------------------------------------
@@ -1500,9 +1501,9 @@ END INTERFACE
      REAL(KIND=dp) :: RealTime
 #endif
      
-!$omp parallel
-!$   IF(.NOT.GaussPointsInitialized()) CALL GaussPointsInit
-!$omp end parallel
+     !$OMP PARALLEL
+     IF(.NOT.GaussPointsInitialized()) CALL GaussPointsInit()
+     !$OMP END PARALLEL
 
      nSolvers = CurrentModel % NumberOfSolvers
      DO i=1,nSolvers

--- a/fem/src/ListMatrixArray.F90
+++ b/fem/src/ListMatrixArray.F90
@@ -1,0 +1,522 @@
+!/*****************************************************************************/
+! *
+! *  Elmer, A Finite Element Software for Multiphysical Problems
+! *
+! *  Copyright 1st April 1995 - , CSC - IT Center for Science Ltd., Finland
+! * 
+! * This library is free software; you can redistribute it and/or
+! * modify it under the terms of the GNU Lesser General Public
+! * License as published by the Free Software Foundation; either
+! * version 2.1 of the License, or (at your option) any later version.
+! *
+! * This library is distributed in the hope that it will be useful,
+! * but WITHOUT ANY WARRANTY; without even the implied warranty of
+! * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+! * Lesser General Public License for more details.
+! * 
+! * You should have received a copy of the GNU Lesser General Public
+! * License along with this library (in file ../LGPL-2.1); if not, write 
+! * to the Free Software Foundation, Inc., 51 Franklin Street, 
+! * Fifth Floor, Boston, MA  02110-1301  USA
+! *
+! *****************************************************************************/
+!
+!/******************************************************************************
+! *
+! *  Authors: Mikko Byckling
+! *
+! *  Original Date: 25 September 2017
+! *
+! ****************************************************************************/
+
+!> \ingroup ElmerLib 
+!> \{
+
+
+MODULE ListMatrixArray
+  USE Messages
+  USE Types
+  USE GeneralUtils, ONLY : I2S
+  
+  IMPLICIT NONE
+CONTAINS
+  
+  !-------------------------------------------------------------------------------
+  !> Allocates an empty array list matrix.
+  !-------------------------------------------------------------------------------
+  SUBROUTINE ListMatrixArray_Allocate(ListMatrixArray, N, PoolSize, Atomic)
+    IMPLICIT NONE
+    TYPE(ListMatrixArray_t) :: ListMatrixArray
+    INTEGER,INTENT(IN) :: N
+    INTEGER, OPTIONAL :: PoolSize
+    LOGICAL, OPTIONAL :: Atomic
+    
+    INTEGER :: i,istat, nthr, TID, psize
+    LOGICAL :: InitLocks
+    
+    psize = 1024
+    IF (PRESENT(PoolSize)) psize = PoolSize
+
+    InitLocks = .FALSE.
+    IF (PRESENT(Atomic)) InitLocks = Atomic
+    
+    ! Allocate ListMatrix and associated pools
+    nthr = 1
+    !$ nthr = omp_get_max_threads()
+    ALLOCATE( ListMatrixArray % Rows(n), &
+              ListMatrixArray % Pool(nthr), STAT=istat )
+    IF( istat /= 0 ) THEN
+      CALL Fatal('ListMatrixArray_AllocateMatrix',&
+                 'Allocation error for ListMatrix of size: '//TRIM(I2S(n)))
+    END IF
+    IF (InitLocks) CALL ListMatrixArray_InitializeAtomic(ListMatrixArray)
+    
+    !$OMP PARALLEL &
+    !$OMP SHARED(ListMatrixArray, N, psize) &
+    !$OMP PRIVATE(i, TID) DEFAULT(NONE)
+    
+    TID = 1
+    !$ TID = omp_get_thread_num()+1
+
+    CALL ListMatrixPool_Initialize(ListMatrixArray % Pool(TID), psize)
+    
+    !$OMP DO
+    DO i=1,N
+      ListMatrixArray % Rows(i) % Head => NULL()
+      ListMatrixArray % Rows(i) % Level = 0
+      ListMatrixArray % Rows(i) % Degree = 0
+    END DO
+    !$OMP END DO NOWAIT
+    !$OMP END PARALLEL
+  END SUBROUTINE ListMatrixArray_Allocate
+ 
+  !-------------------------------------------------------------------------------
+  !> Free an array list matrix.
+  !-------------------------------------------------------------------------------
+  SUBROUTINE ListMatrixArray_Free( ListMatrixArray )
+    IMPLICIT NONE
+    TYPE(ListMatrixArray_t) :: ListMatrixArray
+
+    TYPE(ListMatrixEntryPool_t), POINTER :: p, p1
+    INTEGER :: N,TID
+    
+    N = SIZE(ListMatrixArray % Pool)
+    !$OMP PARALLEL &
+    !$OMP SHARED(ListMatrixArray, N) &
+    !$OMP PRIVATE(p, p1, TID) DEFAULT(NONE)
+
+    !$OMP DO
+    DO TID=1,N
+       CALL ListMatrixPool_Free(ListMatrixArray % Pool(TID))
+    END DO
+    !$OMP END DO
+    !$OMP END PARALLEL
+
+    CALL ListMatrixArray_FreeAtomic(ListMatrixArray)
+    
+    DEALLOCATE(ListMatrixArray % Rows, ListMatrixArray % Pool)
+  END SUBROUTINE ListMatrixArray_Free
+
+  SUBROUTINE ListMatrixArray_InitializeAtomic(ListMatrixArray)
+    IMPLICIT NONE
+    TYPE(ListMatrixArray_t) :: ListMatrixArray
+
+    INTEGER :: i, N, istat
+    
+#ifdef _OPENMP
+    N = SIZE(ListMatrixArray % Rows)
+    
+    ALLOCATE( ListMatrixArray % RowLocks(n), STAT=istat )
+    IF( istat /= 0 ) THEN
+      CALL Fatal('ListMatrixArray_InitializeAtomic',&
+            'Allocation error for ListMatrix row locks of size: '//TRIM(I2S(n)))
+    END IF
+      
+    !$OMP PARALLEL DO &
+    !$OMP SHARED(ListMatrixArray,N) &
+    !$OMP PRIVATE(i) DEFAULT(NONE)
+    DO i=1,N
+      CALL omp_init_lock(ListMatrixArray % RowLocks(i))
+    END DO
+    !$OMP END PARALLEL DO
+#endif
+  END SUBROUTINE ListMatrixArray_InitializeAtomic
+
+  SUBROUTINE ListMatrixArray_FreeAtomic(ListMatrixArray)
+    IMPLICIT NONE
+    TYPE(ListMatrixArray_t) :: ListMatrixArray
+
+    INTEGER :: i, N
+
+#ifdef _OPENMP
+    IF (ALLOCATED(ListMatrixArray % RowLocks)) THEN
+      N = SIZE(ListMatrixArray % RowLocks)
+      
+      !$OMP PARALLEL DO &
+      !$OMP SHARED(ListMatrixArray,N) &
+      !$OMP PRIVATE(i) DEFAULT(NONE)
+      DO i=1,N
+        CALL omp_destroy_lock(ListMatrixArray % RowLocks(i))
+      END DO
+      !$OMP END PARALLEL DO
+
+      DEALLOCATE(ListMatrixArray % RowLocks)
+    END IF
+#endif
+  END SUBROUTINE ListMatrixArray_FreeAtomic
+
+  SUBROUTINE ListMatrixArray_LockRow(ListMatrixArray, row, Atomic)
+    IMPLICIT NONE
+    TYPE(ListMatrixArray_t) :: ListMatrixArray
+    INTEGER, INTENT(IN) :: row
+    LOGICAL, OPTIONAL :: Atomic
+
+#ifdef _OPENMP
+    IF (PRESENT(ATOMIC)) THEN
+      IF (Atomic) CALL omp_set_lock(ListMatrixArray % RowLocks(row))
+    END IF
+#endif
+  END SUBROUTINE ListMatrixArray_LockRow
+
+  SUBROUTINE ListMatrixArray_UnlockRow(ListMatrixArray, row, Atomic)
+    IMPLICIT NONE
+    TYPE(ListMatrixArray_t) :: ListMatrixArray
+    INTEGER, INTENT(IN) :: row
+    LOGICAL, OPTIONAL :: Atomic
+
+#ifdef _OPENMP
+    IF (PRESENT(ATOMIC)) THEN
+      IF (Atomic) CALL omp_unset_lock(ListMatrixArray % RowLocks(row))
+    END IF
+#endif
+  END SUBROUTINE ListMatrixArray_UnlockRow
+  
+  !-------------------------------------------------------------------------------
+  !> Transfer sparsity pattern of the array list matrix format to a graph format,
+  !> used in most places of the code. 
+  !-------------------------------------------------------------------------------
+  SUBROUTINE ListMatrixArray_ToGraph( ListMatrixArray, Graph)
+    IMPLICIT NONE
+    TYPE(ListMatrixArray_t) :: ListMatrixArray
+    TYPE(Graph_t) :: Graph
+    
+    ! TODO
+    CALL Fatal('ListMatrixArray_ToGraph','Not implemented yet!')
+  END SUBROUTINE ListMatrixArray_ToGraph
+
+  !-------------------------------------------------------------------------------
+  !> Transfer the flexible list matrix to the more efficient CRS matrix that is 
+  !> used in most places of the code. The matrix structure can accommodate both forms.
+  !-------------------------------------------------------------------------------
+  SUBROUTINE ListMatrixArray_ToCRSMatrix( ListMatrixArray, CRSMatrix )
+    IMPLICIT NONE
+    TYPE(ListMatrixArray_t) :: ListMatrixArray
+    TYPE(Matrix_t) :: CRSMatrix
+    
+    ! TODO
+    CALL Fatal('ListMatrixArray_ToCRSMatrix','Not implemented yet!')
+  END SUBROUTINE ListMatrixArray_ToCRSMatrix
+
+  SUBROUTINE ListMatrixArray_FromCRSMatrix( ListMatrixArray, CRSMatrix )
+    IMPLICIT NONE
+    TYPE(ListMatrixArray_t) :: ListMatrixArray
+    TYPE(Matrix_t) :: CRSMatrix
+    
+    ! TODO
+    CALL Fatal('ListMatrixArray_FromCRSMatrix','Not implemented yet!')
+  END SUBROUTINE ListMatrixArray_FromCRSMatrix
+
+  !-------------------------------------------------------------------------------
+  !> Add index (row,col) to the matrix sparsity structure 
+  !-------------------------------------------------------------------------------
+  SUBROUTINE ListMatrixArray_AddEntry(ListMatrixArray, row, col, val, Atomic)
+    IMPLICIT NONE
+    TYPE(ListMatrixArray_t) :: ListMatrixArray
+    INTEGER, INTENT(IN) :: row, col
+    REAL(KIND=dp), OPTIONAL :: val
+    LOGICAL, OPTIONAL :: Atomic
+
+    TYPE(ListMatrixEntry_t), POINTER :: CEntryPtr, PEntryPtr, NEntryPtr
+    INTEGER :: TID
+
+    TID = 1
+    !$ TID = omp_get_thread_num() + 1
+
+    CALL ListMatrixArray_LockRow(ListMatrixArray, row, Atomic)
+    
+    CEntryPtr => ListMatrixArray % Rows(row) % Head
+    IF (.NOT. ASSOCIATED(CEntryPtr)) THEN
+       ! Empty matrix row, add entry and return
+       ListMatrixArray % Rows(row) % Head => &
+            ListMatrixPool_GetListEntry(ListMatrixArray % Pool(TID), col, NULL())
+       ListMatrixArray % Rows(row) % Degree = 1
+       CALL ListMatrixArray_UnlockRow(ListMatrixArray, row, Atomic)
+       RETURN
+    ELSE IF (CEntryPtr % Index == col) THEN
+       ! Do not add duplicates, nothing to do!
+       CALL ListMatrixArray_UnlockRow(ListMatrixArray, row, Atomic)
+       RETURN
+    ELSE IF (CEntryPtr % Index > col) THEN
+       ! Add a new entry to the Head of list
+       ListMatrixArray % Rows(row) % Head => &
+            ListMatrixPool_GetListEntry(ListMatrixArray % Pool(TID), col, CEntryPtr)
+       ListMatrixArray % Rows(row) % Degree = & 
+            ListMatrixArray % Rows(row) % Degree + 1
+       CALL ListMatrixArray_UnlockRow(ListMatrixArray, row, Atomic)
+       RETURN
+    END IF
+    
+    ! Seach a correct place for the element
+    PEntryPtr => CEntryPtr
+    CEntryPtr => CEntryPtr % Next
+    
+    DO WHILE( ASSOCIATED(CEntryPtr) )
+       ! Do not add duplicates
+       IF (CEntryPtr % Index == col) THEN
+         CALL ListMatrixArray_UnlockRow(ListMatrixArray, row, Atomic)
+         RETURN
+       END IF
+       ! Place found, exit search loop
+       IF (CEntryPtr % Index > col) EXIT
+       
+       PEntryPtr => CEntryPtr
+       CEntryPtr => CEntryPtr % Next
+    END DO
+
+    ! Add entry to the correct place in the list
+    PEntryPtr % Next => ListMatrixPool_GetListEntry(ListMatrixArray % Pool(TID), col, CEntryPtr)
+    ListMatrixArray % Rows(row) % Degree = & 
+          ListMatrixArray % Rows(row) % Degree + 1
+    CALL ListMatrixArray_UnlockRow(ListMatrixArray, row, Atomic)
+  END SUBROUTINE ListMatrixArray_AddEntry
+
+  !-------------------------------------------------------------------------------
+  !> Add indexes on a single row to the matrix sparsity structure.
+  !-------------------------------------------------------------------------------
+  SUBROUTINE ListMatrixArray_AddEntries(ListMatrixArray, row, nentry, Indexes, Perm, Atomic)
+    IMPLICIT NONE
+    TYPE(ListMatrixArray_t) :: ListMatrixArray
+    INTEGER, INTENT(IN) :: row, nentry
+    INTEGER, INTENT(IN) :: Indexes(nentry), Perm(nentry)
+    LOGICAL, OPTIONAL :: Atomic
+    
+    TYPE(ListMatrixEntry_t), POINTER :: CEntryPtr, PEntryPtr, NEntryPtr
+    INTEGER :: TID, centry, sentry, rentry, col
+        
+    TID = 1
+    !$ TID = omp_get_thread_num() + 1
+
+    CALL ListMatrixArray_LockRow(ListMatrixArray, row, Atomic)
+    
+    CEntryPtr => ListMatrixArray % Rows(row) % Head
+    sentry = 1
+    col = Indexes(Perm(1))
+    IF (.NOT. ASSOCIATED(CEntryPtr)) THEN
+       ! Empty matrix row, add entry and continue
+       CEntryPtr => ListMatrixPool_GetListEntry(ListMatrixArray % Pool(TID), col, NULL())
+       ListMatrixArray % Rows(row) % Head => CEntryPtr
+       ListMatrixArray % Rows(row) % Degree = 1
+       sentry = 2
+    ELSE IF (CEntryPtr % Index == col) THEN
+       ! Do not add duplicates, continue with next element!
+       sentry = 2
+    ELSE IF (CEntryPtr % Index > col) THEN
+       ! Add a new entry to the Head of list
+       NEntryPtr => ListMatrixPool_GetListEntry(ListMatrixArray % Pool(TID), col, CEntryPtr)
+       CEntryPtr => NEntryPtr
+       ListMatrixArray % Rows(row) % Head => CEntryPtr
+       ListMatrixArray % Rows(row) % Degree = & 
+            ListMatrixArray % Rows(row) % Degree + 1
+       sentry = 2
+    END IF
+    
+    ! Seach a correct place for the element
+    PEntryPtr => CEntryPtr
+    CEntryPtr => CEntryPtr % Next
+
+    DO centry=sentry,nentry
+       col=Indexes(Perm(centry))
+
+       ! Find a correct place to add index to
+       DO WHILE( ASSOCIATED(CEntryPtr) )
+         IF (CEntryPtr % Index >= col) EXIT
+         PEntryPtr => CEntryPtr
+         CEntryPtr => PEntryPtr % Next
+       END DO
+       
+       IF (ASSOCIATED(CEntryPtr)) THEN
+         ! Do not add duplicates
+         IF (CEntryPtr % Index /= col) THEN
+           ! Create new element between PEntryPtr and CEntryPtr
+           NEntryPtr => ListMatrixPool_GetListEntry(ListMatrixArray % Pool(TID), col, CEntryPtr)
+           PEntryPtr % Next => NEntryPtr
+           ListMatrixArray % Rows(row) % Degree = & 
+                ListMatrixArray % Rows(row) % Degree + 1
+
+           ! Advance to next element in list
+           PEntryPtr => NEntryPtr
+           CEntryPtr => NEntryPtr % Next
+         ELSE
+           ! Advance to next element in list
+           PEntryPtr => CEntryPtr
+           CEntryPtr => CEntryPtr % Next
+         END IF
+       ELSE
+         ! List matrix row contains no more entries
+         EXIT
+       END IF
+     END DO
+
+     ! Add rest of the entries in Indexes to list matrix row (if any)
+     DO rentry=centry,nentry
+       col=Indexes(Perm(rentry))
+       NEntryPtr => ListMatrixPool_GetListEntry(ListMatrixArray % Pool(TID), col, NULL())
+       PEntryPtr % Next => NEntryPtr
+       PEntryPtr => NEntryPtr
+       ListMatrixArray % Rows(row) % Degree = & 
+            ListMatrixArray % Rows(row) % Degree + 1
+     END DO
+
+     CALL ListMatrixArray_UnlockRow(ListMatrixArray, row, Atomic)
+   END SUBROUTINE ListMatrixArray_AddEntries
+
+   !-------------------------------------------------------------------------------
+   !> Delete entry (row,col) from the matrix sparsity structure 
+   !-------------------------------------------------------------------------------
+   SUBROUTINE ListMatrixArray_DeleteEntry(ListMatrixArray, row, col, Atomic)
+     IMPLICIT NONE
+     TYPE(ListMatrixArray_t) :: ListMatrixArray
+     INTEGER, INTENT(IN) :: row, col
+     LOGICAL, OPTIONAL :: Atomic
+     
+     TYPE(ListMatrixEntry_t), POINTER :: CEntryPtr, PEntryPtr
+     INTEGER :: TID
+     LOGICAL :: NotFound
+     
+     TID = 1
+     !$ TID = omp_get_thread_num() + 1
+
+     CALL ListMatrixArray_LockRow(ListMatrixArray, row, Atomic)
+     
+     ! Search for element from the list
+     PEntryPtr => NULL()
+     CEntryPtr => ListMatrixArray % Rows(row) % Head     
+     DO WHILE( ASSOCIATED(CEntryPtr) )
+       IF (CEntryPtr % Index >= col) EXIT
+       
+       PEntryPtr => CEntryPtr
+       CEntryPtr => CEntryPtr % Next
+     END DO
+
+     IF (ASSOCIATED(CEntryPtr)) THEN
+       IF (CEntryPtr % Index == col) THEN
+         ! Element found, delete it from list and add it to
+         ! the pooled list of deleted entries
+         IF (ASSOCIATED(PEntryPtr)) THEN
+           PEntryPtr % Next => CEntryPtr % Next
+         ELSE
+           ListMatrixArray % Rows(row) % Head => CEntryPtr % Next
+         END IF
+         CALL ListMatrixPool_AddDeletedEntry(ListMatrixArray % Pool(TID), CEntryPtr)
+         
+         ListMatrixArray % Rows(row) % Degree = &
+           MAX(ListMatrixArray % Rows(row) % Degree - 1, 0)
+       END IF
+     END IF
+     
+     CALL ListMatrixArray_UnlockRow(ListMatrixArray, row, Atomic)
+   END SUBROUTINE ListMatrixArray_DeleteEntry
+   
+   !-------------------------------------------------------------------------------
+   !> ListMatrixPool support routines
+   !-------------------------------------------------------------------------------
+   SUBROUTINE ListMatrixPool_Initialize(Pool, PoolSize)
+     IMPLICIT NONE
+     
+     TYPE(ListMatrixPool_t) :: Pool
+     INTEGER, INTENT(IN) :: PoolSize
+     
+     Pool % EntryPool => NULL()
+     Pool % Deleted => NULL()
+     Pool % PoolSize = PoolSize
+     CALL ListMatrixPool_EnLarge(Pool)
+   END SUBROUTINE ListMatrixPool_Initialize
+
+   SUBROUTINE ListMatrixPool_Enlarge(Pool)
+     IMPLICIT NONE
+
+     TYPE(ListMatrixPool_t) :: Pool
+
+     TYPE(ListMatrixEntryPool_t), POINTER :: EntryPool
+
+     INTEGER :: astat
+     
+     ALLOCATE(EntryPool, STAT=astat)
+     IF (astat == 0) ALLOCATE(EntryPool % Entries(Pool % PoolSize), STAT=astat)
+     IF (astat /= 0) THEN
+        CALL Fatal('ListMatrixPool_Enlarge','Pool allocation failed')
+     END IF
+
+     EntryPool % NextIndex = 1
+
+     EntryPool % Next => Pool % EntryPool
+     Pool % EntryPool => EntryPool
+   END SUBROUTINE ListMatrixPool_Enlarge
+
+   SUBROUTINE ListMatrixPool_Free(Pool)
+     IMPLICIT NONE
+
+     TYPE(ListMatrixPool_t) :: Pool
+     TYPE(ListMatrixEntryPool_t), POINTER :: EntryPool, EntryPoolNext
+
+     EntryPool => Pool % EntryPool
+     DO WHILE (ASSOCIATED(EntryPool))
+        EntryPoolNext => EntryPool % Next
+        DEALLOCATE(EntryPool % Entries)
+        DEALLOCATE(EntryPool)
+        EntryPool => EntryPoolNext
+     END DO
+   END SUBROUTINE ListMatrixPool_Free
+
+   FUNCTION ListMatrixPool_GetListEntry(Pool, ind, Next) RESULT(ListEntry)
+     IMPLICIT NONE
+
+     TYPE(ListMatrixPool_t) :: Pool
+     INTEGER, INTENT(IN) :: ind
+     TYPE(ListMatrixEntry_t), POINTER :: Next
+
+     TYPE(ListMatrixEntry_t), POINTER :: ListEntry
+
+     ! Check if deleted entries are available
+     IF (ASSOCIATED(Pool % Deleted)) THEN
+        ListEntry => Pool % Deleted
+        Pool % Deleted => ListEntry % Next
+     ELSE
+        ! No deleted entries available, allocate a new pool if necessary
+        IF (Pool % PoolSize < Pool % EntryPool % NextIndex) THEN
+           CALL ListMatrixPool_Enlarge(Pool)
+        END IF
+        
+        ! Get next element from pool
+        ListEntry => Pool % EntryPool % Entries(Pool % EntryPool % NextIndex)
+        Pool % EntryPool % NextIndex = Pool % EntryPool % NextIndex + 1
+     END IF
+     
+     ListEntry % Index = ind
+     ListEntry % Next => Next
+   END FUNCTION ListMatrixPool_GetListEntry
+
+   SUBROUTINE ListMatrixPool_AddDeletedEntry(Pool, DEntry)
+     IMPLICIT NONE
+
+     TYPE(ListMatrixPool_t) :: Pool
+     TYPE(ListMatrixEntry_t), POINTER :: DEntry
+
+     ! Add new deleted entry to the head of the deleted entries list
+     DEntry % Next => Pool % Deleted
+     Pool % Deleted => DEntry
+   END SUBROUTINE ListMatrixPool_AddDeletedEntry
+
+END MODULE ListMatrixArray
+
+!> \} ElmerLib

--- a/fem/src/Lists.F90
+++ b/fem/src/Lists.F90
@@ -1515,7 +1515,7 @@ CONTAINS
       str = Namespace
     ELSE
       l = .FALSE.
-      str = ''
+!      str = '' ! Namespace string not needed when returning .FALSE.
     END IF
 !------------------------------------------------------------------------------
    END FUNCTION ListGetNamespace

--- a/fem/src/MagnetoDynamicsUtils.F90
+++ b/fem/src/MagnetoDynamicsUtils.F90
@@ -10,7 +10,7 @@
                    CoilBody,CoilType) RESULT (Tcoef)  
 !------------------------------------------------------------------------------
     IMPLICIT NONE
-    REAL(KIND=dp), POINTER :: Cwrk(:,:,:) => Null()
+    REAL(KIND=dp), POINTER :: Cwrk(:,:,:)
     TYPE(Element_t), POINTER :: Element
     INTEGER :: n, i, j
     TYPE(Valuelist_t), POINTER :: Material
@@ -20,6 +20,7 @@
     LOGICAL :: Found
     LOGICAL :: CoilBody
 
+    Cwrk => NULL()
     Tcoef=0._dp
     Material => GetMaterial( Element )
     IF ( ASSOCIATED(Material) ) THEN
@@ -95,7 +96,7 @@
                   RESULT (mu)
 !------------------------------------------------------------------------------
     IMPLICIT NONE
-    REAL(KIND=dp), POINTER :: Cwrk(:,:,:) => Null()
+    REAL(KIND=dp), POINTER :: Cwrk(:,:,:)
     TYPE(Element_t), POINTER :: Element
     INTEGER :: n, i, j
     TYPE(Valuelist_t), POINTER :: Material
@@ -103,6 +104,7 @@
     CHARACTER(LEN=2) :: Part
     LOGICAL :: Found
 
+    Cwrk => NULL()
     mu=0._dp
     Material => GetMaterial( Element )
     IF ( ASSOCIATED(Material) ) THEN
@@ -140,7 +142,7 @@
                   RESULT (T)
 !------------------------------------------------------------------------------
     IMPLICIT NONE
-    REAL(KIND=dp), POINTER :: Cwrk(:,:,:) => Null()
+    REAL(KIND=dp), POINTER :: Cwrk(:,:,:)
     TYPE(Element_t), POINTER :: Element
     INTEGER :: n, i, j, slen, tsize 
     TYPE(Valuelist_t), POINTER :: Material
@@ -149,6 +151,7 @@
     CHARACTER(LEN=*) :: varname
     LOGICAL, OPTIONAL :: Found
 
+    Cwrk => NULL()
     IF (.NOT. ASSOCIATED(Element)) CALL Fatal ('GetTensor', 'Element not associated')
     T=0._dp
     Material => GetMaterial( Element )

--- a/fem/src/Types.F90
+++ b/fem/src/Types.F90
@@ -563,16 +563,36 @@ END INTERFACE
 
 !------------------------------------------------------------------------------
    TYPE ListMatrixEntry_t
-     INTEGER :: INDEX
-     REAL(KIND=dp) :: VALUE
+     INTEGER :: Index
+     REAL(KIND=dp) :: Value
      TYPE(ListMatrixEntry_t), POINTER :: Next
    END TYPE ListMatrixEntry_t
 
+   TYPE ListMatrixEntryPool_t
+      TYPE(ListMatrixEntry_t), ALLOCATABLE :: Entries(:)
+      INTEGER :: NextIndex = 0
+      TYPE(ListMatrixEntryPool_t), POINTER :: Next => NULL()
+   END type ListMatrixEntryPool_t
+
+   TYPE ListMatrixPool_t
+     TYPE(ListMatrixEntryPool_t), POINTER :: EntryPool => NULL()
+     TYPE(ListMatrixEntry_t), POINTER :: Deleted => NULL()
+     INTEGER :: PoolSize = 0
+   END TYPE ListMatrixPool_t
+   
    TYPE ListMatrix_t
      INTEGER :: Degree, Level
      TYPE(ListMatrixEntry_t), POINTER :: Head
    END TYPE ListMatrix_t
 
+   TYPE ListMatrixArray_t
+     TYPE(ListMatrix_t), ALLOCATABLE :: Rows(:)
+     TYPE(ListMatrixPool_t), ALLOCATABLE :: Pool(:)
+#ifdef _OPENMP
+     INTEGER(KIND=omp_lock_kind), ALLOCATABLE :: RowLocks(:)
+#endif
+   END TYPE ListMatrixArray_t
+   
 !------------------------------------------------------------------------------
 
    TYPE Factors_t 
@@ -790,7 +810,7 @@ END INTERFACE
       INTEGER(KIND=AddrInt) :: MortarProc, &
           BoundaryElementProcedure=0, BulkElementProcedure=0
 
-      TYPE(Graph_t), POINTER :: ColourIndexList => NULL()
+      TYPE(Graph_t), POINTER :: ColourIndexList => NULL(), BoundaryColourIndexList => NULL()
       INTEGER :: CurrentColour = 0
       INTEGER :: DirectMethod = DIRECT_NORMAL
       LOGICAL :: GlobalBubbles = .FALSE., DG = .FALSE.

--- a/fem/src/modules/Elmer2OpenFoamIO.F90
+++ b/fem/src/modules/Elmer2OpenFoamIO.F90
@@ -163,14 +163,23 @@ CONTAINS
     
     NoDir = 0
     IF( ParEnv % MyPe /= 0 ) RETURN
-    
-    INQUIRE( File = BaseDir, Exist = FileExists )
+
+#ifdef __INTEL_COMPILER
+    ! Fortran standard states that inquiry for a file returns true if the queried entity is a file
+    INQUIRE( Directory = TRIM(BaseDir), Exist = FileExists )
+#else
+    INQUIRE( File = TRIM(BaseDir), Exist = FileExists )
+#endif
     IF(.NOT. FileExists ) THEN
       CALL Fatal('Elmer2OpenFoamWrite','OpenFOAM directory does not exist: '//TRIM(BaseDir))
     END IF
 
     DirName = TRIM(BaseDir)//'/0/'
+#ifdef __INTEL_COMPILER
+    INQUIRE( Directory = DirName, Exist = FileExists )
+#else
     INQUIRE( File = DirName, Exist = FileExists )
+#endif
     IF(.NOT. FileExists ) THEN
       CALL Fatal('Elmer2OpenFoamWrite','OpenFOAM mesh does not exist: '//TRIM(DirName))
     END IF
@@ -189,7 +198,7 @@ CONTAINS
     DirCommand = 'ls -d '//TRIM(DirName)//'*/ > OpenFOAMBlocks.txt' 
     CALL Info('Elmer2OpenFoamWrite','Performing command: '//TRIM(DirCommand),Level=12)
     CALL SystemCommand( DirCommand )
-      
+
     OPEN(InFileUnit,File='OpenFOAMBlocks.txt',IOStat=IOstatus)
     IF(IOStatus /= 0 ) THEN
       CALL Fatal('Elmer2OpenFoamWrite','Could not open file: OpenFOAMBlocks.txt')

--- a/fem/src/modules/MagnetoDynamics2D.F90
+++ b/fem/src/modules/MagnetoDynamics2D.F90
@@ -433,7 +433,7 @@ CONTAINS
     LOGICAL :: Cubic, HBcurve, Found, Stat
 
     REAL(KIND=dp), POINTER :: Bval(:), Hval(:), Cval(:), &
-      CubicCoeff(:) => NULL(), HB(:,:) => NULL()
+      CubicCoeff(:), HB(:,:)
     TYPE(ValueListEntry_t), POINTER :: Lst
     TYPE(ValueList_t), POINTER :: Material, BodyForce
 
@@ -447,7 +447,8 @@ CONTAINS
     REAL(KIND=dp) :: nu_tensor(2,2)
     REAL(KIND=dp) :: B_ip(2), Alocal
 !------------------------------------------------------------------------------
-
+    CubicCoeff => NULL()
+    HB => NULL()
     CALL GetElementNodes( Nodes,Element )
     STIFF = 0._dp
     JAC  = 0._dp

--- a/fem/src/modules/SaveData/SaveLine.F90
+++ b/fem/src/modules/SaveData/SaveLine.F90
@@ -327,7 +327,7 @@ CONTAINS
 
     IF( PRESENT( NoComponents ) ) NoComponents = k
 
-    CALL Info('VariableGetN','Variable: '//TRIM(VarName)//': '//TRIM(I2S(k)),Level=32)
+    CALL Info('VariableGetN','Variable: '//TRIM(VarName)//': '//TRIM(I2S(k)),Level=31)
  
   END FUNCTION VariableGetN
 

--- a/fhutiter/src/huti_cg.F90
+++ b/fhutiter/src/huti_cg.F90
@@ -287,7 +287,7 @@ contains
     ! Local variables
 
     double precision :: alpha, beta, rho, oldrho
-    integer iter_count
+    integer iter_count, i
     double precision :: residual, rhsnorm, precrhsnorm
 
     !
@@ -328,8 +328,16 @@ contains
 
     call matvecsubr( X, R, ipar )
 
+#ifdef _OPENMP
+    !$OMP PARALLEL DO SIMD
+    do i=1,ndim
+      work(i,R_ind)=rhsvec(i)-work(i,R_ind)
+    end do
+    !$OMP END PARALLEL DO SIMD
+#else
     R = B - R
-
+#endif
+    
     !
     ! This is where the loop starts (that is we continue from here after
     ! the first iteration)
@@ -347,19 +355,50 @@ contains
     end if
 
     if ( iter_count .eq. 1 ) then
+#ifdef _OPENMP
+       !$OMP PARALLEL DO SIMD
+       DO i=1,ndim
+          work(i,P_ind)=work(i,Z_ind)
+       END DO  
+       !$OMP END PARALLEL DO SIMD
+#else
        P = Z
-    else
+#endif
+     else
        beta = rho / oldrho
+#ifdef _OPENMP
+       !$OMP PARALLEL DO SIMD
+       DO i=1,ndim
+          work(i,P_ind)=work(i,Z_ind) + beta * work(i,P_ind)
+       END DO  
+       !$OMP END PARALLEL DO SIMD
+#else
        P = Z + beta * P
+#endif
     end if
 
     call matvecsubr( P, Q, ipar )
 
     alpha = rho / dotprodfun( HUTI_NDIM, P, 1, Q, 1 )
 
+#ifdef _OPENMP
+    !$OMP PARALLEL PRIVATE(i)
+    !$OMP DO SIMD
+    DO i=1,ndim
+       xvec(i) = xvec(i) + alpha * work(i,P_ind)
+    END DO
+    !$OMP END DO SIMD NOWAIT
+    !$OMP DO SIMD
+    DO i=1,ndim
+       work(i,R_ind) = work(i,R_ind) - alpha * work(i,Q_ind)
+    END DO
+    !$OMP END DO SIMD NOWAIT
+    !$OMP END PARALLEL
+#else
     X = X + alpha * P
     R = R - alpha * Q
-
+#endif
+    
     !
     ! Check the convergence against selected stopping criterion
     !
@@ -367,11 +406,27 @@ contains
     select case (HUTI_STOPC)
     case (HUTI_TRUERESIDUAL)
        call matvecsubr( X, Z, ipar )
+#ifdef _OPENMP
+       !$OMP PARALLEL DO SIMD
+       DO i=1,ndim
+         work(i,Z_ind) = work(i,Z_ind) - rhsvec(i)
+       END DO
+       !$OMP END PARALLEL DO SIMD
+#else
        Z = Z - B
+#endif
        residual = normfun( HUTI_NDIM, Z, 1 )
     case (HUTI_TRESID_SCALED_BYB)
        call matvecsubr( X, Z, ipar )
+#ifdef _OPENMP
+       !$OMP PARALLEL DO SIMD
+       DO i=1,ndim
+         work(i,Z_ind) = work(i,Z_ind) - rhsvec(i)
+       END DO
+       !$OMP END PARALLEL DO SIMD
+#else
        Z = Z - B
+#endif
        residual = normfun( HUTI_NDIM, Z, 1 ) / rhsnorm
     case (HUTI_PSEUDORESIDUAL)
        residual = normfun( HUTI_NDIM, R, 1 )
@@ -380,13 +435,29 @@ contains
     case (HUTI_PRESID_SCALED_BYPRECB)
        residual = normfun( HUTI_NDIM, R, 1 ) / precrhsnorm
     case (HUTI_XDIFF_NORM)
+#ifdef _OPENMP
+       !$OMP PARALLEL DO SIMD
+       DO i=1,ndim
+         work(i,Z_ind) = alpha * work(i,P_ind)
+       END DO
+       !$OMP END PARALLEL DO SIMD
+#else
        Z = alpha * P
+#endif   
        residual = normfun( HUTI_NDIM, Z, 1 )
     case (HUTI_USUPPLIED_STOPC)
        residual = stopcfun( X, B, R, ipar, dpar )
     case default
        call matvecsubr( X, Z, ipar )
+#ifdef _OPENMP
+       !$OMP PARALLEL DO SIMD
+       DO i=1,ndim
+         work(i,Z_ind) = work(i,Z_ind) - rhsvec(i)
+       END DO
+       !$OMP END PARALLEL DO SIMD
+#else
        Z = Z - B
+#endif
        residual = normfun( HUTI_NDIM, Z, 1 )
     end select
 


### PR DESCRIPTION
Collection of multithreading improvements. Also some minor fixes regarding code correctness.

Multithreading improvements:

- Added multithreading to HUTI double precision CG algorithm.
- Added partial implementation of **ListMatrixArray** type and module. **ListMatrixArray** which offers the same operations as **ListMatrix** but allows thread safe access per matrix row. **ListMatrixArray** also pools **ListEntry** allocations per thread, which is more time efficient with multiple threads than allocating **ListEntries** one at a time (less locking in the Fortran runtime and OS).
- Modified CreateMatrix to use **ListMatrixArray** and multicoloring when constructing the initial matrix sparsity structure and multithreaded startup is enabled.
- Added partial multithreading to selected matrix scaling routines.
- Added multithreading to matrix bandwidth computation. Bandwidth optimization routines not multithreaded due to serial nature of the used RCM algorithm.

Bug fixes:

- Corrected race conditions arising from implicit SAVE variables from MagnetoDynamicsUtils and MagnetoDynamics.
- Corrected OpenFOAM IO module to work with the Intel Fortran compiler.
- Corrected SaveLine output level to use the maximum of 31
- Corrected uninitialized variable access in ElmerGrid

Misc. improvements:

- Boundary mesh is now also colored in AddEquationBasics when Keyword MultiColour Solver is set to True. Colour index lists for boundary mesh are available in Mesh % BoundaryColourIndexList similarly to regular colour index lists.
- Modified MakePermUsingMask to use List_AllocateMatrix