### PR TITLE
ctest: fix in ElasticBeamRestart test

### DIFF
--- a/fem/tests/ElasticBeamRestart/CMakeLists.txt
+++ b/fem/tests/ElasticBeamRestart/CMakeLists.txt
@@ -1,4 +1,3 @@
-INCLUDE(test_macros)
 INCLUDE_DIRECTORIES(${CMAKE_BINARY_DIR}/fem/src)
 
 CONFIGURE_FILE( restart.sif restart.sif COPYONLY)

--- a/fem/tests/ElasticBeamRestart/runtest.cmake
+++ b/fem/tests/ElasticBeamRestart/runtest.cmake
@@ -1,4 +1,4 @@
-INCLUDE(test_macros)
 execute_process(COMMAND ${ELMERGRID_BIN} 1 2 beam2d)
-execute_process(COMMAND ${ELMERSOLVER_BIN} ref.sif)
+# execute_process(COMMAND ${ELMERSOLVER_BIN} ref.sif)
+EXECUTE_ELMER_SOLVER(ref.sif)
 RUN_ELMER_TEST()


### PR DESCRIPTION
Fix `ElasticBeamRestart` too to use `EXECUTE_ELMER_SOLVER` macro.