### PR TITLE
ElmerGUI bugs

### DIFF
--- a/ElmerGUI/Application/src/mainwindow.cpp
+++ b/ElmerGUI/Application/src/mainwindow.cpp
@@ -1784,6 +1784,7 @@ void MainWindow::saveProjectContents(QDomDocument projectDoc,
 
   QDomElement editorBlock = projectDoc.createElement(blockName);
   projectDoc.documentElement().appendChild(editorBlock);
+  int index = 0; // index excluding removed DynamicEditor instances
 
   for(int i = 0; i < Nmax; i++) {
     DynamicEditor *de = editor[i];
@@ -1793,7 +1794,7 @@ void MainWindow::saveProjectContents(QDomDocument projectDoc,
 
     // Menu item number:
     QDomElement item = projectDoc.createElement("item");
-    item.setAttribute("index", QString::number(i));
+    item.setAttribute("index", QString::number(index++));
     editorBlock.appendChild(item);
 
     // Is active?
@@ -2759,8 +2760,8 @@ void MainWindow::pdeEditorFinishedSlot(int signal, int id)
     pe->menuAction = NULL;
     pe->close();
 
-    int k = equationEditor.indexOf(pe);
-    if(k>=0) equationEditor.remove(k);
+    pe->ID = -100;
+    pe->nameEdit->setText("***removed***");
 
     logMessage("Equation deleted");
   }
@@ -2901,8 +2902,8 @@ void MainWindow::matEditorFinishedSlot(int signal, int id)
     pe->menuAction = NULL;
     pe->close();
 
-    int k = materialEditor.indexOf(pe);
-    if(k>=0) materialEditor.remove(k);
+    pe->ID = -100;
+    pe->nameEdit->setText("***removed***");
 
     logMessage("Material deleted");
 
@@ -3034,8 +3035,8 @@ void MainWindow::bodyForceEditorFinishedSlot(int signal, int id)
     pe->menuAction = NULL;
     pe->close();
 
-    int k = bodyForceEditor.indexOf(pe);
-    if(k>=0) bodyForceEditor.remove(k);
+    pe->ID = -100;
+    pe->nameEdit->setText("***removed***");
 
     logMessage("Body force deleted");
   }
@@ -3163,8 +3164,8 @@ void MainWindow::initialConditionEditorFinishedSlot(int signal, int id)
     pe->menuAction = NULL;
     pe->close();
     
-    int k = initialConditionEditor.indexOf(pe);
-    if(k>=0) initialConditionEditor.remove(k);
+    pe->ID = -100;
+    pe->nameEdit->setText("***removed***");
 
     logMessage("Initial condition deleted");
   }
@@ -3375,10 +3376,8 @@ void MainWindow::boundaryConditionEditorFinishedSlot(int signal, int id)
     pe->menuAction = NULL;
     pe->close();
 
-    int k = boundaryConditionEditor.indexOf(pe);
-    if(k>=0) {
-        boundaryConditionEditor.remove(k);
-    }
+    pe->ID = -100;
+    pe->nameEdit->setText("***removed***");
 
     logMessage("Boundary condition deleted");
   }

--- a/ElmerGUI/Application/src/mainwindow.cpp
+++ b/ElmerGUI/Application/src/mainwindow.cpp
@@ -5297,18 +5297,11 @@ void MainWindow::surfaceUnifySlot()
   }
   
   int targetindex = -1, selected=0;
-  QVector<BoundaryPropertyEditor*> unusedBoundary;
   for(int i=0; i<lists; i++) {
     list_t *l = glWidget->getList(i);
     if(l->isSelected() && (l->getType() == SURFACELIST) && (l->getNature() == PDE_BOUNDARY)) {
       selected++;
       if(targetindex < 0) targetindex = l->getIndex();
-      else{
-        int v = glWidget->boundaryMap.value(l->getIndex());
-        if(v >= 0 && v < boundaryPropertyEditor.size() && boundaryPropertyEditor[v] != NULL){
-          unusedBoundary.append(v);
-        }
-      }
     }
   }
   
