### PR TITLE
GUI fix - crash by checkbox

### DIFF
--- a/ElmerGUI/Application/plugins/egnative.cpp
+++ b/ElmerGUI/Application/plugins/egnative.cpp
@@ -5496,7 +5496,7 @@ int SaveElmerInput(struct FemType *data,struct BoundaryType *bound,
 
   fail = chdir(directoryname);
   if(fail) {
-#ifdef MINGW32
+#ifdef __MINGW32__
     fail = mkdir(directoryname);
 #else
     fail = mkdir(directoryname,0750);

--- a/ElmerGUI/Application/src/objectbrowser.cpp
+++ b/ElmerGUI/Application/src/objectbrowser.cpp
@@ -257,50 +257,44 @@ void ObjectBrowser::focusChangedSlot(QWidget *old, QWidget *now) {
 }
 
 void ObjectBrowser::treeItemClickedSlot(QTreeWidgetItem *item, int column) {
-  /*  Moved to treeItemDoubleClickedSlot(QTreeWidgetItem *item, int column)
-    MainWindow* mainwindow = (MainWindow*) mainWindow;
-    if(item == geometryParentTreeItem) return;
-
-    if(item == setupParentTreeItem){
-      mainwindow->modelSetupSlot();
-      return;
+  MainWindow* mainwindow = (MainWindow*) mainWindow;
+ 
+  // clicking [Add...] button
+  if (item == equationParentTreeItem) {
+    if (column == 1) {
+      mainwindow->addEquationSlot();
+      addEquationSlot();
     }
-    if(item == equationParentTreeItem){
-          if(column == 1){
-                  mainwindow->addEquationSlot();
-                  addEquationSlot();
-          }
-          return;
+    return;
+  }
+  if (item == materialParentTreeItem) {
+    if (column == 1) {
+      mainwindow->addMaterialSlot();
+      addMaterialSlot();
     }
-    if(item == materialParentTreeItem){
-          if(column == 1){
-                  mainwindow->addMaterialSlot();
-                  addMaterialSlot();
-          }
-          return;
+    return;
+  }
+  if (item == bodyForceParentTreeItem) {
+    if (column == 1) {
+      mainwindow->addBodyForceSlot();
+      addBodyForceSlot();
     }
-    if(item == bodyForceParentTreeItem){
-          if(column == 1){
-                  mainwindow->addBodyForceSlot();
-                  addBodyForceSlot();
-          }
-          return;
+    return;
+  }
+  if (item == initialConditionParentTreeItem) {
+    if (column == 1) {
+      mainwindow->addInitialConditionSlot();
+      addInitialConditionSlot();
     }
-    if(item == initialConditionParentTreeItem){
-          if(column == 1){
-                  mainwindow->addInitialConditionSlot();
-                  addInitialConditionSlot();
-          }
-          return;
+    return;
+  }
+  if (item == boundaryConditionParentTreeItem) {
+    if (column == 1) {
+      mainwindow->addBoundaryConditionSlot();
+      addBoundaryConditionSlot();
     }
-    if(item == boundaryConditionParentTreeItem){
-          if(column == 1){
-                  mainwindow->addBoundaryConditionSlot();
-                  addBoundaryConditionSlot();
-          }
-          return;
-    }
-  */
+    return;
+  }
 }
 
 void ObjectBrowser::treeItemDoubleClickedSlot(QTreeWidgetItem *item,
@@ -529,48 +523,6 @@ void ObjectBrowser::treeItemDoubleClickedSlot(QTreeWidgetItem *item,
     snap(pe);
     pe->show();
     pe->raise();
-    return;
-  }
-
-  // double clicking [Add...] button
-  if (item == equationParentTreeItem) {
-    if (column == 1) {
-      mainwindow->addEquationSlot();
-      addEquationSlot();
-      tree->collapseItem(equationParentTreeItem);
-    }
-    return;
-  }
-  if (item == materialParentTreeItem) {
-    if (column == 1) {
-      mainwindow->addMaterialSlot();
-      addMaterialSlot();
-      tree->collapseItem(materialParentTreeItem);
-    }
-    return;
-  }
-  if (item == bodyForceParentTreeItem) {
-    if (column == 1) {
-      mainwindow->addBodyForceSlot();
-      addBodyForceSlot();
-      tree->collapseItem(bodyForceParentTreeItem);
-    }
-    return;
-  }
-  if (item == initialConditionParentTreeItem) {
-    if (column == 1) {
-      mainwindow->addInitialConditionSlot();
-      addInitialConditionSlot();
-      tree->collapseItem(initialConditionParentTreeItem);
-    }
-    return;
-  }
-  if (item == boundaryConditionParentTreeItem) {
-    if (column == 1) {
-      mainwindow->addBoundaryConditionSlot();
-      addBoundaryConditionSlot();
-      tree->collapseItem(boundaryConditionParentTreeItem);
-    }
     return;
   }
 }


### PR DESCRIPTION
Hi all,

This change is to solve crashing issue of ElmerGUI on Windows, reported in[ Elmer Discussion Forum ](http://www.elmerfem.org/forum/viewtopic.php?p=23724#p23724).  In more detail, this issue is caused by an additional itemClicked signal after itemDoubeClicked signal.  Interestingly, I didn't see such crash in Ubuntu, but only in Window.

To avoid the crashing, [Add..] button on Object browser was changed to work by a single click instead of doubleclick. Hope this helps.

Regards,
Saeki