### PR TITLE
crsmatrix: fixed CONTIG statements in CRSMatrix.F90

### DIFF
--- a/fem/src/CRSMatrix.F90
+++ b/fem/src/CRSMatrix.F90
@@ -2032,9 +2032,9 @@ SUBROUTINE CRS_RowSumInfo( A, Values )
     REAL(KIND=dp), OPTIONAL :: RemoveEps
     !-------------------------------------------------------------------------------------------
     INTEGER :: i,j,k,l,iml,kb,kb0,n,rowkb
-    INTEGER, POINTER :: Cols(:), Rows(:), Diag(:)
+    INTEGER, POINTER CONTIG :: Cols(:), Rows(:), Diag(:)
     REAL(KIND=DP) :: val, imval, reps
-    REAL(KIND=DP), POINTER :: Values(:)
+    REAL(KIND=DP), POINTER CONTIG :: Values(:)
     LOGICAL :: IsComplex, Hit, ImHit, CheckDiag
     
     N = A % NumberOfRows
@@ -3732,9 +3732,9 @@ SUBROUTINE CRS_RowSumInfo( A, Values )
       INTEGER :: i,j,k,l,istat, RowMin, RowMax
       REAL(KIND=dp) :: NORMA
 
-      REAL(KIND=dp), POINTER :: Values(:), ILUValues(:), CWork(:)
+      REAL(KIND=dp), POINTER CONTIG :: Values(:), ILUValues(:), CWork(:)
 
-      INTEGER, POINTER :: Cols(:), Rows(:), Diag(:), &
+      INTEGER, POINTER CONTIG :: Cols(:), Rows(:), Diag(:), &
            ILUCols(:), ILURows(:), ILUDiag(:), IWork(:)
 
       LOGICAL :: C(n)
@@ -3946,10 +3946,10 @@ SUBROUTINE CRS_RowSumInfo( A, Values )
       INTEGER :: i,j,k,l,istat,RowMin,RowMax
       REAL(KIND=dp) :: NORMA
 
-      REAL(KIND=dp), POINTER :: Values(:)
-      COMPLEX(KIND=dp), POINTER :: ILUValues(:), CWork(:)
+      REAL(KIND=dp), POINTER CONTIG :: Values(:)
+      COMPLEX(KIND=dp), POINTER CONTIG :: ILUValues(:), CWork(:)
 
-      INTEGER, POINTER :: Cols(:), Rows(:), Diag(:), &
+      INTEGER, POINTER CONTIG :: Cols(:), Rows(:), Diag(:), &
            ILUCols(:), ILURows(:), ILUDiag(:), IWork(:)
 
       LOGICAL :: C(n)

--- a/fem/src/ListMatrix.F90
+++ b/fem/src/ListMatrix.F90
@@ -172,7 +172,7 @@ CONTAINS
     TYPE(ListMatrix_t), POINTER :: L(:)   
     INTEGER :: i,j,n
     TYPE(ListMatrixEntry_t), POINTER :: P
-    INTEGER, POINTER :: Rows(:),Cols(:),Diag(:)
+    INTEGER, POINTER CONTIG :: Rows(:),Cols(:),Diag(:)
     REAL(KIND=dp), POINTER :: Values(:)
 
     IF( A % FORMAT /= MATRIX_LIST ) THEN


### PR DESCRIPTION
Newer versions of gfortran (8.1 at least) require that RHS of pointer assignment must be `contiguous` if LHS is.