### PR TITLE
FIx various typos

### DIFF
--- a/ElmerGUI/Application/edf/linearelasticity.xml
+++ b/ElmerGUI/Application/edf/linearelasticity.xml
@@ -129,7 +129,7 @@ stress. </Whatis>
 
         <Parameter Widget="CheckBox" Enabled="False"> 
             <Name> Fix Displacements </Name>
-            <Whatis> This keyword defined if the displacements or forces are set and thereby chooces the model lumping algorhitm.</Whatis>
+            <Whatis> This keyword defined if the displacements or forces are set and thereby chooces the model lumping algorithm.</Whatis>
         </Parameter>
 
         <Parameter Widget="Label"> <Name> More Options </Name> </Parameter>
@@ -307,7 +307,7 @@ stress. </Whatis>
          <Parameter Widget="Label" > <Name> Properties </Name> </Parameter>
          <Parameter Widget="Edit" >
             <Name>Youngs modulus</Name>
-            <Whatis> The elastic modulus must be given with this keyword. The modulus may be given as a scalar for the isotropic case or as 6 × 6 (3D) or 4 × 4 (2D and axisymmetric) matrix for the anisotropic case. Although the matrices are symmetric, all entries must be given. </Whatis>
+            <Whatis> The elastic modulus must be given with this keyword. The modulus may be given as a scalar for the isotropic case or as 6 ï¿½ 6 (3D) or 4 ï¿½ 4 (2D and axisymmetric) matrix for the anisotropic case. Although the matrices are symmetric, all entries must be given. </Whatis>
          </Parameter>
 
          <Parameter Widget="Edit" >

--- a/ElmerGUI/Application/plugins/egmesh.cpp
+++ b/ElmerGUI/Application/plugins/egmesh.cpp
@@ -5958,7 +5958,7 @@ void CreateKnotsExtruded(struct FemType *dataxy,struct BoundaryType *boundxy,
     printf("CreateKnotsExtruded: not implemented for elementtypes %d!\n",origtype);
     return;
   }
-  printf("Maxium elementtype %d extruded to type %d.\n",origtype,elemtype);
+  printf("Maximum elementtype %d extruded to type %d.\n",origtype,elemtype);
 
   nonodes2d = origtype%100;
   data->maxnodes = nonodes3d = elemtype%100;
