### PR TITLE
GUI segmentation fault by doubleclicking

### DIFF
--- a/ElmerGUI/Application/src/glwidget.cpp
+++ b/ElmerGUI/Application/src/glwidget.cpp
@@ -876,7 +876,7 @@ void GLWidget::mouseDoubleClickEvent(QMouseEvent *event)
     if(l->getType() == SHARPEDGELIST) {
 
 	  /* 
-	  Restoration of view settings. These are adjusted at the begining of this function.
+	  Restoration of view settings. These were adjusted at the begining of this function.
 	  */
 	  stateDrawCoordinates = prevStateDrawCoordinates;
 	  stateDrawSurfaceNumbers = prevStateDrawSurfaceNumbers;
@@ -884,6 +884,7 @@ void GLWidget::mouseDoubleClickEvent(QMouseEvent *event)
 	  stateDrawNodeNumbers = prevStateDrawNodeNumbers;
 	  stateDrawBoundaryIndex = prevStateDrawBoundaryIndex;
 	  stateDrawBodyIndex = prevStateDrawBodyIndex;  
+	  
 
       updateGL();
 	  return;
@@ -1064,7 +1065,7 @@ void GLWidget::mouseDoubleClickEvent(QMouseEvent *event)
   }
 
   /* 
-  Restoration of view settings. These are adjusted at the begining of this function.
+  Restoration of view settings. These were adjusted at the begining of this function.
   */
   stateDrawCoordinates = prevStateDrawCoordinates;
   stateDrawSurfaceNumbers = prevStateDrawSurfaceNumbers;
@@ -1072,6 +1073,8 @@ void GLWidget::mouseDoubleClickEvent(QMouseEvent *event)
   stateDrawNodeNumbers = prevStateDrawNodeNumbers;
   stateDrawBoundaryIndex = prevStateDrawBoundaryIndex;
   stateDrawBodyIndex = prevStateDrawBodyIndex;  
+  
+  
   updateGL();
 }
 
@@ -2007,6 +2010,10 @@ void GLWidget::indexColors(int *c, int i)
 
 
 void GLWidget::setMeshVisibility(bool stateDrawSurfaceMesh, bool stateDrawVolumeMesh, bool stateDrawSharpEdges){
+/*
+  This function is used in mouseDoubleClickEvent(mouseEvent event) to avoid segmentation fault observed Linux
+  emvironment with old hardware.
+*/
 
   mesh_t *mesh = getMesh();
   int lists = getLists();
@@ -2018,7 +2025,8 @@ void GLWidget::setMeshVisibility(bool stateDrawSurfaceMesh, bool stateDrawVolume
 
   for (int i = 0; i < lists; i++) {
     list_t *l = getList(i);
-    if (l->getType() == SURFACEMESHLIST) {
+	int type = l->getType();
+    if (type == SURFACEMESHLIST) {
       l->setVisible(stateDrawSurfaceMesh);
 
       // do not set visible if the parent surface list is hidden
@@ -2028,13 +2036,10 @@ void GLWidget::setMeshVisibility(bool stateDrawSurfaceMesh, bool stateDrawVolume
         if (!lp->isVisible())
           l->setVisible(false);
       }
-    }
-
-    if (l->getType() == VOLUMEMESHLIST)
+    }else if (type == VOLUMEMESHLIST) {
       l->setVisible(stateDrawVolumeMesh);
-
-    if (l->getType() == SHARPEDGELIST)
+	}else if (type == SHARPEDGELIST) {
       l->setVisible(stateDrawSharpEdges);
-
+	}
   }
 }

--- a/ElmerGUI/Application/src/glwidget.cpp
+++ b/ElmerGUI/Application/src/glwidget.cpp
@@ -796,7 +796,7 @@ void GLWidget::mouseDoubleClickEvent(QMouseEvent *event)
   GLint hits;
   GLint i, j;
 
-////  updateGL(); // Maybe unneccesary
+  //updateGL(); This is maybe unneccesary. I tried to comment this out to suppress blinking of mesh. 
   
   glSelectBuffer(bufferSize, buffer);
   glRenderMode(GL_SELECT);
@@ -873,7 +873,7 @@ void GLWidget::mouseDoubleClickEvent(QMouseEvent *event)
 	  stateDrawSurfaceMesh = prevStateDrawSurfaceMesh;
 	  stateDrawVolumeMesh  = prevStateDrawVolumeMesh;
 	  stateDrawSharpEdges  = prevStateDrawSharpEdges;
-      //// updateGL();  // Maybe unneccesary
+      updateGL();
 	  return;
 	}
     
