### PR TITLE
The unauthenticated git protocol on port 9418 is no longer supported.

### DIFF
--- a/docker/elmer.dockerfile
+++ b/docker/elmer.dockerfile
@@ -27,7 +27,7 @@ RUN apt update -o Acquire::CompressionTypes::Order::=gz && apt upgrade -y && apt
         curl
 
 # Clone the ElmerIce source code and compile Elmer/Ice
-RUN git clone git://www.github.com/ElmerCSC/elmerfem elmer \
+RUN git clone https://www.github.com/ElmerCSC/elmerfem elmer \
         && mkdir elmer/builddir \
 	&& cd elmer/builddir \
 	&& cmake /home/elmer \


### PR DESCRIPTION
This is necessary to make the docker image build to work again.