### PR TITLE
GUI body selection

### DIFF
--- a/ElmerGUI/Application/src/glwidget.cpp
+++ b/ElmerGUI/Application/src/glwidget.cpp
@@ -1041,11 +1041,16 @@ void GLWidget::mouseDoubleClickEvent(QMouseEvent *event)
 	  count++;
 	  found = i;
 	}
+//	cout << i << ": tmp1,2= " << tmp1[i] << "," << tmp2[i] << endl; 
       }
       
       if((count == 1) && (found >= 0))
 	currentlySelectedBody = found;
-      
+    else if((count > 1)){
+	  int m = mostVisibleBody(MAX_BULK_INDEX, tmp1);
+	  if(m >=0) currentlySelectedBody = m;
+	}
+     
       delete [] tmp1;
       delete [] tmp2;
     }
@@ -2042,4 +2047,58 @@ void GLWidget::setMeshVisibility(bool stateDrawSurfaceMesh, bool stateDrawVolume
       l->setVisible(stateDrawSharpEdges);
 	}
   }
+}
+
+int GLWidget::mostVisibleBody(int n, bool* tmp1){
+/*
+This function is called in GLWidget::mouseDoubleClickEvent(QMouseEvent *event) to
+identify the most visible body when the double-clicked surface is shared by multiple bodies.
+This is a public function to be called from ObjectBrowser. 
+*/
+
+  long *nElement = new long[n];
+  long *nVisibleElement = new long[n];
+  for(int i = 0; i < n; i++){
+    nElement[i] = 0;
+    nVisibleElement[i] = 0;
+  }
+
+  for(int i = 0; i < getLists(); i++) {
+    list_t *l2 = getList(i);
+	if(l2->getNature() == PDE_BOUNDARY && l2->getType() == SURFACELIST) {
+      for(int j = 0; j < mesh->getSurfaces(); j++) {
+	    surface_t *surf = mesh->getSurface(j);
+	    if(surf->getIndex() == l2->getIndex()) { 
+	      for(int k = 0; k < surf->getElements(); k++) {
+		    int l = surf->getElementIndex(k);
+ 		    if(l < 0) 
+		      break;
+		    element_t *elem = mesh->getElement(l);
+		    if((elem->getIndex() < 0) || (elem->getIndex() >= n))
+		      break;
+		  	nElement[elem->getIndex()]++;
+		    if(l2->isVisible())nVisibleElement[elem->getIndex()]++;
+          }
+		}
+      }
+    }
+  }
+  
+  double max = -1.0;
+  int selected = -1;
+  double visibility = -2.0;
+  for(int i = 0; i < n; i++){
+    if(tmp1[i] && nElement[i] > 0){
+    visibility = ((double) nVisibleElement[i]) / nElement[i];
+cout << i << " visibility=" << visibility << " (" << nVisibleElement[i] << "/" << nElement[i] << ")" << endl; 
+      if(visibility > max){
+		max = visibility;
+		selected = i;
+	  }
+    }
+  }
+  delete[] nElement;
+  delete[] nVisibleElement;
+cout << "selected: " << selected << endl;  
+  return selected;
 }

--- a/ElmerGUI/Application/src/glwidget.cpp
+++ b/ElmerGUI/Application/src/glwidget.cpp
@@ -2090,7 +2090,7 @@ This is a public function to be called from ObjectBrowser.
   for(int i = 0; i < n; i++){
     if(tmp1[i] && nElement[i] > 0){
     visibility = ((double) nVisibleElement[i]) / nElement[i];
-cout << i << " visibility=" << visibility << " (" << nVisibleElement[i] << "/" << nElement[i] << ")" << endl; 
+//cout << i << " visibility=" << visibility << " (" << nVisibleElement[i] << "/" << nElement[i] << ")" << endl; 
       if(visibility > max){
 		max = visibility;
 		selected = i;
@@ -2099,6 +2099,6 @@ cout << i << " visibility=" << visibility << " (" << nVisibleElement[i] << "/" <
   }
   delete[] nElement;
   delete[] nVisibleElement;
-cout << "selected: " << selected << endl;  
+//cout << "selected: " << selected << endl;  
   return selected;
 }

--- a/ElmerGUI/Application/src/glwidget.h
+++ b/ElmerGUI/Application/src/glwidget.h
@@ -239,6 +239,9 @@ private:
   void changeNormalDirection(double*, double*);
  
   void setMeshVisibility(bool, bool, bool);
+
+public:  
+  int mostVisibleBody(int, bool*);
 };
 
 #endif

--- a/ElmerGUI/Application/src/objectbrowser.cpp
+++ b/ElmerGUI/Application/src/objectbrowser.cpp
@@ -1374,7 +1374,9 @@ int ObjectBrowser::boundaryListToBodyIndex(list_t *l) {
       mainwindow->glWidget->currentlySelectedBody = found;
       ret = found;
       // cout << "*****boundary found: " << found << endl;
-    }
+    }else{
+	  ret = mainwindow->glWidget->mostVisibleBody(MAX_BULK_INDEX, tmp1);
+	}
     delete[] tmp1;
     delete[] tmp2;
   }


### PR DESCRIPTION
This PR is to mitigate the body selection issue of ElmerGUI discussed in [Elmer Discussion Forum](http://www.elmerfem.org/forum/viewtopic.php?t=7692) . When users double-click a surface shared by multiple bodies, ElmerGUI cannot determine right body to select ( and actually selects nothing.) This causes a problem especially when a body is fully surrounded by another body.  Unfortunately, selecting body by using ObjectBrowser also didn't work in such case. I have added an procedure to 'guess' right body and it also helps select the body by using Object Browser even in such case.
 
This is just a guess based on the assumption that users must hide at least one surface of the outer body to double click the inner body. (This is not always correct as clipping makes it possible to see the inner body without hiding the outer body, but it must be rare case.) The guess may not right in all the cases, but users can select the body by Object Browser.