### PR TITLE
Added GetBulkMaterialAtBoundary subroutine

### DIFF
--- a/fem/src/DefUtils.F90
+++ b/fem/src/DefUtils.F90
@@ -2194,6 +2194,48 @@ CONTAINS
 !------------------------------------------------------------------------------
 
 
+!------------------------------------------------------------------------------
+!> Returns handle to Material value list of the bulk material meeting  
+!> element with larger body id. Typically Element is a boundary element.
+  FUNCTION GetBulkMaterialAtBoundary( Element, Found ) RESULT(Material)
+!------------------------------------------------------------------------------
+    TYPE(Element_t), OPTIONAL :: Element
+    LOGICAL, OPTIONAL :: Found
+
+    TYPE(ValueList_t), POINTER :: Material
+    type(element_t), pointer :: BoundaryElement, BulkElementL, &
+        BulkElementR, BulkElement
+
+    LOGICAL :: L
+    INTEGER :: mat_id, BodyIdL, BodyIdR
+
+    Material => NULL()
+
+    BoundaryElement => GetCurrentElement(Element)
+
+    IF ( .NOT. ASSOCIATED(BoundaryElement % boundaryinfo)) return
+    BulkElementR => BoundaryElement % boundaryinfo % right
+    BulkElementL => BoundaryElement % boundaryinfo % left
+    BodyIdR = 0; BodyIdL = 0
+
+    IF (ASSOCIATED(BulkElementR)) BodyIdR = BulkElementR % BodyId
+    IF (ASSOCIATED(BulkElementL)) BodyIdL = BulkElementL % BodyId
+
+    if (BodyIdR == 0 .and. BodyIdL == 0) return
+    if (BodyIdR > BodyIdL) then
+      BulkElement => BulkElementR
+    end if
+    if (bodyIdL >= BodyIdR) then
+      BulkElement => BulkElementL
+    end if
+
+    mat_id = GetMaterialId( BulkElement, L )
+
+    IF ( L ) Material => CurrentModel % Materials(mat_id) % Values
+    IF ( PRESENT( Found ) ) Found = L
+!------------------------------------------------------------------------------
+  END FUNCTION GetBulkMaterialAtBoundary
+!------------------------------------------------------------------------------
 
 !------------------------------------------------------------------------------
 !> Return handle to the Body Force value list of the active element

--- a/fem/src/modules/VectorHelmholtz.F90
+++ b/fem/src/modules/VectorHelmholtz.F90
@@ -554,12 +554,10 @@ CONTAINS
        n  = GetElementNOFNodes(Element)
        Model % CurrentElement => Element
 
-       Material => GetMaterial(Element % BoundaryInfo % Left)
+       Material => GetBulkMaterialAtBoundary(Element)
        Tcoef = 0.0_dp
+
        IF ( ASSOCIATED(Material) ) THEN
-         CALL GetInvPermeability(Material, Tcoef, n)
-       ELSE
-         Material => GetMaterial(Element % BoundaryInfo % Right)
          CALL GetInvPermeability(Material, Tcoef, n)
        END IF
 


### PR DESCRIPTION
Returns the material of the bulk element meeting given boundary element
that has the larger BodyId. Usable when Neumann/Robin condition depends
on a material parameter given in bulk.