### PR TITLE
Fix typos in post/ subdirectory

### DIFF
--- a/matc/src/str.c
+++ b/matc/src/str.c
@@ -267,7 +267,7 @@ void str_com_init()
   static char *sprintfHelp =
   {
      "str = sprintf( fmt[, vec] )\n"
-     "Return a string formated using fmt and values from vec. A call to\n"
+     "Return a string formatted using fmt and values from vec. A call to\n"
      "corresponding C-language function is made.\n\n"
   };
 

--- a/post/doc/matc/node15.html
+++ b/post/doc/matc/node15.html
@@ -17,7 +17,7 @@
 <BR> <P>
 <H1><A NAME="SECTION005100000000000000000"> str = fread(fp,n)</A></H1>
 <P>
-Read n bytes from file given by fp.  File pointer fp shoud have been
+Read n bytes from file given by fp.  File pointer fp should have been
 obtained from a call to fopen or freopen, or be the standard input
 file stdin. Data is returned as function value.
 <P>

--- a/post/doc/matc/node16.html
+++ b/post/doc/matc/node16.html
@@ -18,7 +18,7 @@
 <H1><A NAME="SECTION005110000000000000000"> vec = fscanf(fp,fmt)</A></H1>
 <P>
 Read file fp as given in format. Format fmt is equal to C-language format.
-File pointer fp shoud have been obtained from a call to fopen or freopen,
+File pointer fp should have been obtained from a call to fopen or freopen,
 or be the standard input.
 <P>
 SEE ALSO: fopen,freopen,fgets,fread,matcvt,cvtmat.

--- a/post/doc/matc/node17.html
+++ b/post/doc/matc/node17.html
@@ -17,7 +17,7 @@
 <BR> <P>
 <H1><A NAME="SECTION005120000000000000000"> str = fgets(fp)</A></H1>
 <P>
-Read next line from fp. File pointer fp shoud have been obtained from a call
+Read next line from fp. File pointer fp should have been obtained from a call
 to fopen or freopen or be the standard input.
 <P>
 SEE ALSO: fopen,freopen,fread,fscanf,matcvt,cvtmat.

--- a/post/doc/matc/node18.html
+++ b/post/doc/matc/node18.html
@@ -17,7 +17,7 @@
 <BR> <P>
 <H1><A NAME="SECTION005130000000000000000"> n = fwrite(fp,buf,n)</A></H1>
 <P>
-Write n bytes form buf to file fp. File pointer fp shoud have been obtained
+Write n bytes form buf to file fp. File pointer fp should have been obtained
 from a call to fopen or freopen or be the standard output (stdout) or standard
 error (stderr). Return value is number of bytes actually written.
 <P>

--- a/post/doc/matc/node19.html
+++ b/post/doc/matc/node19.html
@@ -17,7 +17,7 @@
 <BR> <P>
 <H1><A NAME="SECTION005140000000000000000"> n = fprintf(fp,fmt[, vec])</A></H1>
 <P>
-Write formatted string to file fp. File pointer fp shoud have been obtained
+Write formatted string to file fp. File pointer fp should have been obtained
 from a call to fopen or freopen or be the standard output (stdout) or standard
 error (stderr). The format fmt is equal to C-language format.
 <P>

--- a/post/doc/matc/node2.html
+++ b/post/doc/matc/node2.html
@@ -12,7 +12,7 @@
 <BODY LANG="EN">
  <A NAME="tex2html74" HREF="node3.html"><IMG WIDTH=37 HEIGHT=24 ALIGN=BOTTOM ALT="next" SRC="lh-figs/next_motif.gif"></A> <A NAME="tex2html72" HREF="kirja.html"><IMG WIDTH=26 HEIGHT=24 ALIGN=BOTTOM ALT="up" SRC="lh-figs/up_motif.gif"></A> <A NAME="tex2html66" HREF="node1.html"><IMG WIDTH=63 HEIGHT=24 ALIGN=BOTTOM ALT="previous" SRC="lh-figs/previous_motif.gif"></A>   <BR>
 <B> Next:</B> <A NAME="tex2html75" HREF="node3.html">MATC Operators</A>
-<B>Up:</B> <A NAME="tex2html73" HREF="kirja.html">MATC Matrix Languge</A>
+<B>Up:</B> <A NAME="tex2html73" HREF="kirja.html">MATC Matrix Language</A>
 <B> Previous:</B> <A NAME="tex2html67" HREF="node1.html">MATC Variables</A>
 <BR> <P>
 <H1><A NAME="SECTION00200000000000000000">MATC general flow control structures</A></H1>

--- a/post/doc/matc/node3.html
+++ b/post/doc/matc/node3.html
@@ -67,7 +67,7 @@
 <P>
  <IMG WIDTH=90 HEIGHT=25 ALIGN=MIDDLE ALT="tex2html_wrap_inline303" SRC="img16.gif"  >    resize <I>a</I> to matrix of size <I>n</I> by <I>m</I>.
 <P>
-<I>b</I>=<I>a</I>           assing <I>a</I> to <I>b</I>.
+<I>b</I>=<I>a</I>           assign <I>a</I> to <I>b</I>.
 <P>
 <BR> <HR>
 <P><ADDRESS>

--- a/post/doc/matc/node4.html
+++ b/post/doc/matc/node4.html
@@ -37,7 +37,7 @@ Functions have their own list of variables. Global variables are not seen
 in this function unless imported by import or given as arguments. Local
 variables can be made global by the export statement.
 <P>
-Functions, if returing matrices,  behave in many ways as variables do.  So if
+Functions, if returning matrices,  behave in many ways as variables do.  So if
 you have defined function mult as follows
 <P>
 <PRE>function mult(a,b)

