### PR TITLE
GUI color settings restoration

### DIFF
--- a/ElmerGUI/Application/src/glwidget.cpp
+++ b/ElmerGUI/Application/src/glwidget.cpp
@@ -165,6 +165,7 @@ GLWidget::GLWidget(QWidget *parent)
   edgeColor = Qt::green;
   surfaceMeshColor = Qt::black;
   sharpEdgeColor = Qt::black;
+  selectionColor = Qt::red;
 
   stateOrtho = false;
   stateFlatShade = true;
@@ -872,7 +873,7 @@ void GLWidget::mouseDoubleClickEvent(QMouseEvent *event)
     // Highlight current selection:
     if(l->getType() == SURFACELIST) {
       if(l->isSelected()) {
-	l->setObject(generateSurfaceList(l->getIndex(), Qt::red)); // red
+	l->setObject(generateSurfaceList(l->getIndex(), selectionColor)); // red
       } else {
 	l->setObject(generateSurfaceList(l->getIndex(), surfaceColor)); // cyan
       }
@@ -884,7 +885,7 @@ void GLWidget::mouseDoubleClickEvent(QMouseEvent *event)
 
     } else if(l->getType() == EDGELIST) {
       if(l->isSelected()) {
-	l->setObject(generateEdgeList(l->getIndex(), Qt::red)); // red
+	l->setObject(generateEdgeList(l->getIndex(), selectionColor)); // red
       } else {
 	l->setObject(generateEdgeList(l->getIndex(), edgeColor)); // green
       }
@@ -1059,7 +1060,7 @@ void GLWidget::rebuildSurfaceLists()
      {
        glDeleteLists( l->getObject(), 1 );
        if(l->isSelected()) {
- 	 l->setObject(generateSurfaceList(l->getIndex(), Qt::red)); // red
+ 	 l->setObject(generateSurfaceList(l->getIndex(), selectionColor)); // red
        } else {
  	 l->setObject(generateSurfaceList(l->getIndex(), surfaceColor)); // cyan
        }
@@ -1078,7 +1079,7 @@ void GLWidget::rebuildEdgeLists()
      {
        glDeleteLists( l->getObject(), 1 );
        if(l->isSelected()) {
- 	 l->setObject(generateEdgeList(l->getIndex(), Qt::red)); // red
+ 	 l->setObject(generateEdgeList(l->getIndex(), selectionColor)); // red
        } else {
  	 l->setObject(generateEdgeList(l->getIndex(), edgeColor)); // green
        }

--- a/ElmerGUI/Application/src/glwidget.h
+++ b/ElmerGUI/Application/src/glwidget.h
@@ -173,6 +173,7 @@ public:
   QColor edgeColor;
   QColor surfaceMeshColor;
   QColor sharpEdgeColor;
+  QColor selectionColor;
   
   // public hash tables:
   QMap<int, int> boundaryMap; // QHash<int, int> boundaryMap;

--- a/ElmerGUI/Application/src/mainwindow.cpp
+++ b/ElmerGUI/Application/src/mainwindow.cpp
@@ -4664,7 +4664,7 @@ void MainWindow::resetSlot() {
     return;
   }
 
-  //glWidget->stateFlatShade = true;
+  glWidget->stateFlatShade = true;
   glWidget->stateDrawSurfaceMesh = true;
 #ifndef WIN32
   glWidget->stateDrawSharpEdges = true;
@@ -7689,20 +7689,7 @@ void MainWindow::loadSettings() {
     case 2: selectParaViewSlot(); break;
   }
   
-  // view menu settings
-  //glWidget->stateDrawSurfaceMesh = settings_value("view/surfaceMesh", glWidget->stateDrawSurfaceMesh).toBool(); 
-  //glWidget->stateDrawVolumeMesh = settings_value("view/volumeMesh", glWidget->stateDrawVolumeMesh).toBool(); 
-  //glWidget->stateDrawSharpEdges = settings_value("view/sharpEdge", glWidget->stateDrawSharpEdges).toBool(); 
-  glWidget->stateDrawCoordinates = settings_value("view/compass", glWidget->stateDrawCoordinates).toBool(); 
-  glWidget->stateFlatShade = settings_value("view/flatShade", glWidget->stateFlatShade).toBool(); 
-  glWidget->stateOrtho = settings_value("view/orthogonal", glWidget->stateOrtho).toBool();
-  //glWidget->stateDrawSurfaceNumbers = settings_value("view/surfaceNumbers", glWidget->stateDrawSurfaceNumbers).toBool();
-  //glWidget->stateDrawEdgeNumbers = settings_value("view/edgeNumbers", glWidget->stateDrawEdgeNumbers).toBool();
-  //glWidget->stateDrawNodeNumbers = settings_value("view/nodeNumbers", glWidget->stateDrawNodeNumbers).toBool();
-  //glWidget->stateDrawBoundaryIndex = settings_value("view/boundaryIndex", glWidget->stateDrawBoundaryIndex).toBool();
-  //glWidget->stateDrawBodyIndex = settings_value("view/bodyIndex", glWidget->stateDrawBodyIndex).toBool();
-  //glWidget->stateBcColors = settings_value("view/colorBoundaries", glWidget->stateBcColors).toBool();
-  //glWidget->stateBodyColors = settings_value("view/colorBodies", glWidget->stateBodyColors).toBool();
+  // Color settings
   glWidget->backgroundColor = settings_value("color/background", glWidget->backgroundColor).value<QColor>();
   glWidget->surfaceColor = settings_value("color/surface", glWidget->surfaceColor).value<QColor>();
   glWidget->edgeColor = settings_value("color/edge", glWidget->edgeColor).value<QColor>();
@@ -7748,20 +7735,7 @@ void MainWindow::saveSettings() {
     settings_setValue("postProcessor/i", 2);
   }
   
-  // view menu settings
-  //settings_setValue("view/surfaceMesh", glWidget->stateDrawSurfaceMesh); 
-  //settings_setValue("view/volumeMesh", glWidget->stateDrawVolumeMesh); 
-  //settings_setValue("view/sharpEdge", glWidget->stateDrawSharpEdges); 
-  settings_setValue("view/compass", glWidget->stateDrawCoordinates); 
-  settings_setValue("view/flatShade", glWidget->stateFlatShade); 
-  settings_setValue("view/orthogonal", glWidget->stateOrtho);
-  //settings_setValue("view/surfaceNumbers", glWidget->stateDrawSurfaceNumbers);
-  //settings_setValue("view/edgeNumbers", glWidget->stateDrawEdgeNumbers);
-  //settings_setValue("view/nodeNumbers", glWidget->stateDrawNodeNumbers);
-  //settings_setValue("view/boundaryIndex", glWidget->stateDrawBoundaryIndex);
-  //settings_setValue("view/bodyIndex", glWidget->stateDrawBodyIndex);
-  //settings_setValue("view/colorBoundaries", glWidget->stateBcColors);
-  //settings_setValue("view/colorBodies", glWidget->stateBodyColors);
+  // Color settings
   settings_setValue("color/background", glWidget->backgroundColor);
   settings_setValue("color/surface", glWidget->surfaceColor);
   settings_setValue("color/edge", glWidget->edgeColor);

--- a/ElmerGUI/Application/src/mainwindow.cpp
+++ b/ElmerGUI/Application/src/mainwindow.cpp
@@ -7179,7 +7179,8 @@ void MainWindow::showaboutSlot() {
 
   QMessageBox msgBox(this);
   msgBox.setTextFormat(Qt::RichText);
-  msgBox.setIconPixmap( windowIcon().pixmap(32));
+  QIcon icon(windowIcon());
+  msgBox.setIconPixmap( icon.pixmap(32));
   msgBox.setWindowTitle(tr("Information about ElmerGUI"));
   msgBox.setText(
       tr("ElmerGUI is a preprocessor for two and "

--- a/ElmerGUI/Application/src/mainwindow.cpp
+++ b/ElmerGUI/Application/src/mainwindow.cpp
@@ -750,7 +750,7 @@ void MainWindow::createActions() {
           SLOT(sharpEdgeColorSlot()));
 
   // View -> Colors -> Selection
-  chooseSelectionColorAct = new QAction(QIcon(), tr("Selection ..."), this);
+  chooseSelectionColorAct = new QAction(QIcon(), tr("Selection..."), this);
   chooseSelectionColorAct->setStatusTip(tr("Set selection color"));
   connect(chooseSelectionColorAct, SIGNAL(triggered()), this,
           SLOT(selectionColorSlot()));

--- a/ElmerGUI/Application/src/mainwindow.h
+++ b/ElmerGUI/Application/src/mainwindow.h
@@ -172,6 +172,7 @@ private slots:
   void edgeColorSlot();             // View -> Colors -> Edges
   void surfaceMeshColorSlot();      // View -> Colors -> Surface mesh
   void sharpEdgeColorSlot();        // View -> Colors -> Sharp edges
+  void selectionColorSlot();        // View -> Colors -> Selection
   void colorizeBoundarySlot();      // View -> Colors -> Boundaries
   void colorizeBodySlot();          // View -> Colors -> Bodies
   void selectDefinedSurfacesSlot(); // View -> Select defined surfaces
@@ -377,6 +378,7 @@ private:
   QAction *chooseSurfaceMeshColorAct; // View -> Colors -> Surface mesh
   QAction *chooseSharpEdgeColorAct;   // View -> Colors -> Sharp edges
   QAction *chooseEdgeColorAct;        // View -> Colors -> Edge color
+  QAction *chooseSelectionColorAct;   // View -> Colors -> Selection
   QAction *showBoundaryColorAct;      // View -> Colors -> Boundaries
   QAction *showBodyColorAct;          // View -> Colors -> Body
   QAction *hideselectedAct;           // View -> Show selected


### PR DESCRIPTION
Hi,

This PR is to save and restore color settings in view menu. In view menu, a new sub-menu to change the color for Selected body/boundary (red in default) was added.
This also includes a bug fix for icon handling in "Information about ElmerGUI" dialog.

Regards.
Saeki