### PR TITLE
MPI_init and _finalize only if requested + Bugfix in i2s

### DIFF
--- a/fem/src/SParIterComm.F90
+++ b/fem/src/SParIterComm.F90
@@ -132,6 +132,7 @@ CONTAINS
     ParEnv % MyPE = 0
     ParEnv % PEs  = 1
     ParEnv % ActiveComm = 0
+    ParEnv % ExternalInit = .FALSE.
 
     ierr = 0
 #ifdef _OPENMP
@@ -145,7 +146,11 @@ CONTAINS
       CALL Fatal( 'ParCommInit', Message )
     END IF
 #else
-    CALL MPI_INIT( ierr )
+    CALL MPI_INITIALIZED(ParEnv % ExternalInit, ierr)
+    IF ( ierr /= 0 ) RETURN
+    IF (.NOT. ParEnv % ExternalInit) THEN
+        CALL MPI_INIT( ierr )
+    END IF
 #endif
     IF ( ierr /= 0 ) RETURN
 
@@ -4877,11 +4882,13 @@ SUBROUTINE ParEnvFinalize()
 
   !*********************************************************************
   CALL MPI_BARRIER( ELMER_COMM_WORLD, ierr )
-  CALL MPI_FINALIZE( ierr )
+  IF (.NOT. ParEnv % ExternalInit) THEN
+    CALL MPI_FINALIZE( ierr )
 
-  IF ( ierr /= 0 ) THEN
-     WRITE( Message, * ) 'MPI Finalization failed ! (ierr=', ierr, ')'
-     CALL Fatal( 'ParEnvFinalize', Message )
+    IF ( ierr /= 0 ) THEN
+       WRITE( Message, * ) 'MPI Finalization failed ! (ierr=', ierr, ')'
+       CALL Fatal( 'ParEnvFinalize', Message )
+    END IF
   END IF
 !*********************************************************************
 END SUBROUTINE ParEnvFinalize

--- a/fem/src/Types.F90
+++ b/fem/src/Types.F90
@@ -267,6 +267,7 @@ MODULE Types
      LOGICAL, DIMENSION(:), POINTER   :: SendingNB
      INTEGER                          :: NumOfNeighbours
      INTEGER                          :: NumberOfThreads = 1
+     LOGICAL                          :: ExternalInit
    END TYPE ParEnv_t
 
 


### PR DESCRIPTION
2 small changes that are as follows:

1. MPI_Init only if required

   When using Elmer as a library from a software that already runs MPI calling MPI_Init again is not working, so to enable this check if MPI is already initialized and skip Init if it is already there. In this case we also don't want to call MPI_Finalize as the other  oftware should take care of that.

2. Shorten i2s

    The old version would give wrong results if the numbers became too large due to a division by zero.

If you have any questions, let me know.