### PR TITLE
Implement Calculate Relative Permeability as field

### DIFF
--- a/fem/tests/mgdyn_bh/case.sif
+++ b/fem/tests/mgdyn_bh/case.sif
@@ -68,6 +68,7 @@ Solver 3
    Calculate Magnetic Vector Potential = False
    Calculate Magnetic Flux Density = True
    Calculate Magnetic Field Strength = Logical True
+   Calculate Relative Permeability = Logical True
    Separate Magnetic Energy = True
    Steady State Convergence Tolerance = 0
    Linear System Solver = "Iterative"
@@ -209,7 +210,7 @@ Body Force 1
   Current Density 3 = Equals Volume current 3
 End
 
-Solver 3 :: Reference Norm = Real 17.869450
+Solver 3 :: Reference Norm = Real 150.847866
 Solver 5 :: reference norm = real 2.204993E-05
 RUN
 !End Of File


### PR DESCRIPTION
* Calculate Relative Permeability keyword activates the feature
* Computation as 1/Nu/mu0 (tensorial nu not taken into account)
* modified:   fem/tests/mgdyn_bh/case.sif
  * we add a keyword to test the Calculate Relative Permeability feature
  * The test reference norm is changed as the calculated new field is
    entering in the process.

#348 