--- a/post/matc/src/clip.c
+++ b/post/matc/src/clip.c
@@ -87,7 +87,7 @@
    RETURN: Number of points in the polygon inside the box
 
    NOTICE! The new number of points may be GRATER than the in origin!
-           The theoretical number of points newer execeeds twice 
+           The theoretical number of points newer exceeds twice 
            the number in origin. 
 ************************************o*************************************/
 int clip_poly(n,x,y)
@@ -169,7 +169,7 @@ int *n;                            /* Number of points in polygon      */
         else
           if(this) 
           {
-            if(j+2 > i)            /* Too many points whitout shift */
+            if(j+2 > i)            /* Too many points without shift */
             {
               for(k=nn; k>i ; k--) { x[k]=x[k-1]; y[k]=y[k-1]; }
               nn++;

--- a/post/matc/src/elmer/matc.h
+++ b/post/matc/src/elmer/matc.h
@@ -205,7 +205,7 @@ typedef struct function
 #define FUNCSIZE sizeof(FUNCTION)
 
 /*******************************************************************
-               MISC DEFINITONS FOR PARSER
+               MISC DEFINITIONS FOR PARSER
 *******************************************************************/
 
 typedef enum symbols {
@@ -478,6 +478,6 @@ extern void PrintOut( char *format, ... );
 #include "fnames.h"
 
 /*******************************************************************
-                  graphics package defitions
+                  graphics package definitions
 *******************************************************************/ 
 #include "gra.h"

--- a/post/matc/src/error.c
+++ b/post/matc/src/error.c
@@ -69,7 +69,7 @@
 
 void sig_trap(int sig)
 /*======================================================================
-?  Interrupt or floating point exeption. Free all memory allocated 
+?  Interrupt or floating point exception. Free all memory allocated 
 |  after last call to doread, give an error message and
 |  longjump back to doread.
 &  longjmp, mem_free_all

--- a/post/matc/src/eval.c
+++ b/post/matc/src/eval.c
@@ -353,7 +353,7 @@ VARIABLE *evaltree(root) TREE *root;
     */
 
     /******************************************************
-       deleteting temporaries, preparing for next loop
+       deleting temporaries, preparing for next loop
     *******************************************************/
     if (subs != NULL)
     {
@@ -584,7 +584,7 @@ VARIABLE *evalclause(root) CLAUSE *root;
         par = NULL;
 
         /*
-         *   there is an explicit assigment  (ie. x = x + 1, not x + 1)
+         *   there is an explicit assignment  (ie. x = x + 1, not x + 1)
          */
         if (root->this)
         {

--- a/post/matc/src/files.c
+++ b/post/matc/src/files.c
@@ -565,7 +565,7 @@ void fil_com_init()
   static char *freadHelp =
   {
       "str = fread( fp,len )\n\n"
-      "Read len character  from file fp.  File pointer fp shoud have been\n"
+      "Read len character  from file fp.  File pointer fp should have been\n"
       "obtained from a call to fopen or freopen, or be the standard input\n"
       "file stdin. Characters are returned as function value.\n"
       "\n"
@@ -576,7 +576,7 @@ void fil_com_init()
   {
       "vec = fscanf( fp,format )\n\n"
       "Read file fp as given in format. Format is equal to C-language format\n"
-      "File pointer fp shoud have been obtained from a call to fopen or freopen,\n"
+      "File pointer fp should have been obtained from a call to fopen or freopen,\n"
       "or be the standard input.\n"
       "\n"
       "SEE ALSO: fopen,freopen,fgets,fread,matcvt,cvtmat.\n"
@@ -585,7 +585,7 @@ void fil_com_init()
   static char *fgetsHelp =
   {
       "str = fgets( fp )\n\n"
-      "Read next line from fp. File pointer fp shoud have been obtained from a call\n"
+      "Read next line from fp. File pointer fp should have been obtained from a call\n"
       "to fopen or freopen or be the standard input.\n"
       "\n"
       "SEE ALSO: fopen,freopen,fread,fscanf,matcvt,cvtmat.\n"
@@ -594,7 +594,7 @@ void fil_com_init()
   static char *fwriteHelp =
   {
       "n = fwrite( fp, buf,len )\n\n"
-      "Write len bytes form buf to file fp. File pointer fp shoud have been obtained\n"
+      "Write len bytes form buf to file fp. File pointer fp should have been obtained\n"
       "from a call to fopen or freopen or be the standard output (stdout) or standard\n"
       "error (stderr). Return value is number of characters actually written.\n"
       "\n"
@@ -604,7 +604,7 @@ void fil_com_init()
   static char *fprintfHelp =
   {
       "n = fprintf( fp, format[, vec] )\n\n"
-      "Write formatted string to file fp. File pointer fp shoud have been obtained\n"
+      "Write formatted string to file fp. File pointer fp should have been obtained\n"
       "from a call to fopen or freopen or be the standard output (stdout) or standard\n"
       "error (stderr). The format is equal to C-language format.\n"
       "\n"

--- a/post/matc/src/matc.c
+++ b/post/matc/src/matc.c
@@ -184,7 +184,7 @@ void mtc_init( FILE *input_file, FILE *output_file, FILE *error_file )
 
 #if 0
   /*
-   *  trap INTERRUPT and Floating Point Exeption signals
+   *  trap INTERRUPT and Floating Point Exception signals
    */ 
    signal(SIGFPE, sig_trap);
 
@@ -605,7 +605,7 @@ VARIABLE *com_pointw(sub, ptr)  double (*sub)(); VARIABLE *ptr;
 ?  This routine does a function call (*sub)(), for each element in
 |  matrix given by ptr.  
 |
-=  a temporay VARIABLE for which M(res, i, j) = (*sub)(M(ptr, i, j)
+=  a temporary VARIABLE for which M(res, i, j) = (*sub)(M(ptr, i, j)
 &  var_temp_new(), *(sub)()
 ^=====================================================================*/
 {
@@ -660,7 +660,7 @@ VARIABLE *com_el(ptr) VARIABLE *ptr;
 {
   VARIABLE *res,               /* result ... */
            *par = NEXT(ptr);   /* pointer to list of VARIABLES */
-                               /* containig indexes            */
+                               /* containing indexes            */
 
   static double defind = 0.0;
 
@@ -843,7 +843,7 @@ VARIABLE *com_apply(ptr) VARIABLE *ptr;
 
 void mem_free(void *mem)
 /*======================================================================
-?  Free memory given by argument, and unlink it from alloction list.
+?  Free memory given by argument, and unlink it from allocation list.
 |  Currently FREEMEM(ptr) is defined to be mem_free(ptr).
 |
 &  free()

--- a/post/matc/src/oper.c
+++ b/post/matc/src/oper.c
@@ -60,7 +60,7 @@ $  usage of the function and type of the parameters
 @  globals effected directly by this routine
 !  current known bugs or limitations
 &  functions called by this function
-~  these functions may intrest you as an alternative function or
+~  these functions may interest you as an alternative function or
 |  because they control this function somehow
 =====================================================================*/
 

--- a/post/matc/src/parser.c
+++ b/post/matc/src/parser.c
@@ -375,7 +375,7 @@ TREE *nameorvar()
       scan(); LEFT(treeptr) = equation();
       if (symbol != rightpar)
       {
-        error("Right paranthesis missing.\n");
+        error("Right parenthesis missing.\n");
       }
       ETYPE(treeptr) = ETYPE_EQUAT;
       break;

--- a/post/matc/src/str.c
+++ b/post/matc/src/str.c
@@ -248,7 +248,7 @@ void str_com_init()
   static char *sprintfHelp =
   {
      "str = sprintf( fmt[, vec] )\n"
-     "Return a string formated using fmt and values from vec. A call to\n"
+     "Return a string formatted using fmt and values from vec. A call to\n"
      "corresponding C-language function is made.\n\n"
   };
 

--- a/post/src/camera/camera.c
+++ b/post/src/camera/camera.c
@@ -133,7 +133,7 @@ void cam_set_projection( camera_t *camera,camera_proj_t projection )
  *
  *     Parameters:
  *
- *         Input:   (float) intput field angle.
+ *         Input:   (float) input field angle.
  *
  *         Output:  (camera_t *) camera structure is modified
  *

--- a/post/src/geometry.c
+++ b/post/src/geometry.c
@@ -488,7 +488,7 @@ void geo_vertex_normals( geometry_t *geometry, double Ang )
         v = t[i].Fu[1];
         w = t[i].Fu[2];
 
-        for( j=0; j<3; j++ )                   /* trough face vertices */
+        for( j=0; j<3; j++ )                   /* through face vertices */
         {
             t[i].u[j][0] = u;
             t[i].u[j][1] = v;
@@ -497,7 +497,7 @@ void geo_vertex_normals( geometry_t *geometry, double Ang )
             vertex = &p[t[i].v[j]];
 
             /*
-             * loop trough faces connected to a vertex
+             * loop through faces connected to a vertex
              */
             for( Faces=vertex->Faces; Faces != NULL; Faces=Faces->Next )
             {

--- a/post/src/help/matc/node15.html
+++ b/post/src/help/matc/node15.html
@@ -17,7 +17,7 @@
 <BR> <P>
 <H1><A NAME="SECTION005100000000000000000"> str = fread(fp,n)</A></H1>
 <P>
-Read n bytes from file given by fp.  File pointer fp shoud have been
+Read n bytes from file given by fp.  File pointer fp should have been
 obtained from a call to fopen or freopen, or be the standard input
 file stdin. Data is returned as function value.
 <P>

--- a/post/src/help/matc/node16.html
+++ b/post/src/help/matc/node16.html
@@ -18,7 +18,7 @@
 <H1><A NAME="SECTION005110000000000000000"> vec = fscanf(fp,fmt)</A></H1>
 <P>
 Read file fp as given in format. Format fmt is equal to C-language format.
-File pointer fp shoud have been obtained from a call to fopen or freopen,
+File pointer fp should have been obtained from a call to fopen or freopen,
 or be the standard input.
 <P>
 SEE ALSO: fopen,freopen,fgets,fread,matcvt,cvtmat.

--- a/post/src/help/matc/node17.html
+++ b/post/src/help/matc/node17.html
@@ -17,7 +17,7 @@
 <BR> <P>
 <H1><A NAME="SECTION005120000000000000000"> str = fgets(fp)</A></H1>
 <P>
-Read next line from fp. File pointer fp shoud have been obtained from a call
+Read next line from fp. File pointer fp should have been obtained from a call
 to fopen or freopen or be the standard input.
 <P>
 SEE ALSO: fopen,freopen,fread,fscanf,matcvt,cvtmat.

--- a/post/src/help/matc/node18.html
+++ b/post/src/help/matc/node18.html
@@ -17,7 +17,7 @@
 <BR> <P>
 <H1><A NAME="SECTION005130000000000000000"> n = fwrite(fp,buf,n)</A></H1>
 <P>
-Write n bytes form buf to file fp. File pointer fp shoud have been obtained
+Write n bytes form buf to file fp. File pointer fp should have been obtained
 from a call to fopen or freopen or be the standard output (stdout) or standard
 error (stderr). Return value is number of bytes actually written.
 <P>

--- a/post/src/help/matc/node19.html
+++ b/post/src/help/matc/node19.html
@@ -17,7 +17,7 @@
 <BR> <P>
 <H1><A NAME="SECTION005140000000000000000"> n = fprintf(fp,fmt[, vec])</A></H1>
 <P>
-Write formatted string to file fp. File pointer fp shoud have been obtained
+Write formatted string to file fp. File pointer fp should have been obtained
 from a call to fopen or freopen or be the standard output (stdout) or standard
 error (stderr). The format fmt is equal to C-language format.
 <P>

--- a/post/src/help/matc/node2.html
+++ b/post/src/help/matc/node2.html
@@ -12,7 +12,7 @@
 <BODY LANG="EN">
  <A NAME="tex2html74" HREF="node3.html"><IMG WIDTH=37 HEIGHT=24 ALIGN=BOTTOM ALT="next" SRC="lh-figs/next_motif.gif"></A> <A NAME="tex2html72" HREF="kirja.html"><IMG WIDTH=26 HEIGHT=24 ALIGN=BOTTOM ALT="up" SRC="lh-figs/up_motif.gif"></A> <A NAME="tex2html66" HREF="node1.html"><IMG WIDTH=63 HEIGHT=24 ALIGN=BOTTOM ALT="previous" SRC="lh-figs/previous_motif.gif"></A>   <BR>
 <B> Next:</B> <A NAME="tex2html75" HREF="node3.html">MATC Operators</A>
-<B>Up:</B> <A NAME="tex2html73" HREF="kirja.html">MATC Matrix Languge</A>
+<B>Up:</B> <A NAME="tex2html73" HREF="kirja.html">MATC Matrix Language</A>
 <B> Previous:</B> <A NAME="tex2html67" HREF="node1.html">MATC Variables</A>
 <BR> <P>
 <H1><A NAME="SECTION00200000000000000000">MATC general flow control structures</A></H1>

--- a/post/src/help/matc/node3.html
+++ b/post/src/help/matc/node3.html
@@ -67,7 +67,7 @@
 <P>
  <IMG WIDTH=90 HEIGHT=25 ALIGN=MIDDLE ALT="tex2html_wrap_inline303" SRC="img16.gif"  >    resize <I>a</I> to matrix of size <I>n</I> by <I>m</I>.
 <P>
-<I>b</I>=<I>a</I>           assing <I>a</I> to <I>b</I>.
+<I>b</I>=<I>a</I>           assign <I>a</I> to <I>b</I>.
 <P>
 <BR> <HR>
 <P><ADDRESS>

--- a/post/src/help/matc/node4.html
+++ b/post/src/help/matc/node4.html
@@ -37,7 +37,7 @@ Functions have their own list of variables. Global variables are not seen
 in this function unless imported by import or given as arguments. Local
 variables can be made global by the export statement.
 <P>
-Functions, if returing matrices,  behave in many ways as variables do.  So if
+Functions, if returning matrices,  behave in many ways as variables do.  So if
 you have defined function mult as follows
 <P>
 <PRE>function mult(a,b)

--- a/post/src/objects/transformations.c
+++ b/post/src/objects/transformations.c
@@ -276,7 +276,7 @@ static void obj_translate_matrix( matrix_t M, double x, double y, double z )
  *
  *     Parameters:
  *
- *         Input:    (double,double,double) scaleings x,y,and z
+ *         Input:    (double,double,double) scalings x,y,and z
  *
  *         Output:   (matrix_t) resulting transformation matrix
  *
@@ -541,7 +541,7 @@ static void obj_rotate_mult_matrix(transform_t *transform,double *x,double *y,do
  *     Name:          obj_compute_matrix( transform_t * )
  *
  *     Purpose:       Return total transformation matrix_t given rotations,
- *                    scaleing, and translations. Internal only.
+ *                    scaling, and translations. Internal only.
  *
  *     Parameters:
  *
@@ -655,7 +655,7 @@ int obj_set_parent( object_t *object,object_t *parent )
  *
  *     Name:          obj_rotate( object_t *,double,double,double,int,int )
  *
- *     Purpose:       Modifify object transformation matrix given rotations
+ *     Purpose:       Modify object transformation matrix given rotations
  *
  *     Parameters:
  *
@@ -762,13 +762,13 @@ void obj_rotate( object_t *object,double x,double y,double z,int which,int relat
  *
  *     Name:          obj_scale( object_t *,double,double,double,int,int )
  *
- *     Purpose:       Modifify object transformation matrix given scaleings
+ *     Purpose:       Modify object transformation matrix given scalings
  *
  *     Parameters:
  *
  *         Input:    (object_t *)
- *                   (double,double,double) input scaleings
- *                   (int) flag if scaleings should be relative (TRUE)
+ *                   (double,double,double) input scalings
+ *                   (int) flag if scalings should be relative (TRUE)
  *                          or absolute (FALSE)
  *
  *         Output:   (object->Transform_t *)->XXXMatrix are modified
@@ -847,7 +847,7 @@ void obj_scale( object_t *object,double x,double y,double z,int which, int relat
  *
  *     Name:          obj_translate( object_t *,double,double,double,int,int  )
  *
- *     Purpose:       Modifify object transformation matrix given translations
+ *     Purpose:       Modify object transformation matrix given translations
  *
  *     Parameters:
  *

--- a/post/src/plugins/README.txt
+++ b/post/src/plugins/README.txt
@@ -12,5 +12,5 @@ Usually ELMER_POST_HOME is defined as
 $ export ELMER_POST_HOME=$ELMER_HOME/share/elmerpost
 
 If the configuration script fails to determine correct
-setting, compilation intructions can be found from the
+setting, compilation instructions can be found from the
 headers of the individual files (*.c).

--- a/post/src/plugins/savempg.c
+++ b/post/src/plugins/savempg.c
@@ -260,7 +260,7 @@ static int SaveMPG( ClientData cl,Tcl_Interp *interp,int argc,char **argv ) {
       return TCL_ERROR;
     }
 
-    // Detemine output file name:
+    // Determine output file name:
     //---------------------------
     if( argc < 3 ) {
       strcpy( fname, "elmerpost.es" );

--- a/post/src/sico2elmer/sico2elmerc.c
+++ b/post/src/sico2elmer/sico2elmerc.c
@@ -111,7 +111,7 @@ void STDCALLBULL FC_FUNC(postgrid,POSTGRID) (float  *xi, /* unscaled x coordinat
 /*     free(staggered_grid[0]);free(staggered_grid[1]);free(iced);  */
 /*     return; */
   }else{
-    printf("| number of iced colums:       %d out of %d (%3.2f %%)\n", number_of_iced_collums, (imax+1)*(jmax+1), ((float) number_of_iced_collums)*100.0/((float) (imax+1)*(jmax+1)));
+    printf("| number of iced columns:       %d out of %d (%3.2f %%)\n", number_of_iced_collums, (imax+1)*(jmax+1), ((float) number_of_iced_collums)*100.0/((float) (imax+1)*(jmax+1)));
     boundary = (int *) malloc((size_t) number_of_iced_collums*4*sizeof(int));
   }
   if (boundary==NULL){
@@ -248,7 +248,7 @@ void STDCALLBULL FC_FUNC(postgrid,POSTGRID) (float  *xi, /* unscaled x coordinat
    *     3\  |     2\  |          *
    *       \ |        E|          *
    *      W \|        \|          *
-   *         +---------+  ­­­­>i  *
+   *         +---------+  ï¿½ï¿½ï¿½ï¿½>i  *
    *         0    S    1          *
    ********************************/
   boundary_nr=0;
@@ -612,7 +612,7 @@ void STDCALLBULL FC_FUNC(elmerdata,ELMERDATA) (int   *imax_in, /* grid steps in 
   number_of_iced_nodes = get_grid_map(imax,jmax,iced,gridmap);
   if (*flag) number_of_written_nodes=nodes_in_layer_of_staggered_grid+number_of_iced_nodes*(ktmax+kcmax);
   else number_of_written_nodes=nodes_in_layer_of_staggered_grid+number_of_iced_nodes*(kcmax);
-  printf("| number of iced colums:       %d out of %d (%3.2f %%)\n", number_of_iced_collums, (imax+1)*(jmax+1), ((float) number_of_iced_collums)*100.0/((float) (imax+1)*(jmax+1)));
+  printf("| number of iced columns:       %d out of %d (%3.2f %%)\n", number_of_iced_collums, (imax+1)*(jmax+1), ((float) number_of_iced_collums)*100.0/((float) (imax+1)*(jmax+1)));
   printf("| number of iced nodes in layer of staggered grid: %d out of %d\n", number_of_iced_nodes, nodes_in_layer_of_staggered_grid);
   printf("| number of nodes in written grid: %d of %d\n", number_of_written_nodes, number_of_nodes);
   printf("| number of properties written for each node: %d\n", number_of_properties);
@@ -982,7 +982,7 @@ void STDCALLBULL FC_FUNC(pregrid,PREGRID) (float  *xi, /* unscaled x coordinate 
 /*     free(staggered_grid[0]);free(staggered_grid[1]);free(iced);  */
 /*     return; */
   }else{
-    printf("| number of iced colums:       %d out of %d (%3.2f %%)\n", number_of_iced_collums, (imax+1)*(jmax+1), ((float) number_of_iced_collums)*100.0/((float) (imax+1)*(jmax+1)));
+    printf("| number of iced columns:       %d out of %d (%3.2f %%)\n", number_of_iced_collums, (imax+1)*(jmax+1), ((float) number_of_iced_collums)*100.0/((float) (imax+1)*(jmax+1)));
   }
   gridmap = (int *) malloc((size_t) nodes_in_one_layer*sizeof(int));
   if (gridmap==NULL){
@@ -1066,7 +1066,7 @@ void STDCALLBULL FC_FUNC(pregrid,PREGRID) (float  *xi, /* unscaled x coordinate 
   fprintf(ptFile,"2\n");
   fprintf(ptFile,"808 %d\n", number_of_bulk_elements);
   fprintf(ptFile,"404 %d\n", number_of_boundary_elements);
-  printf("| succeeded in writting mesh header file %s.\n",filename);
+  printf("| succeeded in writing mesh header file %s.\n",filename);
   printf("---------------------------------------------------------------\n");
   fclose(ptFile);
   /* check min/max values of grid */
@@ -1165,7 +1165,7 @@ void STDCALLBULL FC_FUNC(pregrid,PREGRID) (float  *xi, /* unscaled x coordinate 
     fclose(ptFile);
     return;
   }
-  printf("| succeeded in writting node file %s.\n",filename);
+  printf("| succeeded in writing node file %s.\n",filename);
   printf("---------------------------------------------------------------\n");
   /* writing element file */
   sprintf(filename,"mesh.elements");
@@ -1286,7 +1286,7 @@ void STDCALLBULL FC_FUNC(pregrid,PREGRID) (float  *xi, /* unscaled x coordinate 
     free(staggered_grid[0]);free(staggered_grid[1]);free(iced);free(boundary);free(gridmap);free(nodes_of_side_element);free(parent_of_side_element);
     return;
   }
-  printf("| succeeded in writting bulk element file %s.\n",filename);
+  printf("| succeeded in writing bulk element file %s.\n",filename);
   printf("---------------------------------------------------------------\n");  
   fclose(ptFile);
   /* writing boundary element file */
@@ -1364,7 +1364,7 @@ void STDCALLBULL FC_FUNC(pregrid,PREGRID) (float  *xi, /* unscaled x coordinate 
   if (boundary_nr!=number_of_boundary_elements){
     printf("ERROR: Number of written boundary elements %d does not match calculated %d.\n", boundary_nr, number_of_boundary_elements);
   }else{
-    printf("| succeeded in writting boundary element file %s.\n",filename);
+    printf("| succeeded in writing boundary element file %s.\n",filename);
     printf("---------------------------------------------------------------\n");
   }
   fclose(ptFile);
@@ -1435,7 +1435,7 @@ void STDCALLBULL FC_FUNC(asciidata,ASCIIDATA) (float  *xi, /* unscaled x coordin
     }
     else if (errno ==  EACCES)
       printf("WARNING: No permission to read file .sico2elmer.rc. Writing all output-components by default\n");
-    else printf("WARNING: Error occured during reading  preference-file .sico2elmer.rc. Writing all output-components by default\n");
+    else printf("WARNING: Error occurred during reading  preference-file .sico2elmer.rc. Writing all output-components by default\n");
     failed=1;
   }else{
     if((ptFile=fopen(".sico2elmer.rc", "r"))==NULL){
@@ -1506,7 +1506,7 @@ void STDCALLBULL FC_FUNC(asciidata,ASCIIDATA) (float  *xi, /* unscaled x coordin
   }
   if (failed){
     for (n=0;n<12;++n) outputflags[n]=1;
-    printf("| Error occured during reading of file\n");
+    printf("| Error occurred during reading of file\n");
     printf("| Taking default values\n");
   }else printf("| Loading of preferences succeessful\n");
   printf("| Following values for output are set (1=yes,0=no):\n");
@@ -2152,7 +2152,7 @@ void STDCALLBULL FC_FUNC(solvergrid,SOLVERGRID)(float  *xi, /* unscaled x coordi
   if (number_of_iced_collums<1){
     printf("WARNING: domain seems to be ice-free\n");
   }
-  printf("| number of iced colums:       %d out of %d (%3.2f %%)\n", number_of_iced_collums, (imax+1)*(jmax+1), ((float) number_of_iced_collums)*100.0/((float) (imax+1)*(jmax+1)));
+  printf("| number of iced columns:       %d out of %d (%3.2f %%)\n", number_of_iced_collums, (imax+1)*(jmax+1), ((float) number_of_iced_collums)*100.0/((float) (imax+1)*(jmax+1)));
   printf("---------------------------------------------------------------\n");
   printf("| number of nodes:             %d=%d * %d\n",number_of_nodes, nodes_in_one_layer, kmax+1);
   printf("| number of bulk elements:     %d=%d * %d\n",number_of_bulk_elements, elements_in_one_layer, kmax);
@@ -2177,7 +2177,7 @@ void STDCALLBULL FC_FUNC(solvergrid,SOLVERGRID)(float  *xi, /* unscaled x coordi
   fprintf(ptFile,"404 %d\n", number_of_boundary_elements + sidebulk*elements_in_one_layer);
   fprintf(ptFile,"808 %d\n", number_of_bulk_elements);
 
-  printf("| succeeded in writting mesh header file %s.\n",filename);
+  printf("| succeeded in writing mesh header file %s.\n",filename);
   printf("---------------------------------------------------------------\n");
   fclose(ptFile);
 
@@ -2294,7 +2294,7 @@ void STDCALLBULL FC_FUNC(solvergrid,SOLVERGRID)(float  *xi, /* unscaled x coordi
   }else{
     printf("| %d number of bulk elements written.\n", n);
     printf("| %d number of sidebulk elements written.\n", m);
-    printf("| succeeded in writting bulk element file %s.\n",filename);
+    printf("| succeeded in writing bulk element file %s.\n",filename);
     printf("---------------------------------------------------------------\n");
   }
   
@@ -2319,7 +2319,7 @@ void STDCALLBULL FC_FUNC(solvergrid,SOLVERGRID)(float  *xi, /* unscaled x coordi
       nodes_of_element[3] = (j+1)*(imax+1) + i;
       parent_element = j*imax + i;
       if (parent_element+1 > number_of_bulk_elements){
-	printf("parent element %d > number of bulk elments %d\n",parent_element+1, number_of_bulk_elements);
+	printf("parent element %d > number of bulk elements %d\n",parent_element+1, number_of_bulk_elements);
 	return;
       }
       fprintf(ptFile,"%d %d %d 0 404 %d %d %d %d\n",
@@ -2338,7 +2338,7 @@ void STDCALLBULL FC_FUNC(solvergrid,SOLVERGRID)(float  *xi, /* unscaled x coordi
       nodes_of_element[3] = kmax*nodes_in_one_layer + (j+1)*(imax+1) + i;
       parent_element = (kmax-1)*elements_in_one_layer + j*imax + i; /* same numbering as in bulk */
       if (parent_element > number_of_bulk_elements){
-	printf("parent element %d > number of bulk elments %d\n",parent_element+1, number_of_bulk_elements);
+	printf("parent element %d > number of bulk elements %d\n",parent_element+1, number_of_bulk_elements);
 	return;
       }
       fprintf(ptFile,"%d %d %d 0 404 %d %d %d %d\n",
@@ -2359,7 +2359,7 @@ void STDCALLBULL FC_FUNC(solvergrid,SOLVERGRID)(float  *xi, /* unscaled x coordi
       nodes_of_element[3] = (k+1)*nodes_in_one_layer + j*(imax+1) + i;
       parent_element = k*elements_in_one_layer + j*imax + i; /* same numbering as in bulk */
       if (parent_element+1 > number_of_bulk_elements){
-	printf("parent element %d > number of bulk elments %d\n",parent_element+1, number_of_bulk_elements);
+	printf("parent element %d > number of bulk elements %d\n",parent_element+1, number_of_bulk_elements);
 	return;
       }
       fprintf(ptFile,"%d %d %d 0 404 %d %d %d %d\n",
@@ -2379,7 +2379,7 @@ void STDCALLBULL FC_FUNC(solvergrid,SOLVERGRID)(float  *xi, /* unscaled x coordi
       nodes_of_element[3] = (k+1)*nodes_in_one_layer + j*(imax+1) + i;
       parent_element = k*elements_in_one_layer + j*imax + i; /* same numbering as in bulk */ 
       if (parent_element+1 > number_of_bulk_elements){
-	printf("parent element %d > number of bulk elments %d\n",parent_element+1, number_of_bulk_elements);
+	printf("parent element %d > number of bulk elements %d\n",parent_element+1, number_of_bulk_elements);
 	return;
       }
       fprintf(ptFile,"%d %d %d 0 404 %d %d %d %d\n",
@@ -2399,7 +2399,7 @@ void STDCALLBULL FC_FUNC(solvergrid,SOLVERGRID)(float  *xi, /* unscaled x coordi
       ++n;
       parent_element = k*elements_in_one_layer + (jmax-1)*imax + i; /* same numbering as in bulk */
       if (parent_element+1 > number_of_bulk_elements){
-	printf("parent element %d > number of bulk elments %d\n",parent_element+1, number_of_bulk_elements);
+	printf("parent element %d > number of bulk elements %d\n",parent_element+1, number_of_bulk_elements);
 	return;
       }
       fprintf(ptFile,"%d %d %d 0 404 %d %d %d %d\n",
@@ -2419,7 +2419,7 @@ void STDCALLBULL FC_FUNC(solvergrid,SOLVERGRID)(float  *xi, /* unscaled x coordi
       ++n;
       parent_element = k*elements_in_one_layer + j*imax + i-1; /* same numbering as in bulk */
       if (parent_element >= number_of_bulk_elements){
-	printf("parent element %d > number of bulk elments %d\n",parent_element, number_of_bulk_elements);
+	printf("parent element %d > number of bulk elements %d\n",parent_element, number_of_bulk_elements);
 /* 	return; */
       }
       fprintf(ptFile,"%d %d %d 0 404 %d %d %d %d\n",
@@ -2486,7 +2486,7 @@ void STDCALLBULL FC_FUNC(solvergrid,SOLVERGRID)(float  *xi, /* unscaled x coordi
   }else{
     printf("| %d number of boundary elements for bulk written.\n", n);
     printf("| %d number of boundary elements for sidebulk written.\n", m);
-    printf("| succeeded in writting boundary element file %s.\n",filename);
+    printf("| succeeded in writing boundary element file %s.\n",filename);
     printf("---------------------------------------------------------------\n");
   }
 

--- a/post/src/tcl/file.tcl
+++ b/post/src/tcl/file.tcl
@@ -176,8 +176,8 @@ proc fs_GetFileList {directory pattern} {
 }
 
 #
-# get the selection from listbox and update view and/or give singal
-# for completition. called by signal.
+# get the selection from listbox and update view and/or give signal
+# for completion. called by signal.
 #
 # 11 Sep 95 
 #

--- a/post/src/tcl/material.tcl
+++ b/post/src/tcl/material.tcl
@@ -199,7 +199,7 @@ proc background { args } {
 #
 # Create a material editor toplevel window for a user to use.
 # There can be several editors running at any time provided 
-# a different name for editor is given at each invokation.
+# a different name for editor is given at each invocation.
 #
 # 12 Sep 1995
 #

--- a/post/src/tcl/text.tcl
+++ b/post/src/tcl/text.tcl
@@ -56,7 +56,7 @@ set txt_fontname ""
 #
 # Create a text editor toplevel window for a user to use.
 # There can be several editors running at any time provided 
-# a different name for editor is given at each invokation.
+# a different name for editor is given at each invocation.
 #
 # 12 Sep 1995
 #

--- a/post/src/visuals/arrows.c
+++ b/post/src/visuals/arrows.c
@@ -54,7 +54,7 @@
 
 /******************************************************************************
  * 
- * Parameter sructure definitios for arrow visual class
+ * Parameter structure definitions for arrow visual class
  *
  ******************************************************************************/
 typedef struct arrow_s
@@ -93,7 +93,7 @@ typedef struct arrow_s
  *
  *         Output:  graphics
  *
- *   Return value:  if mouse interaction is going on, and time used exeeds
+ *   Return value:  if mouse interaction is going on, and time used exceeds
  *                  given value (TooLong1,2) FALSE, otherwise TRUE
  *
  ******************************************************************************/

--- a/post/src/visuals/colscale.c
+++ b/post/src/visuals/colscale.c
@@ -49,7 +49,7 @@
 
 /******************************************************************************
  * 
- * Parameter sructure definitios for colscale visual class
+ * Parameter structure definitions for colscale visual class
  *
  ******************************************************************************/
 
@@ -78,7 +78,7 @@ typedef struct colscale_s
  *
  *         Output:  graphics
  *   
- *   Return value:  if mouse interaction is going on, and time used exeeds
+ *   Return value:  if mouse interaction is going on, and time used exceeds
  *                  given value (TooLong1,2) FALSE, otherwise TRUE
  *
  ******************************************************************************/

--- a/post/src/visuals/contour_lines.c
+++ b/post/src/visuals/contour_lines.c
@@ -23,7 +23,7 @@
 
 /*******************************************************************************
  *
- * Action routines for visual classe ContourLines.
+ * Action routines for visual class ContourLines.
  *
  *******************************************************************************
  *
@@ -52,7 +52,7 @@
 
 /******************************************************************************
  * 
- * Parameter sructure definitios for Contour Lines visual class
+ * Parameter structure definitions for Contour Lines visual class
  *
  ******************************************************************************/
 
@@ -193,7 +193,7 @@ static void vis_draw_line( line_t *line, int quick, double width )
  *
  *         Output:  graphics
  *   
- *   Return value:  if mouse interaction is going on, and time used exeeds
+ *   Return value:  if mouse interaction is going on, and time used exceeds
  *                  given value (TooLong1,2) FALSE, otherwise TRUE
  *
  ******************************************************************************/

--- a/post/src/visuals/isosurface.c
+++ b/post/src/visuals/isosurface.c
@@ -52,7 +52,7 @@
 #include "../elements/elements.h"
 /******************************************************************************
  * 
- * Parameter sructure definitios for Isosurface visual class
+ * Parameter structure definitions for Isosurface visual class
  *
  ******************************************************************************/
 
@@ -171,7 +171,7 @@ static int vis_get_isosurface
  *
  *         Output:  graphics
  *   
- *   Return value:  if mouse interaction is going on, and time used exeeds
+ *   Return value:  if mouse interaction is going on, and time used exceeds
  *                  given value (TooLong1,2) FALSE, otherwise TRUE
  *
  ******************************************************************************/

--- a/post/src/visuals/mesh.c
+++ b/post/src/visuals/mesh.c
@@ -53,7 +53,7 @@
 
 /******************************************************************************
  * 
- * Parameter sructure definitios for mesh visual class
+ * Parameter structure definitions for mesh visual class
  *
  ******************************************************************************/
 static char *mesh_style_names[] =
@@ -117,7 +117,7 @@ void vis_polygon( polygon_t *poly)
  *         Input:    (triangle_t *) triangle
  *                   (vertex_t   *) vertex array
  *                   (double     *) quantity to use color the edges (or NULL)
- *                   (double,double ) CScl,CAdd are constatnt to scale color
+ *                   (double,double ) CScl,CAdd are constant to scale color
  *                                  range (0-1)
  *                   (line_style_t) line style, either line_style_line or
  *                                  line_style_cylider
@@ -163,7 +163,7 @@ void vis_triangle
  *         Input:    (vertex_t   *) vertex array
  *                   (int,int)      edge vertex indices
  *                   (double *)      color quantity
- *                   (double,double ) CScl,CAdd are constatnt to scale color
+ *                   (double,double ) CScl,CAdd are constant to scale color
  *                                  range (0-1)
  *                   (line_style_t) line style, either line_style_line or
  *                                  line_style_cylider
@@ -206,7 +206,7 @@ static void vis_draw_edge(vertex_t *vertex,int v0,int v1,double *color,double CS
  *
  *         Output:  graphics
  *   
- *   Return value:  if mouse interaction is going on, and time used exeeds
+ *   Return value:  if mouse interaction is going on, and time used exceeds
  *                  given value (TooLong1,2) FALSE, otherwise TRUE
  *
  ******************************************************************************/

--- a/post/src/visuals/particles.c
+++ b/post/src/visuals/particles.c
@@ -122,7 +122,7 @@ static double vis_particles_interpolate
         if ( !elmt->PointInside )
         {
             fprintf(
-               stderr, "WARINING: Particles not implemented for element type: [%s]. Element ingnored.\n",
+               stderr, "WARNING: Particles not implemented for element type: [%s]. Element ignored.\n",
                             elmt->ElementName
                 );
             continue;

--- a/post/src/visuals/sphere.c
+++ b/post/src/visuals/sphere.c
@@ -56,7 +56,7 @@
 #include "../elmerpost.h"
 /******************************************************************************
  * 
- * Parameter sructure definitios for sphere visual class
+ * Parameter structure definitions for sphere visual class
  *
  ******************************************************************************/
 typedef struct shpere_s
@@ -89,7 +89,7 @@ typedef struct shpere_s
  *
  *         Output:  graphics
  *   
- *   Return value:  if mouse interaction is going on, and time used exeeds
+ *   Return value:  if mouse interaction is going on, and time used exceeds
  *                  given value (TooLong1,2) FALSE, otherwise TRUE
  *
  ******************************************************************************/


### PR DESCRIPTION
Found via `odespell -q 3 -S *.ps,./mathlibs,./contrib,./misc,./umfpack,./ElmerGUI/netgen,./elmergrid/src/metis* -L addres,amin,ang,ba,cas,cna,defind,dof,dum,emiss,enew,iff,ifset,impres,indeces,infor,inout,isnt,ist,ith,matc,muder,nd,ned,nin,numer,objext,oce,ot,pres,projectio,sord,splitted,stran,strat,te,teh,thisy,tim,totat,uint,vave,workd`