### PR TITLE
Fix typos

### DIFF
--- a/ElmerGUI/Application/plugins/tetgen.h
+++ b/ElmerGUI/Application/plugins/tetgen.h
@@ -948,10 +948,10 @@ public:
 // storage in the data structure). Give each edge the same index as the node //
 // opposite it in the triangle. The six versions of a triangle are:          //
 //                                                                           //
-//                 | edge 0   edge 1   edge 2                                //
-//  ---------------|--------------------------                               //
-//   ccw orieation |   0        2        4                                   //
-//    cw orieation |   1        3        5                                   //
+//                    | edge 0   edge 1   edge 2                             //
+//  ------------------|--------------------------                            //
+//    ccw orientation |   0        2        4                                //
+//     cw orientation |   1        3        5                                //
 //                                                                           //
 // In the following, a 'triface' is a handle of tetrahedron, and a 'face' is //
 // a handle of a triangle.                                                   //

--- a/ElmerGUI/Application/src/meshutils.cpp
+++ b/ElmerGUI/Application/src/meshutils.cpp
@@ -1957,7 +1957,7 @@ void Meshutils::increaseElementOrder(mesh_t *mesh)
     delete [] hash;
   }
 
-  // Then redifine the mesh using the additional nodes
+  // Then redefine the mesh using the additional nodes
   int quadnodes = mesh->getNodes() + noedges;  
   node_t *quadnode = new node_t[quadnodes];
   

--- a/ElmerGUI/PythonQt/src/PythonQtDoc.h
+++ b/ElmerGUI/PythonQt/src/PythonQtDoc.h
@@ -175,7 +175,7 @@ registered as well (and all intermediate parents).
  properties of the objects as if they where normal python properties.
 
  In addition to this, the wrapped objects support
- - className() - returns a string that reprents the classname of the QObject
+ - className() - returns a string that represents the classname of the QObject
  - help() - shows all properties, slots, enums, decorator slots and constructors
 of the object, in a printable form
  - connect(signal, function) - connect the signal of the given object to a

--- a/ElmerGUI/matc/src/eig.c
+++ b/ElmerGUI/matc/src/eig.c
@@ -55,7 +55,7 @@
 |FUNCTION NAME(...) params ...
 |
 $  usage of the function and type of the parameters
-?  explane the effects of the function
+?  explain the effects of the function
 =  return value and the type of value if not of type int
 @  globals effected directly by this routine
 !  current known bugs or limitations

--- a/ElmerGUI/matc/src/eval.c
+++ b/ElmerGUI/matc/src/eval.c
@@ -55,7 +55,7 @@
 |FUNCTION NAME(...) params ...
 |
 $  usage of the function and type of the parameters
-?  explane the effects of the function
+?  explain the effects of the function
 =  return value and the type of value if not of type int
 @  globals effected directly by this routine
 !  current known bugs or limitations

--- a/ElmerGUI/matc/src/files.c
+++ b/ElmerGUI/matc/src/files.c
@@ -73,7 +73,7 @@
 |FUNCTION NAME(...) params ...
 |
 $  usage of the function and type of the parameters
-?  explane the effects of the function
+?  explain the effects of the function
 =  return value and the type of value if not of type int
 @  globals effected directly by this routine
 !  current known bugs or limitations

--- a/ElmerGUI/matc/src/funcs.c
+++ b/ElmerGUI/matc/src/funcs.c
@@ -55,7 +55,7 @@
 |FUNCTION NAME(...) params ...
 |
 $  usage of the function and type of the parameters
-?  explane the effects of the function
+?  explain the effects of the function
 =  return value and the type of value if not of type int
 @  globals effected directly by this routine
 !  current known bugs or limitations

--- a/ElmerGUI/matc/src/lists.c
+++ b/ElmerGUI/matc/src/lists.c
@@ -71,7 +71,7 @@
 |FUNCTION NAME(...) params ...
 |
 $  usage of the function and type of the parameters
-?  explane the effects of the function
+?  explain the effects of the function
 =  return value and the type of value if not of type int
 @  globals effected directly by this routine
 !  current known bugs or limitations

--- a/ElmerGUI/matc/src/lu.c
+++ b/ElmerGUI/matc/src/lu.c
@@ -55,7 +55,7 @@
 |FUNCTION NAME(...) params ...
 |
 $  usage of the function and type of the parameters
-?  explane the effects of the function
+?  explain the effects of the function
 =  return value and the type of value if not of type int
 @  globals effected directly by this routine
 !  current known bugs or limitations

