### PR TITLE
Some fixed bugs in GUI

### DIFF
--- a/ElmerGUI/Application/src/mainwindow.cpp
+++ b/ElmerGUI/Application/src/mainwindow.cpp
@@ -8116,3 +8116,11 @@ void MainWindow::selectParaViewSlot(){
   selectVtkPostAct->setChecked(false);
   selectParaViewAct->setChecked(true);
 }
+
+void MainWindow::rebuildGLLists(){
+  /*
+  This function is assumed to be called from ObjectBrowser to avoid a problem of 3D surface
+  mesh not shown correctly when project loading (typically, TemperatureGeneric sample)
+  */
+  glWidget->rebuildLists();
+}

--- a/ElmerGUI/Application/src/mainwindow.cpp
+++ b/ElmerGUI/Application/src/mainwindow.cpp
@@ -1814,11 +1814,12 @@ void MainWindow::saveAsSlot() {
 
   QString defaultDirName = getDefaultDirName();
 
-  saveDirName = QFileDialog::getExistingDirectory(
+  QString dirName = QFileDialog::getExistingDirectory(
       this, tr("Open directory to save mesh"), defaultDirName);
 
-  if (!saveDirName.isEmpty()) {
-    logMessage("Output directory " + saveDirName);
+  if (!dirName.isEmpty()) {
+    logMessage("Output directory " + dirName);
+    saveDirName = dirName;
   } else {
     logMessage("Unable to save: directory undefined");
     return;

--- a/ElmerGUI/Application/src/mainwindow.cpp
+++ b/ElmerGUI/Application/src/mainwindow.cpp
@@ -309,11 +309,13 @@ MainWindow::MainWindow() {
   // default size:
   int defW = egIni->value("width").toInt();
   int defH = egIni->value("height").toInt();
-  if (defW <= 200)
-    defW = 200;
-  if (defH <= 200)
-    defH = 200;
+  if (defW <= 300)
+    defW = 300;
+  if (defH <= 300)
+    defH = 300;
   this->resize(defW, defH);
+  sifWindow->resize(defW - 50, defH - 50);  
+  solverLogWindow->resize(defW - 50, defH - 50);
 
   loadSettings();
 }

--- a/ElmerGUI/Application/src/mainwindow.h
+++ b/ElmerGUI/Application/src/mainwindow.h
@@ -561,6 +561,13 @@ private:
 
 
   ObjectBrowser *objectBrowser;
+
+public:  
+  /*
+  rebuildGLLists() is assumed to be called from ObjectBrowser to avoid a problem of 3D surface 
+  mesh not shown correctly when project loading (typically, TemperatureGeneric sample)
+  */
+  void rebuildGLLists();
 };
 
 #endif // MAINWINDOW_H

--- a/ElmerGUI/Application/src/objectbrowser.cpp
+++ b/ElmerGUI/Application/src/objectbrowser.cpp
@@ -878,6 +878,10 @@ void ObjectBrowser::loadProjectSlot() {
 
   tree->resizeColumnToContents(0);
   tree->resizeColumnToContents(1);
+  
+  /* Call rebuildGLLists() to avoid a problem of 3D surface mesh not shown
+  correctly when project loading (typically, TemperatureGeneric sample) */
+  mainwindow->rebuildGLLists();
 }
 
 void ObjectBrowser::saveProjectSlot() {


### PR DESCRIPTION
This PR is for fixing some bugs:

**Very small Sif Window and Solver Log Window** 
 Initial window size for Sif Window and Solver Log Window was not set and it caused very small window when launching ElmerGUI for the first time.  This is fixed in the PR by adding initial size for these windows.

**Default directory name for mesh saving** 
Default directory name for mesh saving was not retained when users canceled saving mesh.  This is improved in the PR by storing default directory name in MainWindow::saveAsSlot().
 
**3D mesh display**
In some cases, 3D mesh was not displayed correctly when loading project (typically, GenericTemperature sample in GUI tutorial). This is improved in the PR by adding redraw operation in the end of  ObjectBrowser::loadProjectSlot(). 