### PR TITLE
fixed CONTIG attributes in minimal number of cases

### DIFF
--- a/fem/src/BlockSolve.F90
+++ b/fem/src/BlockSolve.F90
@@ -1605,7 +1605,8 @@ CONTAINS
     REAL(KIND=dp), TARGET, INTENT(in) :: v(*)
     INTEGER :: ipar(*)
 !---------------------------------------------------------------------------------
-    REAL(KIND=dp), POINTER :: rtmp(:),vtmp(:),xtmp(:),b(:), x(:), rhs_save(:), a_rhs_save(:)
+    REAL(KIND=dp), POINTER :: rtmp(:),vtmp(:),xtmp(:),b(:), x(:), a_rhs_save(:)
+    REAL(KIND=dp), POINTER CONTIG :: rhs_save(:)
     INTEGER :: i,j,k,l,NoVar
     TYPE(Solver_t), POINTER :: Solver, Solver_save, ASolver
     INTEGER, POINTER :: Offset(:)
@@ -1929,7 +1930,8 @@ CONTAINS
     INTEGER :: i,j,NoVar,RowVar,iter,LinIter,MinIter
     INTEGER, POINTER :: BlockOrder(:)
     LOGICAL :: GotIt, GotBlockOrder, BlockGS
-    REAL(KIND=dp), POINTER :: b(:), rhs_save(:), dx(:)
+    REAL(KIND=dp), POINTER CONTIG :: rhs_save(:), b(:)
+    REAL(KIND=dp), POINTER :: dx(:)
     TYPE(Matrix_t), POINTER :: A, mat_save
     TYPE(Variable_t), POINTER :: Var, SolverVar
     REAL(KIND=dp) :: LinTol, TotNorm, dxnorm, xnorm, Relax
@@ -2335,7 +2337,8 @@ CONTAINS
 !------------------------------------------------------------------------------
     TYPE(Matrix_t), POINTER :: A
     TYPE(Solver_t), TARGET :: Solver
-    REAL(KIND=dp), TARGET :: x(:),b(:)
+    REAL(KIND=dp), TARGET :: x(:)
+    REAL(KIND=dp), TARGET CONTIG :: b(:)
 !------------------------------------------------------------------------------
     TYPE(Solver_t), POINTER :: PSolver
     TYPE(Variable_t), POINTER :: Var
@@ -2346,7 +2349,8 @@ CONTAINS
     REAL(KIND=dp) :: NonlinearTol, Norm, PrevNorm, Residual, PrevResidual, &
         TotNorm, MaxChange, alpha, beta, omega, rho, oldrho, s, r, PrevTotNorm, &
         Coeff
-    REAL(KIND=dp), POINTER :: SaveValues(:), SaveRHS(:)
+    REAL(KIND=dp), POINTER :: SaveValues(:)
+    REAL(KIND=dp), POINTER CONTIG :: SaveRHS(:)
     CHARACTER(LEN=max_name_len) :: str, VarName, ColName, RowName
     LOGICAL :: Robust, LinearSearch, ErrorReduced, IsProcedure, ScaleSystem,&
         ReuseMatrix, LS, BlockScaling

--- a/fem/src/CircuitUtils.F90
+++ b/fem/src/CircuitUtils.F90
@@ -1,4 +1,4 @@
-!/*****************************************************************************/
+
 ! *
 ! *  Elmer, A Finite Element Software for Multiphysical Problems
 ! *
@@ -1713,11 +1713,12 @@ CONTAINS
     IMPLICIT NONE
     TYPE(Matrix_t), POINTER :: CM
     TYPE(Solver_t), POINTER :: ASolver
-    INTEGER, POINTER :: PS(:), Rows(:), Cols(:), Cnts(:)
+    INTEGER, POINTER :: PS(:), Cnts(:)
+    INTEGER, POINTER CONTIG :: Rows(:), Cols(:)
     INTEGER :: nm, Circuit_tot_n, n, i
     LOGICAL :: dofsdone
     LOGICAL*1, ALLOCATABLE :: Done(:)
-    REAL(KIND=dp), POINTER :: Values(:)
+    REAL(KIND=dp), POINTER CONTIG :: Values(:)
 
     ASolver => CurrentModel % Asolver
     IF (.NOT.ASSOCIATED(ASolver)) CALL Fatal('Circuits_MatrixInit','ASolver not found!')

--- a/fem/src/DefUtils.F90
+++ b/fem/src/DefUtils.F90
@@ -3063,7 +3063,8 @@ CONTAINS
 
     TYPE(Matrix_t), POINTER   :: A
     TYPE(Variable_t), POINTER :: x
-    REAL(KIND=dp), POINTER CONTIG :: b(:), SOL(:)
+    REAL(KIND=dp), POINTER CONTIG :: b(:)
+    REAL(KIND=dp), POINTER :: SOL(:)
 
     LOGICAL :: Found, BackRot
 
@@ -3248,7 +3249,7 @@ CONTAINS
      TYPE(Variable_t), POINTER :: x
      TYPE(Element_t), POINTER  :: Element, P1, P2
      REAL(KIND=dp), POINTER CONTIG   :: b(:)
-     REAL(KIND=dp), POINTER :: SaveValues(:)
+     REAL(KIND=dp), POINTER CONTIG :: SaveValues(:)
 
      CHARACTER(LEN=MAX_NAME_LEN) :: str
 
@@ -3452,7 +3453,7 @@ CONTAINS
      TYPE(Matrix_t), POINTER   :: A
      TYPE(Variable_t), POINTER :: x
      TYPE(Element_t), POINTER  :: Element, P1, P2
-     REAL(KIND=dp), POINTER    :: b(:), SaveValues(:)
+     REAL(KIND=dp), POINTER  CONTIG :: b(:), SaveValues(:)
 
      REAL(KIND=dp), POINTER :: G(:,:), F(:)
 
@@ -3761,7 +3762,7 @@ CONTAINS
      TYPE(Variable_t), POINTER :: x
      TYPE(Element_t), POINTER  :: Element, P1, P2
 