--- a/ElmerGUI/matc/src/matc.c
+++ b/ElmerGUI/matc/src/matc.c
@@ -55,7 +55,7 @@
 |FUNCTION NAME(...) params ...
 |
 $  usage of the function and type of the parameters
-?  explane the effects of the function
+?  explain the effects of the function
 =  return value and the type of value if not of type int
 @  globals effected directly by this routine
 !  current known bugs or limitations

--- a/ElmerGUI/matc/src/matrix.c
+++ b/ElmerGUI/matc/src/matrix.c
@@ -55,7 +55,7 @@
 |FUNCTION NAME(...) params ...
 |
 $  usage of the function and type of the parameters
-?  explane the effects of the function
+?  explain the effects of the function
 =  return value and the type of value if not of type int
 @  globals effected directly by this routine
 !  current known bugs or limitations

--- a/ElmerGUI/matc/src/oper.c
+++ b/ElmerGUI/matc/src/oper.c
@@ -55,7 +55,7 @@
 |FUNCTION NAME(...) params ...
 |
 $  usage of the function and type of the parameters
-?  explane the effects of the function
+?  explain the effects of the function
 =  return value and the type of value if not of type int
 @  globals effected directly by this routine
 !  current known bugs or limitations

--- a/ElmerGUI/matc/src/parser.c
+++ b/ElmerGUI/matc/src/parser.c
@@ -55,7 +55,7 @@
 |FUNCTION NAME(...) params ...
 |
 $  usage of the function and type of the parameters
-?  explane the effects of the function
+?  explain the effects of the function
 =  return value and the type of value if not of type int
 @  globals effected directly by this routine
 !  current known bugs or limitations

--- a/ElmerGUI/matc/src/urand.c
+++ b/ElmerGUI/matc/src/urand.c
@@ -55,7 +55,7 @@
 |FUNCTION NAME(...) params ...
 |
 $  usage of the function and type of the parameters
-?  explane the effects of the function
+?  explain the effects of the function
 =  return value and the type of value if not of type int
 @  globals effected directly by this routine
 !  current known bugs or limitations

--- a/ElmerGUI/matc/src/variable.c
+++ b/ElmerGUI/matc/src/variable.c
@@ -55,7 +55,7 @@
 |FUNCTION NAME(...) params ...
 |
 $  usage of the function and type of the parameters
-?  explane the effects of the function
+?  explain the effects of the function
 =  return value and the type of value if not of type int
 @  globals effected directly by this routine
 !  current known bugs or limitations

--- a/elmergrid/src/egparallel.c
+++ b/elmergrid/src/egparallel.c
@@ -3489,7 +3489,7 @@ int OptimizePartitioning(struct FemType *data,struct BoundaryType *bound,int noo
 			 int partbw, int info)
 /* Optimize partitioning of elements so that each partition has as closely as possible the 
    desired amount of elements. Also, ir requested, check that there are no odd couplings within 
-   elelements that are not directly present at the given partition. It is a bit unclear 
+   elements that are not directly present at the given partition. It is a bit unclear 
    to which extent these checks are needed in the current Elmer version. */
 {
   int i,j,k,l,n,m,noelements,partitions,ind,hit;

--- a/elmerice/IceSheet/Greenland/SSA_FRICTION_INIT/OPTIM_BETA.sif
+++ b/elmerice/IceSheet/Greenland/SSA_FRICTION_INIT/OPTIM_BETA.sif
@@ -1,7 +1,7 @@
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 ! .sif file for the inverse method
 !   Optimize the friction coefficient to reduce mismatch with obs. surface velocities
-!   with contrains on the flux divergence and assume smoothness of the friction field
+!   with constraints on the flux divergence and assume smoothness of the friction field
 !  
 ! Author: F. Gillet-Chaulet (IGE-Grenoble-FR)
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!

--- a/elmerice/IceSheet/Tools/ConservativeInterpolation/README
+++ b/elmerice/IceSheet/Tools/ConservativeInterpolation/README
@@ -32,6 +32,6 @@ RUN the example:
 	4. RUN MakeCDOGridDesc.sif : 
 		- this will produce an unstructured grid description file of the mesh for CDO
 		- required fortrangis to compute (lon,lat) from (x,y) coordinates
-		- restructed to 2D meshes with 303 elements only
+		- restructured to 2D meshes with 303 elements only
 	5. The script Interpolate.sh uses CDO for the conservative interpolation from the initial structured Grid to the Elmer unstructured grid. Results are given as cell values
 	6. READ_CELL_NETCDF.sif shows how to read the unstructured netcdf to get the variable on the 2D mesh; eventually use conservative FE interpolation to convert the elemental variable to a nodal variable 

--- a/elmerice/Meshers/ExtrudeMesh.c
+++ b/elmerice/Meshers/ExtrudeMesh.c
@@ -1148,7 +1148,7 @@ int main(int argc, char *argv[])
   printf("    ... percentage: %10.4f\n",percentage);
   printf("    ... ratio: %10.4f\n",ratio);
   if (partitions < 1){
-    printf("(%s) Wrong number of paritions %i\n",argv[0],partitions);
+    printf("(%s) Wrong number of partitions %i\n",argv[0],partitions);
     printf("(%s) Assuming serial mesh (N=1)\n",argv[0]);
     partitions=1;
   }
@@ -1358,7 +1358,7 @@ int main(int argc, char *argv[])
     fprintf(infofid,"    ... corrbed: %1i\n\n",corrbed);
   }
 
