### PR TITLE
Qt5 detection

### DIFF
--- a/ElmerGUI/CMakeLists.txt
+++ b/ElmerGUI/CMakeLists.txt
@@ -16,6 +16,11 @@ SET(WITH_VTK FALSE CACHE BOOL "ElmerGUI: Use VTK for postprocessing?")
 SET(WITH_QWT TRUE CACHE BOOL "ElmerGUI: Use QWT for convergence monitor?")
 SET(WITH_ELMERGUILOGGER FALSE CACHE BOOL "ElmerGUI: Include ElmerGUIlogger")
 
+find_package(Qt5 COMPONENTS Widgets)
+if (Qt5_FOUND)
+set(WITH_QT5 TRUE CACHE BOOL "ElmerGUI: Use Qt5")
+endif()
+
 IF(WITH_QT5)
   MESSAGE(STATUS "------------------------------------------------")
   IF(WIN32)


### PR DESCRIPTION
Just added Qt5 detection in CMakeLists.txt to skip manual definition of WITH_QT5. I'm not so sure this is helpful for all the people, but is convenient at least for myself who uses cmake-gui. 