### PR TITLE
Fix tzdata interactive question in Docker build

### DIFF
--- a/docker/elmerice.dockerfile
+++ b/docker/elmerice.dockerfile
@@ -8,6 +8,8 @@ WORKDIR /home
 RUN printf "Acquire::http::Pipeline-Depth 0;\nAcquire::http::No-Cache true;\nAcquire::BrokenProxy true;" \
 	>> /etc/apt/apt.conf.d/99fixbadproxy
 
+ENV DEBIAN_FRONTEND="noninteractive"
+
 # Add the necessary packages to compile Elmer/Ice
 RUN apt update -o Acquire::CompressionTypes::Order::=gz && apt upgrade -y && apt install -y \
 	build-essential \


### PR DESCRIPTION
If I try to build the docker image using the following command:

```
docker build . -f docker/elmerice.dockerfile
```

Eventually this message appears in the screen:

```
Configuring tzdata
------------------

Please select the geographic area in which you live. Subsequent configuration
questions will narrow this down by presenting a list of cities, representing
the time zones in which they are located.

  1. Africa      4. Australia  7. Atlantic  10. Pacific  13. Etc
  2. America     5. Arctic     8. Europe    11. SystemV
  3. Antarctica  6. Asia       9. Indian    12. US
Geographic area:
```

In order to remove this message, an environment variable should be defined before the `apt` install:

```
ENV DEBIAN_FRONTEND="noninteractive"
```