@@ -5338,11 +5331,6 @@ void MainWindow::surfaceUnifySlot()
 	  s->setIndex(targetindex);
       }
     }
-  }
-
-  for(int i=0; i<unusedBoundary.size(); i++){
-    boundaryPropertyEditor.remove(boundaryPropertyEditor.indexOf(unusedBoundary[i]));
-    delete unusedBoundary[i];
   }
   
   cout << "Selected surfaces marked with index " << targetindex << endl;
@@ -5559,18 +5547,11 @@ void MainWindow::edgeUnifySlot()
   }
   
   int targetindex = -1, selected=0;
-  QVector<BoundaryPropertyEditor*> unusedBoundary;
   for(int i=0; i<lists; i++) {
     list_t *l = glWidget->getList(i);
     if(l->isSelected() && l->getType() == EDGELIST && l->getNature() == PDE_BOUNDARY) {
       selected++;
       if(targetindex < 0) targetindex = l->getIndex();
-      else{
-        int v = glWidget->boundaryMap.value(l->getIndex());
-        if(v >= 0 && v < boundaryPropertyEditor.size() && boundaryPropertyEditor[v] != NULL){
-          unusedBoundary.append(v);
-        }
-      }
     }
   }
   
@@ -5601,11 +5582,6 @@ void MainWindow::edgeUnifySlot()
 	  e->setIndex(targetindex);
       }
     }
-  }
-  
-  for(int i=0; i<unusedBoundary.size(); i++){
-    boundaryPropertyEditor.remove(boundaryPropertyEditor.indexOf(unusedBoundary[i]));
-    delete unusedBoundary[i];
   }
   
   cout << "Selected edges marked with index " << targetindex << endl;

--- a/ElmerGUI/Application/src/mainwindow.cpp
+++ b/ElmerGUI/Application/src/mainwindow.cpp
@@ -3373,6 +3373,8 @@ void MainWindow::boundaryConditionEditorFinishedSlot(int signal, int id)
 
        if ( bndry->condition == pe ) {
            bndry->condition=NULL;
+           bndry->ui.boundaryConditionCombo->setCurrentIndex(0);
+           bndry->touched = true;
        }
     }
 

--- a/ElmerGUI/Application/src/mainwindow.cpp
+++ b/ElmerGUI/Application/src/mainwindow.cpp
@@ -5297,11 +5297,18 @@ void MainWindow::surfaceUnifySlot()
   }
   
   int targetindex = -1, selected=0;
+  QVector<BoundaryPropertyEditor*> unusedBoundary;
   for(int i=0; i<lists; i++) {
     list_t *l = glWidget->getList(i);
     if(l->isSelected() && (l->getType() == SURFACELIST) && (l->getNature() == PDE_BOUNDARY)) {
       selected++;
       if(targetindex < 0) targetindex = l->getIndex();
+      else{
+        int v = glWidget->boundaryMap.value(l->getIndex());
+        if(v >= 0 && v < boundaryPropertyEditor.size() && boundaryPropertyEditor[v] != NULL){
+          unusedBoundary.append(boundaryPropertyEditor[v]);
+        }
+      }
     }
   }
   
@@ -5331,6 +5338,11 @@ void MainWindow::surfaceUnifySlot()
 	  s->setIndex(targetindex);
       }
     }
+  }
+
+  for(int i=0; i<unusedBoundary.size(); i++){
+    boundaryPropertyEditor.remove(boundaryPropertyEditor.indexOf(unusedBoundary[i]));
+    delete unusedBoundary[i];
   }
   
   cout << "Selected surfaces marked with index " << targetindex << endl;
@@ -5547,11 +5559,18 @@ void MainWindow::edgeUnifySlot()
   }
   
   int targetindex = -1, selected=0;