@@ -7549,7 +7549,7 @@ void NodesToBoundaryChain(struct FemType *data,struct BoundaryType *bound,
 
   AllocateBoundary(bound,sideelements);
   
-  /* Calculate how may times a node apppears */
+  /* Calculate how may times a node appears */
   possible = Ivector(1,noknots);
   for(i=1;i<=noknots;i++) possible[i] = 0; 
   for(elemind=1;elemind <= data->noelements;elemind++) { 

--- a/ElmerGUI/Application/src/mainwindow.cpp
+++ b/ElmerGUI/Application/src/mainwindow.cpp
@@ -463,7 +463,7 @@ void MainWindow::createActions() {
   saveProjectAsAct = new QAction(QIcon(":/icons/edit-copy.png"),
                                  tr("&Save project as..."), this);
   saveProjectAsAct->setStatusTip(
-      tr("Save current project by specifing directory"));
+      tr("Save current project by specifying directory"));
   connect(saveProjectAsAct, SIGNAL(triggered()), this,
           SLOT(saveProjectAsSlot()));
 
@@ -6965,7 +6965,7 @@ void MainWindow::resultsSlot() {
   QFile file(postName);
   if (!file.exists()) {
     logMessage("Elmerpost input file does not exist.");
-    /*Even though input file does not exist, lauch ElmerPost*/
+    /*Even though input file does not exist, launch ElmerPost*/
     post->start("ElmerPost");
     killresultsAct->setEnabled(true);
     if (!post->waitForStarted()) {

--- a/ElmerGUI/Application/src/meshtype.cpp
+++ b/ElmerGUI/Application/src/meshtype.cpp
@@ -515,7 +515,7 @@ bool mesh_t::load(char* dirName)
       elements_three_d += ntype;
       break;
     default:
-      cout << "Unknown element family (possibly not implamented)" << endl;
+      cout << "Unknown element family (possibly not implemented)" << endl;
       cout.flush();
       return false;
       // exit(0);

--- a/ElmerGUI/Application/src/meshutils.cpp
+++ b/ElmerGUI/Application/src/meshutils.cpp
@@ -1232,7 +1232,7 @@ int Meshutils::divideEdgeBySharpPoints(mesh_t *mesh)
   }
 
   if ( count==0 ) {
-    cout << "No boundary edges to divde." << endl;
+    cout << "No boundary edges to divide." << endl;
     return 0;
   }
 
@@ -1439,7 +1439,7 @@ int Meshutils::divideSurfaceBySharpEdges(mesh_t *mesh)
   }
 
   if ( count==0 ) {
-    cout << "No boundary surfaces to divde." << endl;
+    cout << "No boundary surfaces to divide." << endl;
     return 0;
   }
 

--- a/ElmerGUI/Application/src/objectbrowser.cpp
+++ b/ElmerGUI/Application/src/objectbrowser.cpp
@@ -978,7 +978,7 @@ void ObjectBrowser::treeItemExpandedSlot(
     updateBodyProperties();
     for (int i = 0; i < bodyPropertyParentTreeItem->childCount(); i++)
       bodyPropertyParentTreeItem->child(i)->setExpanded(true);
-    updateBoundaryProperties(); // This was added to avoid crushing when chosing
+    updateBoundaryProperties(); // This was added to avoid crushing when choosing
                                 // body property just after loading 3D mesh
                                 // without expanding boundary condition parent
                                 // item.

--- a/ElmerGUI/LICENSES
+++ b/ElmerGUI/LICENSES
@@ -504,7 +504,7 @@ necessary.  Here is a sample; alter the names:
 
 That's all there is to it!
 
-Lincese tetlib:
+License tetlib:
 ---------------
 
 TetGen License

--- a/elmergrid/src/egextra.c
+++ b/elmergrid/src/egextra.c
@@ -1390,7 +1390,7 @@ int ReadRealVector(Real *vector,int first,int last,char *filename)
   Real num;
     
   if ((in = fopen(filename,"r")) == NULL) {
-    printf("The opening of the real vector file '%s' wasn't succesfull !\n",filename);
+    printf("The opening of the real vector file '%s' wasn't successful !\n",filename);
     return(1);
   }
   for(i=first;i<=last;i++) {
@@ -1427,7 +1427,7 @@ int ReadIntegerVector(int *vector,int first,int last,char *filename)
   int num;
 
   if ((in = fopen(filename,"r")) == NULL) {
-    printf("The opening of the int vector file '%s' wasn't succesfull !\n",filename);
+    printf("The opening of the int vector file '%s' wasn't successful !\n",filename);
     return(1);
   }
   for(i=first;i<=last;i++) {
@@ -1464,7 +1464,7 @@ int ReadRealMatrix(Real **matrix,int row_first,int row_last,
   Real num;
 
   if ((in = fopen(filename,"r")) == NULL) {
-    printf("The opening of the real matrix file '%s' wasn't succesfull!\n",filename);
+    printf("The opening of the real matrix file '%s' wasn't successful!\n",filename);
     return(1);
   }
 
@@ -1508,7 +1508,7 @@ int ReadIntegerMatrix(int **matrix,int row_first,int row_last,
   int num;
 
   if ((in = fopen(filename,"r")) == NULL) {
-    printf("The opening of the int matrix file '%s' wasn't succesfull!\n",filename);
+    printf("The opening of the int matrix file '%s' wasn't successful!\n",filename);
     return(FALSE);
   }
 

--- a/elmergrid/src/egmesh.c
+++ b/elmergrid/src/egmesh.c
@@ -5958,7 +5958,7 @@ void CreateKnotsExtruded(struct FemType *dataxy,struct BoundaryType *boundxy,
     printf("CreateKnotsExtruded: not implemented for elementtypes %d!\n",origtype);
     return;
   }
-  printf("Maxium elementtype %d extruded to type %d.\n",origtype,elemtype);
+  printf("Maximum elementtype %d extruded to type %d.\n",origtype,elemtype);
 
   nonodes2d = origtype%100;
   data->maxnodes = nonodes3d = elemtype%100;
@@ -7549,7 +7549,7 @@ void NodesToBoundaryChain(struct FemType *data,struct BoundaryType *bound,
 
   AllocateBoundary(bound,sideelements);
   
-  /* Calculate how may times a node apppears */
+  /* Calculate how may times a node appears */
   possible = Ivector(1,noknots);
   for(i=1;i<=noknots;i++) possible[i] = 0; 
   for(elemind=1;elemind <= data->noelements;elemind++) { 

--- a/elmerice/Solvers/CalvingRemesh.F90
+++ b/elmerice/Solvers/CalvingRemesh.F90
@@ -3026,7 +3026,7 @@ CONTAINS
     CASE(3)
        Var % Values = Mesh % Nodes % z
     CASE DEFAULT
-       CALL FATAL("Remesh","Problem setting coordinate variable.  This shoudn't have happened.")
+       CALL FATAL("Remesh","Problem setting coordinate variable.  This shouldn't have happened.")
     END SELECT
 
   END SUBROUTINE SetCoordVar

--- a/elmerice/Solvers/Documentation/AdjointStokes_GradientBetaSolver.md
+++ b/elmerice/Solvers/Documentation/AdjointStokes_GradientBetaSolver.md
@@ -32,7 +32,7 @@ If a change of variable is used for the input slip coefficient, the derivative o
 the friction coefficient with respect to your input variable can directly be provided
 in the *Boundary Condition* section. 
 
-Be carefull:  
+Be careful:  
   - **This solver must be executed on the bottom boundary where the slip condition is applied**   
   - **The NormalTangential system has to be used**  
   - **In 3D Slip Coefficient 2 and 3 have to be equal**  

--- a/elmerice/Solvers/Documentation/Adjoint_CostContSolver.md
+++ b/elmerice/Solvers/Documentation/Adjoint_CostContSolver.md
@@ -22,7 +22,7 @@ The variable that contains the derivative must exist.
 To be consistent with other solvers it should be named *velocityb* if the model variable is *Flow Solution* (i.e. solving Stokes) or *ssavelocity* (i.e. solving SSA), or *Varb* for other direct equations (where *Var* is the name of the direct solver variable). 
 It's dimension should be consistent with the dimension of the Model Variable. The derivative of the cost function should also be provided by the user in the Body Force and should provide the exact derivative of the Cost with respect to the given componenet of the direct variable.
 
-Be carefull, this solver will reset the values of the cost and sensitivity to 0; so that it must be used in first place in an assimilation sequence.
+Be careful, this solver will reset the values of the cost and sensitivity to 0; so that it must be used in first place in an assimilation sequence.
 
 In general this solver will be executed on the whole mesh for vertically integrated models or on the upper free surface
 for a 3D model and 2D surface observations.

--- a/elmerice/Solvers/Documentation/Adjoint_CostDiscSolver.md
+++ b/elmerice/Solvers/Documentation/Adjoint_CostDiscSolver.md
@@ -30,7 +30,7 @@ The observations can be given in an ascii or netcdf file.
 
 The model variable can be a scalar or a vector, and the observations can be only the first *n* components of the variable, e.g. in general only the horizontal components of the surface velocity vector are observed.
 
-Be carefull, this solver will reset the values of the cost and sensitivity to 0; so that it must be used in first place in an assimilation sequence.
+Be careful, this solver will reset the values of the cost and sensitivity to 0; so that it must be used in first place in an assimilation sequence.
 
 In general this solver will be executed on the whole mesh for vertically integrated models or on the upper free surface
 for a 3D model and 2D surface observations.

--- a/elmerice/Solvers/Documentation/Adjoint_CostRegSolver.md
+++ b/elmerice/Solvers/Documentation/Adjoint_CostRegSolver.md
@@ -75,7 +75,7 @@ Solver *solver id*
 
 Values for the nodal variable **V** can be given in the body force if  *Optimized Variable Name* was
 not provided in the solver parameters. 
-This can be usefull if we want to apply some change of variable compared to the variable that is optimised,
+This can be useful if we want to apply some change of variable compared to the variable that is optimised,
 However it will be to the user responsability to provide the exact derivative of his change of variable 
 as, by default, the solver computes the derivative with respect to the nodal value.
 In this cas ethe user can directly provide the derivative with the keyword *CostReg Nodal Variable der = Real ...*

--- a/elmerice/Solvers/Documentation/Introduction.md
+++ b/elmerice/Solvers/Documentation/Introduction.md
@@ -40,7 +40,7 @@ Some solvers are model specific.
 
 The following chapters describe solvers specific to compute the gradients (4), and are model specific.
 
-The adjoint codes have been derived by hand as usually the stucture of Elmer is too complex
+The adjoint codes have been derived by hand as usually the structure of Elmer is too complex
 to use  automatic differentiation softwares.
 
 The solvers have been designed to be as generic as possible. A strength of Elmer is its modularity,

--- a/elmerice/Solvers/Documentation/SSA.md
+++ b/elmerice/Solvers/Documentation/SSA.md
@@ -23,7 +23,7 @@ The mandatory input variables are the bottom surface elevation and top surface e
 For the Flow law the SSA solver uses a “power-law” formulation and uses the keywords Viscosity Exponent, Critical Shear Rate, and Mean Viscosity. It doesn't work with the built-in Glen's flow law (TODO).
 Newton linearisation of the viscosity can be used using the keywords Nonlinear System Newton After Tolerance and/or Nonlinear System Newton After Iterations. It is automatically reset to False at the beginning of a new iteration.
 
-The Mean Density and Mean Viscosity, if not uniform along the vertical direction, can be computed using the GetMeanValueSolver routine or the StucturedProjectToPlan solver (preferred solution).
+The Mean Density and Mean Viscosity, if not uniform along the vertical direction, can be computed using the GetMeanValueSolver routine or the StructuredProjectToPlan solver (preferred solution).
 
 Contrary to the NS solver, the gravity must be orientated along the z-axis and is taken from the value of Flow BodyForce 2 for a SSA-1D problem or Flow BodyForce 3 for a SSA-2D problem.
 

--- a/elmerice/Solvers/Documentation/Scattered2DInterpolator.md
+++ b/elmerice/Solvers/Documentation/Scattered2DInterpolator.md
@@ -49,7 +49,7 @@ Solver
   
   Bounding Box dx = Real 1.0e3  
   ! will take only the data points that are within Max/Min mesh corrdinates + the real Value
-  ! can be usefull in parallel if all the data are stored in one file
+  ! can be useful in parallel if all the data are stored in one file
   ! (Default) no bounding box
   
   CheckNaN = Logical True ! Default True; check is interpolation method gives NaN 

--- a/elmerice/Solvers/Documentation/ThicknessSolver.md
+++ b/elmerice/Solvers/Documentation/ThicknessSolver.md
@@ -18,7 +18,7 @@ As for the Free surface solver Min and Max limiters can be used.
 As for the Free surface solver only a Dirichlet boundary condition can be imposed.
 This solver can be used on a mesh of the same dimension as the problem (e.g. solve on the bottom or top boundary of a 3D mesh to solve the 2D thickness field) or on a mesh of lower dimension (e.g. can be use in a 2D plane view mesh with the [SSA solver](./SSA.md) for example).
 
-When working on a mesh of the same dimension as the problem it can be usefull to have an extruded mesh along the vertical direction and to use the StructuredProjectToPlane and StructuredMeshMapper solvers to compute the mean horizontal velocity (from the Stokes solution), export the value of H computed on one boundary in the whole mesh and update the mesh (see examples).
+When working on a mesh of the same dimension as the problem it can be useful to have an extruded mesh along the vertical direction and to use the StructuredProjectToPlane and StructuredMeshMapper solvers to compute the mean horizontal velocity (from the Stokes solution), export the value of H computed on one boundary in the whole mesh and update the mesh (see examples).
 
 ## SIF contents
 Solver section:

--- a/elmerice/Solvers/Permafrost.F90
+++ b/elmerice/Solvers/Permafrost.F90
@@ -7,7 +7,7 @@
 ! *  This program is free software; you can redistribute it and/or
 ! *  modify it under the terms of the GNU General Public License
 ! *  as published by the Free Software Foundation; either version 2
-! *  of the License, or (at your option) asny later version.
+! *  of the License, or (at your option) any later version.
 ! * 
 ! *  This program is distributed in the hope that it will be useful,
 ! *  but WITHOUT ANY WARRANTY; without even the implied warranty of
@@ -560,7 +560,7 @@ CONTAINS
 
       ! unfrozen pore-water content at IP
       SELECT CASE(PhaseChangeModel)
-      CASE('anderson') ! classic simpified Anderson model
+      CASE('anderson') ! classic simplified Anderson model
         XiAtIP(IPPerm) = &
              GetXiAnderson(0.011_dp,-0.66_dp,9.8d-08,&
              CurrentSolventMaterial % rhow0,GlobalRockMaterial % rhos0(RockMaterialID),&

--- a/elmerice/UserFunctions/Documentation/FrictionLoads.md
+++ b/elmerice/UserFunctions/Documentation/FrictionLoads.md
@@ -5,7 +5,7 @@
 - **Required Input Variable(s):** None
 
 ## General Description
-The function getFrictionLoads replaces the old function getFrictionHeat, which still remains in the svn because of compability issues (from **revision 6834** on). It is recommended to switch to this newer version. The two user functions are however different since getFrictionLoads gives a result in W whereas getFrictionHeat gives a result in W/m2. Therefore, they have to be used in a different way (see the sif example).
+The function getFrictionLoads replaces the old function getFrictionHeat, which still remains in the svn because of compatibility issues (from **revision 6834** on). It is recommended to switch to this newer version. The two user functions are however different since getFrictionLoads gives a result in W whereas getFrictionHeat gives a result in W/m2. Therefore, they have to be used in a different way (see the sif example).
 This approach is based on the coupling of surface heat production to the residual of the Stokes solver - the first three components of the residual represent the nodal forces acting on the surface. This is the natural way of coupling in FEM.
 Note, in the case of a restart-run, the (Navier-)Stokes Solver needs to exist in the sif-file (option Exec Solver = Never is sufficient), otherwise the Loads are not found.
 Note, the function has not yet been tested in the case of basal melting, but should be working.

--- a/elmerice/examples/Adjoint_CostRegSolver/Valid_CostRegSolver2.sif
+++ b/elmerice/examples/Adjoint_CostRegSolver/Valid_CostRegSolver2.sif
@@ -46,7 +46,7 @@ End
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 Body Force 1
   ! Nodal Value prescribed here
-  ! can be usefull if we want to make a change of variable
+  ! can be useful if we want to make a change of variable
   CostReg Nodal Variable = Variable Var
    Real procedure "ElmerIceUSF" "TenPowerA"
   ! Provide a function that give teh derivative

--- a/elmerice/examples/Inverse_Methods/DATA/README.md
+++ b/elmerice/examples/Inverse_Methods/DATA/README.md
@@ -28,7 +28,7 @@ ncks -d x,-1515000.0,-535000.0,4 -d y,135000.0,1040000.0,4 antarctica_ice_veloci
 2. In addition to run RonneFilchner2 you need the topography (bedrock and thickness):
 
    - You can get [BedMachine](https://sites.uci.edu/morlighem/dataproducts/bedmachine-antarctica)
-   - It can be usefull to define thickness values in the cells that correspond to the ocean to a novalue so that 
+   - It can be useful to define thickness values in the cells that correspond to the ocean to a novalue so that 
    the interpolation with the [Scattered2DDataInterpolator solver](http://elmerfem.org/elmerice/wiki/doku.php?id=solvers:scattered) will not use these values if a node if close to the front. This can be achieved using nco tools as:
 
 ```

--- a/elmerice/examples/Inverse_Methods/MacAyeal_SSA/RUN.sh
+++ b/elmerice/examples/Inverse_Methods/MacAyeal_SSA/RUN.sh
@@ -21,7 +21,7 @@ DATAFILE="..\/DATA\/MacAyeal_VELOCITIES_NOISE.txt"
 
 rm -rf LCurve.dat
 
-# looop over reg. coefs.
+# loop over reg. coefs.
 c=0
 for i in $lambda
 do
@@ -41,7 +41,7 @@ do
     ElmerSolver
   fi
 
-  # psot process
+  # post process
   python ../SCRIPTS/MakeReport.py $NAME
   echo $(tail -n 1 Cost_"$NAME".dat | awk '{print $3}') $(tail -n 1 CostReg_"$NAME".dat | awk '{print $2}') $i >> LCurve.dat 
 done

--- a/elmerice/examples/Inverse_Methods/MacAyeal_Stokes/README.md
+++ b/elmerice/examples/Inverse_Methods/MacAyeal_Stokes/README.md
@@ -8,7 +8,7 @@ Optimisation of the basal friction coefficient.
 
 - RUN_TWIN_DISC.sh:
 	- twin experiment using the discrete cost function
-	- Be carefull the data file in DATA has been generated with the SSA Solver so the cost will not converge to 0.
+	- Be careful the data file in DATA has been generated with the SSA Solver so the cost will not converge to 0.
 
 
 

--- a/elmerice/examples/Inverse_Methods/MassConservation/GradientValidation/Validation.sif
+++ b/elmerice/examples/Inverse_Methods/MassConservation/GradientValidation/Validation.sif
@@ -76,7 +76,7 @@ Initial Condition 1
   Velocity 2 = Variable USolution 2, r 2
     REAL LUA "tx[0]+tx[1]"
 
-! the perturbation variable for the finite diffence computation
+! the perturbation variable for the finite difference computation
 !  use a random field
   VarP 1 = Variable 20.0, 0.0
     REAL procedure "Random" "Random"

--- a/elmerice/examples/Inverse_Methods/MassConservation/README.md
+++ b/elmerice/examples/Inverse_Methods/MassConservation/README.md
@@ -13,7 +13,7 @@ The example is based on an analytical solution for an ice shelf ramp in 2D, cf *
 
 	- there is a calving front in x=Lx
 
-	- there is no friction and no velocicty accross the side boundaries in y=0 and y=Ly, i.e. uy=0
+	- there is no friction and no velocicty across the side boundaries in y=0 and y=Ly, i.e. uy=0
 
 As there is no lateral variation along y, the velocity and SMB should be identical to the 1D analytical solution
 
@@ -21,7 +21,7 @@ As there is no lateral variation along y, the velocity and SMB should be identic
 
 	- **src** : source codes and inputs to run the tests
 
-	- **DirectValidation** : The SSA solver and thickness solver are validated againt the analytical solution
+	- **DirectValidation** : The SSA solver and thickness solver are validated against the analytical solution
 
 	- **GradientValidation** : Validation of the adjoint based gradient of the steady-state thickness with respect to the velocity field
 

--- a/elmerice/examples/Inverse_Methods/MassConservation/src/MakeMesh.sh
+++ b/elmerice/examples/Inverse_Methods/MassConservation/src/MakeMesh.sh
@@ -4,7 +4,7 @@
 #  from rectangle .geo
 #
 # INPUTS:
-#	- SRC_DIR: environnement variable with the path to this directory
+#	- SRC_DIR: environment variable with the path to this directory
 #	- Arguments:
 #		- $1 : element size
 #		- $2 : output mesh name (.msh) (OPTIONAL)

--- a/elmerice/examples/Inverse_Methods/MassConservation/src/Makefile
+++ b/elmerice/examples/Inverse_Methods/MassConservation/src/Makefile
@@ -1,4 +1,4 @@
-# define the environnement variable SRC_DIR
+# define the environment variable SRC_DIR
 LIBS= RAMP Random
       
 all: $(LIBS)

--- a/elmerice/examples/Inverse_Methods/RonneFilchner2_SSA/SIF/Physical_Params.IN
+++ b/elmerice/examples/Inverse_Methods/RonneFilchner2_SSA/SIF/Physical_Params.IN
@@ -1,5 +1,5 @@
 !#############################################################
-! A list of usefull constants for ice-sheet simulations
+! A list of useful constants for ice-sheet simulations
 !  - Can be included in elmer configuration .sif files using
 !       include PATH_TO/Physical_Params.IN 
 !  - Unit System =
@@ -8,7 +8,7 @@
 !     -- MPa
 !#############################################################
 
-!## Convertion factor year to seconds
+!## Conversion factor year to seconds
 $yearinsec = 31556926.0
 
 !## Ice density

--- a/elmerice/examples/Inverse_Methods/SCRIPTS/README.md
+++ b/elmerice/examples/Inverse_Methods/SCRIPTS/README.md
@@ -1,5 +1,5 @@
 
-This directory contains python scripts taht can be used to post-process the simulations:
+This directory contains python scripts that can be used to post-process the simulations:
 
 - MakeReport.py: create a pdf report from the inverse method output files to check convergence
 - PlotHist.py:   Make histogram plots from inverse methods results

--- a/elmerice/examples/Inverse_Methods/src/README.md
+++ b/elmerice/examples/Inverse_Methods/src/README.md
@@ -3,4 +3,4 @@ This directory contains user functions for elmer used in the simulation
 
 - MacAyeal_USFs.F90 : a collection of user functions that implement the definition of various variable for the Mac Ayeal test case.
 
-- USFs_RonneFilchner.F90: User function for Ronne-Filchner test case to impose Conditionnal Dirichlet conditions  for Grounded ice.
+- USFs_RonneFilchner.F90: User function for Ronne-Filchner test case to impose Conditional Dirichlet conditions for Grounded ice.

--- a/elmerice/examples/Inverse_Methods/src/USFs_RonneFilchner.F90
+++ b/elmerice/examples/Inverse_Methods/src/USFs_RonneFilchner.F90
@@ -1,6 +1,6 @@
 !#
 !# A User function for Ronne-Filchner test case;
-!# to impose Conditionnal Dirichlet conditions only for Grounded ice and GL
+!# to impose Conditional Dirichlet conditions only for Grounded ice and GL
 !#   VarIn=GroundedMask (-1 : for floating ice; 0 : for GL; 1: for grounded ice)
 !#   Varout return a positive value for Grounded ice and GL
        FUNCTION GM_CONDITION(Model,nodenumber,VarIn) RESULT(VarOut)

--- a/elmerice/examples/Test_SurfaceBoundaryEnth/SteadyEnthalpyField.sif
+++ b/elmerice/examples/Test_SurfaceBoundaryEnth/SteadyEnthalpyField.sif
@@ -47,7 +47,7 @@ Constants
   !PrecipFile = File "Data/temp_rikha.csv"  !Contain daily precipitation (optional)
     
   Precip = real 0.300  		!Mean annual precipitation if PrecipFile not provided
-  TempCorrec= real -0.12	!Possibility of shifting temperature to get steady state mass balance for exemple (optional)
+  TempCorrec= real -0.12	!Possibility of shifting temperature to get steady state mass balance for example (optional)
   PrecipCorrec = real 1.0	!Possibility of adding a correcting factor on precipitation if PrecipFile provided (optional)
   
   GradTemp = real 0.0065	!Air temperature Lapse Rate (K m^-1)

--- a/fem/src/ElmerSolver.F90
+++ b/fem/src/ElmerSolver.F90
@@ -159,7 +159,7 @@ END INTERFACE
            i = i + 1 
            CALL GET_COMMAND_ARGUMENT(i, OptionString)
            IF( OptionString=='-rpar' ) THEN
-             ! Followed by number of paramters + the parameter values
+             ! Followed by number of parameters + the parameter values
              i = i + 1
              CALL GET_COMMAND_ARGUMENT(i, OptionString)
              READ( OptionString,*) nr             
@@ -174,7 +174,7 @@ END INTERFACE
            END IF
 
            IF( OptionString=='-ipar' ) THEN
-             ! Followed by number of paramters + the parameter values
+             ! Followed by number of parameters + the parameter values
              i = i + 1
              CALL GET_COMMAND_ARGUMENT(i, OptionString)
              READ( OptionString,*) ni             
@@ -2035,17 +2035,17 @@ END INTERFACE
          
        END DO
      END IF
- 
+
      ! Do the standard global restart
      !-----------------------------------------------------------------
      RestartList => CurrentModel % Simulation
 
-     ! We may supress restart from certain meshes.
-     ! This was initially only related to calving, but no need to limit to that. 
+     ! We may suppress restart from certain meshes.
+     ! This was initially only related to calving, but no need to limit to that.
      l = 0
      MeshesToRestart => ListGetIntegerArray(RestartList,&
          'Meshes To Restart', CheckMesh )
-     
+
      RestartFile = ListGetString( RestartList, 'Restart File', GotIt )
      IF ( GotIt ) THEN      
        k = ListGetInteger( RestartList,'Restart Position',GotIt, minv=0 )
@@ -2941,7 +2941,7 @@ END INTERFACE
         Mesh => Mesh % Next
       END DO
     END IF
-! We want to seprate saving of ElmerPost file and Result file.    
+! We want to separate saving of ElmerPost file and Result file.
 !    CALL SaveToPost(CurrentStep)
 !------------------------------------------------------------------------------
   END SUBROUTINE SaveCurrent

--- a/fem/src/ExchangeCorrelations.F90
+++ b/fem/src/ExchangeCorrelations.F90
@@ -387,7 +387,7 @@ CONTAINS
                                                                         
 !                                                                       
 !     Perdew & Wang (1992) correlation energy (Energies are in hartree) 
-!     Exhange energy is added                                           
+!     Exchange energy is added                                           
 !     J. P. Perdew and Y. Wang, Phys. Rev. B 45,13244 (1992).           
 !                                                                       
       FUNCTION excpw (n, s) 

--- a/fem/src/InterpVarToVar.F90
+++ b/fem/src/InterpVarToVar.F90
@@ -235,7 +235,7 @@ CONTAINS
           IF ( Parenv % mype == i-1 .OR. .NOT. ParEnv % Active(i) ) CYCLE
           proc = i-1
           ! extract those of the missing nodes that are within the other
-          ! partions bounding box:
+          ! partitions bounding box:
           ! --------------------------------------------------------
           myBB = BB(:,i) !Actually theirBB, but saves var names...
           npart = 0

--- a/fem/src/InterpolateMeshToMesh.F90
+++ b/fem/src/InterpolateMeshToMesh.F90
@@ -190,7 +190,7 @@
           proc = i-1
 
           ! extract those of the missing nodes that are within the other
-          ! partions bounding box:
+          ! partitions bounding box:
           ! ------------------------------------------------------------
           myBB = BB(:,i)
           npart = 0

--- a/fem/src/MainUtils.F90
+++ b/fem/src/MainUtils.F90
@@ -3236,7 +3236,7 @@ CONTAINS
 !> This is a line of monolithic solvers where different physics and constraints 
 !> are assemblied to the same matrix.
 !> Provide assembly loop and solution of linear and nonlinear systems
-!> This routine uses minimalistic assmebly routines to create the 
+!> This routine uses minimalistic assembly routines to create the 
 !> matrices. Often the results to less labour in coding which may be 
 !> comprimized by less flexibility.
 ! 

--- a/fem/src/MeshUtils.F90
+++ b/fem/src/MeshUtils.F90
@@ -5656,7 +5656,7 @@ CONTAINS
             
       DO ind=1,BMesh1 % NumberOfBulkElements        
         
-        ! Optionally save the submesh for specified element, for vizualization and debugging
+        ! Optionally save the submesh for specified element, for visualization and debugging
         SaveElem = ( SaveInd == ind )
         DebugElem = ( DebugInd == ind )
 
@@ -9073,7 +9073,7 @@ CONTAINS
               
       DO ind=1,BMesh1 % NumberOfBulkElements
 
-        ! Optionally save the submesh for specified element, for vizualization and debugging
+        ! Optionally save the submesh for specified element, for visualization and debugging
         SaveElem = ( SaveInd == ind )
         DebugElem = ( DebugInd == ind )
 
@@ -10238,7 +10238,7 @@ CONTAINS
 
       DO ind=1,BMesh1 % NumberOfBulkElements
 
-        ! Optionally save the submesh for specified element, for vizualization and debugging
+        ! Optionally save the submesh for specified element, for visualization and debugging
         SaveElem = ( SaveInd == ind )
 
         Element => BMesh1 % Elements(ind)        
@@ -22148,7 +22148,7 @@ CONTAINS
     arr(n+1)=arr(n)+indi
   END SUBROUTINE ComputeCRSIndexes
 
-  !> Calcalate body average for a discontinuous galerkin field.
+  !> Calculate body average for a discontinuous galerkin field.
   !> The intended use is in conjunction of saving the results. 
   !> This tampers the field and therefore may have unwanted side effects
   !> if the solution is to be used for something else too.

--- a/fem/src/ModelDescription.F90
+++ b/fem/src/ModelDescription.F90
@@ -3140,7 +3140,7 @@ CONTAINS
     END DO
 
 
-    ! This is intended to simplify the setting up of command file for structure-stucture
+    ! This is intended to simplify the setting up of command file for structure-structure
     ! coupling. In effect only one keyword should be needed for the coupling.
     ! This hack is of course prone to errors if the underlaying assumptions change. 
     DO i=1,Model % NumberOfSolvers
@@ -5973,12 +5973,12 @@ END SUBROUTINE GetNodalElementSize
      PRINT *,'Parameters:',NoParam,Param
    END IF
 
-   ! Set parametes to be accessible to the MATC preprocessor when reading sif file. 
+   ! Set parameters to be accessible to the MATC preprocessor when reading sif file.
    CALL SetRealParametersMATC(NoParam,Param)
 
    CALL Info(Caller, '-----------------------------------------', Level=5 )
 
-   
+
  CONTAINS
 
 

--- a/fem/src/SolverUtils.F90
+++ b/fem/src/SolverUtils.F90
@@ -11346,7 +11346,7 @@ END FUNCTION SearchNodeL
     LOGICAL :: PreSolve
     LOGICAL, OPTIONAL :: NoSolve
     !------------------------------------------------------------------------------
-    ! We have a special stucture for the iterates and residuals so that we can
+    ! We have a special structure for the iterates and residuals so that we can
     ! cycle over the pointers instead of the values. 
     TYPE AndersonVect_t
       LOGICAL :: Additive
@@ -14042,7 +14042,7 @@ END FUNCTION SearchNodeL
 
       CALL LinearSystemResidual( A, b, x, res )
       bb => res
-      ! Set the initial guess for the redidual system to zero
+      ! Set the initial guess for the residual system to zero
       x = 0.0_dp
     ELSE
       bb => b
@@ -16754,7 +16754,7 @@ CONTAINS
     END IF
 
     IF(.NOT. ASSOCIATED( A ) ) THEN
-      CALL Fatal(Caller,'Matrix not assciated!')
+      CALL Fatal(Caller,'Matrix not associated!')
     END IF
 
     SaveMass = ListGetLogical( Params,'Linear System Save Mass',Found)
@@ -20622,7 +20622,7 @@ CONTAINS
          nd = LEN_TRIM(OutputDirectory)
        END IF
        ! To be on the safe side create the directory. If it already exists no harm done.
-       ! Note that only one direcory may be created. Hence if there is a path with many subdirectories
+       ! Note that only one directory may be created. Hence if there is a path with many subdirectories
        ! that will be a problem. Fortran does not have a standard ENQUIRE for directories hence
        ! we just try to make it. 
        IF( DoDir ) THEN

--- a/fem/src/modules/CoilSolver.F90
+++ b/fem/src/modules/CoilSolver.F90
@@ -617,7 +617,7 @@ CONTAINS
          k = Cols(j)
          s2 = Set(k)
          IF( s1 * s2 < 0 ) THEN
-           ! The diagonal needs also to be compensated for the cutted connections.
+           ! The diagonal needs also to be compensated for the cut connections.
            ! For Laplace operator the row sum is known to be zero. 
            A % BulkValues(dia) = A % BulkValues(dia) + A % BulkValues(j)
            A % BulkValues(j) = 0.0_dp

--- a/fem/src/modules/DCRComplexSolve.F90
+++ b/fem/src/modules/DCRComplexSolve.F90
@@ -205,7 +205,7 @@ SUBROUTINE DCRComplexSolver( Model,Solver,dt,TransientSimulation )
      CALL Info( 'DCRComplexSolve', Message, Level=4 )
      CALL Info( 'DCRComplexSolve', '-------------------------------------', Level=4 )
      CALL Info( 'DCRComplexSolve', ' ', Level=4 )
-     CALL Info( 'DCRComplexSolve', 'Starting Assmebly', Level=4 )
+     CALL Info( 'DCRComplexSolve', 'Starting Assembly', Level=4 )
 
      CALL InitializeToZero( StiffMatrix, ForceVector )
 !

--- a/fem/src/modules/ElasticSolve.F90
+++ b/fem/src/modules/ElasticSolve.F90
@@ -4707,7 +4707,7 @@ END SUBROUTINE ElasticSolver
           'Normal Force', En, Edge % NodeIndexes, GotIt )
 
 !       If dirichlet BC for displacement in any direction given,
-!       nullify force in that directon:
+!       nullify force in that direction:
 !       ------------------------------------------------------------------
         Dir = 1.0d0
         s = ListGetConstReal( Model % BCs(j) % Values, 'Displacement 1', GotIt )

--- a/fem/src/modules/Electrokinetics.F90
+++ b/fem/src/modules/Electrokinetics.F90
@@ -287,7 +287,7 @@ FUNCTION helmholtz_smoluchowski_comp( Model, NodeNumber, direction) RESULT(hs_ve
   END IF
   ! just to be on the save side, check again
   IF ( .NOT. ASSOCIATED(ParentElement) ) THEN
-     CALL FATAL('electrokinetics (helmholtz_smoluchowski_comp)','No parent element found for boudnary element')
+     CALL FATAL('electrokinetics (helmholtz_smoluchowski_comp)','No parent element found for boundary element')
   END IF
 
   body_id = ParentElement % BodyId

--- a/fem/src/modules/Elmer2OpenFoamIO.F90
+++ b/fem/src/modules/Elmer2OpenFoamIO.F90
@@ -157,7 +157,7 @@ SUBROUTINE Elmer2OpenFoamWrite( Model,Solver,dt,TransientSimulation )
       OFMesh % Nodes % z = 0.0_dp
     END IF
 
-    CALL Info('Elmer2OpenFoamWrite','Mapping data to the temporal mesh using libary routines',Level=6)
+    CALL Info('Elmer2OpenFoamWrite','Mapping data to the temporal mesh using library routines',Level=6)
     
     OFVar => VariableGet(OFMesh % Variables, VarName )
     
@@ -408,7 +408,7 @@ CONTAINS
     Mesh % NumberOfNodes = n
          
 
-    ! This is just empty left paranthesis
+    ! This is just empty left parenthesis
     IF(.NOT. InlineCoords ) THEN
       READ( InFileUnit,'(A)',IOSTAT=IOStatus ) ReadStr
     END IF
@@ -433,11 +433,11 @@ CONTAINS
         
       IF( j == 0 ) THEN
         CALL Fatal('Elmer2OpenFoamWrite',&
-            'Expecting a paranthesis at the start of OpenFOAM line: '//TRIM(I2S(i)))
+            'Expecting a parenthesis at the start of OpenFOAM line: '//TRIM(I2S(i)))
       END IF
       IF( k == 0 ) THEN
         CALL Fatal('Elmer2OpenFoamWrite',&
-            'Expecting a paranthesis at the end of OpenFOAM line: '//TRIM(I2S(i)))
+            'Expecting a parenthesis at the end of OpenFOAM line: '//TRIM(I2S(i)))
       END IF
 
       READ( ReadStr(j+1:k-1),*,IOSTAT=IOStatus ) x,y,z

--- a/fem/src/modules/FlowSolve.F90
+++ b/fem/src/modules/FlowSolve.F90
@@ -1665,7 +1665,7 @@ CONTAINS
 
 !
 !       If dirichlet BC for velocity in any direction given,
-!       nullify force in that directon:
+!       nullify force in that direction:
 !       ------------------------------------------------------------------
         Dir = 1
         s = ListGetConstReal( Model % BCs(bc) % Values, 'Velocity 1', GotIt )

--- a/fem/src/modules/FreeSurfaceReduced.F90
+++ b/fem/src/modules/FreeSurfaceReduced.F90
@@ -260,7 +260,7 @@ SUBROUTINE FreeSurfaceReduced( Model,Solver,dt,TransientSimulation )
 
        END DO
 
-       ! The initial displacement shoud be zero
+       ! The initial displacement should be zero
        MoveCoord % Values = 0.0d0
      END IF
 

--- a/fem/src/modules/HeatSolveVec.F90
+++ b/fem/src/modules/HeatSolveVec.F90
@@ -96,7 +96,7 @@ END SUBROUTINE HeatSolver_Init
 
 
 !-----------------------------------------------------------------------------
-!> A modern version for the heat eqution supporting multi-threading and
+!> A modern version for the heat equation supporting multi-threading and
 !> SIMD friendly ElmerSolver kernels. This tries to be backward compatible
 !> with the lagacy HeatSolver but some rarely used features are missing. 
 !------------------------------------------------------------------------------
@@ -650,7 +650,7 @@ CONTAINS
 
 !------------------------------------------------------------------------------
 ! Compute the fraction to be assembled. In serial case it is always one,
-! in parallel case only true parents result to assmebly, mixed parents gives
+! in parallel case only true parents result to assembly, mixed parents gives
 ! assembly fraction of 1/2. 
 !------------------------------------------------------------------------------
   FUNCTION BCAssemblyFraction( Element ) RESULT ( AssFrac ) 

--- a/fem/src/modules/MagnetoDynamics/Utils.F90
+++ b/fem/src/modules/MagnetoDynamics/Utils.F90
@@ -732,7 +732,7 @@ CONTAINS
 
   
   !-------------------------------------------------------------------------------
-  ! Mark nodes that are on outher boundary using face elements and node parmutation.
+  ! Mark nodes that are on outer boundary using face elements and node parmutation.
   !-------------------------------------------------------------------------------
   SUBROUTINE MarkOuterNodes(Mesh,Perm,SurfaceNodes,SurfacePerm,EnsureBC) 
 

--- a/fem/src/modules/MarchingODESolver.F90
+++ b/fem/src/modules/MarchingODESolver.F90
@@ -200,7 +200,7 @@ SUBROUTINE MarchingODESolver( Model,Solver,dt,Transient)
       IF(BotPointer(j) /= i) CYCLE
 
       ! Ok, check that also the next node would be at BC
-      ! The 1st layer may be an exeption, check for 2nd too
+      ! The 1st layer may be an exception, check for 2nd too
 
       ! The variable to be marched does not exist 
       IF( Var3D % Perm(UpPointer(j)) == 0 ) CYCLE

--- a/fem/src/modules/OpenFoam2ElmerIO.F90
+++ b/fem/src/modules/OpenFoam2ElmerIO.F90
@@ -337,7 +337,7 @@ CONTAINS
     
     Mesh % NumberOfNodes = NumberOfNodes
          
-    ! This is just empty left paranthesis
+    ! This is just empty left parenthesis
     READ( InFileUnit,'(A)',IOSTAT=IOStatus ) ReadStr
    
     DO i=1,n
@@ -349,12 +349,12 @@ CONTAINS
       j =  INDEX( ReadStr,'(',.TRUE.) 
       IF( j == 0 ) THEN
         CALL Fatal('OpenFoam2ElmerFit',&
-            'Expecting a paranthesis at the start of OpenFOAM line: '//TRIM(I2S(i)))
+            'Expecting a parenthesis at the start of OpenFOAM line: '//TRIM(I2S(i)))
       END IF
       k =  INDEX( ReadStr,')',.TRUE.) 
       IF( k == 0 ) THEN
         CALL Fatal('OpenFoam2ElmerFit',&
-            'Expecting a paranthesis at the end of OpenFOAM line: '//TRIM(I2S(i)))
+            'Expecting a parenthesis at the end of OpenFOAM line: '//TRIM(I2S(i)))
       END IF
       
       READ( ReadStr(j+1:k-1),*,IOSTAT=IOStatus ) x,y,z
@@ -464,7 +464,7 @@ CONTAINS
     CALL Info('OpenFoam2ElmerFit','Number of OpenFOAM nodes: '&
         //TRIM(I2S(n)),Level=10)
     
-    ! This is just empty left paranthesis
+    ! This is just empty left parenthesis
     READ( InFileUnit,'(A)',IOSTAT=IOStatus ) ReadStr
    
     DO i=1,OFMesh % NumberOfNodes

--- a/fem/src/modules/ParticleDynamics.F90
+++ b/fem/src/modules/ParticleDynamics.F90
@@ -594,7 +594,7 @@ SUBROUTINE ParticleDynamics( Model,Solver,dt,TransientSimulation )
     CALL ParticleStatistics( Particles, 1 )
   END IF
 
-  ! a logaritmic scale of indexes is used to estimate time
+  ! a logarithmic scale of indexes is used to estimate time
   !--------------------------------------------------------
   IF( TimeInfo ) THEN
     cput1 = CPUTime()

--- a/fem/src/modules/PhaseChangeSolve.F90
+++ b/fem/src/modules/PhaseChangeSolve.F90
@@ -343,7 +343,7 @@ SUBROUTINE PhaseChangeSolve( Model,Solver,dt,TransientSimulation )
 
 !--------------------------------------------------------------------
 ! The transient algorithm 
-! In the transient algorhitm a heat flux over the interface is computed and 
+! In the transient algorithm a heat flux over the interface is computed and 
 ! it is assumed to be used solely in the melting of the solid into liquid. 
 ! This melting speed gives an estimate for the melting speed that may be 
 ! improved by iteration.

--- a/fem/src/modules/StressSolve.F90
+++ b/fem/src/modules/StressSolve.F90
@@ -2388,7 +2388,7 @@ CONTAINS
 
 
 !------------------------------------------------------------------------------
-! At the end of each iteration assemblys one line of the Kmatrix and finally 
+! At the end of each iteration assemblies one line of the Kmatrix and finally 
 ! invert the matrix. The displacements and the springs are taken to be the 
 ! average values on the surface.
 !------------------------------------------------------------------------------
@@ -2924,7 +2924,7 @@ CONTAINS
      ExtPressure(1:En) = GetReal( BC, 'Normal Force', Found )
 
      ! If dirichlet BC for displacement in any direction given,
-     ! nullify force in that directon:
+     ! nullify force in that direction:
      ! --------------------------------------------------------
      Dir = 1.0d0
      IF ( ListCheckPresent( BC, 'Displacement' ) )   Dir = 0

--- a/fem/src/modules/TransientPhaseChange.F90
+++ b/fem/src/modules/TransientPhaseChange.F90
@@ -260,7 +260,7 @@ SUBROUTINE TransientPhaseChange( Model,Solver,dt,TransientSimulation )
     IF ( istat /= 0 ) CALL Fatal( 'TransientPhaseChange', 'Memory allocation error 1.' )     
     
 
-    ! Check whether normals are computed by an auxialiary solver
+    ! Check whether normals are computed by an auxiliary solver
     !---------------------------------------------------------------------------------
     VariableName = ListGetString( Params, 'Normal Variable', Stat )
     IF(Stat) THEN

--- a/fem/tests/ArteryOutlet/case.sif
+++ b/fem/tests/ArteryOutlet/case.sif
@@ -18,7 +18,7 @@
 ! Peter Raback, Juha Ruokolainen, Mikko Lyly, and Esko Jarvinen
 !
 ! 13.8.2013 / P.R. - case included as test
-! 27.1.2020 / P.R. - minor modifcation to simplify geometry
+! 27.1.2020 / P.R. - minor modification to simplify geometry
 
  Check Keywords Warn
 
@@ -193,7 +193,7 @@ Solver 6
   Vtu format = Logical True
   Save Geometry IDs = True
 
-! Supress saving of lines
+! Suppress saving of lines
   Minimum Mesh Dimension = Integer 2
 End
 

--- a/fem/tests/ConstantParamFunc/case.sif
+++ b/fem/tests/ConstantParamFunc/case.sif
@@ -72,7 +72,7 @@ Material 1
   Heat Capacity = Real 1.0
 End
 
-! Four body forces with alternating second paramater
+! Four body forces with alternating second parameter
 Body Force 1
   Name = "Heater1"
   Heat Source = Variable "time, 1"

--- a/fem/tests/ElmerSolver_cmake_test-how-to.txt
+++ b/fem/tests/ElmerSolver_cmake_test-how-to.txt
@@ -8,8 +8,8 @@ to create a minimalistic test problem using cmake/ctest.
 
 Background
 ----------
-The test cases are used to check for possible bugs, and to ensure consistancy
-and backward compability. For that purpose they are currently around 700
+The test cases are used to check for possible bugs, and to ensure consistency
+and backward compatibility. For that purpose they are currently around 700
 (situation 8/2020) cases. Most of these are minimalistic but there are also
 computationally more expensive cases.
 

--- a/fem/tests/Hybrid2dMeshPartitionCyl/case.sif
+++ b/fem/tests/Hybrid2dMeshPartitionCyl/case.sif
@@ -1,6 +1,6 @@
 !---------------------------------------------------------
 ! Test case for the consistency of partitioning.
-! This case is partitoned exactly using Cylindrical partitioning
+! This case is partitioned exactly using Cylindrical partitioning
 ! into 8 partitions. The number of 
 ! partitions can not be freely chosen here.
 !

--- a/fem/tests/Hybrid2dMeshPartitionMetis/case.sif
+++ b/fem/tests/Hybrid2dMeshPartitionMetis/case.sif
@@ -1,6 +1,6 @@
 !---------------------------------------------------------
 ! Test case for the consistency of partitioning.
-! This case is partitoned exactly using Metis partitioning
+! This case is partitioned exactly using Metis partitioning
 ! into 8 partitions. The number of 
 ! partitions can not be freely chosen here.
 !

--- a/fem/tests/Hybrid2dMeshPartitionMetisConnect/case.sif
+++ b/fem/tests/Hybrid2dMeshPartitionMetisConnect/case.sif
@@ -1,6 +1,6 @@
 !---------------------------------------------------------
 ! Test case for the consistency of partitioning.
-! This case is partitoned exactly using Metis partitioning
+! This case is partitioned exactly using Metis partitioning
 ! into 8 partitions. The number of 
 ! partitions can not be freely chosen here.
 !

--- a/fem/tests/MazeMeshPartitionMetisContig/case.sif
+++ b/fem/tests/MazeMeshPartitionMetisContig/case.sif
@@ -1,6 +1,6 @@
 !---------------------------------------------------------
 ! Test case for the consistency of partitioning.
-! This case is partitoned exactly using Metis partitioning
+! This case is partitioned exactly using Metis partitioning
 ! into 6 partitions. The partitioning is enforced to being
 ! contiguous. Without the flag it would not be.
 !

--- a/fem/tests/Q1Q0/Q1Q0.f90
+++ b/fem/tests/Q1Q0/Q1Q0.f90
@@ -2,7 +2,7 @@ SUBROUTINE StokesSolver( Model,Solver,dt,TransientSimulation )
 !------------------------------------------------------------------------------
 !******************************************************************************
 !
-! A Navier-Stokes solver for Q1/Q0 eleemnt
+! A Navier-Stokes solver for Q1/Q0 elemnt
 !
 !  ARGUMENTS:
 !

--- a/fem/tests/RotatingBCMagnetoDynamics/case.sif
+++ b/fem/tests/RotatingBCMagnetoDynamics/case.sif
@@ -2,7 +2,7 @@
 ! 
 ! This case includes 4-fold symmetry in the rotations and 
 ! an optional skew of 20 degrees in the rotor. 
-! Increse number of extruded layers for better accuracy. 
+! Increase number of extruded layers for better accuracy. 
 
 $skew=0.0  ! does not yet work with skew
 $omega=20.0 

--- a/fem/tests/RotatingBCMagnetoDynamics2/case.sif
+++ b/fem/tests/RotatingBCMagnetoDynamics2/case.sif
@@ -3,7 +3,7 @@
 ! 
 ! This case includes 4-fold symmetry in the rotations and 
 ! an optional skew of 20 degrees in the rotor. 
-! Increse number of extruded layers for better accuracy. 
+! Increase number of extruded layers for better accuracy. 
 !
 ! This test case uses a level projector which assumes that 
 ! the extruded layers are at constant z-levels.

--- a/fem/tests/RotatingBCMagnetoDynamicsConforming/case.sif
+++ b/fem/tests/RotatingBCMagnetoDynamicsConforming/case.sif
@@ -3,7 +3,7 @@
 ! 
 ! This case includes 4-fold symmetry in the rotations and 
 ! an optional skew of 20 degrees in the rotor. 
-! Increse number of extruded layers for better accuracy. 
+! Increase number of extruded layers for better accuracy. 
 !
 ! This test case uses a generic projector for the airgap which does not make 
 ! any assumptions on the characteristics of the 2D mesh.

--- a/fem/tests/RotatingBCMagnetoDynamicsConforming/ref.sif
+++ b/fem/tests/RotatingBCMagnetoDynamicsConforming/ref.sif
@@ -3,7 +3,7 @@
 ! 
 ! This case includes 4-fold symmetry in the rotations and 
 ! an optional skew of 20 degrees in the rotor. 
-! Increse number of extruded layers for better accuracy. 
+! Increase number of extruded layers for better accuracy. 
 !
 ! This test case uses a generic projector which does not make 
 ! any assumptions on the characteristics of the 2D mesh.

--- a/fem/tests/RotatingBCMagnetoDynamicsConformingAnti/case.sif
+++ b/fem/tests/RotatingBCMagnetoDynamicsConformingAnti/case.sif
@@ -3,7 +3,7 @@
 ! 
 ! This case includes 4-fold symmetry in the rotations and 
 ! an optional skew of 20 degrees in the rotor. 
-! Increse number of extruded layers for better accuracy. 
+! Increase number of extruded layers for better accuracy. 
 !
 ! This test case uses a generic projector for the airgap which does not make 
 ! any assumptions on the characteristics of the 2D mesh.

--- a/fem/tests/RotatingBCMagnetoDynamicsConformingAnti/ref.sif
+++ b/fem/tests/RotatingBCMagnetoDynamicsConformingAnti/ref.sif
@@ -3,7 +3,7 @@
 ! 
 ! This case includes 4-fold symmetry in the rotations and 
 ! an optional skew of 20 degrees in the rotor. 
-! Increse number of extruded layers for better accuracy. 
+! Increase number of extruded layers for better accuracy. 
 !
 ! This test case uses a generic projector which does not make 
 ! any assumptions on the characteristics of the 2D mesh.

--- a/fem/tests/RotatingBCMagnetoDynamicsGeneric/case.sif
+++ b/fem/tests/RotatingBCMagnetoDynamicsGeneric/case.sif
@@ -3,7 +3,7 @@
 ! 
 ! This case includes 4-fold symmetry in the rotations and 
 ! an optional skew of 20 degrees in the rotor. 
-! Increse number of extruded layers for better accuracy. 
+! Increase number of extruded layers for better accuracy. 
 !
 ! This test case uses a generic projector which does not make 
 ! any assumptions on the characteristics of the 2D mesh.

--- a/fem/tests/RotatingBCPoisson3DSymmSkew/case.sif
+++ b/fem/tests/RotatingBCPoisson3DSymmSkew/case.sif
@@ -3,7 +3,7 @@
 ! 
 ! This case includes 4-fold symmetry in the rotations and 
 ! a skew of 20 degrees in the rotor. 
-! Increse number of extruded layers for better accuracy. 
+! Increase number of extruded layers for better accuracy. 
 
 Header
   CHECK KEYWORDS Warn

--- a/fem/tests/RotatingBCPoisson3DSymmSkew/level_strong.sif
+++ b/fem/tests/RotatingBCPoisson3DSymmSkew/level_strong.sif
@@ -3,7 +3,7 @@
 ! 
 ! This case includes 4-fold symmetry in the rotations and 
 ! a skew of 20 degrees in the rotor. 
-! Increse number of extruded layers for better accuracy. 
+! Increase number of extruded layers for better accuracy. 
 !
 ! This is a variation of the test case using strong version of the 
 ! Level Projector.

--- a/fem/tests/RotatingBCPoisson3DSymmSkew/level_weak.sif
+++ b/fem/tests/RotatingBCPoisson3DSymmSkew/level_weak.sif
@@ -3,7 +3,7 @@
 ! 
 ! This case includes 4-fold symmetry in the rotations and 
 ! a skew of 20 degrees in the rotor. 
-! Increse number of extruded layers for better accuracy. 
+! Increase number of extruded layers for better accuracy. 
 !
 ! This is a variation of the test case using weak version of the 
 ! Level Projector.

--- a/fem/tests/RunControlStructured/case.sif
+++ b/fem/tests/RunControlStructured/case.sif
@@ -1,7 +1,7 @@
 !--------------------------------------------------------------------
-! A test case for combined Run Control and Stuctured mesh mapper.
+! A test case for combined Run Control and Structured mesh mapper.
 ! The combination is used to repetitively run through several
-! sequencies such that the previous end results acts as start conditions
+! sequences such that the previous end results acts as start conditions
 ! for the next simulation.
 !
 ! P.R. 25.5.2020

--- a/fem/tests/SinusFlowTunedVelo/cavity.sif
+++ b/fem/tests/SinusFlowTunedVelo/cavity.sif
@@ -34,7 +34,7 @@ Run Control
   Initial Step Size = Real 1.0e-3
   Max Step Size = Real 1.0
 ! For this linear case we would find the optimum with one shot.
-! This would be more usefull in nonlinear cases...
+! This would be more useful in nonlinear cases...
   Step Size Relaxation Factor = Real 0.8
 
 ! This is a design task with the goal flx=1.0

--- a/fem/tests/WinkelBmNavierInternalFETI/case.sif
+++ b/fem/tests/WinkelBmNavierInternalFETI/case.sif
@@ -5,7 +5,7 @@
 ! This is derived from a cononical benchmark test with the 
 ! simplest 3D rectangular structure. 
 !
-! This case may be partitoned exactly to 4*8^n cubes. The number 
+! This case may be partitioned exactly to 4*8^n cubes. The number 
 ! of partitions can not be freely chosen here.
 !
 ! This test case with Internal FETI.

--- a/fem/tests/WinkelBmNavierMumps/case.sif
+++ b/fem/tests/WinkelBmNavierMumps/case.sif
@@ -5,7 +5,7 @@
 ! This is derived from a cononical benchmark test with the 
 ! simplest 3D rectangular structure. 
 !
-! This case may be partitoned exactly to 4*8^n cubes. The number 
+! This case may be partitioned exactly to 4*8^n cubes. The number 
 ! of partitions can not be freely chosen here.
 !
 ! This test case with MUMPS

--- a/fem/tests/WinkelBmNavierPermon/case.sif
+++ b/fem/tests/WinkelBmNavierPermon/case.sif
@@ -5,7 +5,7 @@
 ! This is derived from a cononical benchmark test with the 
 ! simplest 3D rectangular structure. 
 !
-! This case may be partitoned exactly to 4*8^n cubes. The number 
+! This case may be partitioned exactly to 4*8^n cubes. The number 
 ! of partitions can not be freely chosen here.
 !------------------------------------------------------------
 

--- a/fem/tests/WinkelPartitionMetis/case.sif
+++ b/fem/tests/WinkelPartitionMetis/case.sif
@@ -1,6 +1,6 @@
 !---------------------------------------------------------
 ! Test case for the consistency of partitioning.
-! This case is partitoned exactly using basic Metis partitioning
+! This case is partitioned exactly using basic Metis partitioning
 ! into 8 partitions. The number of 
 ! partitions can not be freely chosen here.
 !

--- a/fem/tests/WinkelPartitionMetisConnect/case.sif
+++ b/fem/tests/WinkelPartitionMetisConnect/case.sif
@@ -1,6 +1,6 @@
 !---------------------------------------------------------
 ! Test case for the consistency of partitioning.
-! This case is partitoned exactly using Metis partitioning
+! This case is partitioned exactly using Metis partitioning
 ! into 8 partitions. The number of 
 ! partitions can not be freely chosen here.
 !

--- a/fem/tests/WinkelPartitionMetisRec/case.sif
+++ b/fem/tests/WinkelPartitionMetisRec/case.sif
@@ -1,6 +1,6 @@
 !---------------------------------------------------------
 ! Test case for the consistency of partitioning.
-! This case is partitoned exactly using basic Metis partitioning
+! This case is partitioned exactly using basic Metis partitioning
 ! into 8 partitions. The number of 
 ! partitions can not be freely chosen here.
 !

--- a/fem/tests/WinkelPartitionRecursive/case.sif
+++ b/fem/tests/WinkelPartitionRecursive/case.sif
@@ -1,6 +1,6 @@
 !---------------------------------------------------------
 ! Test case for the consistency of partitioning.
-! This case is partitoned exactly using recursive geometric partition
+! This case is partitioned exactly using recursive geometric partition
 ! into 8 partitions. The number of 
 ! partitions can not be freely chosen here.
 !

--- a/fem/tests/WinkelPartitionRecursiveHaloBC/case.sif
+++ b/fem/tests/WinkelPartitionRecursiveHaloBC/case.sif
@@ -1,6 +1,6 @@
 !---------------------------------------------------------
 ! Test case for the consistency of partitioning.
-! This case is partitoned exactly using recursive geometric partition
+! This case is partitioned exactly using recursive geometric partition
 ! into 8 partitions. The number of 
 ! partitions can not be freely chosen here.
 !

--- a/fem/tests/WinkelPartitionRecursiveLevel2/case.sif
+++ b/fem/tests/WinkelPartitionRecursiveLevel2/case.sif
@@ -1,6 +1,6 @@
 !---------------------------------------------------------
 ! Test case for the consistency of partitioning.
-! This case is partitoned exactly using recursive geometric partition
+! This case is partitioned exactly using recursive geometric partition
 ! into 8 partitions. The number of 
 ! partitions can not be freely chosen here.
 !

--- a/fem/tests/WinkelPartitionUniform/case.sif
+++ b/fem/tests/WinkelPartitionUniform/case.sif
@@ -1,6 +1,6 @@
 !---------------------------------------------------------
 ! Test case for the consistency of partitioning.
-! This case is partitoned exactly using uniform geometric partition
+! This case is partitioned exactly using uniform geometric partition
 ! into 4 partitions. The number of 
 ! partitions can not be freely chosen here.
 !

--- a/fem/tests/WinkelPartitionUniformHaloBC/case.sif
+++ b/fem/tests/WinkelPartitionUniformHaloBC/case.sif
@@ -1,6 +1,6 @@
 !---------------------------------------------------------
 ! Test case for the consistency of partitioning.
-! This case is partitoned exactly using uniform geometric partition
+! This case is partitioned exactly using uniform geometric partition
 ! into 4 partitions. The number of 
 ! partitions can not be freely chosen here.
 !

--- a/fem/tests/WinkelPartitionUniformLevel2/case.sif
+++ b/fem/tests/WinkelPartitionUniformLevel2/case.sif
@@ -1,6 +1,6 @@
 !---------------------------------------------------------
 ! Test case for the consistency of partitioning.
-! This case is partitoned exactly using uniform geometric partition
+! This case is partitioned exactly using uniform geometric partition
 ! into 4 partitions. The number of 
 ! partitions can not be freely chosen here.
 !

--- a/fem/tests/WinkelPoissonPartitionRecursive/case.sif
+++ b/fem/tests/WinkelPoissonPartitionRecursive/case.sif
@@ -5,7 +5,7 @@
 ! This is derived from a cononical benchmark test with the 
 ! simplest 3D rectangular structure. 
 !
-! This case is partitoned exactly using recursive geometric partition
+! This case is partitioned exactly using recursive geometric partition
 ! into 8 partitions. The number of partitions can not be freely chosen here.
 !------------------------------------------------------------
 

--- a/fem/tests/WinkelPoissonPartitionUniform/case.sif
+++ b/fem/tests/WinkelPoissonPartitionUniform/case.sif
@@ -5,7 +5,7 @@
 ! This is derived from a cononical benchmark test with the 
 ! simplest 3D rectangular structure. 
 !
-! This case is partitoned exactly to four cubes. The number 
+! This case is partitioned exactly to four cubes. The number 
 ! of partitions can not be freely chosen here.
 !------------------------------------------------------------
 

--- a/fem/tests/bentonite/BentoniteSolver.F90
+++ b/fem/tests/bentonite/BentoniteSolver.F90
@@ -183,7 +183,7 @@ RECURSIVE SUBROUTINE BentoniteSolver( Model,Solver,dt,TransientSimulation )
      CALL Info( 'BentoniteSolve', Message, Level=4 )
      CALL Info( 'BentoniteSolve', '-------------------------------------', Level=4 )
      CALL Info( 'BentoniteSolve', ' ', Level=4 )
-     CALL Info( 'BentoniteSolve', 'Starting Assmebly', Level=4 )
+     CALL Info( 'BentoniteSolve', 'Starting Assembly', Level=4 )
 
 !
 !    Do the bulk assembly:

--- a/fem/tests/circuits_transient_stranded_full_coil/sif/coil.sif
+++ b/fem/tests/circuits_transient_stranded_full_coil/sif/coil.sif
@@ -99,7 +99,7 @@ Solver 1  !---- CoilSolver, CoilSolver
   Linear System Convergence Tolerance = 1e-6
   Linear System Iterative Method = BiCGStab
   Linear System Residual Output = 1
-  ! When we normalize, we introduce propably some divergence that
+  ! When we normalize, we introduce probably some divergence that
   ! does not impress the solver very much... Helmholtz projection needed?
   Normalize Coil Current = Logical False 
   Nonlinear System Consistent Norm = Logical True

--- a/fem/tests/structmap4/case.sif
+++ b/fem/tests/structmap4/case.sif
@@ -1,7 +1,7 @@
 !--------------------------------------------------------------------
-! A test case for Stuctured mesh mapper with a middle layer.
+! A test case for Structured mesh mapper with a middle layer.
 !
-! Peter Råback / 29.7.2015
+! Peter Rï¿½back / 29.7.2015
 !--------------------------------------------------------------------
 
 Header

--- a/fem/tests/structmap5/case.sif
+++ b/fem/tests/structmap5/case.sif
@@ -1,7 +1,7 @@
 !--------------------------------------------------------------------
-! A test case for Stuctured mesh mapper with a middle layer.
+! A test case for Structured mesh mapper with a middle layer.
 !
-! Peter Råback / 29.7.2015
+! Peter Rï¿½back / 29.7.2015
 !--------------------------------------------------------------------
 
 Header

--- a/fem/tests/structmap6/case.sif
+++ b/fem/tests/structmap6/case.sif
@@ -1,9 +1,9 @@
 !--------------------------------------------------------------------
-! A test case for Stuctured mesh mapper with a mask.
+! A test case for Structured mesh mapper with a mask.
 ! The extruded structure and related operations are only covered where
 ! the mask variable has positive permutation. 
 !
-! Peter Råback / 10.8.2018
+! Peter Rï¿½back / 10.8.2018
 !--------------------------------------------------------------------
 
 Header

--- a/fem/tests/structmap7/case.sif
+++ b/fem/tests/structmap7/case.sif
@@ -1,9 +1,9 @@
 !--------------------------------------------------------------------
-! A test case for Stuctured mesh mapper with a mask.
+! A test case for Structured mesh mapper with a mask.
 ! The extruded structure and related operations are only covered where
 ! the mask name is true. 
 !
-! Peter Råback / 24.8.2020
+! Peter Rï¿½back / 24.8.2020
 !--------------------------------------------------------------------
 
 Header

--- a/fem/tests/structmap8/case.sif
+++ b/fem/tests/structmap8/case.sif
@@ -1,11 +1,11 @@
 !--------------------------------------------------------------------
-! A test case for Stuctured mesh mapper with a mask.
+! A test case for Structured mesh mapper with a mask.
 ! The extruded structure and related operations are only covered where
 ! the mask name is true.
 !
 ! This one with reduced basis dg. 
 !
-! Peter Råback / 24.8.2020
+! Peter Rï¿½back / 24.8.2020
 !--------------------------------------------------------------------
 
 Header


### PR DESCRIPTION
Found via `codespell -q 3 -S ./mathlibs,./contrib,./misc,./umfpack,./ElmerGUI/netgen -L cas,dof,enew,ifset,inout,isnt,ist,matc,ned,nd,stran,vertexes`