-  fprintf(infofid,"    ... total poitns in 2d mesh: %i \n",pointsinlevel);
+  fprintf(infofid,"    ... total points in 2d mesh: %i \n",pointsinlevel);
   fprintf(infofid,"    ... total elements in 2d mesh: %i \n",elementsinlevel);
   fprintf(infofid,"    ... total boundary elements in 2d mesh: %i \n",belementsinlevel);
   fprintf(infofid,"    ... no of element type 101: %i \n",points);

--- a/elmerice/Solvers/Calving3D_lset.F90
+++ b/elmerice/Solvers/Calving3D_lset.F90
@@ -775,7 +775,7 @@
           !TODO - Ask Eef about this ---^
           NodeHolder = MATMUL(RotationMatrix, NodeHolder)
           y_coord(2) = NodeHolder(2)
-          LeftToRight = y_coord(2) > y_coord(1) ! TO DO check if this doesnt break for special cases
+          LeftToRight = y_coord(2) > y_coord(1) ! TODO check if this doesn't break for special cases
           IF(LeftToRight) THEN
              CrevX(CrevStart(i):CrevEnd(i))=CrevX(CrevEnd(i):CrevStart(i):-1)
              CrevY(CrevStart(i):CrevEnd(i))=CrevY(CrevEnd(i):CrevStart(i):-1)

--- a/elmerice/Solvers/Documentation/Adjoint_CostContSolver.md
+++ b/elmerice/Solvers/Documentation/Adjoint_CostContSolver.md
@@ -20,7 +20,7 @@ at the mesh nodes.
 This solver also computes the derivative of the cost function with respect to some model nodal variable that is solution of a solver  (Stokes, SSA, etc..).
 The variable that contains the derivative must exist. 
 To be consistent with other solvers it should be named *velocityb* if the model variable is *Flow Solution* (i.e. solving Stokes) or *ssavelocity* (i.e. solving SSA), or *Varb* for other direct equations (where *Var* is the name of the direct solver variable). 
-It's dimension should be consistent with the dimension of the Model Variable. The derivative of the cost function should also be provided by the user in the Body Force and should provide the exact derivative of the Cost with respect to the given componenet of the direct variable.
+It's dimension should be consistent with the dimension of the Model Variable. The derivative of the cost function should also be provided by the user in the Body Force and should provide the exact derivative of the Cost with respect to the given component of the direct variable.
 
 Be careful, this solver will reset the values of the cost and sensitivity to 0; so that it must be used in first place in an assimilation sequence.
 

--- a/elmerice/Solvers/Documentation/ISCAL.md
+++ b/elmerice/Solvers/Documentation/ISCAL.md
@@ -42,7 +42,7 @@ There are two extra output variables for the coupling code which you can view in
 
 - Error Estimation Intervals = Integer 20 How often you want to do error estimation, in this case it will be every 20th timestep
 
-- Error Estimation Method = String “solution” The options are in theory “solution”, “functional” and “residual” It will estimate the error based on the horizontal velocity error directly, in a fucntional of the solution or in the residual of the solution.
+- Error Estimation Method = String “solution” The options are in theory “solution”, “functional” and “residual” It will estimate the error based on the horizontal velocity error directly, in a functional of the solution or in the residual of the solution.
 
 **Keywords for solution based estimate**
 - Relative Error Allowed In Percent = Real 15.0 Maximum allowed relative error of SIA in percent, in this case 15 %

