### PR TITLE
Fix various typos

### DIFF
--- a/ElmerGUI/Application/edf-extra/nonlinearelasticity.xml
+++ b/ElmerGUI/Application/edf-extra/nonlinearelasticity.xml
@@ -83,7 +83,7 @@
          </Parameter>
          <Parameter Widget="CheckBox">
             <Name> Plane Stress </Name>
-            <Whatis> If checked, compute the solution according to the plane stress situtation zz = 0, otherwise plane strain model is assumed. Applies only in 2D.  </Whatis> 
+            <Whatis> If checked, compute the solution according to the plane stress situation zz = 0, otherwise plane strain model is assumed. Applies only in 2D.  </Whatis> 
          </Parameter>
         <Parameter Widget="Label" > <Name> This and that </Name> </Parameter>
         <Parameter Widget="Edit">
@@ -211,7 +211,7 @@
          <Parameter Widget="Label" > <Name> Properties </Name> </Parameter>
          <Parameter Widget="Edit" >
             <Name>Youngs modulus</Name>
-            <Whatis> The elastic modulus must be given with this keyword. The modulus may be given as a scalar for the isotropic case or as 6 × 6 (3D) or 4 × 4 (2D and axisymmetric) matrix for the anisotropic case. Although the matrices are symmetric, all entries must be given. </Whatis>
+            <Whatis> The elastic modulus must be given with this keyword. The modulus may be given as a scalar for the isotropic case or as 6 ï¿½ 6 (3D) or 4 ï¿½ 4 (2D and axisymmetric) matrix for the anisotropic case. Although the matrices are symmetric, all entries must be given. </Whatis>
          </Parameter>
 
          <Parameter Widget="Edit" >

--- a/ElmerGUI/Application/edf/linearelasticity.xml
+++ b/ElmerGUI/Application/edf/linearelasticity.xml
@@ -160,7 +160,7 @@ stress. </Whatis>
 
          <Parameter Widget="CheckBox">
             <Name> Plane Stress </Name>
-            <Whatis> If checked, compute the solution according to the plane stress situtation zz = 0, otherwise plane strain model is assumed. Applies only in 2D.  </Whatis> 
+            <Whatis> If checked, compute the solution according to the plane stress situation zz = 0, otherwise plane strain model is assumed. Applies only in 2D.  </Whatis> 
          </Parameter>
         <Parameter Widget="Label" > <Name> This and that </Name> </Parameter>
         <Parameter Widget="Edit">
@@ -343,7 +343,7 @@ stress. </Whatis>
              <Whatis> Strain engineering 6-vector corresponding to a prestressed state. This is converted to the corresponding stress and added to the load case in buckling and/or geometric stiffness analysis. </Whatis>
           </Parameter>
  
-        <Parameter Widget="Label"> <Name> Material pricipal directions </Name> </Parameter>
+        <Parameter Widget="Label"> <Name> Material principal directions </Name> </Parameter>
         <Parameter Widget="CheckBox">
           <Name> Rotate Elasticity Tensor </Name>
           <Whatis> For anisotropic materials the principal directions of anisotropy do not always correspond to the coordinate axes. Setting this keyord to True enables the user to input Youngs Modulus matrix with respect to the principal directions of anisotropy. Otherwise Youngs Modulus should be given with respect to the coordinate axis directions. </Whatis>

--- a/ElmerGUI/Application/plugins/egconvert.cpp
+++ b/ElmerGUI/Application/plugins/egconvert.cpp
@@ -1105,7 +1105,7 @@ omstart:
 
   if( boundarynodes > 0 ) {
     if(info) printf("Number of nodes in boundary sets: %d\n",boundarynodes);      
-    /* Temporarily supress the deallocation while trying to find a bug */
+    /* Temporarily suppress the deallocation while trying to find a bug */
     free_Ivector(nodeindx,1,boundarynodes);
     free_Ivector(boundindx,1,boundarynodes);
   }    

--- a/ElmerGUI/Application/src/glwidget.cpp
+++ b/ElmerGUI/Application/src/glwidget.cpp
@@ -27,7 +27,7 @@
  *                                                                           *
  *****************************************************************************
  *                                                                           *
- *  Authors: Mikko Lyly, Juha Ruokolainen and Peter Råback                   *
+ *  Authors: Mikko Lyly, Juha Ruokolainen and Peter Rï¿½back                   *
  *  Email:   Juha.Ruokolainen@csc.fi                                         *
  *  Web:     http://www.csc.fi/elmer                                         *
  *  Address: CSC - IT Center for Science Ltd.                                 *
@@ -876,7 +876,7 @@ void GLWidget::mouseDoubleClickEvent(QMouseEvent *event)
     if(l->getType() == SHARPEDGELIST) {
 
 	  /* 
-	  Restoration of view settings. These were adjusted at the begining of this function.
+	  Restoration of view settings. These were adjusted at the beginning of this function.
 	  */
 	  stateDrawCoordinates = prevStateDrawCoordinates;
 	  stateDrawSurfaceNumbers = prevStateDrawSurfaceNumbers;
@@ -1070,7 +1070,7 @@ void GLWidget::mouseDoubleClickEvent(QMouseEvent *event)
   }
 
   /* 
-  Restoration of view settings. These were adjusted at the begining of this function.
+  Restoration of view settings. These were adjusted at the beginning of this function.
   */
   stateDrawCoordinates = prevStateDrawCoordinates;
   stateDrawSurfaceNumbers = prevStateDrawSurfaceNumbers;

--- a/ElmerGUI/matc/src/matc.c
+++ b/ElmerGUI/matc/src/matc.c
@@ -843,7 +843,7 @@ VARIABLE *com_apply(ptr) VARIABLE *ptr;
 
 void mem_free(void *mem)
 /*======================================================================
-?  Free memory given by argument, and unlink it from alloction list.
+?  Free memory given by argument, and unlink it from allocation list.
 |  Currently FREEMEM(ptr) is defined to be mem_free(ptr).
 |
 &  free()

--- a/cmake/Modules/GetPrerequisites.cmake
+++ b/cmake/Modules/GetPrerequisites.cmake
@@ -50,7 +50,7 @@
 # prerequisites are listed. <exclude_system> must be 0 or 1 indicating whether
 # to include or exclude "system" prerequisites. With <verbose> set to 0 only
 # the full path names of the prerequisites are printed, set to 1 extra
-# informatin will be displayed.
+# information will be displayed.
 #
 #  LIST_PREREQUISITES_BY_GLOB(<glob_arg> <glob_exp>)
 # Print the prerequisites of shared library and executable files matching a

--- a/elmergrid/README.md
+++ b/elmergrid/README.md
@@ -1,21 +1,21 @@
 # ElmerGrid mesh generation and manipulation
 
 This directory includes files for ElmerGrid which is a mesh
-generation utility bundled with Elmer project. 
+generation utility bundled with Elmer project.
 
 ElmerGrid can create simple structured 2D meshes consisting
 of quadrilaterals or triangles. Also limited 3D functionality is provided
 in terms of extruded 2D meshes resulting to hexahedrons or prisms.
 
-The program may also be used as a mesh import and export utility. It    
+The program may also be used as a mesh import and export utility. It
 is able to read several different formats (Gmsh, UNIVERSAL file format,
-COMSOL mphtxt files,..) and writes mainly Elmer input 
+COMSOL mphtxt files,..) and writes mainly Elmer input
 and output formats, and also VTK format.
 
 The meshes may also be given some simple operations such as scaling,
-rotation, cloning, extrusion ect. 
+rotation, cloning, extrusion etc...
 
 ElmerGrid includes also partitioning capabilities of Elmer meshes.
 The partitioning may be done using internal geometric division or
-Metis library. 
+Metis library.
 

--- a/elmergrid/src/egconvert.c
+++ b/elmergrid/src/egconvert.c
@@ -1105,7 +1105,7 @@ omstart:
 
   if( boundarynodes > 0 ) {
     if(info) printf("Number of nodes in boundary sets: %d\n",boundarynodes);      
-    /* Temporarily supress the deallocation while trying to find a bug */
+    /* Temporarily suppress the deallocation while trying to find a bug */
     free_Ivector(nodeindx,1,boundarynodes);
     free_Ivector(boundindx,1,boundarynodes);
   }    