-     REAL(KIND=dp),  POINTER :: SaveValues(:)
+     REAL(KIND=dp),  POINTER CONTIG :: SaveValues(:)
 
      INTEGER :: i,j,n
      INTEGER, POINTER :: Indexes(:)
@@ -3827,7 +3828,7 @@ CONTAINS
      TYPE(Element_t), POINTER  :: Element, P1, P2
 
      REAL(KIND=dp), ALLOCATABLE :: M(:,:)
-     REAL(KIND=dp),  POINTER :: SaveValues(:)
+     REAL(KIND=dp),  POINTER CONTIG :: SaveValues(:)
 
      INTEGER :: i,j,n,DOFs
      INTEGER, POINTER :: Indexes(:)
@@ -4040,7 +4041,7 @@ CONTAINS
      TYPE(Variable_t), POINTER :: x
      TYPE(Element_t), POINTER  :: Element, P1, P2
 
-     REAL(KIND=dp), POINTER :: SaveValues(:)
+     REAL(KIND=dp), POINTER CONTIG :: SaveValues(:)
 
      INTEGER :: i,j,n
      INTEGER, POINTER :: Indexes(:)
@@ -4106,7 +4107,7 @@ CONTAINS
      TYPE(Variable_t), POINTER :: x
      TYPE(Element_t), POINTER  :: Element, P1, P2
 
-     REAL(KIND=dp), POINTER :: SaveValues(:)
+     REAL(KIND=dp), POINTER CONTIG :: SaveValues(:)
 
      REAL(KIND=dp), ALLOCATABLE :: B(:,:)
 
@@ -4186,7 +4187,7 @@ CONTAINS
      TYPE(Variable_t), POINTER :: x
      TYPE(Element_t), POINTER  :: Element, P1, P2
 
-     REAL(KIND=dp), POINTER :: SaveValues(:)
+     REAL(KIND=dp), POINTER CONTIG :: SaveValues(:)
 
      INTEGER :: i,j,n
      INTEGER, POINTER :: Indexes(:)
@@ -4259,7 +4260,7 @@ CONTAINS
      TYPE(Variable_t), POINTER :: x
      TYPE(Element_t), POINTER  :: Element, P1, P2
 
-     REAL(KIND=dp), POINTER :: SaveValues(:)
+     REAL(KIND=dp), POINTER CONTIG :: SaveValues(:)
 
      REAL(KIND=dp), ALLOCATABLE :: B(:,:),F(:)
 

--- a/fem/src/EigenSolve.F90
+++ b/fem/src/EigenSolve.F90
@@ -108,7 +108,7 @@ CONTAINS
 
       COMPLEX(KIND=dp) :: s
 !
-      REAL(KIND=dp), POINTER :: SaveValues(:), SaveRhs(:)
+      REAL(KIND=dp), POINTER CONTIG :: SaveValues(:), SaveRhs(:)
       TYPE(ValueList_t), POINTER :: Params
 
 !     %--------------------------------------%
@@ -760,7 +760,7 @@ END SUBROUTINE CheckResiduals
 
       COMPLEX(KIND=dp) :: s
 !
-      REAL(KIND=dp), POINTER :: SaveValues(:)
+      REAL(KIND=dp), POINTER CONTIG :: SaveValues(:)
 
 !     %-----------------------%
 !     | Executable Statements |
@@ -1111,7 +1111,7 @@ END SUBROUTINE CheckResiduals
       REAL(KIND=dp), TARGET :: x(2*n), b(2*n)
       REAL(KIND=dp) :: SigmaR, SigmaI, TOL, RWORK(N)
 !
-      REAL(KIND=dp), POINTER :: SaveValues(:), SaveRhs(:)
+      REAL(KIND=dp), POINTER CONTIG :: SaveValues(:), SaveRhs(:)
 
       TYPE(ValueList_t), POINTER :: Params
 !
@@ -1513,7 +1513,7 @@ END SUBROUTINE CheckResiduals
       COMPLEX(KIND=dp) :: Eigs(:), EigVectors(:,:)
 
       REAL(KIND=dp), ALLOCATABLE, TARGET :: vals(:)
-      REAL(KIND=dp), POINTER :: svals(:)
+      REAL(KIND=dp), POINTER CONTIG :: svals(:)
       COMPLEX(KIND=dp) :: c,m
       COMPLEX(KIND=dp), ALLOCATABLE :: x(:), y(:)
 

--- a/fem/src/ElementUtils.F90
+++ b/fem/src/ElementUtils.F90
@@ -2128,7 +2128,7 @@ CONTAINS
    TYPE(Model_t) :: Model
 ! TARGET only for CurrentElement
    TYPE(Element_t), TARGET :: LineElement
-   REAL(KIND=dp), DIMENSION(:,:), TARGET :: LineElementNodes
+   REAL(KIND=dp), DIMENSION(:,:), TARGET CONTIG :: LineElementNodes
    CHARACTER(LEN=*) :: IntegrandFunctionName
    REAL(KIND=dp) :: Integral
    LOGICAL :: QuadrantTreeExists

--- a/fem/src/Feti.F90
+++ b/fem/src/Feti.F90
@@ -1719,7 +1719,7 @@ END SUBROUTINE FetiProject
 !------------------------------------------------------------------------------
     TYPE(Matrix_t), POINTER :: a
     TYPE(Solver_t) :: Solver
-    REAL(KIND=dp), TARGET :: x(:),b(:)
+    REAL(KIND=dp), TARGET CONTIG :: x(:),b(:)
 !------------------------------------------------------------------------------
     INTEGER :: n
     REAL(KIND=dp), POINTER CONTIG :: tx(:),tb(:)
@@ -1949,8 +1949,9 @@ END SUBROUTINE FetiProject
     EXTERNAL :: AddrFunc
 #endif
 
