### PR TITLE
[cmake] fix module path in `test_macros` 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -88,8 +88,7 @@ if(${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
 endif(${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
 
 
-# SET(CMAKE_MODULE_PATH "${CMAKE_ROOT}/Modules;${PROJECT_SOURCE_DIR}/cmake/Modules")
-SET(CMAKE_MODULE_PATH "${PROJECT_SOURCE_DIR}/cmake/Modules;${CMAKE_ROOT}/Modules")
+SET(CMAKE_MODULE_PATH "${CMAKE_ROOT}/Modules;${PROJECT_SOURCE_DIR}/cmake/Modules")
 
 SET(CMAKE_Fortran_MODULE_DIRECTORY
   ${PROJECT_BINARY_DIR}/fmodules CACHE PATH "Directory for Fortran modules")

--- a/cmake/Modules/test_macros.cmake
+++ b/cmake/Modules/test_macros.cmake
@@ -5,6 +5,8 @@ ENDMACRO()
 
 
 MACRO(ADD_ELMER_TEST TestName)
+  # Escape \; in CMAKE_MODULE_PATH allowing to pass it as argument to `COMMAND` in `add_test()`
+  string(REPLACE ";" "\\;" CMAKE_MODULE_PATH_escaped "${CMAKE_MODULE_PATH}")
   # Parse optional named arguments, NPROCS and LABELS, which can be lists
   CMAKE_PARSE_ARGUMENTS(_parsedArgs "" "" "NPROCS;LABELS" "${ARGN}")
 
@@ -48,7 +50,7 @@ MACRO(ADD_ELMER_TEST TestName)
       ADD_TEST(NAME ${_this_test_name}
         WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
         COMMAND ${CMAKE_COMMAND}
-        -DCMAKE_MODULE_PATH=${CMAKE_MODULE_PATH}
+        -DCMAKE_MODULE_PATH=${CMAKE_MODULE_PATH_escaped}
         -DELMERGRID_BIN=${ELMERGRID_BIN}
         -DELMERSOLVER_BIN=${ELMERSOLVER_BIN}
         -DFINDNORM_BIN=${FINDNORM_BIN}


### PR DESCRIPTION
https://github.com/ElmerCSC/elmerfem/pull/303#issuecomment-971400868

> I had to revert this since I got reports that it caused the tests not running succesfully. I didn't dig deeper being no cmake wizard myself.

I've pinpointed the issue here, you can't use `${CMAKE_MODULE_PATH}` in `add_test()` directly as it gets expanded and effectively only the first element of the list will get passed to the `COMMAND` arg list.

Quick solution for it would be to escape semicolons in `CMAKE_MODULE_PATH` before passing it as an argument to `COMMAND` in `add_test()`

Rationale: https://github.com/ElmerCSC/elmerfem/pull/303#issuecomment-982979150