### PR TITLE
solver: fix in reading command line args and mpi

### DIFF
--- a/fem/src/ElmerSolver.F90
+++ b/fem/src/ElmerSolver.F90
@@ -252,7 +252,7 @@ END INTERFACE
      ! Read input file name either as an argument, or from the default file:
      !----------------------------------------------------------------------
      GotModelName = .FALSE.
-     IF ( ParEnv % PEs <= 1 .AND. NoArgs > 0 ) THEN
+     IF ( NoArgs > 0 ) THEN
 #ifdef USE_ISO_C_BINDINGS
        CALL GET_COMMAND_ARGUMENT(1, ModelName)
 #else


### PR DESCRIPTION
* Read command line arguments when there are more than
  1 MPI task as well. This should make ELMERSOLVER_STARTINFO
  file superfluous.