-    REAL(KIND=dp), POINTER :: SaveValues(:)
-    INTEGER, POINTER :: SaveCols(:),SaveRows(:),p(:)
+    REAL(KIND=dp), POINTER CONTIG :: SaveValues(:)
+    INTEGER, POINTER CONTIG :: SaveCols(:),SaveRows(:)
+    INTEGER, POINTER  :: p(:)
 
     SAVE SaveValues, SaveCols,  SaveRows
 

--- a/fem/src/InterpolateMeshToMesh.F90
+++ b/fem/src/InterpolateMeshToMesh.F90
@@ -547,7 +547,8 @@ CONTAINS
            TryLinear, KeepUnfoundNodesL
        TYPE(Quadrant_t), POINTER :: RootQuadrant
        
-       INTEGER, POINTER   :: Rows(:), Cols(:), Diag(:)
+       INTEGER, POINTER   CONTIG :: Rows(:), Cols(:)
+       INTEGER, POINTER    :: Diag(:)
 
        TYPE Epntr_t
          TYPE(Element_t), POINTER :: Element
@@ -559,7 +560,8 @@ CONTAINS
        LOGICAL :: Found, EpsAbsGiven,EpsRelGiven, MaskExists, ProjectorAllocated
        INTEGER :: eps_tries, nrow, PassiveCoordinate
        REAL(KIND=dp) :: eps1 = 0.1, eps2, eps_global, eps_local, eps_basis,eps_numeric
-       REAL(KIND=dp), POINTER :: Values(:), LocalU(:), LocalV(:), LocalW(:)
+       REAL(KIND=dp), POINTER CONTIG :: Values(:) 
+       REAL(KIND=dp), POINTER :: LocalU(:), LocalV(:), LocalW(:)
 
        TYPE(Nodes_t), SAVE :: Nodes
 

--- a/fem/src/MainUtils.F90
+++ b/fem/src/MainUtils.F90
@@ -3090,7 +3090,8 @@ CONTAINS
         AllDirFlag, Robust, ReduceStep
     INTEGER, POINTER :: Rows(:),Cols(:),Indexes(:),AllPerm(:)
     TYPE(ListMatrix_t), POINTER :: Alist(:) => NULL()
-    REAL(KIND=dp), POINTER :: ForceVector(:),AllValues(:)
+    REAL(KIND=dp), POINTER :: AllValues(:)
+    REAL(KIND=dp), POINTER CONTIG :: ForceVector(:)
     LOGICAL, POINTER :: AllDir(:)
     TYPE (Matrix_t), POINTER :: Amat
     REAL(KIND=dp), POINTER :: Component(:)

--- a/fem/src/MeshUtils.F90
+++ b/fem/src/MeshUtils.F90
@@ -2635,7 +2635,8 @@ END SUBROUTINE GetMaxDefs
    !------------------------------------------------------------------------------    
    SUBROUTINE MapCoordinates()
 
-     REAL(KIND=dp), POINTER :: NodesX(:), NodesY(:), NodesZ(:), Wrk(:,:)
+     REAL(KIND=dp), POINTER CONTIG :: NodesX(:), NodesY(:), NodesZ(:)
+     REAL(KIND=dp), POINTER :: Wrk(:,:)
      INTEGER, POINTER :: CoordMap(:)
      REAL(KIND=dp) :: CoordScale(3)
      INTEGER :: mesh_dim, model_dim
@@ -9922,7 +9923,7 @@ END SUBROUTINE GetMaxDefs
     !--------------------------------------------------------------------------
     TYPE(Mesh_t), POINTER :: Bmesh
     INTEGER :: FlatDim, MeshDim, MinDiffI, i, j
-    REAL(KIND=dp), POINTER :: Coord(:)
+    REAL(KIND=dp), POINTER CONTIG :: Coord(:)
     REAL(KIND=dp) :: Diff, MaxDiff, MinDiff, RelDiff, RelDiff1
     LOGICAL :: Found, ReduceDim
 
@@ -10170,7 +10171,7 @@ END SUBROUTINE GetMaxDefs
     TYPE(Valuelist_t), POINTER :: BParams
     !--------------------------------------------------------------------------
     LOGICAL :: Found
-    REAL(KIND=dp), POINTER :: NodesX(:), NodesY(:), NodesZ(:), Wrk(:,:)
+    REAL(KIND=dp), POINTER CONTIG:: NodesX(:), NodesY(:), NodesZ(:), Wrk(:,:)
     INTEGER, POINTER :: CoordMap(:)
     INTEGER :: MeshNo
     TYPE(Mesh_t), POINTER :: BMesh
@@ -16621,8 +16622,8 @@ CONTAINS
     !---------------------------------------------------------------   
     REAL(KIND=dp) :: R0(3),R1(3),Coeff,Rad0
     LOGICAL :: Irreversible,FirstTime,Reuse,UpdateNodes,Found
-    REAL(KIND=dp), POINTER :: x0(:),y0(:),z0(:),x1(:),y1(:),z1(:), &
-            NewCoords(:)
+    REAL(KIND=dp), POINTER :: x0(:),y0(:),z0(:),x1(:),y1(:),z1(:)
+    REAL(KIND=dp), POINTER CONTIG :: NewCoords(:)
     INTEGER :: i,j,k,n,Mode
     TYPE(Variable_t), POINTER :: Var
 

--- a/fem/src/Multigrid.F90
+++ b/fem/src/Multigrid.F90
@@ -3389,8 +3389,10 @@ CONTAINS
 !------------------------------------------------------------------------------
        INTEGER, PARAMETER :: FSIZE=1000, CSIZE=100
        INTEGER :: i, j, k, l, Fdofs, Cdofs, ind, ci, cj, Component1, Components, node
-       REAL(KIND=dp), POINTER :: PValues(:), FValues(:)
-       INTEGER, POINTER :: FRows(:), FCols(:), PRows(:), PCols(:), CoeffsInds(:)
+       REAL(KIND=dp), POINTER CONTIG :: PValues(:)
+       REAL(KIND=dp), POINTER :: FValues(:)
+       INTEGER, POINTER :: FRows(:), FCols(:), CoeffsInds(:)
+       INTEGER, POINTER CONTIG :: PRows(:), PCols(:)
        REAL(KIND=dp) :: bond, VALUE, possum, negsum, poscsum, negcsum, diagsum, &
            ProjLim, negbond, posbond, maxbond
        LOGICAL :: Debug, AllocationsDone, DirectInterpolate, Lumping
