### PR TITLE
Compatibility with Qwt 6.2. Fix for #293

### DIFF
--- a/ElmerGUI/Application/src/convergenceview.h
+++ b/ElmerGUI/Application/src/convergenceview.h
@@ -51,8 +51,8 @@
 #include <qwt_plot_curve.h>
 #include <qwt_plot_grid.h>
 #include <qwt_legend.h>
-/*#include <qwt_data.h> <-- deprecated in Qwt6, using qwt_compat.h instead*/
-#include <qwt_compat.h>
+/*#include <qwt_data.h> <-- deprecated in Qwt6, using qwt_compat.h instead
+#include <qwt_compat.h> <-- Removed in Qwt 6.2 */
 #include <qwt_text.h>
 #include <qwt_scale_engine.h>
 
@@ -76,8 +76,8 @@ public:
   
 private:
   int d_count;
-  QwtArray<double> d_x;
-  QwtArray<double> d_y;
+  QVector<double> d_x;
+  QVector<double> d_y;
 };
 
 class Curve


### PR DESCRIPTION
This modification should be compatible with Qwt 6.X. I don't know about older versions, but I think that shouldn't be a problem because v6 has been available in several distros since several years ago (including LTS ones).