### PR TITLE
GUI Crossed solver specific options

### DIFF
--- a/ElmerGUI/Application/src/mainwindow.cpp
+++ b/ElmerGUI/Application/src/mainwindow.cpp
@@ -2502,10 +2502,12 @@ void MainWindow::loadProject(QString projectDirName) {
 
       // following 3 lines were moved into if() block to avoid doubled "Solver
       // specific options" tabs (Nov 2019 by TS)
-      spe->generalOptions->setupTabs(elmerDefs, "Solver", id);
+	  // The argument "index" in the following two functions is changed from "id" to avoid
+	  // crossed parameters (Mar 2022 by TS) See http://www.elmerfem.org/forum/viewtopic.php?t=7696
+      spe->generalOptions->setupTabs(elmerDefs, "Solver", index);
       spe->generalOptions->populateHash(&item);
       spe->ui.solverControlTabs->insertTab(
-          0, spe->generalOptions->tabWidget->widget(id),
+          0, spe->generalOptions->tabWidget->widget(index),
           "Solver specific options");
     }
   }


### PR DESCRIPTION
This PR is to fix a bug reported in [Elmer Discussion Forum](http://www.elmerfem.org/forum/viewtopic.php?t=7696).  I have attached a project of such example for the case you would like to test. 

- [SampleProject.zip](https://github.com/ElmerCSC/elmerfem/files/8190783/SampleProject.zip)

When loading the attached project, as shown in the picture below, settings for Result Output solver showed up in solver specific options tab for Non-liner Elasticity solver in Windows environment.  (Interestingly, settings for Vorticity solver showed up in Ubuntu instead.)  This is fixed by the new code.

![example](https://user-images.githubusercontent.com/53612710/156886277-56beff03-62ca-4887-a6d1-057f27fe85b6.png)

Saeki