### PR TITLE
Crsvec fix

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -43,6 +43,8 @@ SET(WITH_CONTRIB FALSE CACHE BOOL "Include contributed solvers")
 
 SET(WITH_LUA FALSE CACHE BOOL "Include LUA extensions.")
 
+SET(WITH_Zoltan FALSE CACHE BOOL "Link in Zoltan mesh repartitioning library.")
+
 MARK_AS_ADVANCED(WITH_ELMERPOST)
 
 if("${CMAKE_VERSION}" VERSION_GREATER 2.8.12)
@@ -190,34 +192,35 @@ IF(WITH_Trilinos)
   ENDIF()
 ENDIF()
 
-
-# ZOLTAN Remeshing
-MESSAGE(STATUS "------------------------------------------------")
-MESSAGE(STATUS "Mesh (re)partitioning looking for [Zoltan] tools ")
-
-FIND_PACKAGE(Zoltan)
-
-IF(ZOLTAN_FOUND)
-
-  SET(HAVE_ZOLTAN TRUE CACHE BOOL "Has Zoltan tools for mesh (re)partitioning" )
-  GET_FILENAME_COMPONENT(ZOLTAN_LIBDIR ${ZOLTAN_LIBRARY} DIRECTORY)
-
-  MARK_AS_ADVANCED(HAVE_ZOLTAN)
-  MESSAGE(STATUS "  Zoltan:           " "${ZOLTAN_FOUND}")
-  MESSAGE(STATUS "  Zoltan_INC:       " "${ZOLTAN_INCLUDE_DIR}")
-  MESSAGE(STATUS "  Zoltan_LIB:      " "${ZOLTAN_LIBRARY}")
-  MESSAGE(STATUS "  Zoltan_LIBDIR:      " "${ZOLTAN_LIBDIR}")
-  ADD_DEFINITIONS(-DHAVE_ZOLTAN)
-
-  INCLUDE_DIRECTORIES(${ZOLTAN_INCLUDE_DIR})
+IF(WITH_Zoltan)
+  # ZOLTAN Remeshing
   MESSAGE(STATUS "------------------------------------------------")
+  MESSAGE(STATUS "Mesh (re)partitioning looking for [Zoltan] tools ")
 
-ELSE()
-  MESSAGE(STATUS "  Library not found: >ZOLTAN_FOUND< ")
-  MESSAGE(STATUS "    Missing: >ZOLTAN_INCLUDE_DIR< , >ZOLTAN_LIBRARY< for mesh (re)partitioning")
-ENDIF(ZOLTAN_FOUND)
+  FIND_PACKAGE(Zoltan)
 
-MESSAGE(STATUS "------------------------------------------------")
+  IF(ZOLTAN_FOUND)
+
+    SET(HAVE_ZOLTAN TRUE CACHE BOOL "Has Zoltan tools for mesh (re)partitioning" )
+    GET_FILENAME_COMPONENT(ZOLTAN_LIBDIR ${ZOLTAN_LIBRARY} DIRECTORY)
+
+    MARK_AS_ADVANCED(HAVE_ZOLTAN)
+    MESSAGE(STATUS "  Zoltan:           " "${ZOLTAN_FOUND}")
+    MESSAGE(STATUS "  Zoltan_INC:       " "${ZOLTAN_INCLUDE_DIR}")
+    MESSAGE(STATUS "  Zoltan_LIB:      " "${ZOLTAN_LIBRARY}")
+    MESSAGE(STATUS "  Zoltan_LIBDIR:      " "${ZOLTAN_LIBDIR}")
+    ADD_DEFINITIONS(-DHAVE_ZOLTAN)
+
+    INCLUDE_DIRECTORIES(${ZOLTAN_INCLUDE_DIR})
+    MESSAGE(STATUS "------------------------------------------------")
+
+  ELSE()
+    MESSAGE(STATUS "  Library not found: >ZOLTAN_FOUND< ")
+    MESSAGE(STATUS "    Missing: >ZOLTAN_INCLUDE_DIR< , >ZOLTAN_LIBRARY< for mesh (re)partitioning")
+  ENDIF(ZOLTAN_FOUND)
+
+  MESSAGE(STATUS "------------------------------------------------")
+ENDIF(WITH_Zoltan)
 
 # MMG Remeshing
 MESSAGE(STATUS "------------------------------------------------")

--- a/fem/src/CRSMatrix.F90
+++ b/fem/src/CRSMatrix.F90
@@ -702,8 +702,9 @@ CONTAINS
                     ! Get global matrix index for entry (ri,ci).
 !DIR$ INLINE
                     nidx=GetNextIndex(gja, ci, rli, rti)
-                    Lind(nzind+cdof)=nidx
-                    Lvals(nzind+cdof)=Lmtr(NDOFs*(pind(i)-1)+rdof,&
+                    nzind = nzind + 1
+                    Lind(nzind)=nidx
+                    Lvals(nzind)=Lmtr(NDOFs*(pind(i)-1)+rdof,&
                                            NDOFs*(pind(j)-1)+cdof)
 #ifdef __INTEL_COMPILER
                     ! Issue prefetch for every new cache line of gval(nidx)
@@ -713,7 +714,6 @@ CONTAINS
                     END IF
 #endif
                   END DO
-                  nzind = nzind + cdof
                 END IF
               END DO
             END DO
@@ -754,6 +754,7 @@ CONTAINS
         ! More than 1 DOF per node
 
         ! Construct index array
+        nzind = 0
         DO i=1,N
           DO rdof=1,NDOFs
             ! Row index
@@ -768,9 +769,9 @@ CONTAINS
                 ! Get global matrix index for entry (ri,ci).
 !DIR$ INLINE
                 nidx = GetNextIndex(gja, ci, rli, rti)
-                Lind((NDOFs*N)*(i-1)+NDOFs*(j-1)+cdof)=nidx
-                Lvals((NDOFs*N)*(i-1)+NDOFs*(j-1)+cdof)=Lmtr(NDOFs*(pind(i)-1)+rdof,&
-                                                             NDOFs*(pind(j)-1)+cdof)
+                nzind = nzind + 1
+                Lind(nzind) = nidx
+                Lvals(nzind) = Lmtr(NDOFs*(pind(i)-1)+rdof, NDOFs*(pind(j)-1)+cdof)
 #ifdef __INTEL_COMPILER
                 ! Issue prefetch for every new cache line of gval(nidx)
                 IF (nidx > pnidx+8) THEN
@@ -781,8 +782,6 @@ CONTAINS
               END DO
             END DO
           END DO
-
-          nzind = (NDOFs*N)*(NDOFs*N)
         END DO
       END IF ! NDOFs==1 check
     END IF ! Masking check


### PR DESCRIPTION
There was possibly an indexing bug in `CRS_GlueGlobalMatrixVec` when ndofs > 1 and masking was not needed.

I changed the "masking needed" branch to follow same indexing for consistency.

Please disregard CMakeLists.txt stuff. That's from another commit.