### PR TITLE
Commented out RotM call in 3D stranded coils and Changes in 3D transient Massive Coils

### DIFF
--- a/fem/src/modules/MagnetoDynamics/WhitneyAVHarmonicSolver.F90
+++ b/fem/src/modules/MagnetoDynamics/WhitneyAVHarmonicSolver.F90
@@ -421,7 +421,7 @@ CONTAINS
            SELECT CASE (CoilType)
            CASE ('stranded')
               CoilBody = .TRUE.
-              CALL GetElementRotM(Element, RotM, n)
+              !CALL GetElementRotM(Element, RotM, n)
            CASE ('massive')
               CoilBody = .TRUE.
            CASE ('foil winding')


### PR DESCRIPTION
I commented out the GetElementRotM within the Stranded in the WhitneyAVHarmonicSolver. I didn't remove it just in case but in the tests I've been running, this call doesn't seem to be doing anything. It should be removed in the future. 

The second commit are the changes needed to use WVector in 3D massive conductor cases