### PR TITLE
When running the WaveguideGUI tutorial, resultoutput.xml would not

### DIFF
--- a/ElmerGUI/Application/edf/electrostatics.xml
+++ b/ElmerGUI/Application/edf/electrostatics.xml
@@ -3,6 +3,28 @@
 <edf version="1.0" >
    <PDE Name="Electrostatics" >
       <Name>Electrostatics</Name>
+      <Equation>
+         <Parameter Widget="Label">
+           <Name> Electric Field </Name>
+         </Parameter>
+        <Parameter Widget="Combo"> 
+          <Name> Electric Field </Name>
+          <Type> String </Type>
+          <Item Type="Active"> <Name> None </Name> </Item>
+          <Item> <Name> Computed </Name> </Item>
+        </Parameter>
+
+         <Parameter Widget="Label">
+           <Name> Free text input </Name>
+         </Parameter> 
+	 <Parameter Widget="TextEdit" Enabled="True">
+	   <Name> Free text </Name>
+	   <Type> String </Type>
+	   <Whatis> Free text is copied into the Equation-block of the SIF as such. </Whatis>
+	   <StatusTip> Free text is copied into the Equation-block of the SIF as such. </StatusTip>
+	 </Parameter>
+      </Equation>
+
       <Material>
         <Parameter Widget="Label" > <Name> Properties </Name> </Parameter>
          <Parameter Widget="Edit" >
@@ -11,6 +33,7 @@
             <Whatis> Give the relative permittivity compared to vacuum. </Whatis>
          </Parameter>    
       </Material>   
+
       <BodyForce>
       <Parameter Widget="Label" > <Name> Properties </Name> </Parameter>
           <Parameter Widget="Edit" >
@@ -19,6 +42,7 @@
             <Whatis> Give the volume charge density. </Whatis>
          </Parameter>    
       </BodyForce>   
+
       <InitialCondition>   
         <Parameter Widget="Label" > <Name> Properties </Name> </Parameter>
           <Parameter Widget="Edit" >
@@ -27,6 +51,7 @@
             <Whatis> Give the initial condition for electrostatic potential. </Whatis>
          </Parameter>    
       </InitialCondition>   
+
       <Solver>
          <Parameter Widget="Edit" >
            <Name> Procedure </Name>
@@ -73,6 +98,15 @@
             <Type> String </Type>
             <Whatis> File to save the capacitance matrix. </Whatis>
          </Parameter> 
+         <Parameter Widget="Label">
+           <Name> Free text input </Name>
+         </Parameter>
+	 <Parameter Widget="TextEdit" Enabled="True">
+	   <Name> Free text </Name>
+	   <Type> String </Type>
+	   <Whatis> Free text is copied into the Solver-block of the SIF as such. </Whatis>
+	   <StatusTip> Free text is copied into the Solver-block of the SIF as such. </StatusTip>
+	 </Parameter>
        </Solver>
 
       <BoundaryCondition>
@@ -104,7 +138,17 @@
             <Whatis> Use a far field condition for the electric flux. </Whatis>
          </Parameter>
 
-		 </BoundaryCondition>
+        <Parameter Widget="Label">
+          <Name> Free text input </Name>
+        </Parameter>
+        <Parameter Widget="TextEdit" Enabled="True">
+          <Name> Free text </Name>
+          <Type> String </Type>
+          <Whatis> Free text is copied into the Boundary Condition-block of the SIF as such. </Whatis>
+          <StatusTip> Free text is copied into the Boundary Condition-block of the SIF as such. </StatusTip>
+        </Parameter>
+
+	</BoundaryCondition>
    </PDE>
 </edf>
 

--- a/ElmerGUI/Application/edf/resultoutput.xml
+++ b/ElmerGUI/Application/edf/resultoutput.xml
@@ -1,4 +1,4 @@
-<?xml version='1.0' encoding='UTF-8'?>
+﻿<?xml version='1.0' encoding='UTF-8'?>
 <!DOCTYPE edf>
 <edf version="1.0" >
   <PDE Name="Result Output" >
@@ -47,55 +47,46 @@
 
       <Parameter Widget="CheckBox">
         <Name> Single Precision </Name>  
-        <DefaultValue> False </DefaultValue>
         <Whatis> Use single precision when available (vtu). </Whatis>
       </Parameter>
 
       <Parameter Widget="CheckBox">
         <Name> Save Geometry Ids </Name>  
-        <DefaultValue> True </DefaultValue>
         <Whatis> Save number of geometric entities when available (vtu). </Whatis>
       </Parameter>
 
       <Parameter Widget="CheckBox">
         <Name> Discontinuous Galerkin </Name>  
-        <DefaultValue> False </DefaultValue>
         <Whatis> Save fields as a Discontinuous Galerkin field when available (vtu). </Whatis>
       </Parameter>
 
       <Parameter Widget="CheckBox">
         <Name> Discontinuous Bodies </Name>  
-        <DefaultValue> False </DefaultValue>
         <Whatis> Save fields in a minimal discontinuous set over bodies field when available (vtu). </Whatis>
       </Parameter>
 
       <Parameter Widget="CheckBox">
         <Name> Save Elemental Fields </Name>  
-        <DefaultValue> True </DefaultValue>
         <Whatis> If there are elemental fields this flag may be used to eliminate their saving, when available (vtu). </Whatis>
       </Parameter>
 
       <Parameter Widget="CheckBox">
         <Name> Save Nodal Fields </Name>  
-        <DefaultValue> True </DefaultValue>
         <Whatis> If there are nodal fields this flag may be used to eliminate their saving, when available (vtu). </Whatis>
       </Parameter>
 
       <Parameter Widget="CheckBox">
         <Name> Save Linear Elements </Name>  
-        <DefaultValue> False </DefaultValue>
         <Whatis> With higher order elements save the data still using linear basis when available (vtu). </Whatis>
       </Parameter>
 
       <Parameter Widget="CheckBox">
         <Name> Save Boundaries Only </Name>  
-        <DefaultValue> False </DefaultValue>
         <Whatis> Save only boundaries when available (vtu). </Whatis>
       </Parameter>
 
       <Parameter Widget="CheckBox">
         <Name> Eigen Analysis </Name>  
-        <DefaultValue> False </DefaultValue>
         <Whatis> Numbers files by eigenmodes when available (vtu). </Whatis>
       </Parameter>
 


### PR DESCRIPTION
include Geometry Ids in the .vtu output file, even though the check box was checked.
Turns out that the default for Geometry Ids in the Models Manual is 'False',
meanwhile the .xml file had a default setting of 'True'.  The only check box
that should have a default of 'True' is for binary output.  Further,
there is no need to include a default setting of 'False' for any checkbox
in the .xml file, since the .sif generator assumes a lack of a default
setting means 'False' and doesn't emit a line into the .sif file.  Once
this fix is in place, then the WaveguideGUI tutorial will need to be updated
to match the revised .xml definition.