### PR TITLE
Change the MeshGroup and other object naming to fix UNV names

### DIFF
--- a/ElmerWorkflows/FreeCADBatchFEMTools/FreeCADBatchFEMTools.py
+++ b/ElmerWorkflows/FreeCADBatchFEMTools/FreeCADBatchFEMTools.py
@@ -526,7 +526,13 @@ def find_boundaries_with_entities_dict(mesh_object, compound_filter, entities_di
             surface_objs[index_found].References=[(compound_filter, found_cface_names)]
         else:
             # New name, create new MeshGroup
-            surface_objs.append(ObjectsFem.makeMeshGroup(doc, mesh_object, True, face['name']))
+            # The third argument of makeMeshGroup is True, as we want to use face's Labels in VTU, 
+            # not the names, which cannot be changed. 
+            #
+            # WARNING: No other object should have same label than this Mesh Group. 
+            # Otherwise FreeCAD adds numbers to the end of the label to make it unique.
+            surface_objs.append(ObjectsFem.makeMeshGroup(doc, mesh_object, True, face['name']+'_group'))
+            surface_objs[-1].Label=face['name']
             surface_objs[-1].References=[(compound_filter, find_compound_filter_boundary(compound_filter, face['geometric object']))] 
             face_name_list.append(face['name'])
 
@@ -553,7 +559,13 @@ def find_bodies_with_entities_dict(mesh_object, compound_filter, entities_dict, 
             solid_objs[index_found].References=[(compound_filter, found_csolid_names)]
         else:
             # New name, create new MeshGroup
-            solid_objs.append(ObjectsFem.makeMeshGroup(doc, mesh_object, True, solid['name']))
+            # The third argument of makeMeshGroup is True, as we want to use solid's Labels in VTU, 
+            # not the names, which cannot be changed. 
+            #
+            # WARNING: No other object should have same label than this Mesh Group. 
+            # Otherwise FreeCAD adds numbers to the end of the label to make it unique.
+            solid_objs.append(ObjectsFem.makeMeshGroup(doc, mesh_object, True, solid['name']+'_group'))
+            solid_objs[-1].Label=solid['name']
             solid_objs[-1].References=[(compound_filter, find_compound_filter_solid(compound_filter, solid['geometric object']))] 
             solid_name_list.append(solid['name'])
 

--- a/ElmerWorkflows/FreeCADBatchFEMTools/tests/massive_coil/circuits_harmonic_massive/sif/1962.sif
+++ b/ElmerWorkflows/FreeCADBatchFEMTools/tests/massive_coil/circuits_harmonic_massive/sif/1962.sif
@@ -121,21 +121,21 @@ Material 3
 End
 Body 1
    Name = core
-   Target Bodies(1) = $ core001
+   Target Bodies(1) = $ core
    Equation = 1
    Material = 1
    Initial Condition = 1
 End
 Body 2
    Name = air
-   Target Bodies(1) = $ air001
+   Target Bodies(1) = $ air
    Equation = 1
    Material = 2
    Initial Condition = 1
 End
 Body 3
    Name = L1
-   Target Bodies(1) = $ L1001
+   Target Bodies(1) = $ L1
    Equation = 2
    Material = 3
    Initial Condition = 1

--- a/ElmerWorkflows/FreeCADBatchFEMTools/tests/massive_coil/massive_generation.py
+++ b/ElmerWorkflows/FreeCADBatchFEMTools/tests/massive_coil/massive_generation.py
@@ -53,7 +53,7 @@ from FreeCADBatchFEMTools import run_elmergrid
 
 def create_core(h, w, a, b, name, mesh_sizes=None):
     
-    core = doc.addObject('PartDesign::Body',name)
+    core = doc.addObject('PartDesign::Body',name+'_obj')
     sketch = core.newObject('Sketcher::SketchObject',name+' sketch')
     #sketch.Support = (doc.XY_Plane, [''])
     sketch.MapMode = 'FlatFace'
@@ -96,7 +96,7 @@ def create_core(h, w, a, b, name, mesh_sizes=None):
     return entities_out
     
 def create_coil (r, R, h, z, name, face_entities=True, mesh_sizes=None):
-    coil = doc.addObject('PartDesign::Body',name)
+    coil = doc.addObject('PartDesign::Body',name+'_obj')
     sketch = coil.newObject('Sketcher::SketchObject',name+' sketch')
     #sketch.Support = (doc.XY_Plane, [''])
     sketch.MapMode = 'FlatFace'
@@ -140,7 +140,7 @@ def create_air(coil_inner_radius, coil_outer_radius, coil_height, airgap, z, coi
     
     airpluscoil_entities=create_coil(coil_inner_radius-airgap, coil_outer_radius+airgap, coil_height+airgap*2, z, name = "air and coil", face_entities=False)
 	
-    air = doc.addObject("Part::Cut","air")
+    air = doc.addObject("Part::Cut","air"+'_obj')
     air.Base = airpluscoil_entities['main object']
     air.Tool = coil_entities['main object']
     doc.recompute()

--- a/ElmerWorkflows/FreeCADBatchFEMTools/tests/variable_topology/run.sh
+++ b/ElmerWorkflows/FreeCADBatchFEMTools/tests/variable_topology/run.sh
@@ -4,6 +4,8 @@ rm -r variable_topology variable_topology.sif variable_topology.unv scalars.dat*
 
 FreeCAD -c $PWD/variable_topology_generation.py
 
+wait
+
 echo "variable_topology.sif" > ELMERSOLVER_STARTINFO
 ElmerSolver
 


### PR DESCRIPTION
@ettaka : Could you merge this, please!

Previously solid and boundary names could have '001' (or some other number)
added to the end of the UNV solid and boundary names and, hence, in Elmer body and
surface naming. Solved the issue by the renaming original solid objects,
relabeling the MeshGroup and using Labels in VTU export instead of Names.
This required also changes in the sif-files to take into account the corrected
naming.