--- a/elmergrid/src/egparallel.c
+++ b/elmergrid/src/egparallel.c
@@ -2799,7 +2799,7 @@ int PartitionMetisGraph(struct FemType *data,struct BoundaryType *bound,
 			&ncon,         /* number of balancing constraints */
 			xadj, adjncy,  /* the adjacency structure of the graph */
 			vwgt,          /* weights of the vertices */
-			&wgtflag,      /* size of the vectices for computing communication */
+			&wgtflag,      /* size of the vertices for computing communication */
 			adjwgt,        /* weight of the edges */     
 			&nparts,       /* number of partitions */
 			NULL,          /* weights for each partition and constraint */

--- a/elmerice/IceSheet/Greenland/SSA_FRICTION_INIT/OPTIM_BETA.sif
+++ b/elmerice/IceSheet/Greenland/SSA_FRICTION_INIT/OPTIM_BETA.sif
@@ -88,7 +88,7 @@ Material 1
   SSA Mean Density = Real $rhoi
 
   SSA Friction Law = String "linear"
-  ! The friction parameter is 10^the optimised variable to insure > 0
+  ! The friction parameter is 10^the optimised variable to ensure > 0
   SSA Friction Parameter = Variable alpha
       REAL procedure "ElmerIceUSF" "TenPowerA"
   SSA Friction Parameter Derivative = Variable alpha

--- a/elmerice/Meshers/ExtrudeMesh.c
+++ b/elmerice/Meshers/ExtrudeMesh.c
@@ -1092,7 +1092,7 @@ int main(int argc, char *argv[])
     printf("      wexp  ... (optional, but mandatory if previous was given)\n");
     printf("                  exponent of weight for interpolation w=1/r^wexp\n");
     printf("      noval  ... (optional, but mandatory if previous was given)\n");
-    printf("                  value indicating void/unvalid entry in DEM (e.g. -999.99)\n");
+    printf("                  value indicating void/invalid entry in DEM (e.g. -999.99)\n");
     printf("     corrbed ... (optional) value: 1 or any other number\n");
     printf("                 corrections induced by minimum flowdpeth are by default applied\n");
     printf("                 correctiong the side of the free surface, only of value 1 is defined\n");

--- a/elmerice/Meshers/makemoulin.py
+++ b/elmerice/Meshers/makemoulin.py
@@ -79,7 +79,7 @@ if __name__=='__main__':
 	if nbpartition >1:
 		mesh_dir = '%s/partitioning.%s'%(mesh,np.str(nbpartition))
 		if file_donot_exists(mesh_dir):
-			exit_error("Directory %s does not exit: Please use the  ElmerGrid command for mesh partitionning"%(mesh_dir))
+			exit_error("Directory %s does not exit: Please use the  ElmerGrid command for mesh partitioning"%(mesh_dir))
 	else:
 		mesh_dir = '%s'%(mesh)
 		if file_donot_exists(mesh_dir):

--- a/elmerice/Solvers/DJDmu_Adjoint.F90
+++ b/elmerice/Solvers/DJDmu_Adjoint.F90
@@ -44,7 +44,7 @@
 !     - Optimized Variable Name = String ;  ("Mu" default)
 !     - Gradient Variable Name = String ; t ("DJDMu" default)
 !     - SquareFormulation = Logical ; True if the viscosity ios defined as alpha^2
-!                                               and optimisation on alpha to insure Mu> 0
+!                                               and optimisation on alpha to ensure Mu> 0
 !
 !
 ! In the  Material Section:

--- a/elmerice/Solvers/DJDmu_Robin.F90
+++ b/elmerice/Solvers/DJDmu_Robin.F90
@@ -42,7 +42,7 @@
 !     - Optimized Variable Name = String ;  ("Mu" default)
 !     - Gradient Variable Name = String ; t ("DJDMu" default)
 !     - SquareFormulation = Logical ; True if the viscosity ios defined as alpha^2
-!                                               and optimisation on alpha to insure Mu> 0
+!                                               and optimisation on alpha to ensure Mu> 0
 !
 !
 ! In the  Material Section:

--- a/elmerice/Solvers/Documentation/AdjointSSA_CostTaubSolver.md
+++ b/elmerice/Solvers/Documentation/AdjointSSA_CostTaubSolver.md
@@ -101,7 +101,7 @@ e.g.
 
  End
 ```
-Or using ElmerIce build-in user functions:
+Or using ElmerIce built-in user functions:
 
 ```
  Material *id*

--- a/elmerice/Solvers/Documentation/AdjointSSA_GradientSolver.md
+++ b/elmerice/Solvers/Documentation/AdjointSSA_GradientSolver.md
@@ -109,7 +109,7 @@ e.g.
 
  End
 ```
-Or using ElmerIce build-in user functions:
+Or using ElmerIce built-in user functions:
 
 ```
  Material *id*

--- a/elmerice/Solvers/Documentation/Adjoint_CostContSolver.md
+++ b/elmerice/Solvers/Documentation/Adjoint_CostContSolver.md
@@ -38,7 +38,7 @@ Solver *solver id*
   
     Equation = String "Cost"  
     procedure = "ElmerIceSolvers" "Adjoint_CostDiscSolver"
-    ## No need to declare a variable, this is done internally to insure that Solver structures exist
+    ## No need to declare a variable, this is done internally to ensure that Solver structures exist
      
      # Name of an ascii file that will contain the cost value as
      ## Time, J, sqrt(2J/Area)

--- a/elmerice/Solvers/Documentation/Adjoint_CostDiscSolver.md
+++ b/elmerice/Solvers/Documentation/Adjoint_CostDiscSolver.md
@@ -45,7 +45,7 @@ Solver *solver id*
   
     Equation = String "Cost"  
     procedure = "ElmerIceSolvers" "Adjoint_CostDiscSolver"
-    !## No need to declare a variable, this is done internally to insure 
+    !## No need to declare a variable, this is done internally to ensure 
     !## that Solver structures exist
 
     !# If the variable is a vector, 
@@ -63,7 +63,7 @@ Solver *solver id*
      !##  the rms (i.e. not normalised by standard error)
      Cost Filename = File ""
      
-     !# Name of the variable that contain the cost value
+     !# Name of the variable that contains the cost value
      !#  must exist and can be a global variable
      Cost Variable Name = String ""
      
@@ -79,15 +79,15 @@ Solver *solver id*
      !## Coordinates dimension of the Obs. must be consistent with Pb dimension;
      !##  i.e. CoordsystemDim if solver is on the bulk or 
      !###      (CoordsystemDim-1) if solver is on a boundary
-     !## If the observation file is in ASCII it must containt the following columns:
+     !## If the observation file is in ASCII it must contain the following columns:
      !##  coordinates(1:ndim), observations(1:vardim), standard errors(1:vardim) (optional)
      Observation File Name = File "" 
      
-     !# If the variable is a vector, how many component do we observe?
+     !# If the variable is a vector, how many components do we observe?
      !## it will be the first *n* components
      Observed Variable dimension = Integer ...
    
-     !# If true data that have been found in the mesh at the 
+     !# If true data that has been found in the mesh at the 
      !#  first visit will be saved in an ascii file
      !## will save coordinates, observation, standard error (optional), element number
      !## there will be one file per partition

--- a/elmerice/Solvers/Documentation/Adjoint_CostRegSolver.md
+++ b/elmerice/Solvers/Documentation/Adjoint_CostRegSolver.md
@@ -38,7 +38,7 @@ Solver *solver id*
   
     Equation = String "CostReg"  
     procedure = "ElmerIceSolvers" "Adjoint_CostRegSolver"
-    !## No need to declare a variable, this is done internally to insure
+    !## No need to declare a variable, this is done internally to ensure
     !    that Solver structures exist
  
      !# True if cost function and gradient must be initialised 
@@ -115,7 +115,7 @@ Below is a list of features that are not currently possible in this solver but t
 
 - If running on a boundary, we use only the first spatial derivatives, so this solver is intended to be used on a bottom or top surface.
 
-- If Regularisation with respect to the *prior* is used, for the moment we assume no spatial error in the statitics and use only a standard deviation; The cost function could easily be improved if a full background error covariance matrix is known
+- If Regularisation with respect to the *prior* is used, for the moment we assume no spatial error in the statistics and use only a standard deviation; The cost function could easily be improved if a full background error covariance matrix is known
 
 
 ### Tests and Examples

--- a/elmerice/Solvers/Documentation/AdvReactDensity.md
+++ b/elmerice/Solvers/Documentation/AdvReactDensity.md
@@ -7,7 +7,7 @@ This page explains how to use the general AdvectionReactionSolver from the Elmer
 
 where *u* is the velocity vector. In the particular case of the mass conservation equation, one has therefore *gamma = 0* and *sigma = 0*. Solving for the true density (kg/m^3) or the relative density is equivalent (but limit values and Dirichlet boundary conditions have to be set accordingly).
 
-Note 1: equation (4.1) in the Elmer Model Manual for the AdvectionReaction sover is not correct. The previous equation is the one implemented.
+Note 1: equation (4.1) in the Elmer Model Manual for the AdvectionReaction solver is not correct. The previous equation is the one implemented.
 
 Note 2: Have a look to this [post](http://elmerfem.org/forum/viewtopic.php?f=7&t=3066&p=9570#p9570) on the Elmer Forum regarding the initialisation of both the DG primary and exported variables of the AdvectionReaction solver (see the example at the end of this page).
 

--- a/elmerice/Solvers/Documentation/Flotation.md
+++ b/elmerice/Solvers/Documentation/Flotation.md
@@ -37,7 +37,7 @@ The aim of this solver is to apply the flotation criterion to compute the top an
 - If the GroundedMask variable is present:  
   - GroundedMask=1 where $z_b=bedrock$ (grounded ice)
   - GroundedMask=-1 where $z_b>bedrock$ (floating ice)
-  - GroundedMask=0 at the grounding line (list of nodes where $z_b=bedrock$ but the nodes belong to at least one grounded (all nodes grounded) and one floating (at leat one node floating) element  
+  - GroundedMask=0 at the grounding line (list of nodes where $z_b=bedrock$ but the nodes belong to at least one grounded (all nodes grounded) and one floating (at least one node floating) element  
 
 - IF compute ice area fractions = TRUE, compute the element area fractions sftgif (land_ice_area_fraction), sftgrf (grounded_ice_sheet_area_fraction), sftflf (floating_ice_shelf_area_fraction). No sub-scheme is used so values are 0._dp or 1._dp. An element is considered floating if at least one node is floating, otherwise it is grounded. If the solution for the Thickness is limited, then if all nodal H == Lower Limit, all teh area fractions are set to 0.
 

--- a/elmerice/Solvers/Documentation/HydrologyGlaDS.md
+++ b/elmerice/Solvers/Documentation/HydrologyGlaDS.md
@@ -73,7 +73,7 @@ In the Body Force section, one can set a water input source:
     Hydraulic Potential Volume Source = Real $Source
   End
 ```
-GlaDSCoupledSolver solves for the three variables Hydraulic Potential, Sheet Thickness and Channel Area in a coupled way inside the solver itself (Coupled Max Iterations and Coupled Convergence Tolerance). Equations for the Hydraulic Potential and Channel Area are non linear. Only the equation for the Hydraulic Potential needs to solve a system. The two others are local and can be solved either explicitely, implcitely or using the Crank-Nicholson method.
+GlaDSCoupledSolver solves for the three variables Hydraulic Potential, Sheet Thickness and Channel Area in a coupled way inside the solver itself (Coupled Max Iterations and Coupled Convergence Tolerance). Equations for the Hydraulic Potential and Channel Area are non linear. Only the equation for the Hydraulic Potential needs to solve a system. The two others are local and can be solved either explicitly, implcitely or using the Crank-Nicholson method.
 
 ```
 Solver 1

--- a/elmerice/Solvers/Documentation/HydrologyIDS.md
+++ b/elmerice/Solvers/Documentation/HydrologyIDS.md
@@ -13,7 +13,7 @@ This solver treats the diffusion equation with a user-defined upper limit.
 ## SIF contents
 The required keywords in the SIF file for this solver are given below. The IDSSolver can be used alone, coupling between the two layer is treated in the [EPLSolver](./HydrologyEPL.md) section
 
-The hydrological system is only treated at the bed, it requires then a new body with a specific equation and intial condition, the Material and Body Force section are using the one from the ice.
+The hydrological system is only treated at the bed, it requires then a new body with a specific equation and initial condition, the Material and Body Force section are using the one from the ice.
 
 ```
 Body 2

--- a/elmerice/Solvers/Documentation/Introduction.md
+++ b/elmerice/Solvers/Documentation/Introduction.md
@@ -41,17 +41,17 @@ Some solvers are model specific.
 The following chapters describe solvers specific to compute the gradients (4), and are model specific.
 
 The adjoint codes have been derived by hand as usually the structure of Elmer is too complex
-to use  automatic differentiation softwares.
+to use automatic differentiation software.
 
 The solvers have been designed to be as generic as possible. A strength of Elmer is its modularity,
 however it means that the configuration can be complex, and it is possible that when writing the code
-whe have not taken into account all the possibilities offered by Elmer.
+we have not taken into account all the possibilities offered by Elmer.
 
 We have done the maximum to test the solvers and they should be accurate for standard simulations. However, it will
 be to the user responsibility to check that his configuarations leads to accurate gradients and smooth optimisation. 
 A cost which is not decreasing is often the sign the the gradients are not accurates.
 
 **Please contribute to improve this documentation and Elmer/Ice capabilities** by reporting errors or inaccuracies,
-and contribute in developping new test cases and functionnalities.
+and contribute in developing new test cases and functionalities.
 
 

--- a/elmerice/Solvers/Documentation/Optimize_m1qn3.md
+++ b/elmerice/Solvers/Documentation/Optimize_m1qn3.md
@@ -44,7 +44,7 @@ to small velocities, so that we obtained a good compromise during the optimisati
 area of high velocities - high errors. However, for  applications with unstructured meshes where the mesh size
 is not related to the magnitude of the errors, it may be beneficial to change the inner product and scale the gradients by the mesh size.
 This is automatically achieved when setting the keyword *Mesh Independent=TRUE*.
-This will lead to smoother gradients, however for areas with small errors this will lead to small gradients and theses areas will not be affected by the optimisation. In this case it might be beneficial to have a cost function that also measures the relative error.  
+This will lead to smoother gradients, however for areas with small errors this will lead to small gradients and these areas will not be affected by the optimisation. In this case it might be beneficial to have a cost function that also measures the relative error.  
 *Note* that the change of inner product affects the *conditionning* of the minimisation, so in *perfect simulations* both solutions should lead to the same exact minimum....
 
 - Outputs from M1QN3 are saved in the *M1QN3 OutputFile*. The  verbosity level is controlled with the keyword *impres*.

--- a/elmerice/Solvers/Documentation/PlumeSolver.md
+++ b/elmerice/Solvers/Documentation/PlumeSolver.md
@@ -9,7 +9,7 @@
   - GroundedMask (assumed to be called this - defined on the hydrology mesh)
   - Channel Flux (assumed to be called this)
   - Sheet Discharge (assumed to be called this)
-  - Sheet Thickness (assumed to be called tihs)
+  - Sheet Thickness (assumed to be called this)
 - **Optional Output Variable(s):**
   - Toe Calving (Exported Variable 1 = String 'Toe Calving')
 - **Optional Input Variable(s):** 

--- a/elmerice/Solvers/Documentation/README.md
+++ b/elmerice/Solvers/Documentation/README.md
@@ -38,7 +38,7 @@ where *[Name_Of_Model]* can be Stokes, SSA, Thickness (to come...).
 
 A table showing the old solvers and their replacement can be found 
 [here](https://cloud.univ-grenoble-alpes.fr/index.php/s/AHCwsgKgjWimqdG).
-A fatal message is now called in *old* solvers to advertise for the replacements and theses solvers will be removed in future releases.
+A fatal message is now called in *old* solvers to advertise for the replacements and these solvers will be removed in future releases.
 
 Here is the list of supported and documented solvers:
  

--- a/elmerice/Solvers/Documentation/XIOSOutputSolver.md
+++ b/elmerice/Solvers/Documentation/XIOSOutputSolver.md
@@ -24,7 +24,7 @@ svn co http://forge.ipsl.jussieu.fr/ioserver/svn/XIOS/trunk XIOS
 ```  
 
 2. Compile XIOS, see its documentation   
-   - You will have to add **-fPIC** for the *BASE_CFLAGS* and *BASE_FFLAGS* as we wil need a shared library
+   - You will have to add **-fPIC** for the *BASE_CFLAGS* and *BASE_FFLAGS* as we will need a shared library
    - To use the UGRID format we need to have netcdf with parallel I/O support
 
 
@@ -89,7 +89,7 @@ mpirun -np N ElmerSolver_mpi : -np N2 xios_server
 
 ### Saving variables with XIOS
 
-- To use the UGRID format, geographical coordinates are required (Longitude/Latitude); They are computed using gerenic functionnalities in [ProjUtils](../../Utils/Documentation/ProjUtils.md). The projection description should be provided in the *Simulation* section (only south and north polar stereographic projections are supported by default at the moment). The projected coordinates can be saved by requesting to save the elmer coordinates.
+- To use the UGRID format, geographical coordinates are required (Longitude/Latitude); They are computed using generic functionalities in [ProjUtils](../../Utils/Documentation/ProjUtils.md). The projection description should be provided in the *Simulation* section (only south and north polar stereographic projections are supported by default at the moment). The projected coordinates can be saved by requesting to save the elmer coordinates.
 
 - Elmer variables that have to be transferred to XIOS are defined with the Solver keywords *Scalar Field i* for nodal and elemental variables and *Global Variable i* for global variables. The *id* in the XIOS configuration file should be the elmer variable name :warning: **in lower case**.
 
@@ -130,7 +130,7 @@ Solver ..
 
  ! time-step: optional the duration of the tile step; other time_step=time_units*dt
    timestep=String "15d"
- ! for consitency check we check that taking 1/dt time_step leads 
+ ! for consistency check we check that taking 1/dt time_step leads 
  !  to the same duration than time_units with xx seconds
    timestep tolerance = Real 1.0
 

--- a/elmerice/Solvers/GridDataReader/GridDataReader.F90
+++ b/elmerice/Solvers/GridDataReader/GridDataReader.F90
@@ -652,7 +652,7 @@ SUBROUTINE GridDataReader( Model,Solver,dtime,TransientSimulation )
   CoordName = ListGetString( Params,'Elmer Coordinate 1',Found)
   IF (Found) THEN
      ElmerCoord1 => VariableGet(Mesh%Variables,TRIM(CoordName),UnFoundFatal=.TRUE.)
-     If (DEBUG) WRITE( Message, * ) 'using ',TRIM(CoordName),' as fisrt coordinate'
+     If (DEBUG) WRITE( Message, * ) 'using ',TRIM(CoordName),' as 1st coordinate'
      CALL Info('GridDataReader', Message, level=3)
   ENDIF
   CoordName = ListGetString( Params,'Elmer Coordinate 2',Found)
@@ -1441,7 +1441,7 @@ CONTAINS
     dist = SQRT( (xe(1)-coordVar(1)%values(1:nx,1:ny,1))**2 + &
          (xe(2)-coordVar(2)%values(1:nx,1:ny,1) )**2 )
 
-    ! cumlative distance of four netcdf points (comprising a cell) from current ELmer node
+    ! cumulative distance of four netcdf points (comprising a cell) from current Elmer node
     distCum = dist(1:nx-1,1:ny-1) + dist(2:nx,1:ny-1)+ &
          dist(2:nx,2:ny) + dist(1:nx-1,2:ny)
 

--- a/elmerice/Solvers/MeshAdaptation_2D/MMG2DSolver.F90
+++ b/elmerice/Solvers/MeshAdaptation_2D/MMG2DSolver.F90
@@ -191,7 +191,7 @@
       IF (DEBUG) PRINT *,'--**-- COPY MESH TO MMG FORMAT'
 
        !Permuatation table Local Element => Global E
-       ! to insure consistent numbering for different partitionning
+       ! to ensure consistent numbering for different partitioning
        ALLOCATE(LEtoGE(Mesh % NumberOfBulkElements))
         DO ii=1,Mesh % NumberOfBulkElements
           Element => Mesh % Elements(ii)

--- a/elmerice/Solvers/OutPutSolvers/XIOSOutputSolver.F90
+++ b/elmerice/Solvers/OutPutSolvers/XIOSOutputSolver.F90
@@ -848,7 +848,7 @@
                 'Scalar Field ',Vari,' compute cell average'
              Project = ListGetLogical(Params,TRIM(Txt),Found)
              IF (Project) THEN
-                ! check if wee need to send the data
+                ! check if we need to send the data
                 FieldActive=xios_field_is_active(TRIM(Solution%Name)//'_elem',.TRUE.)
                 WRITE( Message,'(A,A,L2)') 'Xios request : ',TRIM(Solution%Name)//'_elem',FieldActive
                 CALL Info(Caller,Message,Level=Olevel)
@@ -890,7 +890,7 @@
              ENDIF
           END IF
 
-          ! check if wee need to send the data
+          ! check if we need to send the data
           FieldActive=xios_field_is_active(TRIM(Solution%Name),.TRUE.)
           WRITE( Message,'(A,A,L2)') 'Xios request : ',TRIM(Solution%Name),FieldActive
           CALL Info(Caller,Message,Level=Olevel)

--- a/elmerice/Solvers/Permafrost/PermafrostMaterials.F90
+++ b/elmerice/Solvers/Permafrost/PermafrostMaterials.F90
@@ -7,7 +7,7 @@
 ! *  This program is free software; you can redistribute it and/or
 ! *  modify it under the terms of the GNU General Public License
 ! *  as published by the Free Software Foundation; either version 2
-! *  of the License, or (at your option) asny later version.
+! *  of the License, or (at your option) any later version.
 ! * 
 ! *  This program is distributed in the hope that it will be useful,
 ! *  but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/elmerice/Solvers/Permafrost/Permafrost_HTEQ.F90
+++ b/elmerice/Solvers/Permafrost/Permafrost_HTEQ.F90
@@ -7,7 +7,7 @@
 ! *  This program is free software; you can redistribute it and/or
 ! *  modify it under the terms of the GNU General Public License
 ! *  as published by the Free Software Foundation; either version 2
-! *  of the License, or (at your option) asny later version.
+! *  of the License, or (at your option) any later version.
 ! * 
 ! *  This program is distributed in the hope that it will be useful,
 ! *  but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/elmerice/examples/ISMIP-HOM/C010/ismip_c.sif
+++ b/elmerice/examples/ISMIP-HOM/C010/ismip_c.sif
@@ -101,7 +101,7 @@ Solver 2
   Linear System Iterative Method = BiCGStab
   Linear System Preconditioning = ILU0
   Linear System Convergence Tolerance = Real 1.0e-6
-  Linear System Abord Not Converged = Logical False
+  Linear System Abort Not Converged = Logical False
 
   Nonlinear System Max Iterations = 50
   Nonlinear System Convergence Tolerance  = 1.0e-5

--- a/elmerice/examples/InverseMethods_OLD/Adjoint_Mu_GradientValid.sif
+++ b/elmerice/examples/InverseMethods_OLD/Adjoint_Mu_GradientValid.sif
@@ -135,7 +135,7 @@ Material 1
   Density = Real 9.1376e-19  
   Viscosity Model = String "power law"
 
-! Viscosity defined as mu^2 to insure >0
+! Viscosity defined as mu^2 to ensure >0
   Viscosity = Variable mu
     Real MATC "tx*tx"
 

--- a/elmerice/examples/Inverse_Methods/MacAyeal_SSA/SIF/OPTIM.sif
+++ b/elmerice/examples/Inverse_Methods/MacAyeal_SSA/SIF/OPTIM.sif
@@ -78,7 +78,7 @@ Material 1
   SSA Mean Viscosity = Real $ mu
 
   SSA Friction Law = String "linear"
-  ! The friction parameter is the square of the optimised variable to insure > 0
+  ! The friction parameter is the square of the optimised variable to ensure > 0
   SSA Friction Parameter = Variable alpha
       REAL procedure "ElmerIceUSF" "Asquare"
 

--- a/elmerice/examples/Inverse_Methods/MacAyeal_SSA/SIF/OPTIM_TAUB.sif
+++ b/elmerice/examples/Inverse_Methods/MacAyeal_SSA/SIF/OPTIM_TAUB.sif
@@ -78,7 +78,7 @@ Material 1
   SSA Mean Viscosity = Real $ 1.8e8*1.0e-6*(2.0*yearinsec)^(-1.0/3.0)
 
   SSA Friction Law = String "linear"
-  ! The friction parameter is the square of the optimised variable to insure > 0
+  ! The friction parameter is the square of the optimised variable to ensure > 0
   SSA Friction Parameter = Variable alpha
       REAL procedure "ElmerIceUSF" "Asquare"
 

--- a/fem/tests/HeatControlExplicit/case.sif
+++ b/fem/tests/HeatControlExplicit/case.sif
@@ -1,5 +1,5 @@
 ! This a test case for a system that depends on values of a control point.
-! The control point is used explicitely. This takes use of some of the
+! The control point is used explicitly. This takes use of some of the
 ! same routines as the implicite control but due to the explicit nature
 ! the user is left in full control how to use the control points coming
 ! from previous timesteps. Maybe a little bit different logic would have

--- a/fhutiter/README.md
+++ b/fhutiter/README.md
@@ -3,7 +3,7 @@
 This library include iterative solvers based on Krylov subspace method.
 The methods work both in serial and parallel.
 
-The name of the library comes from Helsinki Univesity of Technology where
+The name of the library comes from Helsinki University of Technology where
 the initial version was written by Jouni Malinen.
 
-Current version of the library requires ISO C -bindings when used in conjucntion with ElmerSolver. 
+Current version of the library requires ISO C -bindings when used in conjucntion with ElmerSolver.

--- a/fhutiter/doc/hutidoc.tex
+++ b/fhutiter/doc/hutidoc.tex
@@ -95,7 +95,7 @@ Another reason for making this library is the
 master's thesis of the author. HUTI has also been incorporated into
 a software called ELMER which in turn is made for a
 TEKES\footnote{Technology Development Center in Finland}
-funded project VIRKE\footnote{VIRtauslaskentaohjelmiston KEhittäminen}.
+funded project VIRKE\footnote{VIRtauslaskentaohjelmiston KEhittï¿½minen}.
 
 The name HUTI comes from Helsinki University of Technology (HUT) and
 Iterative solvers.
@@ -155,7 +155,7 @@ This eases the optimization of memory usage in each particular case.
 
 In parallel setting it is on users responsibility to define the storage
 convention for the distribution of matrices and vectors.
-Well-known distribution consepts are for example block-cyclic decomposition
+Well-known distribution concepts are for example block-cyclic decomposition
 and domain based decompositions. More information can be found from
 \cite{Kum94,Saa96}. See also chapter \ref{ch:examples} for an example
 of user supplied distribution of data.
@@ -246,7 +246,7 @@ These routines are called from the solver and type of arguments and order
 is presented for each routine.
 
 The matrix $A$ can be stored in any format because it is totally on
-the user's responsability to make it available for the external routines.
+the user's responsibility to make it available for the external routines.
 
 The {\ttfamily IPAR} structure is passed to some of the external routines
 and is used to carry on certain control variables from the solver routine.
@@ -459,7 +459,7 @@ printed if requested.
 
 The {\ttfamily IPAR} structure is used to control the progress and behaviour
 of the iterator routine and to get status back from it. {\ttfamily IPAR}
-is also passed futher to some of the user supplied routines.
+is also passed further to some of the user supplied routines.
 
 Input parameters are described in table \ref{table:ipar-input} along with
 their default values, output parameters are in table \ref{table:ipar-output}.
@@ -516,7 +516,7 @@ for each solver is listed on the corresponding reference pages.
 \hline
 	& {\em Parallel environment parameters} 		& \\
 \hline
-20 	& Processor identifaction number for spesific process 	& \\
+20 	& Processor identification number for specific process 	& \\
 21 	& Number of processors 					& 1 \\
 \hline\hline
 \end{tabular*}
@@ -548,7 +548,7 @@ for each solver is listed on the corresponding reference pages.
 	& 35: Bi-CGSTAB breakdown in $\rho$ \\
 	& 36: Bi-CGSTAB breakdown in $\|s\|$ \\
 	& 37: Bi-CGSTAB breakdown in $\omega$ \\
-31 	& Number of iterations runned through \\
+31 	& Number of iterations run through \\
 \hline\hline
 \end{tabular*}
 
@@ -625,7 +625,7 @@ the library.
         60, 315-339, 1991
 
         \bibitem{Fre93a}
-        Roland W. Freund, {\em An Implmentation of the Look-Ahead
+        Roland W. Freund, {\em An Implementation of the Look-Ahead
 	Lanczos Algorithm for Non-Hermitian Matrices},
         SIAM J. Sci. Comput., Vol. 14, No. 1, pp. 137-158, January 1993
 

--- a/fhutiter/include/huti_fdefs.h
+++ b/fhutiter/include/huti_fdefs.h
@@ -1,5 +1,5 @@
 
-! Fortran preprocessor definitons for HUTIter library
+! Fortran preprocessor definitions for HUTIter library
 !
 ! $Id: huti_fdefs.h,v 1.1.1.1 2005/04/15 10:31:18 vierinen Exp $
 

--- a/fhutiter/src/huti_aux.F90
+++ b/fhutiter/src/huti_aux.F90
@@ -85,7 +85,7 @@ contains
   !*************************************************************************
   !*************************************************************************
   !
-  ! Construct LU decompostion of the given matrix and solve LUu = v
+  ! Construct LU decomposition of the given matrix and solve LUu = v
   !
 
   subroutine  huti_slusolve  ( n, lumat, u, v )
@@ -215,7 +215,7 @@ contains
   !*************************************************************************
   !*************************************************************************
   !
-  ! Construct LU decompostion of the given matrix and solve LUu = v
+  ! Construct LU decomposition of the given matrix and solve LUu = v
   !
 
   subroutine  huti_dlusolve  ( n, lumat, u, v )
@@ -346,7 +346,7 @@ contains
   !*************************************************************************
   !*************************************************************************
   !
-  ! Construct LU decompostion of the given matrix and solve LUu = v
+  ! Construct LU decomposition of the given matrix and solve LUu = v
   !
 
   subroutine  huti_clusolve  ( n, lumat, u, v )
@@ -477,7 +477,7 @@ contains
   !*************************************************************************
   !*************************************************************************
   !
-  ! Construct LU decompostion of the given matrix and solve LUu = v
+  ! Construct LU decomposition of the given matrix and solve LUu = v
   !
 
   subroutine  huti_zlusolve  ( n, lumat, u, v )

--- a/fhutiter/src/huti_cg.F90
+++ b/fhutiter/src/huti_cg.F90
@@ -49,7 +49,7 @@ module huti_cg
   ! work(:,4) = r
   !
   ! Definitions to make the code more understandable and to make it look
-  ! like the pseudo code (these are commond to all precisions)
+  ! like the pseudo code (these are common to all precisions)
   !
 
 #define  X  xvec 

--- a/fhutiter/src/huti_fdefs.h
+++ b/fhutiter/src/huti_fdefs.h
@@ -1,5 +1,5 @@
 
-! Fortran preprocessor definitons for HUTIter library
+! Fortran preprocessor definitions for HUTIter library
 !
 ! $Id: huti_fdefs.h,v 1.1.1.1 2005/04/15 10:31:18 vierinen Exp $
 

--- a/fhutiter/src/huti_gmres.F90
+++ b/fhutiter/src/huti_gmres.F90
@@ -49,7 +49,7 @@ module huti_gmres
   ! work(:,4) = r
   !
   ! Definitions to make the code more understandable and to make it look
-  ! like the pseudo code (these are commond to all precisions)
+  ! like the pseudo code (these are common to all precisions)
   !
 
 #define  X  xvec 

--- a/license_texts/LICENSES
+++ b/license_texts/LICENSES
@@ -19,7 +19,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
 The Elmer source files consist of the following modules (in alphabetical order): 
 
-buildtools - sripts used in building Elmer
+buildtools - scripts used in building Elmer
 ElmerGUI - the new graphical user interface of Elmer based on QT 
 ElmerGUIlogger - launcher for ElmerGUI based on QT
 eio - elmer I/O library used by ElmerSolver for some tasks

--- a/license_texts/LICENSES_GPL.txt
+++ b/license_texts/LICENSES_GPL.txt
@@ -19,7 +19,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
 The Elmer source files consist of the following modules (in alphabetical order): 
 
-buildtools - sripts used in building Elmer
+buildtools - scripts used in building Elmer
 ElmerGUI - the new graphical user interface of Elmer based on QT 
 ElmerGUIlogger - launcher for ElmerGUI based on QT
 eio - elmer I/O library used by ElmerSolver for some tasks

--- a/matc/README.md
+++ b/matc/README.md
@@ -1,4 +1,4 @@
-#MATC libary 
+#MATC library 
 
 MATC is a library for the numerical evaluation of mathematical expressions.
 In the Elmer package it can be used in defining expressions in the command

--- a/matc/doc/node15.html
+++ b/matc/doc/node15.html
@@ -17,7 +17,7 @@
 <BR> <P>
 <H1><A NAME="SECTION005100000000000000000"> str = fread(fp,n)</A></H1>
 <P>
-Read n bytes from file given by fp.  File pointer fp shoud have been
+Read n bytes from file given by fp.  File pointer fp should have been
 obtained from a call to fopen or freopen, or be the standard input
 file stdin. Data is returned as function value.
 <P>

--- a/matc/doc/node16.html
+++ b/matc/doc/node16.html
@@ -18,7 +18,7 @@
 <H1><A NAME="SECTION005110000000000000000"> vec = fscanf(fp,fmt)</A></H1>
 <P>
 Read file fp as given in format. Format fmt is equal to C-language format.
-File pointer fp shoud have been obtained from a call to fopen or freopen,
+File pointer fp should have been obtained from a call to fopen or freopen,
 or be the standard input.
 <P>
 SEE ALSO: fopen,freopen,fgets,fread,matcvt,cvtmat.

--- a/matc/doc/node17.html
+++ b/matc/doc/node17.html
@@ -17,7 +17,7 @@
 <BR> <P>
 <H1><A NAME="SECTION005120000000000000000"> str = fgets(fp)</A></H1>
 <P>
-Read next line from fp. File pointer fp shoud have been obtained from a call
+Read next line from fp. File pointer fp should have been obtained from a call
 to fopen or freopen or be the standard input.
 <P>
 SEE ALSO: fopen,freopen,fread,fscanf,matcvt,cvtmat.

--- a/matc/doc/node18.html
+++ b/matc/doc/node18.html
@@ -17,7 +17,7 @@
 <BR> <P>
 <H1><A NAME="SECTION005130000000000000000"> n = fwrite(fp,buf,n)</A></H1>
 <P>
-Write n bytes form buf to file fp. File pointer fp shoud have been obtained
+Write n bytes form buf to file fp. File pointer fp should have been obtained
 from a call to fopen or freopen or be the standard output (stdout) or standard
 error (stderr). Return value is number of bytes actually written.
 <P>

--- a/matc/doc/node19.html
+++ b/matc/doc/node19.html
@@ -17,7 +17,7 @@
 <BR> <P>
 <H1><A NAME="SECTION005140000000000000000"> n = fprintf(fp,fmt[, vec])</A></H1>
 <P>
-Write formatted string to file fp. File pointer fp shoud have been obtained
+Write formatted string to file fp. File pointer fp should have been obtained
 from a call to fopen or freopen or be the standard output (stdout) or standard
 error (stderr). The format fmt is equal to C-language format.
 <P>

--- a/matc/doc/node2.html
+++ b/matc/doc/node2.html
@@ -12,7 +12,7 @@
 <BODY LANG="EN">
  <A NAME="tex2html74" HREF="node3.html"><IMG WIDTH=37 HEIGHT=24 ALIGN=BOTTOM ALT="next" SRC="lh-figs/next_motif.gif"></A> <A NAME="tex2html72" HREF="kirja.html"><IMG WIDTH=26 HEIGHT=24 ALIGN=BOTTOM ALT="up" SRC="lh-figs/up_motif.gif"></A> <A NAME="tex2html66" HREF="node1.html"><IMG WIDTH=63 HEIGHT=24 ALIGN=BOTTOM ALT="previous" SRC="lh-figs/previous_motif.gif"></A>   <BR>
 <B> Next:</B> <A NAME="tex2html75" HREF="node3.html">MATC Operators</A>
-<B>Up:</B> <A NAME="tex2html73" HREF="kirja.html">MATC Matrix Languge</A>
+<B>Up:</B> <A NAME="tex2html73" HREF="kirja.html">MATC Matrix Language</A>
 <B> Previous:</B> <A NAME="tex2html67" HREF="node1.html">MATC Variables</A>
 <BR> <P>
 <H1><A NAME="SECTION00200000000000000000">MATC general flow control structures</A></H1>

--- a/matc/doc/node3.html
+++ b/matc/doc/node3.html
@@ -67,7 +67,7 @@
 <P>
  <IMG WIDTH=90 HEIGHT=25 ALIGN=MIDDLE ALT="tex2html_wrap_inline303" SRC="img16.gif"  >    resize <I>a</I> to matrix of size <I>n</I> by <I>m</I>.
 <P>
-<I>b</I>=<I>a</I>           assing <I>a</I> to <I>b</I>.
+<I>b</I>=<I>a</I>           assign <I>a</I> to <I>b</I>.
 <P>
 <BR> <HR>
 <P><ADDRESS>

--- a/matc/doc/node4.html
+++ b/matc/doc/node4.html
@@ -37,7 +37,7 @@ Functions have their own list of variables. Global variables are not seen
 in this function unless imported by import or given as arguments. Local
 variables can be made global by the export statement.
 <P>
-Functions, if returing matrices,  behave in many ways as variables do.  So if
+Functions, if returning matrices,  behave in many ways as variables do.  So if
 you have defined function mult as follows
 <P>
 <PRE>function mult(a,b)

--- a/matc/src/clip.c
+++ b/matc/src/clip.c
@@ -87,7 +87,7 @@
    RETURN: Number of points in the polygon inside the box
 
    NOTICE! The new number of points may be GRATER than the in origin!
-           The theoretical number of points newer execeeds twice 
+           The theoretical number of points newer exceeds twice 
            the number in origin. 
 ************************************o*************************************/
 int clip_poly(n,x,y)
@@ -169,7 +169,7 @@ int *n;                            /* Number of points in polygon      */
         else
           if(this) 
           {
-            if(j+2 > i)            /* Too many points whitout shift */
+            if(j+2 > i)            /* Too many points without shift */
             {
               for(k=nn; k>i ; k--) { x[k]=x[k-1]; y[k]=y[k-1]; }
               nn++;

--- a/matc/src/elmer/gra.h
+++ b/matc/src/elmer/gra.h
@@ -1,7 +1,7 @@
 /*
  * Graphics primitives are loaded dynamically to a global
  * array of functions. To make a graphics driver to a specific
- * device one has to make the following functions (named diffrently
+ * device one has to make the following functions (named differently
  * of course) and edit routine gra_init to load these functions
  * to array of functions when the device is selected.
  * 

--- a/matc/src/elmer/matc.h
+++ b/matc/src/elmer/matc.h
@@ -215,7 +215,7 @@ typedef struct function
 #define FUNCSIZE sizeof(FUNCTION)
 
 /*******************************************************************
-               MISC DEFINITONS FOR PARSER
+               MISC DEFINITIONS FOR PARSER
 *******************************************************************/
 
 typedef enum symbols {
@@ -471,6 +471,6 @@ extern void PrintOut( char *format, ... );
 #include "fnames.h"
 
 /*******************************************************************
-                  graphics package defitions
+                  graphics package definitions
 *******************************************************************/ 
 #include "gra.h"

--- a/matc/src/error.c
+++ b/matc/src/error.c
@@ -69,7 +69,7 @@
 
 void sig_trap(int sig)
 /*======================================================================
-?  Interrupt or floating point exeption. Free all memory allocated 
+?  Interrupt or floating point exception. Free all memory allocated 
 |  after last call to doread, give an error message and
 |  longjump back to doread.
 &  longjmp, mem_free_all

--- a/matc/src/eval.c
+++ b/matc/src/eval.c
@@ -353,7 +353,7 @@ VARIABLE *evaltree(root) TREE *root;
     */
 
     /******************************************************
-       deleteting temporaries, preparing for next loop
+       deleting temporaries, preparing for next loop
     *******************************************************/
     if (subs != NULL)
     {
@@ -585,7 +585,7 @@ VARIABLE *evalclause(root) CLAUSE *root;
         par = NULL;
 
         /*
-         *   there is an explicit assigment  (ie. x = x + 1, not x + 1)
+         *   there is an explicit assignment  (ie. x = x + 1, not x + 1)
          */
         if (root->this)
         {

--- a/matc/src/files.c
+++ b/matc/src/files.c
@@ -571,7 +571,7 @@ void fil_com_init()
   static char *freadHelp =
   {
       "str = fread( fp,len )\n\n"
-      "Read len character  from file fp.  File pointer fp shoud have been\n"
+      "Read len character from file fp. File pointer fp should have been\n"
       "obtained from a call to fopen or freopen, or be the standard input\n"
       "file stdin. Characters are returned as function value.\n"
       "\n"
@@ -582,7 +582,7 @@ void fil_com_init()
   {
       "vec = fscanf( fp,format )\n\n"
       "Read file fp as given in format. Format is equal to C-language format\n"
-      "File pointer fp shoud have been obtained from a call to fopen or freopen,\n"
+      "File pointer fp should have been obtained from a call to fopen or freopen,\n"
       "or be the standard input.\n"
       "\n"
       "SEE ALSO: fopen,freopen,fgets,fread,matcvt,cvtmat.\n"
@@ -591,7 +591,7 @@ void fil_com_init()
   static char *fgetsHelp =
   {
       "str = fgets( fp )\n\n"
-      "Read next line from fp. File pointer fp shoud have been obtained from a call\n"
+      "Read next line from fp. File pointer fp should have been obtained from a call\n"
       "to fopen or freopen or be the standard input.\n"
       "\n"
       "SEE ALSO: fopen,freopen,fread,fscanf,matcvt,cvtmat.\n"
@@ -600,7 +600,7 @@ void fil_com_init()
   static char *fwriteHelp =
   {
       "n = fwrite( fp, buf,len )\n\n"
-      "Write len bytes form buf to file fp. File pointer fp shoud have been obtained\n"
+      "Write len bytes form buf to file fp. File pointer fp should have been obtained\n"
       "from a call to fopen or freopen or be the standard output (stdout) or standard\n"
       "error (stderr). Return value is number of characters actually written.\n"
       "\n"
@@ -610,7 +610,7 @@ void fil_com_init()
   static char *fprintfHelp =
   {
       "n = fprintf( fp, format[, vec] )\n\n"
-      "Write formatted string to file fp. File pointer fp shoud have been obtained\n"
+      "Write formatted string to file fp. File pointer fp should have been obtained\n"
       "from a call to fopen or freopen or be the standard output (stdout) or standard\n"
       "error (stderr). The format is equal to C-language format.\n"
       "\n"

--- a/matc/src/matc.c
+++ b/matc/src/matc.c
@@ -209,7 +209,7 @@ void mtc_init( FILE *input_file, FILE *output_file, FILE *error_file )
 
 #if 0
   /*
-   *  trap INTERRUPT and Floating Point Exeption signals
+   *  trap INTERRUPT and Floating Point Exception signals
    */ 
    signal(SIGFPE, sig_trap);
 
@@ -630,7 +630,7 @@ VARIABLE *com_pointw(sub, ptr)  double (*sub)(); VARIABLE *ptr;
 ?  This routine does a function call (*sub)(), for each element in
 |  matrix given by ptr.  
 |
-=  a temporay VARIABLE for which M(res, i, j) = (*sub)(M(ptr, i, j)
+=  a temporary VARIABLE for which M(res, i, j) = (*sub)(M(ptr, i, j)
 &  var_temp_new(), *(sub)()
 ^=====================================================================*/
 {
@@ -671,7 +671,7 @@ VARIABLE *com_pointw(sub, ptr)  double (*sub)(); VARIABLE *ptr;
       }
       if(NEXT(ptr2))
       {
-        error("Currently at most three arguments for pointwise functions allowd,sorry.");
+        error("Currently at most three arguments for pointwise functions allowed, sorry.");
       }
       a3 = MATR(ptr2);
       for(i = 0; i < sz; i++) *b++ = (*sub)(*a++,*a2++,*a3++);
@@ -717,7 +717,7 @@ VARIABLE *com_el(ptr) VARIABLE *ptr;
 {
   VARIABLE *res,               /* result ... */
            *par = NEXT(ptr);   /* pointer to list of VARIABLES */
-                               /* containig indexes            */
+                               /* containing indexes            */
 
   static double defind = 0.0;
 #pragma omp threadprivate (defind)
@@ -900,7 +900,7 @@ VARIABLE *com_apply(ptr) VARIABLE *ptr;
 
 void mem_free(void *mem)
 /*======================================================================
-?  Free memory given by argument, and unlink it from alloction list.
+?  Free memory given by argument, and unlink it from allocation list.
 |  Currently FREEMEM(ptr) is defined to be mem_free(ptr).
 |
 &  free()

--- a/matc/src/oper.c
+++ b/matc/src/oper.c
@@ -60,7 +60,7 @@ $  usage of the function and type of the parameters
 @  globals effected directly by this routine
 !  current known bugs or limitations
 &  functions called by this function
-~  these functions may intrest you as an alternative function or
+~  these functions may interest you as an alternative function or
 |  because they control this function somehow
 =====================================================================*/
 

--- a/matc/src/parser.c
+++ b/matc/src/parser.c
@@ -376,7 +376,7 @@ TREE *nameorvar()
       scan(); LEFT(treeptr) = equation();
       if (symbol != rightpar)
       {
-        error("Right paranthesis missing.\n");
+        error("Right parenthesis missing.\n");
       }
       ETYPE(treeptr) = ETYPE_EQUAT;
       break;


### PR DESCRIPTION
Left over typos from various parts of the codebase.  

Found via `codespell -q 3 -S *.ps,./mathlibs,./contrib,./misc,./umfpack,./ElmerGUI/netgen,./elmergrid/src/metis* -L addres,amin,ang,ba,cas,cna,defind,dof,dum,emiss,enew,iff,ifset,impres,indeces,infor,inout,isnt,ist,ith,matc,muder,nd,ned,nin,numer,objext,oce,ot,pres,projectio,sord,splitted,stran,strat,te,teh,thisy,tim,totat,uint,vave,workd`