--- a/elmerice/Solvers/Documentation/Pointwise.md
+++ b/elmerice/Solvers/Documentation/Pointwise.md
@@ -50,7 +50,7 @@ Solver 1
   Variable 1 Supporting Points = Integer 3 !minimum of points to be used for interpolation
   Variable 1 Dimensions = Integer 2 !dimension of variable, here needs a file with two columns
   Variable 1 Exponent = Real 3.0 ! inverse distance weighting exponent (has to be positive) - default 2.0
-  Variable 1 Area Scaling Factor = Real 2.0 ! increases the max search distance by factor 2 of the maximum distance of dataset poitns
+  Variable 1 Area Scaling Factor = Real 2.0 ! increases the max search distance by factor 2 of the maximum distance of dataset points
   Variable 1 Directions(2) = Integer 2 1 [Here direction 1 and 2 (x and y) would be interchanged]
   
   Exported Variable 1 = -dofs 1 mb !Variablename in Elmer

--- a/elmerice/Solvers/Documentation/SIA.md
+++ b/elmerice/Solvers/Documentation/SIA.md
@@ -60,4 +60,4 @@ End
 ```
 
 ## Examples
-An example using the SIASolver applied to experiment A160 of ISMIP-HOM benchamrks can be found in [ELMER_TRUNK]/elmerice/Tests/SIA.
+An example using the SIASolver applied to experiment A160 of ISMIP-HOM benchmarks can be found in [ELMER_TRUNK]/elmerice/Tests/SIA.

--- a/elmerice/Solvers/Scalar_OUTPUT_Glacier.F90
+++ b/elmerice/Solvers/Scalar_OUTPUT_Glacier.F90
@@ -28,7 +28,7 @@
 ! *
 ! *  Original Date: 03-2018, 
 ! *  11-2020
-! *  O. Gagliardini (IGE) modified the initial version from Fabien to adpat it for Glacier
+! *  O. Gagliardini (IGE) modified the initial version from Fabien to adapt it for Glacier
 ! *****************************************************************************
 !!! Compute standard 1D variables:
 !   1: Time

--- a/elmerice/Solvers/m1qn3.F
+++ b/elmerice/Solvers/m1qn3.F
@@ -10,7 +10,7 @@ c     M1qn3 has two running modes: the SID (Scalar Initial Scaling) mode
 c     and the DIS (Diagonal Initial Scaling) mode. Both do not require
 c     the same amount of storage, the same subroutines, ...
 c     In the description below, items that differ in the DIS mode with
-c     respect to the SIS mode are given in brakets.
+c     respect to the SIS mode are given in brackets.
 c
 c     Use the following subroutines:
 c         M1QN3A

--- a/elmerice/Solvers/pointwise.F90
+++ b/elmerice/Solvers/pointwise.F90
@@ -73,7 +73,7 @@
 !  Variable 1 Supporting Points = Integer 3 !minimum of points to be used for interpolation
 !  Variable 1 Dimensions = Integer 2 !dimension of variable, here needs a file with two columns, NOTE numbers have to be written as 0.04 and not 4e-2
 !  Variable 1 Exponent = Real 3.0 ! inverse distance weighting exponent (has to be positive) - default 2.0
-!  Variable 1 Area Scaling Factor = Real 2.0 ! increases the max search distance by factor 2 of the maximum distance of dataset poitns
+!  Variable 1 Area Scaling Factor = Real 2.0 ! increases the max search distance by factor 2 of the maximum distance of dataset points
 !  Variable 1 Directions(2) = Integer 1 2 !which dimensions are these? Here direction 1 and 2 (x and y)
 !  Exported Variable 1 = mb !Variablename in Elmer
 !  Exported Variable 1 DOFS = Integer 1 !degrees of freedom
@@ -378,7 +378,7 @@ RECURSIVE SUBROUTINE InterpolatePointValue( Model,Solver,Timestep,TransientSimul
                 //TRIM(ADJUSTL(temp))//TRIM(VariableDataNameEnd(VariableNo))
 
         ELSE
-           WRITE(Message,'(A,I2)') "Varialbe DataI has to be 0,1 or 2, but is" , VariableDataIName(VariableNo)
+           WRITE(Message,'(A,I2)') "Variable DataI has to be 0,1 or 2, but is" , VariableDataIName(VariableNo)
            CALL FATAL(SolverName,Message)
         ENDIF
 

--- a/elmerice/Tests/Enthalpy/WithOutCavity/info.dat
+++ b/elmerice/Tests/Enthalpy/WithOutCavity/info.dat
@@ -13,7 +13,7 @@ command line was: ExtrudeMesh teterousse WithOutCavity 14     1.00 1 0   0.00 0.
 
     ... ratio:     0.0000
 
-    ... total poitns in 2d mesh: 383 
+    ... total points in 2d mesh: 383 
     ... total elements in 2d mesh: 691 
     ... total boundary elements in 2d mesh: 73 
     ... no of element type 101: 0 

--- a/elmerice/Tests/MMG2D_Transient/SIFs/MESH_OPTIM_I_J.sif
+++ b/elmerice/Tests/MMG2D_Transient/SIFs/MESH_OPTIM_I_J.sif
@@ -56,7 +56,7 @@ Initial Condition 1
 ! h0 will be: 
 !  - latest value of h if last step of the initialisation loop
  h0 = Equals h
-!  - overwrited if "ReloadSolution" solver is executed
+!  - overwritten if "ReloadSolution" solver is executed
 End
 
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!

--- a/elmerice/UserFunctions/USF_Sliding.F90
+++ b/elmerice/UserFunctions/USF_Sliding.F90
@@ -848,7 +848,7 @@ END FUNCTION Sliding_Budd
 !> USF_Sliding.f90, function FreeSlipShelves
 !> 
 !> Sets the basal drag to zero according to a grounded mask.  Intended for use 
-!> when aplying inverse methods in the presence of floating ice shelves.
+!> when applying inverse methods in the presence of floating ice shelves.
 !> 
 !> For the .sif (bottom boundary):
 !>  Slip Coefficient 2  = Variable beta

--- a/elmerice/examples/Test_SurfaceBoundaryEnth/RikhaSamba/partitioning.3/info.dat
+++ b/elmerice/examples/Test_SurfaceBoundaryEnth/RikhaSamba/partitioning.3/info.dat
@@ -13,7 +13,7 @@ command line was: ExtrudeMesh mesh2D Rikha3Dini2 15     1.00 3 0 0   0.00 1.00  
 
     ... ratio:     1.0000
 
-    ... total poitns in 2d mesh: 1655 
+    ... total points in 2d mesh: 1655 
     ... total elements in 2d mesh: 2987 
     ... total boundary elements in 2d mesh: 321 
     ... no of element type 101: 0 

--- a/fem/src/ClusteringMethods.F90
+++ b/fem/src/ClusteringMethods.F90
@@ -857,7 +857,7 @@ CONTAINS
       CALL CMGClusterForm(Amat, Bonds, Passive, Fixed, Components, Component1, CF)
 
       IF( ParEnv % PEs > 1 ) THEN
-        CALL Fatal('ChooseClusterNodes','Implement paralle stuff')
+        CALL Fatal('ChooseClusterNodes','Implement parallel stuff')
         ! Things to implement here:
         ! 1) Global numbering for CF
         ! 2) ParallelInfo for algebraic systems
@@ -880,7 +880,7 @@ CONTAINS
     SUBROUTINE SetParallelPassive()
       INTEGER :: i,j
 
-      ! If not paralle then return
+      ! If not parallel then return
       IF( ParEnv % PEs <= 1 ) RETURN
 
       ! Note that the ParallelInfo for matrices equals the size of the matrix
@@ -1289,7 +1289,7 @@ CONTAINS
       HalfSize = ListGetInteger(Solver % Values,'MG Cluster Half Size',GotIt)
       IF(.NOT. GotIt) HalfSize = (ClusterSize-1)/2 
       
-      ! Paricularly for small clusters the orphan control seems to be important
+      ! Particularly for small clusters the orphan control seems to be important
       ClusterOrphans = ListGetLogical(Solver % Values,'MG Cluster Orphans',GotIt)
       IF(.NOT. GotIt) ClusterOrphans = .TRUE.
       OrphansBest = ListGetLogical(Solver % Values,'MG Cluster Orphans Best',GotIt)

--- a/fem/src/DefUtils.F90
+++ b/fem/src/DefUtils.F90
@@ -2405,7 +2405,7 @@ END BLOCK
 !------------------------------------------------------------------------------
 
 
-!> Is the actice solver solved in the frequency space
+!> Is the active solver solved in the frequency space
 !------------------------------------------------------------------------------
   FUNCTION EigenOrHarmonicAnalysis(Usolver) RESULT(L)
     LOGICAL :: L

--- a/fem/src/ElementDescription.F90
+++ b/fem/src/ElementDescription.F90
@@ -12411,7 +12411,7 @@ END SUBROUTINE PickActiveFace
           IF(i3 == i1 .OR. i3 == i2 ) CYCLE
 
           ! Vector stretching from edge center to the other nodes
-          ! of the parent elemet. 
+          ! of the parent element. 
           vec2(1) = vec3(1) + x(i3) 
           vec3(1) = vec3(1) + x(i3) 
           vec3(1) = vec3(1) + x(i3) 

--- a/fem/src/ElmerSolver.F90
+++ b/fem/src/ElmerSolver.F90
@@ -369,9 +369,9 @@
          INQUIRE(Unit=InFileUnit, Opened=GotIt)
          IF ( gotIt ) CLOSE(inFileUnit)
 
-         ! Here we read the whole model including command file and detault mesh file
+         ! Here we read the whole model including command file and default mesh file
          !---------------------------------------------------------------------------------
-         OPEN( Unit=InFileUnit, Action='Read',File=ModelName,Status='OLD',IOSTAT=iostat)         
+         OPEN( Unit=InFileUnit, Action='Read',File=ModelName,Status='OLD',IOSTAT=iostat)
          IF( iostat /= 0 ) THEN
            CALL Fatal( 'ElmerSolver', 'Unable to find input file [' // &
                TRIM(Modelname) // '], can not execute.' )

--- a/fem/src/InterpolateMeshToMesh.F90
+++ b/fem/src/InterpolateMeshToMesh.F90
@@ -1187,7 +1187,7 @@ CONTAINS
   ! Create a representative dg index to be used for interpolation.
   ! This is cheating since it does not work in general. It does work
   ! for the reduced basis DG. Even there it works only at intersections
-  ! if there is an additinal mask that is used to pick the correct element.
+  ! if there is an additional mask that is used to pick the correct element.
   ! For generic cases we would need a table to all DG indexes. 
   !------------------------------------------------------------------------
   SUBROUTINE CreateOneDGIndex()

--- a/fem/src/LUDecomposition.F90
+++ b/fem/src/LUDecomposition.F90
@@ -209,7 +209,7 @@ MODULE LUDecomposition
       END DO
 
       IF ( ABS(A(i,j)) == 0.0d0) THEN
-        CALL Error( 'LUDecomp', 'Matrix is singluar.' )
+        CALL Error( 'LUDecomp', 'Matrix is singular.' )
         RETURN
       END IF
 
@@ -355,7 +355,7 @@ MODULE LUDecomposition
       END DO
 
       IF ( ABS(A(i,j))==0.0d0 ) THEN
-        CALL Error( 'ComplexLUDecomp', 'Matrix is singluar.' )
+        CALL Error( 'ComplexLUDecomp', 'Matrix is singular.' )
         RETURN
       END IF
 

--- a/fem/src/LinearAlgebra.F90
+++ b/fem/src/LinearAlgebra.F90
@@ -196,7 +196,7 @@ MODULE LinearAlgebra
       END DO
 
       IF ( ABS(A(i,j)) == 0.0d0) THEN
-        CALL Error( 'LUDecomp', 'Matrix is singluar.' )
+        CALL Error( 'LUDecomp', 'Matrix is singular.' )
         RETURN
       END IF
 
@@ -350,7 +350,7 @@ MODULE LinearAlgebra
       END DO
 
       IF ( ABS(A(i,j))==0.0d0 ) THEN
-        CALL Error( 'ComplexLUDecomp', 'Matrix is singluar.' )
+        CALL Error( 'ComplexLUDecomp', 'Matrix is singular.' )
         RETURN
       END IF
 

--- a/fem/src/Lists.F90
+++ b/fem/src/Lists.F90
@@ -4530,7 +4530,7 @@ use spariterglobals
 #if 0
 !------------------------------------------------------------------------------
 !> Get field values (one or seveal) at the given point. The point may be either
-!> given by basis functions, local coordinates or node. This is definately not
+!> given by basis functions, local coordinates or node. This is definitely not
 !> gauss point usually so we cannot use that information directly. 
 !> Works with different types of fields.
 !------------------------------------------------------------------------------

--- a/fem/src/MeshUtils.F90
+++ b/fem/src/MeshUtils.F90
@@ -935,7 +935,7 @@ CONTAINS
    CALL Info(Caller,'Number of bulk elements staying: '&
        //TRIM(I2S(NoStayingElems)), Level=8)
 
-   ! Set discontinuous nodes only if there is a real moving node associted with it
+   ! Set discontinuous nodes only if there is a real moving node associated with it
    ! Otherwise we would create a zero to the permutation vector. 
    ! If there is just a staying node then no need to create discontinuity at this node.
    DiscontNode = DiscontNode .AND. MovingNode 

--- a/fem/src/PElementBase.F90
+++ b/fem/src/PElementBase.F90
@@ -1448,7 +1448,7 @@ MODULE PElementBase
     END FUNCTION dBrickNodalPBasis
 
 
-    ! As previus except obtain all nodal values at once. 
+    ! As previous except obtain all nodal values at once. 
     SUBROUTINE dBrickNodalPBasisAll(u, v, w, gradphi) 
       IMPLICIT NONE
 

--- a/fem/src/ParallelUtils.F90
+++ b/fem/src/ParallelUtils.F90
@@ -667,7 +667,7 @@ CONTAINS
        ! This is used for a rare condition:
        !
        ! o Linear system solved using Hypre
-       ! o Some paritions have no degrees of freedom assigned, but have matrix entries
+       ! o Some partitions have no degrees of freedom assigned, but have matrix entries
        ! to contribute to the global system (for example from halo elements).
        BLOCK
          INTEGER :: NameSpaceI

--- a/fem/src/SolverUtils.F90
+++ b/fem/src/SolverUtils.F90
@@ -8063,7 +8063,7 @@ CONTAINS
        n = COUNT((ITag > 0) .AND. A % ParallelInfo % NodeInterface)
      END IF
 
-     ! Allocate for the data to sent (s_e) and recieve (r_e)       
+     ! Allocate for the data to sent (s_e) and receive (r_e)
      ALLOCATE( s_e(n, nn ), r_e(n) )
      s_e = 0
      IF( CommI ) THEN
@@ -8119,7 +8119,7 @@ CONTAINS
      
      DO i=1, nn
        j = fneigh(i)
-       ! Recieve size of data coming from partition "j"
+       ! Receive size of data coming from partition "j"
        CALL MPI_RECV( n,1,MPI_INTEGER,j-1,110,ELMER_COMM_WORLD, status,ierr )
        IF ( n>0 ) THEN
          IF( n>SIZE(r_e)) THEN
@@ -8131,10 +8131,10 @@ CONTAINS
            END IF
          END IF
 
-         ! Recieve the global index
+         ! Receive the global index
          CALL MPI_RECV( r_e,n,MPI_INTEGER,j-1,111,ELMER_COMM_WORLD,status,ierr )
          IF( CommI ) THEN
-           ! Recieve the value of the integer tag, if requested
+           ! Receive the value of the integer tag, if requested
            CALL MPI_RECV( r_i,n,MPI_INTEGER,j-1,112,ELMER_COMM_WORLD,status,ierr )
          END IF
          DO j=1,n
@@ -10084,7 +10084,7 @@ END FUNCTION SearchNodeL
     IF( SteadyState ) THEN
       CALL Info(Caller,'Finished updating steady state objects!',Level=32)
     ELSE
-      CALL Info(Caller,'Finished updaing nonlinear objects!',Level=32)
+      CALL Info(Caller,'Finished updating nonlinear objects!',Level=32)
     END IF
 
   END SUBROUTINE UpdateDependentObjects

--- a/fem/src/modules/CompressibleNS.F90
+++ b/fem/src/modules/CompressibleNS.F90
@@ -169,7 +169,7 @@ SUBROUTINE CompressibleNS( Model,Solver,dt,TransientSimulation )
   CALL DefaultStart()
 
   DO iter=1, NonlinearIter
-     ! Initialize the system matrices and vectrors...
+     ! Initialize the system matrices and vectors...
      CALL DefaultInitialize()
 
      DO t=1,Solver % NumberOfActiveElements

--- a/fem/src/modules/HeatSolveVec.F90
+++ b/fem/src/modules/HeatSolveVec.F90
@@ -131,7 +131,7 @@ END SUBROUTINE HeatSolver_Init
 !-----------------------------------------------------------------------------
 !> A modern version for the heat equation supporting multi-threading and
 !> SIMD friendly ElmerSolver kernels. This tries to be backward compatible
-!> with the lagacy HeatSolver but some rarely used features are missing. 
+!> with the legacy HeatSolver but some rarely used features are missing. 
 !------------------------------------------------------------------------------
 SUBROUTINE HeatSolver( Model,Solver,dt,Transient )
 !------------------------------------------------------------------------------

--- a/fem/src/modules/MagnetoDynamics/Utils.F90
+++ b/fem/src/modules/MagnetoDynamics/Utils.F90
@@ -718,7 +718,7 @@ CONTAINS
         END IF
       END IF
 
-      ! We have either none or both parents as actice.
+      ! We have either none or both parents as active.
       ! The BCs will be set only to outer boundaries of the domain. 
       IF( ActParents /= 1 ) CYCLE
       

--- a/fem/src/modules/MarchingODESolver.F90
+++ b/fem/src/modules/MarchingODESolver.F90
@@ -525,7 +525,7 @@ CONTAINS
 
     
     ! When using different integration we may need to access the
-    ! value of cofficients at previous mesh layer.
+    ! value of coefficients at previous mesh layer.
     IF( PRESENT( Set0 ) ) THEN
       IF( Set0 ) THEN
         IF( HaveF ) f0vec = fvec

--- a/fem/src/modules/ResultOutputSolve/DXOutputSolver.F90
+++ b/fem/src/modules/ResultOutputSolve/DXOutputSolver.F90
@@ -446,7 +446,7 @@
           ! Here's a bunch of routines to deal with ELMER -> DX element
           ! translations.
           
-          ! nElem is the number of DX elements, and nVertix is the numbe of
+          ! nElem is the number of DX elements, and nVertix is the number of
           ! vertices per element (either 3 for triangle or 4 for tetrahedra).
           
           SUBROUTINE GetNElem( Model, nElem, nVertix )

--- a/fem/src/modules/StressSolve.F90
+++ b/fem/src/modules/StressSolve.F90
@@ -2562,7 +2562,7 @@ CONTAINS
            END IF
            
            ! The plane  elements only include the  derivatives in the direction
-           ! of the plane. Therefore compute the derivatives of the displacemnt
+           ! of the plane. Therefore compute the derivatives of the displacement
            ! field from the parent element:
            ! -------------------------------------------------------------------
            Up = SUM( xp(1:n) * Basis(1:n) )

--- a/fem/tests/CooksMembrane/cooksmembrane.sif
+++ b/fem/tests/CooksMembrane/cooksmembrane.sif
@@ -50,7 +50,7 @@ Solver 1
   ! With "Mixed Formulation = True" & "Neo-Hookean Material = True"
   ! the following three keyword commands are used automatically in
   ! 2-D simulations (thus, use the components of "Disp" to specify
-  ! the diplacement on a boundary):
+  ! the displacement on a boundary):
   ! ----------------------------------------------------------------
   !  Variable = MixedSol[Disp:2 Pres:1]
   !  Variable DOFs = 3

--- a/fem/tests/CooksMembrane3D/cooksmembrane.sif
+++ b/fem/tests/CooksMembrane3D/cooksmembrane.sif
@@ -50,7 +50,7 @@ Solver 1
   ! With "Mixed Formulation = True" & "Neo-Hookean Material = True"
   ! the following three keyword commands are used automatically in
   ! 3-D simulations (thus, use the components of "Disp" to specify
-  ! the diplacement on a boundary):
+  ! the displacement on a boundary):
   ! ----------------------------------------------------------------
   !  Variable = MixedSol[Disp:3 Pres:1]
   !  Variable DOFs = 4

--- a/fem/tests/ThermalPipe2D/case.sif
+++ b/fem/tests/ThermalPipe2D/case.sif
@@ -1,4 +1,4 @@
-! Test case for a circular hole (represeting a pipe) going through 2D plane (representing the groud)
+! Test case for a circular hole (representing a pipe) going through 2D plane (representing the groud)
 
 Header
   CHECK KEYWORDS Warn


### PR DESCRIPTION
Found via `codespell -q 3 -S *.ps,./mathlibs,./contrib,./misc,./umfpack,./ElmerGUI/netgen,./elmergrid/src/metis* -L addres,amin,ang,ba,cas,cna,defind,dof,dum,emiss,enew,iff,ifset,impres,indeces,infor,inout,isnt,ist,ith,matc,muder,nd,ned,nin,numer,objext,oce,ot,pres,projectio,sord,splitted,stran,strat,te,teh,thisy,tim,totat,trough,uint,vave,workd`