+  QVector<BoundaryPropertyEditor*> unusedBoundary;
   for(int i=0; i<lists; i++) {
     list_t *l = glWidget->getList(i);
     if(l->isSelected() && l->getType() == EDGELIST && l->getNature() == PDE_BOUNDARY) {
       selected++;
       if(targetindex < 0) targetindex = l->getIndex();
+      else{
+        int v = glWidget->boundaryMap.value(l->getIndex());
+        if(v >= 0 && v < boundaryPropertyEditor.size() && boundaryPropertyEditor[v] != NULL){
+          unusedBoundary.append(boundaryPropertyEditor[v]);
+        }
+      }
     }
   }
   
@@ -5582,6 +5601,11 @@ void MainWindow::edgeUnifySlot()
 	  e->setIndex(targetindex);
       }
     }
+  }
+  
+  for(int i=0; i<unusedBoundary.size(); i++){
+    boundaryPropertyEditor.remove(boundaryPropertyEditor.indexOf(unusedBoundary[i]));
+    delete unusedBoundary[i];
   }
   
   cout << "Selected edges marked with index " << targetindex << endl;

--- a/ElmerGUI/Application/src/mainwindow.cpp
+++ b/ElmerGUI/Application/src/mainwindow.cpp
@@ -5297,11 +5297,18 @@ void MainWindow::surfaceUnifySlot()
   }
   
   int targetindex = -1, selected=0;
+  QVector<BoundaryPropertyEditor*> unusedBoundary;
   for(int i=0; i<lists; i++) {
     list_t *l = glWidget->getList(i);
     if(l->isSelected() && (l->getType() == SURFACELIST) && (l->getNature() == PDE_BOUNDARY)) {
       selected++;
       if(targetindex < 0) targetindex = l->getIndex();
+      else{
+        int v = glWidget->boundaryMap.value(l->getIndex());
+        if(v >= 0 && v < boundaryPropertyEditor.size() && boundaryPropertyEditor[v] != NULL){
+          unusedBoundary.append(v);
+        }
+      }
     }
   }
   
@@ -5331,6 +5338,11 @@ void MainWindow::surfaceUnifySlot()
 	  s->setIndex(targetindex);
       }
     }
+  }
+
+  for(int i=0; i<unusedBoundary.size(); i++){
+    boundaryPropertyEditor.remove(boundaryPropertyEditor.indexOf(unusedBoundary[i]));
+    delete unusedBoundary[i];
   }
   
   cout << "Selected surfaces marked with index " << targetindex << endl;
@@ -5547,11 +5559,18 @@ void MainWindow::edgeUnifySlot()
   }
   
   int targetindex = -1, selected=0;
+  QVector<BoundaryPropertyEditor*> unusedBoundary;
   for(int i=0; i<lists; i++) {
     list_t *l = glWidget->getList(i);
     if(l->isSelected() && l->getType() == EDGELIST && l->getNature() == PDE_BOUNDARY) {
       selected++;
       if(targetindex < 0) targetindex = l->getIndex();
+      else{
+        int v = glWidget->boundaryMap.value(l->getIndex());
+        if(v >= 0 && v < boundaryPropertyEditor.size() && boundaryPropertyEditor[v] != NULL){
+          unusedBoundary.append(v);
+        }
+      }
     }
   }
   
@@ -5582,6 +5601,11 @@ void MainWindow::edgeUnifySlot()
 	  e->setIndex(targetindex);
       }
     }
+  }
+  
+  for(int i=0; i<unusedBoundary.size(); i++){
+    boundaryPropertyEditor.remove(boundaryPropertyEditor.indexOf(unusedBoundary[i]));
+    delete unusedBoundary[i];
   }
   
   cout << "Selected edges marked with index " << targetindex << endl;

--- a/ElmerGUI/Application/src/mainwindow.cpp
+++ b/ElmerGUI/Application/src/mainwindow.cpp
@@ -2744,8 +2744,11 @@ void MainWindow::pdeEditorFinishedSlot(int signal, int id)
        if(!body)
 	 continue;
        
