### PR TITLE
GUI geometry handling by mouse

### DIFF
--- a/ElmerGUI/Application/src/glwidget.cpp
+++ b/ElmerGUI/Application/src/glwidget.cpp
@@ -671,15 +671,23 @@ void GLWidget::keyReleaseEvent(QKeyEvent *event)
 
 
 
-// Mouse button clicked...
+// Mouse button pressed...
 //-----------------------------------------------------------------------------
 void GLWidget::mousePressEvent(QMouseEvent *event)
 {
   lastPos = event->pos();
+  lastPressPos = event->pos();
   setFocus();  // for tracing keyboard events
 }
 
-
+// Mouse button released...
+//-----------------------------------------------------------------------------
+void GLWidget::mouseReleaseEvent(QMouseEvent *event)
+{
+  if(event->button() == Qt::RightButton & event->pos() == lastPressPos){
+    ((MainWindow*)parent())->showContextMenu(event->globalPos());
+  }
+}
 
 // Mouse wheel rotates...
 //-----------------------------------------------------------------------------
@@ -706,15 +714,18 @@ void GLWidget::mouseMoveEvent(QMouseEvent *event)
 
   dy = -dy;
   
-  if (((event->buttons() & Qt::LeftButton) && 
-       (event->buttons() & Qt::MidButton)) ) {
+  if (
+  ((event->buttons() & Qt::LeftButton) && (event->buttons() & Qt::MidButton))
+        ||
+    event->buttons() == Qt::RightButton  // added for easy scalng
+       ) {
 
     // Scale:
     double s = exp(dy*0.01);
     glScaled(s, s, s);
     updateGL();
 
-  } else if (event->buttons() & Qt::LeftButton) {
+  } else if (event->buttons() == Qt::LeftButton) {
     
     // Rotation:
     double ax = -(double)dy;
@@ -728,7 +739,11 @@ void GLWidget::mouseMoveEvent(QMouseEvent *event)
     glRotated(s, bx, by, bz);
     updateGL();
 
-  } else if (event->buttons() & Qt::MidButton) {
+  } else if (
+  (event->buttons() == Qt::MidButton)
+  ||
+  (event->buttons() ==  (Qt::LeftButton | Qt::RightButton)) // added for 2 button mouse
+    ){
 
     // Translation:
     double s = 2.0/(double)(viewport[3]+1);

--- a/ElmerGUI/Application/src/glwidget.h
+++ b/ElmerGUI/Application/src/glwidget.h
@@ -193,6 +193,7 @@ protected:
   void focusInEvent(QFocusEvent*);
   void mouseDoubleClickEvent(QMouseEvent*);
   void mousePressEvent(QMouseEvent*);
+  void mouseReleaseEvent(QMouseEvent*);
   void mouseMoveEvent(QMouseEvent*);
   void wheelEvent(QWheelEvent*);
   void keyPressEvent(QKeyEvent*);
@@ -213,6 +214,10 @@ private:
   void getMatrix();
   
   QPoint lastPos;
+  
+  /* lastPressPos decleard below is used to identify whether to show contextmenu or
+   not when releaseing right mouse button*/
+  QPoint lastPressPos;
   
   GLuint generateSurfaceList(int, QColor);
   GLuint generateSurfaceMeshList(int, QColor);

--- a/ElmerGUI/Application/src/mainwindow.cpp
+++ b/ElmerGUI/Application/src/mainwindow.cpp
@@ -4254,6 +4254,7 @@ void MainWindow::modelClearSlot() {
 void MainWindow::viewFullScreenSlot() {
   if (!isFullScreen()) {
     cout << "Switching to full screen mode" << endl;
+    cout << "Press 'Esc' to leave full screen mode" << endl;
     menuBar()->hide();
     statusBar()->hide();
     fileToolBar->hide();
@@ -4289,8 +4290,13 @@ void MainWindow::viewNormalModeSlot() {
 // Context menu event (usually mouse has been right clicked)...
 //-----------------------------------------------------------------------------
 void MainWindow::contextMenuEvent(QContextMenuEvent *event) {
-  // if(isFullScreen())
-  contextMenu->popup(event->globalPos());
+  if(event->reason() != QContextMenuEvent::Mouse){
+    contextMenu->popup(event->globalPos());
+  }
+}
+
+void MainWindow::showContextMenu(QPoint globalPos){
+  contextMenu->popup(globalPos);
 }
 
 // View -> Surface mesh

--- a/ElmerGUI/Application/src/mainwindow.h
+++ b/ElmerGUI/Application/src/mainwindow.h
@@ -114,11 +114,12 @@ public:
                           const QVariant &defaultValue = QVariant()) const;
   void settings_setValue(const QString &key, const QVariant &value);
   void saveAndRun(bool generateSif);
+  void showContextMenu(QPoint);
 
 protected:
   void contextMenuEvent(QContextMenuEvent *event);
   void closeEvent(QCloseEvent *event);
-
+  
 private slots:
   // menu slots:
   void openSlot();                      // File -> Open...


### PR DESCRIPTION
This PR is on geometry handling by mouse drag based on [request](http://www.elmerfem.org/forum/viewtopic.php?p=8028#p8028) in Elmer Discussion Forum.

- Zoom by right mouse button
- Pan by left+right mouse button. This is for Windows/Linux laptops without mouse

The menu by right mouse button click is still available, but the menu appears only when right mouse button is released where it was pressed (i.e. without moving mouse.)