### PR TITLE
GUI: Removal of auto sif generation and "Use as a body" checkbox

### DIFF
--- a/ElmerGUI/Application/src/boundarypropertyeditor.cpp
+++ b/ElmerGUI/Application/src/boundarypropertyeditor.cpp
@@ -48,6 +48,8 @@ BoundaryPropertyEditor::BoundaryPropertyEditor(QWidget *parent)
   : QDialog(parent)
 {
   ui.setupUi(this);
+  ui.boundaryAsABody->setEnabled(false);
+  ui.boundaryAsABody->setVisible(false);
 
   touched = false;
   condition = NULL;

--- a/ElmerGUI/Application/src/mainwindow.h
+++ b/ElmerGUI/Application/src/mainwindow.h
@@ -144,7 +144,6 @@ private slots:
   void modelClearSlot();                // Model -> Clear
   void generateSifSlot();               // Edit -> Generate sif
   void showsifSlot();                   // Edit -> Solver input file...
-  void suppressAutoSifGenerationSlot(); // Sif -> Auto sif generation
   void editDefinitionsSlot();           // Edit -> Definitions...
   void meshcontrolSlot();               // Mesh -> Control...
   void remeshSlot();                    // Mesh -> Remesh
@@ -351,7 +350,6 @@ private:
   QAction *modelClearAct;                // Model -> Clear
   QAction *generateSifAct;               // Edit -> Generate sif
   QAction *showsifAct;                   // Edit -> Edit SIF...
-  QAction *suppressAutoSifGenerationAct; // Sif -> Auto sif generation
   QAction *editDefinitionsAct;           // Edit -> Edit SIF...
   QAction *viewFullScreenAct;            // View -> Full screen
   QAction *hidesurfacemeshAct;           // View -> Show surface mesh
@@ -537,7 +535,6 @@ private:
   // String to store current project dir for "generate, save and run" button
   QString currentProjectDirName;
 
-  bool suppressAutoSifGeneration;
 
   ObjectBrowser *objectBrowser;
 };

--- a/ElmerGUI/Application/src/sifwindow.cpp
+++ b/ElmerGUI/Application/src/sifwindow.cpp
@@ -220,29 +220,6 @@ SifWindow::SifWindow(QWidget *parent) : QMainWindow(parent) {
   } else if (syntaxHighlighting == SIF_HIGHLIGHTING_DARK) {
     highlightingDarkSlot();
   }
-
-  int x, y, w, h;
-  x = ((MainWindow *)parent)->settings_value("sifWindow/x", -10000).toInt();
-  y = ((MainWindow *)parent)->settings_value("sifWindow/y", -10000).toInt();
-  w = ((MainWindow *)parent)->settings_value("sifWindow/width", -10000).toInt();
-  h = ((MainWindow *)parent)
-          ->settings_value("sifWindow/height", -10000)
-          .toInt();
-  if (x != -10000 && y != -10000 && w != -10000 && h != -10000 &&
-      x < QApplication::desktop()->width() - 100 &&
-      y < QApplication::desktop()->height() - 100) {
-    move(x, y);
-    if (w > QApplication::desktop()->width())
-      w = QApplication::desktop()->width();
-    if (h > QApplication::desktop()->height())
-      h = QApplication::desktop()->height();
-    resize(w, h);
-  }
-  if (((MainWindow *)parent)
-          ->settings_value("sifWindow/maximized", false)
-          .toBool()) {
-    setWindowState(windowState() ^ Qt::WindowMaximized);
-  }
 }
 
 SifWindow::~SifWindow() {}

--- a/ElmerGUI/Application/src/solverlogwindow.cpp
+++ b/ElmerGUI/Application/src/solverlogwindow.cpp
@@ -185,35 +185,6 @@ SolverLogWindow::SolverLogWindow(QWidget *parent) : QMainWindow(parent) {
   } else if (syntaxHighlighting == SOLVERLOG_HIGHLIGHTING_DARK) {
     highlightingDarkSlot();
   }
-
-  int x, y, w, h;
-  x = ((MainWindow *)parent)
-          ->settings_value("solverLogWindow/x", -10000)
-          .toInt();
-  y = ((MainWindow *)parent)
-          ->settings_value("solverLogWindow/y", -10000)
-          .toInt();
-  w = ((MainWindow *)parent)
-          ->settings_value("solverLogWindow/width", -10000)
-          .toInt();
-  h = ((MainWindow *)parent)
-          ->settings_value("solverLogWindow/height", -10000)
-          .toInt();
-  if (x != -10000 && y != -10000 && w != -10000 && h != -10000 &&
-      x < QApplication::desktop()->width() - 100 &&
-      y < QApplication::desktop()->height() - 100) {
-    move(x, y);
-    if (w > QApplication::desktop()->width())
-      w = QApplication::desktop()->width();
-    if (h > QApplication::desktop()->height())
-      h = QApplication::desktop()->height();
-    resize(w, h);
-  }
-  if (((MainWindow *)parent)
-          ->settings_value("solverLogWindow/maximized", false)
-          .toBool()) {
-    setWindowState(windowState() ^ Qt::WindowMaximized);
-  }
 }
 
 SolverLogWindow::~SolverLogWindow() {}


### PR DESCRIPTION
Hi,

This is a proposal for some modification in ElmerGUI

- Removal of auto sif generation during loading/saving project
 Conventional ElmerGUI automatically generate sif when loading/saving project and overwrite existing sif which was annoying. In the past I added a menu to suppress the auto sif generation, but now I want to remove the auto sif generation completely for simplicity.  Instead, users can generate sif file anytime by "Generate" command. or can use "Generate, save and run" command for convenience. 
This is just my preference. If you see any benefit of the auto sif generation, please let me know. 

- Removal of "Use as a body" checkbox  
"Use as a body" shouldn't be for a single boundary but for a boundary condition which can include multiple boundaries. In the future, this checkbox may be moved to DynamicEditor for Boundary Condition, but for now the checbox is just hidden and disabled to avoid misleading users.  

Hope you like it.

Regards,
Saeki