-       if ( body->equation == pe )
-	 body->equation = NULL;
+       if ( body->equation == pe ){
+         body->equation = NULL;
+         body->ui.equationCombo->setCurrentIndex(0);
+         body->touched = true;
+       }
     }
 
     // Equation is not in menu:
@@ -2886,8 +2889,11 @@ void MainWindow::matEditorFinishedSlot(int signal, int id)
       if(!body)
 	continue;
 
-      if ( body->material == pe )
-	body->material = NULL;
+      if ( body->material == pe ){
+        body->material = NULL;
+        body->ui.materialCombo->setCurrentIndex(0);
+        body->touched = true;
+      }
     }
 
     // Material is not in menu:
@@ -3020,8 +3026,11 @@ void MainWindow::bodyForceEditorFinishedSlot(int signal, int id)
       if(!body)
 	continue;
 
-      if ( body->force == pe )
-	body->force = NULL;
+      if ( body->force == pe ){
+        body->force = NULL;
+        body->ui.bodyForceCombo->setCurrentIndex(0);
+        body->touched = true;
+      }
     }
 
     if(pe->menuAction == NULL) {
@@ -3148,8 +3157,11 @@ void MainWindow::initialConditionEditorFinishedSlot(int signal, int id)
       if(!body)
 	continue;
 
-      if ( body->initial == pe )
-	body->initial = NULL;
+      if ( body->initial == pe ){
+        body->initial = NULL;
+        body->ui.initialConditionCombo->setCurrentIndex(0);
+        body->touched = true;
+      }
     }
 
     // Initial condition is not in menu:


### PR DESCRIPTION
Hi,

This is a proposal to fix some bugs in ElmerGUI.

**1. A bug described in  [a topic in Elmer Discussion Forum](http://www.elmerfem.org/forum/viewtopic.php?f=15&t=2608&p=8725&hilit=improving#p8028)** 
- _removal of boundary conditions or materials (if not last one in list?) leads sometimes to unstable state: boundary conditions / materials cannot be removed any more, boundary condition box will not close. User has to save the project and restart ElmerGUI before continuing to work._

When removing a material (or boundary condition, equation, initial condition, body force - all same), the DynamicEditor instance is removed from MainWindow::materialEditor.  This causes inconsistency between DynamicEditor::ID of other DynamicEditor instances in materialEditor and their position in materialEditor while DynamicEditor::ID is used as the position in materialEditor  like below. (the second argument id in below example is the the ID)

> // signal (int,int) emitted by material editor when ready:
> //-----------------------------------------------------------------------------
> void MainWindow::matEditorFinishedSlot(int signal, int id)
> {
>   DynamicEditor *pe = materialEditor[id];
>   

So, instead of removing from matrialEditor, I put negative number (-100) to DynamicEditor::ID as DynamicEditor instances which have negative ID are always skipped though the program.  However, this change causes a jump in indexes in egproject.xml which crushes ElmerGUI when loading the egproject.xml. So, I added a code to adjust the indexing in MainWindow::saveProjectContents(...) function.


**2. Another bug described in the same topic**

- _after removal of a body force, the removed body force is still written in the sif file. Workaround: save project, restart ElmerGUI._

This happens when generating sif file before BodyPropertyEditor::ui.bodyForceCombo is updated by calling MainWindow::populateBodyComboBoxes(BodyPropertyEditor*). I manually let the combo select 0th item just after the removal in MainWindow::bodyForceEditorFinishedSlot(int, int).  (same for material, equation, initial condition, boundary condition) 


**3. Boundary conditions mixed up when edges/surfaces are unified after attaching boundary conditions to edges/surfaces**
This is caused by redundant (or unused) BoundaryPropertyEditor instances remaining in MainWindow::boundaryPropertyEditor and solved by just removing the redundants in MainWindow::edgeUnifySlot() and MainWindow::surfaceUnifySlot().


Hope this helps improve ElmerGUI. 


Best regards.
Saeki