### PR TITLE
fix build with Qt5Gui

### DIFF
--- a/ElmerGUI/Application/twod/renderarea.cpp
+++ b/ElmerGUI/Application/twod/renderarea.cpp
@@ -38,6 +38,7 @@
  *                                                                           *
  *****************************************************************************/
 #include <QPainter>
+#include <QPainterPath>
 #include <QMouseEvent>
 #include <QFile>
 #include <QTextStream>


### PR DESCRIPTION
Failed to build ElmerGUI on Debian Bullseye, it reported
```
error: aggregate ‘QPainterPath path’ has incomplete type and cannot be defined
```
It needs to `#include <QPainterPath>` to pass build