@@ -3906,8 +3908,10 @@ CONTAINS
 !------------------------------------------------------------------------------
        INTEGER, PARAMETER :: FSIZE=1000, CSIZE=100
        INTEGER :: i, j, k, l, Fdofs, Cdofs, ind, ci, cj, Component1, Components, node
-       REAL(KIND=dp), POINTER :: PValues(:), FValues(:)
-       INTEGER, POINTER :: FRows(:), FCols(:), PRows(:), PCols(:), CoeffsInds(:)
+       REAL(KIND=dp), POINTER CONTIG :: PValues(:)
+       REAL(KIND=dp), POINTER :: FValues(:)
+       INTEGER, POINTER :: FRows(:), FCols(:), CoeffsInds(:)
+       INTEGER, POINTER CONTIG :: PRows(:), PCols(:)
        REAL(KIND=dp) :: bond, VALUE, possum, negsum, poscsum, negcsum, diagsum, &
            ProjLim, negbond, posbond, maxbond
        LOGICAL :: Debug, AllocationsDone, DirectInterpolate, Lumping
@@ -4155,8 +4159,10 @@ CONTAINS
 !------------------------------------------------------------------------------
        INTEGER, PARAMETER :: FSIZE=1000, CSIZE=100
        INTEGER :: i, j, k, l, Fdofs, Cdofs, ind, ci, cj, node
-       REAL(KIND=dp), POINTER :: PValues(:), FValues(:)
-       INTEGER, POINTER :: FRows(:), FCols(:), PRows(:), PCols(:), CoeffsInds(:)
+       REAL(KIND=dp), POINTER CONTIG :: PValues(:)
+       REAL(KIND=dp), POINTER :: FValues(:)
+       INTEGER, POINTER :: FRows(:), FCols(:), CoeffsInds(:)
+       INTEGER, POINTER CONTIG :: PRows(:), PCols(:)
        REAL(KIND=dp) :: bond, ProjLim, posbond, maxbond
        LOGICAL :: Debug, AllocationsDone, DirectInterpolate, Lumping
        INTEGER :: inds(FSIZE), posinds(CSIZE), no, diag, InfoNode, posi, &
@@ -5112,7 +5118,8 @@ CONTAINS
     INTEGER, POINTER :: CF(:), InvCF(:), Iters(:)
     
     REAL(KIND=dp), ALLOCATABLE, TARGET :: Residual(:),  Solution2(:)
-    REAL(KIND=dp), POINTER CONTIG :: TmpArray(:,:), Residual2(:)
+    REAL(KIND=dp), POINTER CONTIG :: Residual2(:)
+    REAL(KIND=dp), POINTER :: TmpArray(:,:)
     REAL(KIND=dp) :: ResidualNorm, RHSNorm, Tolerance, ILUTOL, Alpha, Rnorm
 #ifdef USE_ISO_C_BINDINGS
     REAL(KIND=dp) :: tt, tmp

--- a/fem/src/ParallelEigenSolve.F90
+++ b/fem/src/ParallelEigenSolve.F90
@@ -131,7 +131,8 @@ INCLUDE "mpif.h"
       REAL(KIND=dp), TARGET :: Solution(n), Solution_im(n),ForceVector(n)
       REAL(KIND=dp) :: SigmaR, SigmaI, TOL, s, Residual(n), LinConv, ILUTOL
 !
-      REAL(KIND=dp), POINTER :: SaveValues(:), SaveRhs(:)
+      REAL(KIND=dp), POINTER CONTIG ::  SaveRhs(:)
+      REAL(KIND=dp), POINTER :: SaveValues(:)
       CHARACTER(LEN=MAX_NAME_LEN) :: str, Method
 
       INTEGER :: me

--- a/fem/src/SolverUtils.F90
+++ b/fem/src/SolverUtils.F90
@@ -1307,7 +1307,7 @@ CONTAINS
 !------------------------------------------------------------------------------
      INTEGER :: i,j,k
      REAL(KIND=dp) :: s,t
-     REAL(KIND=dp), POINTER  :: SaveValues(:)
+     REAL(KIND=dp), POINTER  CONTIG :: SaveValues(:)
 !------------------------------------------------------------------------------
 !    Check first if this element has been defined passive
 !------------------------------------------------------------------------------
@@ -7477,7 +7477,7 @@ END FUNCTION SearchNodeL
      CHARACTER(LEN=MAX_NAME_LEN) :: Method
      LOGICAL :: GotIt
      INTEGER :: i, Order,ndofs
-     REAL(KIND=dp), POINTER :: Work(:), SaveValues(:)
+     REAL(KIND=dp), POINTER CONTIG :: SaveValues(:)
      TYPE(Matrix_t), POINTER :: A
 
 !------------------------------------------------------------------------------
@@ -10448,7 +10448,8 @@ END FUNCTION SearchNodeL
 
     REAL(KIND=dp), POINTER :: LoadValues(:)
     INTEGER :: i,j,k,l,m,ii,This,DOF
-    REAL(KIND=dp), POINTER :: TempRHS(:), TempVector(:), SaveValues(:), Rhs(:), TempX(:)
+    REAL(KIND=dp), POINTER :: TempRHS(:), TempVector(:), Rhs(:), TempX(:)
+    REAL(KIND=dp), POINTER CONTIG :: SaveValues(:)
     REAL(KIND=dp) :: Energy, Energy_im
     TYPE(Matrix_t), POINTER :: Projector
     LOGICAL :: Found, Rotated
@@ -11873,7 +11874,7 @@ SUBROUTINE SolveConstraintModesSystem( StiffMatrix, Solver )
     TYPE(Variable_t), POINTER :: Var
     INTEGER :: i,j,k,n,m
     LOGICAL :: PrecRecompute, Stat, Found, ComputeFluxes, Symmetric