@@ -1062,7 +1062,7 @@ void GLWidget::mouseDoubleClickEvent(QMouseEvent *event)
   stateDrawVolumeMesh  = prevStateDrawVolumeMesh;
   stateDrawSharpEdges  = prevStateDrawSharpEdges;
 
-////  updateGL(); // Maybe unneccesary
+  updateGL();
 }
 
 

--- a/ElmerGUI/Application/src/glwidget.cpp
+++ b/ElmerGUI/Application/src/glwidget.cpp
@@ -769,6 +769,23 @@ void GLWidget::mouseDoubleClickEvent(QMouseEvent *event)
   if(getLists() == 0) 
     return;
 
+
+
+  /*
+  To avoid segmentation fault, compass, surface mesh, etc. are hidden. These
+  will be restored at the end of this function. Do not return before the restration.
+  */
+  bool prevStateDrawCoordinates = stateDrawCoordinates;
+  bool prevStateDrawSurfaceMesh = stateDrawSurfaceMesh;
+  bool prevStateDrawVolumeMesh  = stateDrawVolumeMesh;
+  bool prevStateDrawSharpEdges  = stateDrawSharpEdges;
+  stateDrawCoordinates= false;
+  stateDrawSurfaceMesh = false;
+  stateDrawVolumeMesh = false;
+  stateDrawSharpEdges = false;
+
+  
+
   static list_t dummylist;
   static GLuint buffer[1024];
   const int bufferSize = sizeof(buffer)/sizeof(GLuint);
@@ -779,7 +796,7 @@ void GLWidget::mouseDoubleClickEvent(QMouseEvent *event)
   GLint hits;
   GLint i, j;
 
-  updateGL();
+////  updateGL(); // Maybe unneccesary
   
   glSelectBuffer(bufferSize, buffer);
   glRenderMode(GL_SELECT);
@@ -847,8 +864,18 @@ void GLWidget::mouseDoubleClickEvent(QMouseEvent *event)
     list_t *l = getList(nearest);
 
     // skip sharp edge lists
-    if(l->getType() == SHARPEDGELIST) 
-      return;
+    if(l->getType() == SHARPEDGELIST) {
+	  /* 
+	  Restoration of view setting. These are adjusted to avoid segmentation fault at
+	  the begining of this function.
+	  */
+	  stateDrawCoordinates = prevStateDrawCoordinates;
+	  stateDrawSurfaceMesh = prevStateDrawSurfaceMesh;
+	  stateDrawVolumeMesh  = prevStateDrawVolumeMesh;
+	  stateDrawSharpEdges  = prevStateDrawSharpEdges;
+      //// updateGL();  // Maybe unneccesary
+	  return;
+	}
     
     // substitute surfacemeshlist with the parent surfacelist:
     if(l->getType() == SURFACEMESHLIST)
@@ -1024,7 +1051,18 @@ void GLWidget::mouseDoubleClickEvent(QMouseEvent *event)
 
   }
 
-  updateGL();
+
+  /* 
+  Restoration of view setting. These are adjusted to avoid segmentation fault at
+  the begining of this function.
+  */
+  
+  stateDrawCoordinates = prevStateDrawCoordinates;
+  stateDrawSurfaceMesh = prevStateDrawSurfaceMesh;
+  stateDrawVolumeMesh  = prevStateDrawVolumeMesh;
+  stateDrawSharpEdges  = prevStateDrawSharpEdges;
+
+////  updateGL(); // Maybe unneccesary
 }
 
 

--- a/ElmerGUI/Application/src/glwidget.h
+++ b/ElmerGUI/Application/src/glwidget.h
@@ -237,6 +237,8 @@ private:
   void drawBgImage();
 
   void changeNormalDirection(double*, double*);
+ 
+  void setMeshVisibility(bool, bool, bool);
 };
 
 #endif


### PR DESCRIPTION
I noticed that windows version of ElmerGUI crashes by doubleclicking mesh when compass (or numbers, etc) is shown. This PR is to avoid such crash by just hiding them when handling double click.