### PR TITLE
Add installation of libparmetis-dev

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -79,7 +79,7 @@ You may find the PDFs for the documentation http://www.elmerfem.org/blog/documen
     ** `sudo apt install libqt4-dev libqwt-dev`
     ** `cmake .. -DWITH_OpenMP:BOOLEAN=TRUE -DWITH_MPI:BOOLEAN=TRUE -DWITH_ELMERGUI:BOOLEAN=TRUE`
  * With Elmer/Ice (enabling netcdf and MUMPS):
-    ** `sudo apt install libnetcdf-dev libnetcdff-dev libmumps-dev`
+    ** `sudo apt install libnetcdf-dev libnetcdff-dev libmumps-dev libparmetis-dev`
     ** `cmake .. -DWITH_OpenMP:BOOLEAN=TRUE -DWITH_MPI:BOOLEAN=TRUE -DWITH_ElmerIce:BOOLEAN=TRUE -DWITH_Mumps:BOOL=TRUE` 
  * `make`
  * `sudo make install`


### PR DESCRIPTION
On Kubuntu I followed your Ubuntu instructions for building "With Elmer/Ice (enabling netcdf and MUMPS)" but cmake failed complaining about Parmetis.
I installed it with `sudo apt install libparmetis-dev` and cmake succeeded.
Then make succeded.