-    REAL(KIND=dp), POINTER :: PValues(:)
+    REAL(KIND=dp), POINTER CONTIG :: PValues(:)
     REAL(KIND=dp), ALLOCATABLE :: Fluxes(:), FluxesMatrix(:,:)
     !------------------------------------------------------------------------------
     n = StiffMatrix % NumberOfRows
@@ -12861,7 +12862,8 @@ RECURSIVE SUBROUTINE SolveWithLinearRestriction( StiffMatrix, ForceVector, Solut
   TYPE(Matrix_t), POINTER :: CollectionMatrix, RestMatrix, AddMatrix, &
        RestMatrixTranspose, TMat, XMat
   REAL(KIND=dp), POINTER CONTIG :: CollectionVector(:), RestVector(:),&
-     MultiplierValues(:), AddVector(:), Tvals(:), Vals(:)
+     AddVector(:), Tvals(:), Vals(:)
+  REAL(KIND=dp), POINTER  :: MultiplierValues(:)
   REAL(KIND=dp), ALLOCATABLE, TARGET :: CollectionSolution(:), TotValues(:)
   INTEGER :: NumberOfRows, NumberOfValues, MultiplierDOFs, istat, NoEmptyRows 
   INTEGER :: i, j, k, l, m, n, p,q, ix, Loop
@@ -15177,8 +15179,9 @@ CONTAINS
     INTEGER :: n,i,j,k,k2
     INTEGER, POINTER :: Rows(:),Cols(:),Perm(:)
     TYPE(Matrix_t), POINTER :: A
-    REAL(KIND=dp), POINTER :: BulkValues(:),u(:),M_L(:),M_C(:),udot(:),SaveValues(:),&
+    REAL(KIND=dp), POINTER :: BulkValues(:),u(:),M_L(:),udot(:), &
         pp(:),pm(:),qp(:),qm(:),corr(:),ku(:),ulow(:)
+    REAL(KIND=dp), POINTER CONTIG :: M_C(:), SaveValues(:)
     REAL(KIND=dp) :: rsum, Norm,m_ij,k_ij,du,d_ij,f_ij,c_ij,Ceps,CorrCoeff,&
         rmi,rmj,rpi,rpj,dt
     TYPE(Variable_t), POINTER :: Var, Variables

--- a/fem/src/VankaCreate.F90
+++ b/fem/src/VankaCreate.F90
@@ -48,7 +48,7 @@
       TYPE(SplittedMatrixT), POINTER :: SP
       TYPE(Matrix_t), POINTER :: A
       INTEGER :: i
-      REAL(KIND=dp), POINTER :: SaveValues(:)
+      REAL(KIND=dp), POINTER CONTIG :: SaveValues(:)
       TYPE(BasicMatrix_t), POINTER :: SaveIF(:)
 !-------------------------------------------------------------------------------
       A => GlobalMatrix
@@ -97,7 +97,7 @@
      TYPE(Solver_t) :: Solver
 !------------------------------------------------------------------------------
      INTEGER, POINTER :: Diag(:), Rows(:), Cols(:), Perm(:), Indexes(:), Ind(:)
-     REAL(KIND=dp), POINTER :: ILUValues(:), SValues(:), TotValues(:)
+     REAL(KIND=dp), POINTER CONTIG :: ILUValues(:), SValues(:), TotValues(:)
      REAL(KIND=dp), ALLOCATABLE :: al(:,:)
      LOGICAL ::  found
      TYPE(Element_t), POINTER :: Element

--- a/fem/src/modules/CraigBamptonSolver.F90
+++ b/fem/src/modules/CraigBamptonSolver.F90
@@ -88,7 +88,8 @@ SUBROUTINE CraigBamptonSolver( Model,Solver,dt,TransientSimulation )
   LOGICAL :: Found, SaveThis
   TYPE(Solver_t), POINTER :: ESolver
   TYPE(Variable_t), POINTER :: EVar
-  REAL(KIND=dp), POINTER :: x(:), SaveValues(:)
+  REAL(KIND=dp), POINTER :: x(:)
+  REAL (KIND=dp), POINTER CONTIG :: SaveValues(:)
   REAL(KIND=dp), ALLOCATABLE :: Ahat(:,:)
   REAL(KIND=dp), ALLOCATABLE :: Ax(:)
   TYPE(Matrix_t), POINTER :: A

--- a/fem/src/modules/FluxSolver.F90
+++ b/fem/src/modules/FluxSolver.F90
@@ -65,7 +65,7 @@ SUBROUTINE FluxSolver( Model,Solver,dt,Transient )
       EnforcePositiveMagnitude, UsePot
   REAL(KIND=dp) :: Unorm, Totnorm, val
   REAL(KIND=dp), ALLOCATABLE, TARGET :: ForceVector(:,:)
-  REAL(KIND=dp), POINTER :: SaveRHS(:)
+  REAL(KIND=dp), POINTER CONTIG :: SaveRHS(:)
 #ifdef USE_ISO_C_BINDINGS
   REAL(KIND=dp) :: at0,at1,at2
 #else
@@ -403,7 +403,7 @@ CONTAINS
 !      Update global matrices from local matrices 
 !------------------------------------------------------------------------------
       IF ( .NOT. ConstantBulkMatrixInUse ) THEN
-        Solver % Matrix % Rhs => SaveRhs
+        Solver % Matrix % Rhs => SaveRHS
         CALL DefaultUpdateEquations( STIFF, FORCE(1,1:nd) )
       END IF
 

--- a/fem/src/modules/FourierLoss.F90
+++ b/fem/src/modules/FourierLoss.F90
@@ -240,7 +240,8 @@ SUBROUTINE FourierLossSolver( Model,Solver,dt,Transient )
 #endif
   REAL(KIND=dp), ALLOCATABLE :: BodyLoss(:,:), SeriesLoss(:,:), CompLoss(:)
   TYPE(Variable_t), POINTER :: TargetVar, LossVar, NodalLossVar
-  REAL(KIND=dp), POINTER :: TargetField(:), PrevTargetField(:,:), SaveRhs(:)
+  REAL(KIND=dp), POINTER :: TargetField(:), PrevTargetField(:,:)
+  REAL (KIND=dp), POINTER CONTIG :: SaveRhs(:)
   REAL(KIND=dp), ALLOCATABLE, TARGET :: OtherRhs(:,:)
   REAL(KIND=dp) :: TotalLoss
   LOGICAL :: EndCycle, FourierOutput, SimpsonsRule, ExactIntegration, &
@@ -863,7 +864,7 @@ CONTAINS
     
     SAVE Nodes
     
-    SaveRhs => Solver % Matrix % Rhs
+    SaveRHS => Solver % Matrix % Rhs
 
     n = MAX(Solver % Mesh % MaxElementDOFs,Solver % Mesh % MaxElementNodes)
     ALLOCATE( STIFF(n,n), FORCE(ncomp,n), dgForce(n), Pivot(n), Basis(n), dBasisdx(n,3) )

--- a/fem/src/modules/MagnetoDynamics/CalcFields.F90
+++ b/fem/src/modules/MagnetoDynamics/CalcFields.F90
@@ -615,7 +615,8 @@ END SUBROUTINE MagnetoDynamicsCalcFields_Init
    INTEGER, ALLOCATABLE :: Pivot(:), TorqueGroups(:)
    INTEGER, POINTER :: MasterBodies(:)
 
-   REAL(KIND=dp), POINTER :: Fsave(:), HB(:,:)=>NULL(), CubicCoeff(:)=>NULL(), &
+   REAL(KIND=dp), POINTER CONTIG :: Fsave(:)
+   REAL(KIND=dp), POINTER :: HB(:,:)=>NULL(), CubicCoeff(:)=>NULL(), &
      HBBVal(:), HBCval(:), HBHval(:)
    REAL(KIND=dp) :: Babs
    TYPE(Mesh_t), POINTER :: Mesh
@@ -2527,7 +2528,7 @@ CONTAINS
  SUBROUTINE GlobalSol(Var, m, b, dofs )
 !------------------------------------------------------------------------------
    IMPLICIT NONE
-   REAL(KIND=dp), TARGET :: b(:,:)
+   REAL(KIND=dp), TARGET CONTIG :: b(:,:)
    INTEGER :: m, dofs
    TYPE(Variable_t), POINTER :: Var
 !------------------------------------------------------------------------------

--- a/fem/src/modules/MagnetoDynamics2D.F90
+++ b/fem/src/modules/MagnetoDynamics2D.F90
@@ -1909,7 +1909,7 @@ SUBROUTINE Bsolver( Model,Solver,dt,Transient )
   LOGICAL :: GotIt, Visited = .FALSE.
   REAL(KIND=dp) :: Unorm, Totnorm, val
   REAL(KIND=dp), ALLOCATABLE, TARGET :: ForceVector(:,:)
-  REAL(KIND=dp), POINTER :: SaveRHS(:)  
+  REAL(KIND=dp), POINTER CONTIG :: SaveRHS(:)  
   TYPE(Variable_t), POINTER :: FluxSol, HeatingSol, JouleSol, AzSol
   LOGICAL ::  CSymmetry, LossEstimation, JouleHeating, ComplexPowerCompute,&
               AverageBCompute, BodyICompute, BodyVolumesCompute = .FALSE., &
@@ -2560,7 +2560,7 @@ CONTAINS
 !      Update global matrices from local matrices 
 !------------------------------------------------------------------------------
       IF ( .NOT. ConstantBulkMatrixInUse ) THEN
-        Solver % Matrix % Rhs => SaveRhs
+        Solver % Matrix % Rhs => SaveRHS
         CALL DefaultUpdateEquations( STIFF, FORCE(1,1:nd), &
             BulkUpdate=ConstantBulkMatrix )
       END IF

--- a/fem/src/modules/NonphysicalMeshSolve.F90
+++ b/fem/src/modules/NonphysicalMeshSolve.F90
@@ -74,7 +74,7 @@
   REAL(KIND=dp),ALLOCATABLE:: STIFF(:,:),&
        LOAD(:,:),FORCE(:), ElasticModulus(:),PoissonRatio(:), &
 		Alpha(:,:), Beta(:), Gamma(:), RefSurface(:)
-  REAL(KIND=dp), POINTER :: OrigX(:), OrigY(:), OrigZ(:), &
+  REAL(KIND=dp), POINTER CONTIG :: OrigX(:), OrigY(:), OrigZ(:), &
       TrueX(:), TrueY(:), TrueZ(:)
 
   SAVE STIFF, LOAD, FORCE, AllocationsDone, &

--- a/fem/src/modules/NormalSolver.F90
+++ b/fem/src/modules/NormalSolver.F90
@@ -62,7 +62,7 @@ SUBROUTINE NormalSolver( Model,Solver,dt,Transient )
   LOGICAL :: GotIt, Visited = .FALSE., SetD
   REAL(KIND=dp) :: Unorm, Totnorm, nrm
   REAL(KIND=dp), ALLOCATABLE, TARGET :: ForceVector(:,:)
-  REAL(KIND=dp), POINTER  :: SaveRHS(:)
+  REAL(KIND=dp), POINTER  CONTIG :: SaveRHS(:)
 #ifdef USE_ISO_C_BINDINGS
   REAL(KIND=dp) :: at0,at1,at2
 #else

--- a/fem/src/modules/OdeSolver.F90
+++ b/fem/src/modules/OdeSolver.F90
@@ -119,7 +119,7 @@ CONTAINS
     
     TYPE(Matrix_t), POINTER :: A
     INTEGER :: i,j,Dofs
-    REAL(KIND=dp), POINTER :: SaveValues(:)
+    REAL(KIND=dp), POINTER CONTIG :: SaveValues(:)
     REAL(KIND=dp) :: val
     TYPE(ValueList_t), POINTER :: OdeList
     INTEGER, POINTER :: ActiveComponents(:)

--- a/fem/src/modules/ParStokes.F90
+++ b/fem/src/modules/ParStokes.F90
@@ -1863,7 +1863,7 @@ SUBROUTINE ComputeVarLoads(Solver)
     TYPE(Matrix_t), POINTER :: Aaid, Projector
     TYPE(Variable_t), POINTER ::  NodalLoads
 
-    REAL(KIND=dp), POINTER :: SaveValues(:)
+    REAL(KIND=dp), POINTER CONTIG :: SaveValues(:)
     REAL(KIND=dp), ALLOCATABLE :: x(:),TempVector(:), TempRHS(:)
 
     INTEGER :: DOFs

--- a/fem/src/modules/RichardsSolver.F90
+++ b/fem/src/modules/RichardsSolver.F90
@@ -817,7 +817,7 @@ SUBROUTINE RichardsPostprocess( Model,Solver,dt,Transient )
   INTEGER :: i,j,dim,DOFs,ActiveCoordinate
   LOGICAL :: Found, ConstantBulkMatrix, ConstantBulkMatrixInUse, CSymmetry
   REAL(KIND=dp) :: Unorm, Totnorm, FluxMultiplier
-  REAL(KIND=dp), POINTER :: ForceVector(:,:), SaveRHS(:)
+  REAL(KIND=dp), POINTER CONTIG :: ForceVector(:,:), SaveRHS(:)
 #ifdef USE_ISO_C_BINDINGS
   REAL(KIND=dp) :: at0,at1,at2
 #else

--- a/fem/src/modules/RigidBodyReduction.F90
+++ b/fem/src/modules/RigidBodyReduction.F90
@@ -90,7 +90,8 @@ INTEGER FUNCTION RigidBody( Model, Solver, A, b, x, n, DOFs, Norm )
   REAL(KIND=dp), POINTER :: LocalEigenVectors(:,:), ElimDiriEigenVectors(:,:)
   REAL(KIND=dp), POINTER :: CenterOfRigidBody(:,:), NodeOutput(:), NodeTypes(:)
   REAL(KIND=dp), POINTER :: FVector(:), XVector(:)
-  REAL(KIND=dp), POINTER :: f(:), u(:), u2(:)
+  REAL(KIND=dp), POINTER :: u(:), u2(:)
+  REAL(KIND=dp), POINTER CONTIG :: f(:)
 #ifdef USE_ISO_C_BINDINGS
   REAL(KIND=dp) :: TotTime, at, s, val
 #else
@@ -1200,7 +1201,7 @@ CONTAINS
 
     INTEGER, ALLOCATABLE :: RowPerm(:)
     INTEGER, POINTER :: Cols(:), Rows(:), Diag(:)
-    REAL(KIND=dp), POINTER :: Values(:), MassValues(:), DampValues(:)
+    REAL(KIND=dp), POINTER CONTIG :: Values(:), MassValues(:), DampValues(:)
 
 
     Diag   => A % Diag
@@ -1593,8 +1594,9 @@ CONTAINS
     TYPE(Matrix_t), POINTER :: A
     LOGICAL, OPTIONAL :: DoneAlready
 
-    REAL(KIND=dp), POINTER :: Vals(:), MassVals(:), DampVals(:), b(:)
-    INTEGER, POINTER :: Rows(:), Cols(:), Diag(:), RowEntrys(:)
+    REAL(KIND=dp), POINTER CONTIG :: Vals(:) 
+    REAL(KIND=dp), POINTER CONTIG :: MassVals(:), DampVals(:), b(:)
+    INTEGER, POINTER CONTIG :: Rows(:), Cols(:), Diag(:), RowEntrys(:)
     INTEGER, POINTER :: NewPerm(:), NbrNeighbors(:,:), TempCol(:)
     INTEGER :: RowCompleted, RowAdded, Lag, TempMin
     INTEGER :: i, j, k, n, istat

--- a/fem/src/modules/ShearrateSolver.F90
+++ b/fem/src/modules/ShearrateSolver.F90
@@ -118,8 +118,8 @@ SUBROUTINE ShearrateSolver( Model,Solver,dt,Transient )
   LOGICAL :: ConstantBulkMatrix, ConstantBulkMatrixInUse
   LOGICAL :: CalculateViscosity, GotIt
   REAL(KIND=dp) :: Unorm
-  REAL(KIND=dp), POINTER :: ForceVector(:), ViscVector(:), SaveRHS(:), &
-      ShearrateField(:), ViscField(:)
+  REAL(KIND=dp), POINTER CONTIG :: ForceVector(:), ViscVector(:), SaveRHS(:)
+  REAL(KIND=dp), POINTER :: ShearrateField(:), ViscField(:)
   TYPE(Variable_t), POINTER :: ShearrateSol, ViscSol
   LOGICAL :: AllocationsDone = .FALSE. 
 

--- a/fem/src/modules/StatElecSolve.F90
+++ b/fem/src/modules/StatElecSolve.F90
@@ -150,7 +150,8 @@ SUBROUTINE StatElecSolver( Model,Solver,dt,TransientSimulation )
   
   REAL (KIND=DP), POINTER :: ForceVector(:), Potential(:), Displacement(:,:)
   REAL (KIND=DP), POINTER :: Field(:),Flux(:),Energy(:),PermIso(:)
-  REAL (KIND=dp), POINTER :: PValues(:),Charges(:)
+  REAL (KIND=dp), POINTER CONTIG :: PValues(:)
+  REAL (KIND=dp), POINTER :: Charges(:)
   REAL (KIND=DP), POINTER :: Pwrk(:,:,:), Pz_w(:,:,:)
   REAL (KIND=DP), ALLOCATABLE :: CapMatrix(:,:),CapMatrixPara(:,:)
   REAL (KIND=DP), ALLOCATABLE ::  Permittivity(:,:,:), PiezoCoeff(:,:,:), &

--- a/fem/src/modules/StressSolve.F90
+++ b/fem/src/modules/StressSolve.F90
@@ -175,7 +175,8 @@ SUBROUTINE StressSolver_Init( Model,Solver,dt,Transient )
        PrincipalAngle(:), PrincipalAngleComp(:), &            ! needed for principal angle calculation
        PrincipalStressComp(:), PrincipalStrainComp(:), &
        NormalDisplacement(:), TransformMatrix(:,:), UWrk(:,:), &
-       RayleighAlpha(:), RayleighBeta(:), SaveRHS(:)
+       RayleighAlpha(:), RayleighBeta(:)
+     REAL(KIND=dp), POINTER CONTIG :: SaveRHS(:)
 
      REAL(KIND=dp), POINTER :: Displacement(:)
 
@@ -2183,7 +2184,7 @@ CONTAINS
          xp(maxnodes), yp(maxnodes), zp(maxnodes), KmatMin(6,6), KvecAtIP(6), &
          Strain(3,3),Stress(3,3), dFii, Dx, &
          ForceAtIp(3), MomentAtIp(3), Coord(3),Normal(3)
-     REAL(KIND=dp), POINTER :: PValues(:)
+     REAL(KIND=dp), POINTER CONTIG :: PValues(:)
      REAL(KIND=dp), ALLOCATABLE :: NodalLoads(:)
      LOGICAL, POINTER :: NodeVisited(:)
      INTEGER :: N_Integ, pn

--- a/fem/src/modules/VectorHelmholtz.F90
+++ b/fem/src/modules/VectorHelmholtz.F90
@@ -1142,7 +1142,7 @@ END SUBROUTINE VectorHelmholtzCalcFields_Init
 
    INTEGER, ALLOCATABLE :: Pivot(:)
 
-   REAL(KIND=dp), POINTER :: Fsave(:)
+   REAL(KIND=dp), POINTER CONTIG :: Fsave(:)
    TYPE(Mesh_t), POINTER :: Mesh
    REAL(KIND=dp), ALLOCATABLE, TARGET :: Gforce(:,:), MASS(:,:), FORCE(:,:) 
    REAL(KIND=dp), ALLOCATABLE :: BodyLoss(:), RotM(:,:,:)
@@ -1468,7 +1468,7 @@ CONTAINS
 !------------------------------------------------------------------------------
  SUBROUTINE GlobalSol(Var, m, b, dofs )
 !------------------------------------------------------------------------------
-   REAL(KIND=dp), TARGET :: b(:,:)
+   REAL(KIND=dp), TARGET CONTIG :: b(:,:)
    INTEGER :: m, dofs
    TYPE(Variable_t), POINTER :: Var
 !------------------------------------------------------------------------------

--- a/fem/src/modules/VorticitySolver.F90
+++ b/fem/src/modules/VorticitySolver.F90
@@ -62,7 +62,8 @@ SUBROUTINE VorticitySolver( Model,Solver,dt,Transient )
   LOGICAL :: ConstantBulkMatrix, ConstantBulkMatrixInUse, CSymmetry
   LOGICAL :: GotIt, GotCoeff, Visited = .FALSE., DirMask(3)
   REAL(KIND=dp) :: Unorm, Totnorm
-  REAL(KIND=dp), POINTER :: ForceVectors(:,:), ForceVector(:), SaveRHS(:)
+  REAL(KIND=dp), POINTER CONTIG :: SaveRHS(:)
+  REAL(KIND=dp), POINTER CONTIG :: ForceVectors(:,:), ForceVector(:)
 #ifdef USE_ISO_C_BINDINGS
   REAL(KIND=dp) :: at0,at1,at2
 #else

--- a/fem/tests/ModelPDEevol/ModelPDEevol.F90
+++ b/fem/tests/ModelPDEevol/ModelPDEevol.F90
@@ -139,9 +139,9 @@ CONTAINS
 !------------------------------------------------------------------------------
     REAL(KIND=dp), ALLOCATABLE, SAVE :: Basis(:,:),dBasisdx(:,:,:), DetJ(:)
     REAL(KIND=dp), ALLOCATABLE, SAVE :: MASS(:,:), STIFF(:,:), FORCE(:)
-    REAL(KIND=dp), SAVE, POINTER CONTIG :: DiffCoeff(:), ConvCoeff(:), ReactCoeff(:), &
+    REAL(KIND=dp), SAVE, POINTER  :: DiffCoeff(:), ConvCoeff(:), ReactCoeff(:), &
         TimeCoeff(:), SourceCoeff(:), Velo1Coeff(:), Velo2Coeff(:), Velo3Coeff(:)
-    REAL(KIND=dp), SAVE, POINTER CONTIG :: VeloCoeff(:,:)
+    REAL(KIND=dp), SAVE, POINTER  :: VeloCoeff(:,:)
     REAL(KIND=dp) :: Weight
     LOGICAL :: Stat,Found
     INTEGER :: i,t,p,q,dim,ngp,allocstat

--- a/fem/tests/Shell_With_NormalSolver/CylinderNormalSolver.F90
+++ b/fem/tests/Shell_With_NormalSolver/CylinderNormalSolver.F90
@@ -62,7 +62,7 @@ SUBROUTINE NormalSolver( Model,Solver,dt,Transient )
   LOGICAL :: GotIt, Visited = .FALSE., SetD
   REAL(KIND=dp) :: Unorm, Totnorm, nrm
   REAL(KIND=dp), ALLOCATABLE, TARGET :: ForceVector(:,:)
-  REAL(KIND=dp), POINTER  :: SaveRHS(:)
+  REAL(KIND=dp), POINTER  CONTIG  :: SaveRHS(:)
   REAL(KIND=dp) :: at0,at1,at2
 
   TYPE(Variable_t), POINTER :: NrmSol


### PR DESCRIPTION
gfortran 8 requires that target of pointer assignment is `contiguous` if assignee is `contiguous`, which is reasonable since otherwise compiler might illegally assume contiguity of `contiguous` pointer if it was set to point non-contiguous target.