### PR TITLE
Excess core loss coefficient and interpolation

### DIFF
--- a/fem/src/Interpolation.F90
+++ b/fem/src/Interpolation.F90
@@ -260,6 +260,13 @@ MODULE Interpolation
         sumdist = MAX( -ug, 0.0 ) + MAX( -vg, 0.0 ) + MAX( -wg, 0.0 ) 
         sumdist = sumdist + MAX( ug + vg + wg - 1.0, 0.0 ) 
         
+      CASE(6)
+	sumdist = MAX( -wg, 0.0 )
+        sumdist = sumdist + MAX( ug + wg - 1.0_dp, 0.0 )
+        sumdist = sumdist + MAX( -ug + wg - 1.0_dp, 0.0 )
+        sumdist = sumdist + MAX( vg + wg - 1.0_dp, 0.0 )
+        sumdist = sumdist + MAX( -vg + wg - 1.0_dp, 0.0 )
+        
       CASE(7)
         sumdist = MAX( -ug, 0.0 ) + MAX( -vg, 0.0 ) 
         sumdist = sumdist + MAX( ug + vg - 1.0_dp, 0.0 ) 


### PR DESCRIPTION
For electrical steel, core loss depends on frequency and magnetic field flux.
Three coefficient models are more accurate and used by commercial software.
1) hysteresis core loss coefficient,
2) eddy-current core loss coefficient
3) excess core loss coefficient

Additionally, an interpolation scheme is added for the missing element type.