### PR TITLE
Def dofs use

### DIFF
--- a/fem/src/DefUtils.F90
+++ b/fem/src/DefUtils.F90
@@ -1787,22 +1787,24 @@ CONTAINS
          !
          ! Check finally if 3-D faces are associated with face bubbles
          !
-         DO j=1,Element % TYPE % NumberOfFaces
-           Face => Solver % Mesh % Faces(Element % FaceIndexes(j))
-           face_type = Face % TYPE % ElementCode/100
-           IF (ASSOCIATED(Face % BoundaryInfo % Left)) THEN
-             face_id  = Face % BoundaryInfo % Left % BodyId
-             k = MAX(0,Solver % Def_Dofs(face_type+6,face_id,5))
-           END IF
-           IF (ASSOCIATED(Face % BoundaryInfo % Right)) THEN
-             face_id = Face % BoundaryInfo % Right % BodyId
-             k = MAX(k,Solver % Def_Dofs(face_type+6,face_id,5))
-           END IF
-           IF (k > 0) THEN
-             NeedEdges = .TRUE.
-             EXIT
-           END IF
-         END DO
+         IF ( ASSOCIATED( Element % FaceIndexes ) ) THEN
+           DO j=1,Element % TYPE % NumberOfFaces
+             Face => Solver % Mesh % Faces(Element % FaceIndexes(j))
+             face_type = Face % TYPE % ElementCode/100
+             IF (ASSOCIATED(Face % BoundaryInfo % Left)) THEN
+               face_id  = Face % BoundaryInfo % Left % BodyId
+               k = MAX(0,Solver % Def_Dofs(face_type+6,face_id,5))
+             END IF
+             IF (ASSOCIATED(Face % BoundaryInfo % Right)) THEN
+               face_id = Face % BoundaryInfo % Right % BodyId
+               k = MAX(k,Solver % Def_Dofs(face_type+6,face_id,5))
+             END IF
+             IF (k > 0) THEN
+               NeedEdges = .TRUE.
+               EXIT
+             END IF
+           END DO
+         END IF
        END IF
      END IF
 

--- a/fem/src/ElementDescription.F90
+++ b/fem/src/ElementDescription.F90
@@ -2656,8 +2656,9 @@ CONTAINS
      ! P ELEMENT CODE:
      ! ---------------
      IF ( isActivePElement(element,pSolver) ) THEN
-      ! Check for need of P basis degrees and set degree of
-      ! linear basis if vector asked:
+      !
+      ! Check whether the polynomial degree of each basis functions is asked
+      ! and, if so, initialize by the degree of linear basis:
       ! ---------------------------------------------------
       degrees = .FALSE.
       IF ( PRESENT(BasisDegree)) THEN 
@@ -2683,16 +2684,20 @@ CONTAINS
      ! P element code for line element:
      ! --------------------------------
      CASE(202)
+        ! Get element p
+        p = pSolver % Def_Dofs(2,BodyId,6)
+        BDOFs = MAX(GetBubbleDOFs(Element, p), pSolver % Def_Dofs(2,BodyId,5))
+
         ! Bubbles of line element
-        IF (Element % BDOFs > 0) THEN
+        IF (BDOFs > 0) THEN
            ! For boundary element integration check direction
            invert = .FALSE.
            IF ( Element % PDefs % isEdge .AND. &
                 Element % NodeIndexes(1)>Element % NodeIndexes(2) ) invert = .TRUE.
 
-           ! For each bubble in line element get value of basis function
-           DO i=1, Element % BDOFs
-              IF (q >= SIZE(Basis)) CYCLE
+           ! For each bubble get the value of basis function
+           DO i=1, BDOFs
+              IF (q >= SIZE(Basis)) EXIT
               q = q + 1
               
               Basis(q) = LineBubblePBasis(i+1,u,invert)
@@ -2704,12 +2709,14 @@ CONTAINS
         END IF
 
 !------------------------------------------------------------------------------
-! P element code for edges and bubbles of triangle
+     ! P element code for triangles:
      CASE(303)
+        EDOFs = GetEdgeDOFs(Element, pSolver % Def_Dofs(3,BodyId,6))
         ! Edges of triangle
-        IF ( ASSOCIATED( Element % EdgeIndexes ) ) THEN
+        IF ( ASSOCIATED( Element % EdgeIndexes ) .AND. EDOFs > 0) THEN
+           
            ! For each edge calculate the value of edge basis function
-           DO i=1,3
+           edges_triangle: DO i=1,3
               Edge => pSolver % Mesh % Edges( Element % EdgeIndexes(i) )
 
               ! Get local number of edge start and endpoint nodes
@@ -2721,9 +2728,13 @@ CONTAINS
               invert = .FALSE.
               IF ( Element % NodeIndexes(locali)>Element % NodeIndexes(localj) ) invert=.TRUE.
 
-              ! For each dof in edge get value of p basis function 
-              DO k=1,Edge % BDOFs
-                 IF (q >= SIZE(Basis)) CYCLE
+              ! For each edge DOF get the value of p-basis function
+              ! NOTE: Edges may not have correct information about the count of DOFs
+              !        per edge, so the following would not work:
+              !       EDOFs = GetEdgeDOFs(Edge, pSolver % Def_Dofs(2,BodyId,6))
+              !
+              DO k=1,EDOFs
+                 IF (q >= SIZE(Basis)) EXIT edges_triangle
                  q = q + 1
                  
                  ! Value of basis functions for edge=i and i=k+1 by parity
@@ -2734,16 +2745,23 @@ CONTAINS
                  ! Polynomial degree of basis function to vector
                  IF (degrees) BasisDegree(q) = 1+k
               END DO
-           END DO 
+           END DO edges_triangle
         END IF
 
         ! Bubbles of p triangle      
-        IF ( Element % BDOFs > 0 ) THEN
-           ! Get element p
-           p = Element % PDefs % P
 
-           nb = MAX( GetBubbleDOFs( Element, p ), Element % BDOFs )
-           p = CEILING( ( 3.0d0+SQRT(1.0d0+8.0d0*nb) ) / 2.0d0 - AEPS)
+        ! Get element p
+        p = pSolver % Def_Dofs(3,BodyId,6)
+        nb = pSolver % Def_Dofs(3,BodyId,5)
+        DesignedBubbles = nb > 0
+        BDOFs = MAX(GetBubbleDOFs(Element, p), nb)
+
+        IF (BDOFs > 0) THEN
+
+           IF (DesignedBubbles) THEN
+             Deg_Bubble = CEILING( ( 3.0d0+SQRT(1.0d0+8.0d0*nb) ) / 2.0d0 - AEPS)
+             p = MAX(p, Deg_Bubble)
+           END IF
            
            ! For boundary element direction needs to be calculated
            IF (Element % PDefs % isEdge) THEN
@@ -2752,9 +2770,9 @@ CONTAINS
               direction(1:3) = getTriangleFaceDirection(Element, [ 1,2,3 ])
            END IF
 
-           DO i = 0,p-3
+           bubbles_triangle: DO i = 0,p-3
               DO j = 0,p-i-3
-                 IF ( q >= SIZE(Basis) ) CYCLE
+                 IF ( q >= SIZE(Basis) ) EXIT bubbles_triangle
                  q = q + 1
 
                  ! Get bubble basis functions and their derivatives
@@ -2771,15 +2789,16 @@ CONTAINS
                  ! Polynomial degree of basis function to vector
                  IF (degrees) BasisDegree(q) = 3+i+j
               END DO
-           END DO
+           END DO bubbles_triangle
         END IF
 !------------------------------------------------------------------------------
-! P element code for quadrilateral edges and bubbles 
+     ! P element code for quads:
      CASE(404)
         ! Edges of p quadrilateral
+        EDOFs = GetEdgeDOFs(Element, pSolver % Def_Dofs(4,BodyId,6))
         IF ( ASSOCIATED( Element % EdgeIndexes ) ) THEN
-           ! For each edge begin node calculate values of edge functions 
-           DO i=1,4
+           ! For each edge calculate the values of edge basis functions 
+           edges_quad: DO i=1,4
               Edge => pSolver % Mesh % Edges( Element % EdgeIndexes(i) )
 
               ! Choose correct parity by global edge dofs
@@ -2791,10 +2810,9 @@ CONTAINS
               invert = .FALSE.
               IF (Element % NodeIndexes(locali) > Element % NodeIndexes(localj)) invert = .TRUE. 
 
-              ! For each DOF in edge calculate value of p basis function
-              EDOFs = GetEdgeDOFs(Element, pSolver % Def_Dofs(4,BodyId,6))
+              ! For each DOF in edge calculate the value of p-basis function
               DO k=1,EDOFs
-                 IF ( q >= SIZE(Basis) ) CYCLE
+                 IF ( q >= SIZE(Basis) ) EXIT edges_quad
                  q = q + 1
 
                  ! For pyramid square face edges use different basis
@@ -2812,7 +2830,7 @@ CONTAINS
                  ! Polynomial degree of basis function to vector
                  IF (degrees) BasisDegree(q) = 1+k
               END DO              
-           END DO         
+           END DO edges_quad
         END IF
 
         ! Bubbles of p quadrilateral, the number of which may have been defined explicitly or
@@ -2820,15 +2838,14 @@ CONTAINS
         ! which are part of the FE space of the specified degree
   
         ! Get the specified element P:
-        p = pSolver % Def_Dofs(4,BodyId,6)   
-        ! p = Element % PDefs % P        
-        DesignedBubbles = pSolver % Def_Dofs(4,BodyId,5) > 0
-        BDOFs = MAX(GetBubbleDOFs(Element, p), pSolver % Def_Dofs(4,BodyId,5)) 
+        p = pSolver % Def_Dofs(4,BodyId,6)
+        nb = pSolver % Def_Dofs(4,BodyId,5)
+        DesignedBubbles = nb > 0
+        BDOFs = MAX(GetBubbleDOFs(Element, p), nb) 
 
         IF (BDOFs > 0) THEN
 
            IF (DesignedBubbles) THEN
-             nb = pSolver % Def_Dofs(4,BodyId,5)
              Deg_Bubble = CEILING( (5.0d0+SQRT(1.0d0+8.0d0*nb) ) / 2.0d0 - AEPS )
              p = MAX(p, Deg_Bubble)
            END IF
@@ -2839,11 +2856,11 @@ CONTAINS
               direction = getSquareFaceDirection(Element, [ 1,2,3,4 ])
            END IF
           
-           ! For each bubble calculate value of p basis function
-           ! and their derivatives for index pairs i,j>=2, i+j=4,...,p
-           DO i=2,(p-2)
+           ! For each bubble calculate the value of p basis function
+           ! and its derivatives for index pairs i,j>=2, i+j=4,...,p
+           bubbles_quad: DO i=2,(p-2)
               DO j=2,(p-i)
-                 IF ( q >= SIZE(Basis) ) CYCLE
+                 IF ( q >= SIZE(Basis) ) EXIT bubbles_quad
                  q = q + 1
                  
                  ! Get values of bubble functions
@@ -2860,24 +2877,23 @@ CONTAINS
                  ! Polynomial degree of basis function to vector
                  IF (degrees) BasisDegree(q) = i+j
               END DO
-           END DO
+           END DO bubbles_quad
         END IF
 !------------------------------------------------------------------------------
-! P element code for tetrahedron edges, faces and bubbles
-     CASE(504) 
+     ! P element code for tetrahedra:
+     CASE(504)
+        p = pSolver % Def_Dofs(5,BodyId,6)
+        EDOFs = GetEdgeDOFs(Element, p)
         ! Edges of p tetrahedron
-        IF ( ASSOCIATED( Element % EdgeIndexes ) ) THEN   
-           ! For each edge calculate value of edge functions
-           DO i=1,6
+        IF ( ASSOCIATED( Element % EdgeIndexes ) .AND. EDOFs > 0) THEN   
+           ! For each edge i calculate the values of edge functions
+           edges_tetrahedron: DO i=1,6
               Edge => pSolver % Mesh % Edges (Element % EdgeIndexes(i))
-
-              ! Do not solve edge DOFS if there is not any
-              IF (Edge % BDOFs <= 0) CYCLE
-
-              ! For each DOF in edge calculate value of edge functions 
-              ! and their derivatives for edge=i, i=k+1
-              DO k=1, Edge % BDOFs
-                 IF (q >= SIZE(Basis)) CYCLE
+              
+              ! For each edge DOF k calculate the value of edge function
+              ! and its derivatives
+              DO k=1, EDOFs
+                 IF (q >= SIZE(Basis)) EXIT edges_tetrahedron
                  q = q + 1
 
                  Basis(q) = TetraEdgePBasis(i,k+1,u,v,w, Element % PDefs % TetraType)
@@ -2886,27 +2902,27 @@ CONTAINS
                  ! Polynomial degree of basis function to vector
                  IF (degrees) BasisDegree(q) = 1+k
               END DO
-           END DO
+           END DO edges_tetrahedron
         END IF
 
         ! Faces of p tetrahedron
         IF ( ASSOCIATED( Element % FaceIndexes )) THEN
-           ! For each face calculate value of face functions
-           DO F=1,4
+           ! For each face calculate values of face functions
+           faces_tetrahedron: DO F=1,4
               Face => pSolver % Mesh % Faces (Element % FaceIndexes(F))
 
-              ! Do not solve face DOFs if there is not any
-              IF (Face % BDOFs <= 0) CYCLE
-
               ! Get face p 
-              p = Face % PDefs % P
+              !p = MAX(pSolver % Def_Dofs(5,BodyId,6), Face % PDefs % P)
 
-              ! For each DOF in face calculate value of face functions and 
-              ! their derivatives for face=F and index pairs 
+              ! Do not solve face DOFs if there is not any
+              !IF (GetFaceDOFs(Element, p, F) <= 0) CYCLE
+
+              ! For each DOF in face calculate values of face function and 
+              ! its derivatives for index pairs 
               ! i,j=0,..,p-3, i+j=0,..,p-3
               DO i=0,p-3
                  DO j=0,p-i-3
-                    IF (q >= SIZE(Basis)) CYCLE
+                    IF (q >= SIZE(Basis)) EXIT faces_tetrahedron
                     q = q + 1 
                     
                     Basis(q) = TetraFacePBasis(F,i,j,u,v,w, Element % PDefs % TetraType)
@@ -2916,24 +2932,28 @@ CONTAINS
                     IF (degrees) BasisDegree(q) = 3+i+j
                  END DO
               END DO
-           END DO
+           END DO faces_tetrahedron
         END IF
 
         ! Bubbles of p tetrahedron
-        IF ( Element % BDOFs > 0 ) THEN
-           p = Element % PDefs % P
+        nb = pSolver % Def_Dofs(5,BodyId,5)
+        DesignedBubbles = nb > 0
+        BDOFs = MAX(GetBubbleDOFs(Element, p), nb) 
+        IF ( BDOFs > 0 ) THEN
 
-           nb = MAX( GetBubbleDOFs(Element, p), Element % BDOFs )
-           p=CEILING(1/3d0*(81*nb+3*SQRT(-3d0+729*nb**2))**(1/3d0)+1d0/ &
+           IF (DesignedBubbles) THEN
+             Deg_Bubble = CEILING(1/3d0*(81*nb+3*SQRT(-3d0+729*nb**2))**(1/3d0)+1d0/ &
                    (81*nb+3*SQRT(-3d0+729*nb**2))**(1/3d0)+2 - AEPS)
+             p = MAX(p, Deg_Bubble)
+           END IF
 
-           ! For each DOF in bubbles calculate value of bubble functions
-           ! and their derivatives for index pairs
+           ! For each bubble DOF calculate the value of bubble function
+           ! and its derivatives for index pairs
            ! i,j,k=0,..,p-4 i+j+k=0,..,p-4
-           DO i=0,p-4
+           bubbles_tetrahedron: DO i=0,p-4
               DO j=0,p-i-4
                  DO k=0,p-i-j-4
-                    IF (q >= SIZE(Basis)) CYCLE
+                    IF (q >= SIZE(Basis)) EXIT bubbles_tetrahedron
                     q = q + 1
 
                     Basis(q) = TetraBubblePBasis(i,j,k,u,v,w)
@@ -2943,21 +2963,20 @@ CONTAINS
                     IF (degrees) BasisDegree(q) = 4+i+j+k
                  END DO
               END DO
-           END DO
+           END DO bubbles_tetrahedron
            
         END IF
 !------------------------------------------------------------------------------
-! P element code for pyramid edges, faces and bubbles
+     ! P element code for pyramids:
      CASE(605)
         ! Edges of P Pyramid
-        IF (ASSOCIATED( Element % EdgeIndexes ) ) THEN
-           ! For each edge in wedge, calculate values of edge functions
-           DO i=1,8
+        p = pSolver % Def_Dofs(6,BodyId,6)
+        EDOFs = GetEdgeDOFs(Element, p)
+        IF (ASSOCIATED( Element % EdgeIndexes ) .AND. EDOFs > 0) THEN
+           ! For each edge calculate values of edge functions
+           edges_pyramid: DO i=1,8
               Edge => pSolver % Mesh % Edges( Element % EdgeIndexes(i) )
 
-              ! Do not solve edge dofs, if there is not any
-              IF (Edge % BDOFs <= 0) CYCLE
-              
               ! Get local indexes of current edge
               tmp(1:2) = getPyramidEdgeMap(i)
               locali = tmp(1)
@@ -2969,10 +2988,10 @@ CONTAINS
               ! Invert edge if local first node has greater global index than second one
               IF ( Element % NodeIndexes(locali) > Element % NodeIndexes(localj) ) invert = .TRUE.
 
-              ! For each DOF in edge calculate values of edge functions
-              ! and their derivatives for edge=i and i=k+1
-              DO k=1,Edge % BDOFs
-                 IF ( q >= SIZE(Basis) ) CYCLE
+              ! For each edge DOF k calculate the value of edge function
+              ! and its derivatives
+              DO k=1,EDOFs
+                 IF ( q >= SIZE(Basis) ) EXIT edges_pyramid
                  q = q + 1
 
                  ! Get values of edge basis functions and their derivatives
@@ -2982,20 +3001,20 @@ CONTAINS
                  ! Polynomial degree of basis function to vector
                  IF (degrees) BasisDegree(q) = 1+k
               END DO
-           END DO
+           END DO edges_pyramid
         END IF
         
         ! Faces of P Pyramid
         IF ( ASSOCIATED( Element % FaceIndexes ) ) THEN
-           ! For each face in pyramid, calculate values of face functions
-           DO F=1,5
+           ! For each face in pyramid, calculate the values of face functions
+           faces_pyramid: DO F=1,5
               Face => pSolver % Mesh % Faces( Element % FaceIndexes(F) )
-
-              ! Do not solve face dofs, if there is not any
-              IF ( Face % BDOFs <= 0) CYCLE
               
               ! Get face p
-              p = Face % PDefs % P 
+              !p = MAX(pSolver % Def_Dofs(6,BodyId,6), Face % PDefs % P) 
+
+              ! Do not solve face dofs, if there is not any
+              !IF (GetFaceDOFs(Element, p, F) <= 0) CYCLE
               
               ! Handle triangle and square faces separately
               SELECT CASE(F)
@@ -3005,11 +3024,11 @@ CONTAINS
                  tmp(1:4) = getPyramidFaceMap(F)
                  direction(1:4) = getSquareFaceDirection( Element, tmp(1:4) )
                  
-                 ! For each face calculate values of functions from index
+                 ! For each face calculate the values of functions for index
                  ! pairs i,j=2,..,p-2 i+j=4,..,p
                  DO i=2,p-2
                     DO j=2,p-i
-                       IF ( q >= SIZE(Basis) ) CYCLE
+                       IF ( q >= SIZE(Basis) ) EXIT faces_pyramid
                        q = q + 1
                        
                        Basis(q) = PyramidFacePBasis(F,i,j,u,v,w,direction)
@@ -3026,11 +3045,11 @@ CONTAINS
                  tmp(1:4) = getPyramidFaceMap(F) 
                  direction(1:3) = getTriangleFaceDirection( Element, tmp(1:3) )
                  
-                 ! For each face calculate values of functions from index
+                 ! For each face calculate the values of functions for index
                  ! pairs i,j=0,..,p-3 i+j=0,..,p-3
                  DO i=0,p-3
                     DO j=0,p-i-3
-                       IF ( q >= SIZE(Basis) ) CYCLE
+                       IF ( q >= SIZE(Basis) ) EXIT faces_pyramid
                        q = q + 1
 
                        Basis(q) = PyramidFacePBasis(F,i,j,u,v,w,direction)
@@ -3041,23 +3060,27 @@ CONTAINS
                     END DO
                  END DO
               END SELECT    
-           END DO
+           END DO faces_pyramid
         END IF
 
         ! Bubbles of P Pyramid
-        IF (Element % BDOFs > 0) THEN 
-           ! Get element p
-           p = Element % PDefs % p
-           nb = MAX( GetBubbleDOFs(Element, p), Element % BDOFs )
-           p=CEILING(1/3d0*(81*nb+3*SQRT(-3d0+729*nb**2))**(1/3d0)+1d0/ &
-                   (81*nb+3*SQRT(-3d0+729*nb**2))**(1/3d0)+2 - AEPS)
+        nb = pSolver % Def_Dofs(6,BodyId,5)
+        DesignedBubbles = nb > 0
+        BDOFs = MAX(GetBubbleDOFs(Element, p), nb) 
+        IF ( BDOFs > 0 ) THEN
 
-           ! Calculate value of bubble functions from indexes
+          IF (DesignedBubbles) THEN
+             Deg_Bubble = CEILING(1/3d0*(81*nb+3*SQRT(-3d0+729*nb**2))**(1/3d0)+1d0/ &
+                   (81*nb+3*SQRT(-3d0+729*nb**2))**(1/3d0)+2 - AEPS)
+             p = MAX(p, Deg_Bubble)
+           END IF          
+ 
+           ! Calculate the values of bubble functions for indexes
            ! i,j,k=0,..,p-4 i+j+k=0,..,p-4
-           DO i=0,p-4
+           bubbles_pyramid: DO i=0,p-4
               DO j=0,p-i-4
                  DO k=0,p-i-j-4
-                    IF ( q >= SIZE(Basis)) CYCLE
+                    IF ( q >= SIZE(Basis)) EXIT bubbles_pyramid
                     q = q + 1
 
                     Basis(q) = PyramidBubblePBasis(i,j,k,u,v,w)
@@ -3067,20 +3090,19 @@ CONTAINS
                     IF (degrees) BasisDegree(q) = 4+i+j+k
                  END DO
               END DO
-           END DO
+           END DO bubbles_pyramid
         END IF
         
 !------------------------------------------------------------------------------
-! P element code for wedge edges, faces and bubbles
+     ! P element code wedges:
      CASE(706)
+        p = pSolver % Def_Dofs(7,BodyId,6)
+        EDOFs = GetEdgeDOFs(Element, p)
         ! Edges of P Wedge
-        IF (ASSOCIATED( Element % EdgeIndexes ) ) THEN
-           ! For each edge in wedge, calculate values of edge functions
-           DO i=1,9
+        IF (ASSOCIATED( Element % EdgeIndexes ) .AND. EDOFs > 0) THEN
+           ! For each edge i calculate the values of edge functions
+           edges_prism: DO i=1,9
               Edge => pSolver % Mesh % Edges( Element % EdgeIndexes(i) )
-
-              ! Do not solve edge dofs, if there is not any
-              IF (Edge % BDOFs <= 0) CYCLE
               
               ! Get local indexes of current edge
               tmp(1:2) = getWedgeEdgeMap(i)
@@ -3092,10 +3114,10 @@ CONTAINS
               ! Invert edge if local first node has greater global index than second one
               IF ( Element % NodeIndexes(locali) > Element % NodeIndexes(localj) ) invert = .TRUE.
        
-              ! For each DOF in edge calculate values of edge functions
-              ! and their derivatives for edge=i and i=k+1
-              DO k=1,Edge % BDOFs
-                 IF ( q >= SIZE(Basis) ) CYCLE
+              ! For each edge DOF k calculate the value of edge function
+              ! and its derivatives
+              DO k=1,EDOFs
+                 IF ( q >= SIZE(Basis) ) EXIT edges_prism
                  q = q + 1
 
                  ! Use basis compatible with pyramid if necessary
@@ -3111,19 +3133,19 @@ CONTAINS
                  ! Polynomial degree of basis function to vector
                  IF (degrees) BasisDegree(q) = 1+k
               END DO
-           END DO
+           END DO edges_prism
         END IF
 
-        ! Faces of P Wedge 
+        ! The faces of p-wedge 
         IF ( ASSOCIATED( Element % FaceIndexes ) ) THEN
-           ! For each face in wedge, calculate values of face functions
-           DO F=1,5
+           ! For each face in wedge, calculate the values of face functions
+           faces_prism: DO F=1,5
               Face => pSolver % Mesh % Faces( Element % FaceIndexes(F) )
 
-              ! Do not solve face dofs, if there is not any
-              IF ( Face % BDOFs <= 0) CYCLE
+              !p = MAX(pSolver % Def_Dofs(7,BodyId,6), Face % PDefs % P) 
 
-              p = Face % PDefs % P 
+              ! Do not solve face dofs, if there is not any
+              !IF (GetFaceDOFs(Element, p, F) <= 0) CYCLE
               
               ! Handle triangle and square faces separately
               SELECT CASE(F)
@@ -3133,11 +3155,11 @@ CONTAINS
                  tmp(1:4) = getWedgeFaceMap(F) 
                  direction(1:3) = getTriangleFaceDirection( Element, tmp(1:3) )
                  
-                 ! For each face calculate values of functions from index
+                 ! For each face calculate the values of functions for index
                  ! pairs i,j=0,..,p-3 i+j=0,..,p-3
                  DO i=0,p-3
                     DO j=0,p-i-3
-                       IF ( q >= SIZE(Basis) ) CYCLE
+                       IF ( q >= SIZE(Basis) ) EXIT faces_prism
                        q = q + 1
 
                        Basis(q) = WedgeFacePBasis(F,i,j,u,v,w,direction)
@@ -3166,7 +3188,7 @@ CONTAINS
                  ! pairs i,j=2,..,p-2 i+j=4,..,p
                  DO i=2,p-2
                     DO j=2,p-i
-                       IF ( q >= SIZE(Basis) ) CYCLE
+                       IF ( q >= SIZE(Basis) ) EXIT faces_prism
                        q = q + 1
 
                        IF (.NOT. invert) THEN
@@ -3183,23 +3205,27 @@ CONTAINS
                  END DO
               END SELECT
                            
-           END DO
+           END DO faces_prism
         END IF
 
         ! Bubbles of P Wedge
-        IF ( Element % BDOFs > 0 ) THEN
-           ! Get p from element
-           p = Element % PDefs % P
-           nb = MAX( GetBubbleDOFs( Element, p ), Element % BDOFs )
-           p=CEILING(1/3d0*(81*nb+3*SQRT(-3d0+729*nb**2))**(1/3d0)+1d0/ &
-                   (81*nb+3*SQRT(-3d0+729*nb**2))**(1/3d0)+3 - AEPS)
+        nb = pSolver % Def_Dofs(7,BodyId,5)
+        DesignedBubbles = nb > 0
+        BDOFs = MAX(GetBubbleDOFs(Element, p), nb) 
+        IF ( BDOFs > 0 ) THEN
+
+           IF (DesignedBubbles) THEN
+             Deg_Bubble = CEILING(1/3d0*(81*nb+3*SQRT(-3d0+729*nb**2))**(1/3d0)+1d0/ &
+                 (81*nb+3*SQRT(-3d0+729*nb**2))**(1/3d0)+3 - AEPS)
+             p = MAX(p, Deg_Bubble)
+           END IF
            
-           ! For each bubble calculate value of basis function and its derivative
+           ! For each bubble calculate the value of basis function and its derivative
            ! for index pairs i,j=0,..,p-5 k=2,..,p-3 i+j+k=2,..,p-3
-           DO i=0,p-5
+           bubbles_prism: DO i=0,p-5
               DO j=0,p-5-i
                  DO k=2,p-3-i-j
-                    IF ( q >= SIZE(Basis) ) CYCLE
+                    IF ( q >= SIZE(Basis) ) EXIT bubbles_prism
                     q = q + 1
 
                     Basis(q) = WedgeBubblePBasis(i,j,k,u,v,w)
@@ -3209,20 +3235,19 @@ CONTAINS
                     IF (degrees) BasisDegree(q) = 3+i+j+k
                  END DO
               END DO
-           END DO
+           END DO bubbles_prism
         END IF
 
 !------------------------------------------------------------------------------
-! P element code for brick edges, faces and bubbles
+     ! P element code for bricks:
      CASE(808) 
+        p = pSolver % Def_Dofs(8,BodyId,6)
+        EDOFs = GetEdgeDOFs(Element, p)
         ! Edges of P brick
-        IF ( ASSOCIATED( Element % EdgeIndexes ) ) THEN
-           ! For each edge in brick, calculate values of edge functions 
-           DO i=1,12
+        IF ( ASSOCIATED( Element % EdgeIndexes ) .AND. EDOFs > 0) THEN
+           ! For each edge i calculate the values of edge functions 
+           edges_brick: DO i=1,12
               Edge => pSolver % Mesh % Edges( Element % EdgeIndexes(i) )
-
-              ! Do not solve edge dofs, if there is not any
-              IF (Edge % BDOFs <= 0) CYCLE
               
               ! Get local indexes of current edge
               tmp(1:2) = getBrickEdgeMap(i)
@@ -3235,10 +3260,10 @@ CONTAINS
               ! Invert edge if local first node has greater global index than second one
               IF ( Element % NodeIndexes(locali) > Element % NodeIndexes(localj) ) invert = .TRUE.
               
-              ! For each DOF in edge calculate values of edge functions
-              ! and their derivatives for edge=i and i=k+1
-              DO k=1,Edge % BDOFs
-                 IF ( q >= SIZE(Basis) ) CYCLE
+              ! For each edge DOF k calculate the values of edge function
+              ! and its derivatives
+              DO k=1,EDOFs
+                 IF ( q >= SIZE(Basis) ) EXIT edges_brick
                  q = q + 1
 
                  ! For edges connected to pyramid square face, use different basis
@@ -3256,30 +3281,30 @@ CONTAINS
                  ! Polynomial degree of basis function to vector
                  IF (degrees) BasisDegree(q) = 1+k
               END DO
-           END DO 
+           END DO edges_brick
         END IF
 
         ! Faces of P brick
         IF ( ASSOCIATED( Element % FaceIndexes ) ) THEN
            ! For each face in brick, calculate values of face functions
-           DO F=1,6
+           faces_brick: DO F=1,6
               Face => pSolver % Mesh % Faces( Element % FaceIndexes(F) )
+
+              ! Get p for face
+              !p = MAX(pSolver % Def_Dofs(8,BodyId,6), Face % PDefs % P)
                           
               ! Do not calculate face values if no dofs
-              IF (Face % BDOFs <= 0) CYCLE
-              
-              ! Get p for face
-              p = Face % PDefs % P
+              !IF (GetFaceDOFs(Element, p, F)<= 0) CYCLE
               
               ! Generate direction vector for this face
               tmp(1:4) = getBrickFaceMap(F)
               direction(1:4) = getSquareFaceDirection(Element, tmp)
               
-              ! For each face calculate values of functions from index
+              ! For each face calculate the values of functions for index
               ! pairs i,j=2,..,p-2 i+j=4,..,p
               DO i=2,p-2
                  DO j=2,p-i
-                    IF ( q >= SIZE(Basis) ) CYCLE
+                    IF ( q >= SIZE(Basis) ) EXIT faces_brick
                     q = q + 1
                     Basis(q) = BrickFacePBasis(F,i,j,u,v,w,direction)
                     dLBasisdx(q,:) = dBrickFacePBasis(F,i,j,u,v,w,direction)
@@ -3288,24 +3313,27 @@ CONTAINS
                     IF (degrees) BasisDegree(q) = i+j
                  END DO
               END DO
-           END DO
+           END DO faces_brick
         END IF
 
         ! Bubbles of p brick
-        IF ( Element % BDOFs > 0 ) THEN
-           ! Get p from bubble DOFs 
-           p = Element % PDefs % P
-           nb = MAX( GetBubbleDOFs(Element, p), Element % BDOFs )
-           p=CEILING(1/3d0*(81*nb+3*SQRT(-3d0+729*nb**2))**(1/3d0)+1d0/ &
-                   (81*nb+3*SQRT(-3d0+729*nb**2))**(1/3d0)+4 - AEPS)
+        nb = pSolver % Def_Dofs(8,BodyId,5)
+        DesignedBubbles = nb > 0
+        BDOFs = MAX(GetBubbleDOFs(Element, p), nb) 
+        IF ( BDOFs > 0 ) THEN
 
+          IF (DesignedBubbles) THEN
+             Deg_Bubble = CEILING(1/3d0*(81*nb+3*SQRT(-3d0+729*nb**2))**(1/3d0)+1d0/ &
+                   (81*nb+3*SQRT(-3d0+729*nb**2))**(1/3d0)+4 - AEPS)
+             p = MAX(p, Deg_Bubble)
+           END IF
            
-           ! For each bubble calculate value of basis function and its derivative
+           ! For each bubble calculate the value of basis function and its derivative
            ! for index pairs i,j,k=2,..,p-4, i+j+k=6,..,p
-           DO i=2,p-4
+           bubbles_brick: DO i=2,p-4
               DO j=2,p-i-2
                  DO k=2,p-i-j
-                    IF ( q >= SIZE(Basis) ) CYCLE
+                    IF ( q >= SIZE(Basis) ) EXIT bubbles_brick
                     q = q + 1
                     Basis(q) = BrickBubblePBasis(i,j,k,u,v,w)
                     dLBasisdx(q,:) = dBrickBubblePBasis(i,j,k,u,v,w)
@@ -3314,7 +3342,7 @@ CONTAINS
                     IF (degrees) BasisDegree(q) = i+j+k
                  END DO
               END DO
-           END DO
+           END DO bubbles_brick
         END IF
 
      END SELECT
@@ -3375,7 +3403,7 @@ CONTAINS
 !    and product of two diagonally opposed nodal basisfunctions of the
 !    corresponding (bi-,tri-)linear element for 1d-elements, quads and hexas.
 !------------------------------------------------------------------------------
-     IF ( PRESENT( Bubbles ) ) THEN
+     IF ( PRESENT( Bubbles ) .AND. .NOT. isActivePElement(Element,pSolver)) THEN
        Bubble % BDOFs = 0
        NULLIFY( Bubble % PDefs )
        NULLIFY( Bubble % EdgeIndexes )

--- a/fem/src/Lists.F90
+++ b/fem/src/Lists.F90
@@ -327,7 +327,10 @@ CONTAINS
        END IF
      END IF
 
-
+     ! In the case of p-elements two neighbouring elements may have different
+     ! degrees of approximation, find out the highest order associated with 
+     ! a particular edge or face: 
+     !
      IF ( ANY(Solver % Def_Dofs(:,:,6)>=0) ) THEN
        IF ( Mesh % NumberOFEdges>0 ) THEN
           ALLOCATE(EdgeDOFs(Mesh % NumberOfEdges))
@@ -410,10 +413,8 @@ CONTAINS
              ndofs = 0
              IF ( Def_Dofs(2) >= 0) THEN
                ndofs = Def_Dofs(2)
-             ELSE IF (Def_Dofs(6)>=0) THEN
+             ELSE IF (Def_Dofs(6)>=1) THEN
                ndofs = EdgeDOFs(Element % EdgeIndexes(i))
-!              IF (Def_Dofs(6)==0) ndofs = MAX(Edge % BDOFs,ndofs)
-               ndofs = MAX(Edge % BDOFs,ndofs)
              END IF
 
              DO e=1,ndofs
@@ -431,7 +432,7 @@ CONTAINS
              Face => Mesh % Faces( Element % FaceIndexes(i) )
              IF(Element % Type % ElementCode==Face % Type % ElementCode.AND..NOT.GB) CYCLE
 
-              l = MAX(0,Def_Dofs(3))
+             l = MAX(0,Def_Dofs(3))
              j = Face % TYPE % ElementCode/100
 
              IF(l==0) THEN
@@ -453,10 +454,8 @@ CONTAINS
              ndofs = 0
              IF (l > 0) THEN
                ndofs = l
-             ELSE IF (Def_Dofs(6)>=0) THEN
+             ELSE IF (Def_Dofs(6)>=1) THEN
                ndofs = FaceDOFs(Element % FaceIndexes(i))
-!              IF ( Def_Dofs(6)==0 ) ndofs = MAX(Face % BDOFs,ndofs)
-               ndofs = MAX(Face % BDOFs,ndofs)
              END IF
 
              DO e=1,ndofs
@@ -472,11 +471,12 @@ CONTAINS
 
        IF ( GB .AND. ASSOCIATED(Element % BubbleIndexes) ) THEN
          ndofs = 0
-         IF ( Def_Dofs(5) >= 0) THEN
-            ndofs = Def_Dofs(5)
-         ELSE IF (Def_Dofs(6)>=0) THEN
-            ndofs = GetBubbleDOFs(Element, Def_Dofs(6))
-            IF ( Def_Dofs(6)==0 ) ndofs = MAX(Element % BDOFs,ndofs)
+         IF ( Def_Dofs(5) > 0) THEN
+           ndofs = Def_Dofs(5)
+         ELSE IF (Def_Dofs(6)>=1) THEN
+           ndofs = GetBubbleDOFs(Element, Def_Dofs(6))
+         ELSE
+           ndofs = Element % BDOFs
          END IF
 
          DO i=1,ndofs

--- a/fem/src/Lists.F90
+++ b/fem/src/Lists.F90
@@ -479,6 +479,9 @@ CONTAINS
            IF (j > 1) ndofs = GetBubbleDOFs(Element, j)
            ndofs = MAX(BDOFs, ndofs) 
          ELSE
+           ! The following is not an ideal way to obtain the bubble count
+           ! in order to support solverwise definitions, but we are not expected 
+           ! to end up in this branch anyway:
            ndofs = Element % BDOFs
          END IF
 

--- a/fem/src/MatrixAssembly.F90
+++ b/fem/src/MatrixAssembly.F90
@@ -681,22 +681,24 @@ CONTAINS
          !
          ! Check finally if 3-D faces are associated with face bubbles
          !
-         DO j=1,Element % TYPE % NumberOfFaces
-           Face => Solver % Mesh % Faces(Element % FaceIndexes(j))
-           face_type = Face % TYPE % ElementCode/100
-           IF (ASSOCIATED(Face % BoundaryInfo % Left)) THEN
-             face_id  = Face % BoundaryInfo % Left % BodyId
-             k = MAX(0,Solver % Def_Dofs(face_type+6,face_id,5))
-           END IF
-           IF (ASSOCIATED(Face % BoundaryInfo % Right)) THEN
-             face_id = Face % BoundaryInfo % Right % BodyId
-             k = MAX(k,Solver % Def_Dofs(face_type+6,face_id,5))
-           END IF
-           IF (k > 0) THEN
-             NeedEdges = .TRUE.
-             EXIT
-           END IF
-         END DO        
+         IF ( ASSOCIATED( Element % FaceIndexes ) ) THEN
+           DO j=1,Element % TYPE % NumberOfFaces
+             Face => Solver % Mesh % Faces(Element % FaceIndexes(j))
+             face_type = Face % TYPE % ElementCode/100
+             IF (ASSOCIATED(Face % BoundaryInfo % Left)) THEN
+               face_id  = Face % BoundaryInfo % Left % BodyId
+               k = MAX(0,Solver % Def_Dofs(face_type+6,face_id,5))
+             END IF
+             IF (ASSOCIATED(Face % BoundaryInfo % Right)) THEN
+               face_id = Face % BoundaryInfo % Right % BodyId
+               k = MAX(k,Solver % Def_Dofs(face_type+6,face_id,5))
+             END IF
+             IF (k > 0) THEN
+               NeedEdges = .TRUE.
+               EXIT
+             END IF
+           END DO
+         END IF
        END IF
      END IF
 

--- a/fem/src/MatrixAssembly.F90
+++ b/fem/src/MatrixAssembly.F90
@@ -923,6 +923,9 @@ BLOCK
            IF (p > 1) BDOFs = GetBubbleDOFs(Element, p)
            BDOFs = MAX(nb, BDOFs)
          ELSE
+           ! The following is not an ideal way to obtain the bubble count
+           ! in order to support solverwise definitions, but we are not expected 
+           ! to end up in this branch anyway:
            BDOFs = Element % BDOFs
          END IF
          DO i=1,BDOFs

--- a/fem/src/ModelDescription.F90
+++ b/fem/src/ModelDescription.F90
@@ -2561,7 +2561,7 @@ CONTAINS
       ! Note that the element sets associated with the indices 9 and 10 are only used to check
       ! the number of facewise bubbles in 3D, so in this case only the entries Def_Dofs(9,:,5)
       ! and Def_Dofs(10,:,5) affect the execution. In addition, currently the case 
-      ! Solver % Def_Dofs(:,:,1) > 1 leads to an error.
+      ! Solver % Def_Dofs(:,:,1) > 1 has additional limitations.
       !
       ! This function also uses a local variable Def_Dofs(:,:) which is similar to
       ! Solver % Def_Dofs(:,:,:) but it uses reduced indexing by omitting bodywise dependencies. 
@@ -2956,6 +2956,7 @@ CONTAINS
         END IF
 
         Def_Dofs = -1
+        Def_Dofs(:,1) = 1
         DO k=1,Model % NumberOfSolvers
           IF(MeshSolvers(MeshI,k)) THEN
             DO i=1,6

--- a/fem/src/PElementMaps.F90
+++ b/fem/src/PElementMaps.F90
@@ -903,7 +903,7 @@ CONTAINS
 
 
 !------------------------------------------------------------------------------
-!> Checks if given element is a p element active in a particular solver.   
+!> Checks if given element is a p-element active in a particular solver.   
 !------------------------------------------------------------------------------
   FUNCTION isActivePElement(Element,USolver) RESULT(retVal)
 !------------------------------------------------------------------------------
@@ -911,9 +911,9 @@ CONTAINS
 
     TYPE(Element_t), INTENT(IN) :: Element
     TYPE(Solver_t), POINTER, OPTIONAL :: USolver
+    LOGICAL :: retVal
 
     INTEGER :: m
-    LOGICAL :: retVal
     TYPE(Solver_t), POINTER :: pSolver
         
     retVal = isPelement(Element)
@@ -924,7 +924,7 @@ CONTAINS
     IF( PRESENT( USolver ) ) THEN
       pSolver => USolver
     ELSE
-      pSOlver => CurrentModel % Solver
+      pSolver => CurrentModel % Solver
     END IF
     
     IF(ASSOCIATED(pSolver))THEN
@@ -940,7 +940,8 @@ CONTAINS
 
 
 !------------------------------------------------------------------------------
-!> Checks if given element is a p element active in a particular solver.   
+!> Checks whether given solver has active p-element definitions (for some
+!> element type and for some body)
 !------------------------------------------------------------------------------
   FUNCTION isActivePSolver(Solver) RESULT(retVal)
 !------------------------------------------------------------------------------
@@ -963,7 +964,7 @@ CONTAINS
   
 
 !------------------------------------------------------------------------------
-!> Checks if given element is a p element.   
+!> Checks whether given element has p-element information associated  
 !------------------------------------------------------------------------------
     FUNCTION isPElement( Element ) RESULT(retVal)
 !------------------------------------------------------------------------------

--- a/fem/src/modules/IncompressibleNSVec.F90
+++ b/fem/src/modules/IncompressibleNSVec.F90
@@ -1464,7 +1464,7 @@ SUBROUTINE IncompressibleNSSolver(Model, Solver, dt, Transient)
       ! When the number of bubbles is obtained with the Update=.TRUE. flag,
       ! we need to call GetElementNOFBDOFs before calling GetElementNOFDOFs.
       !
-      nb = GetElementNOFBDOFs(Element, Update=.TRUE.)
+      nb = GetElementNOFBDOFs(Element)
       nd = GetElementNOFDOFs(Element)
       
       ! Get element local matrix and rhs vector:

--- a/fem/tests/FaceElement3D_BCs/interpolationtest.sif
+++ b/fem/tests/FaceElement3D_BCs/interpolationtest.sif
@@ -54,8 +54,8 @@ Solver 1
 
   ! Element definition:
   !-------------------------------------------------------------------
-  Element = "n:0 f:1"      ! the Nedelec tetrahedra of the first kind
-  ! Element = "n:0 f:3"      ! the Nedelec tetrahedra of the second kind
+  Element = "n:0 -tri_face b:1"      ! the Nedelec tetrahedra of the first kind
+  ! Element = "n:0 -tri_face b:3"      ! the Nedelec tetrahedra of the second kind
 
   Optimize Bandwidth = True
   Bubbles in Global System = Logical True

--- a/fem/tests/FaceElement3D_BCs/interpolationtest_2nd_kind.sif
+++ b/fem/tests/FaceElement3D_BCs/interpolationtest_2nd_kind.sif
@@ -54,8 +54,8 @@ Solver 1
 
   ! Element definition:
   !-------------------------------------------------------------------
-  !Element = "n:0 f:1"      ! the Nedelec tetrahedra of the first kind
-  Element = "n:0 f:3"      ! the Nedelec tetrahedra of the second kind
+  !Element = "n:0 -tri_face b:1"      ! the Nedelec tetrahedra of the first kind
+  Element = "n:0 -tri_face b:3"      ! the Nedelec tetrahedra of the second kind
 
   Optimize Bandwidth = True
   Bubbles in Global System = Logical True

--- a/fem/tests/LinearFormsAssembly/LinearFormsAssembly.F90
+++ b/fem/tests/LinearFormsAssembly/LinearFormsAssembly.F90
@@ -194,6 +194,9 @@ CONTAINS
     IF (ALLOCATED(Solver % Def_Dofs)) THEN
       tag = ecode / 100
       Solver % Def_Dofs(tag,1,6) = P
+      Solver % Def_Dofs(tag,1,1) = 1
+    ELSE
+      CALL Fatal('TestElement', 'def_dofs are not allocated') 
     END IF
     IF (ecode==404) THEN
       Quadrature = GaussPointsQuad((P+1)**2)
@@ -214,7 +217,7 @@ CONTAINS
     Element => ClonePElement(SingleElement)
 
     nndof = Element % Type % NumberOfNodes
-    nbasis = nndof + GetElementNOFDOFs( Element )
+    nbasis = GetElementNOFDOFs( Element, Solver )
     
     ! Reserve workspace
     ALLOCATE(STIFF(nbasis, nbasis), FORCE(nbasis), &
@@ -279,6 +282,8 @@ CONTAINS
     IF (ALLOCATED(Solver % Def_Dofs)) THEN
       tag = ecode / 100
       Solver % Def_Dofs(tag,1,6) = 0
+    ELSE
+      CALL Fatal('TestElement', 'def_dofs was not allocated') 
     END IF
   END FUNCTION TestElement
   
@@ -551,6 +556,7 @@ CONTAINS
     IMPLICIT NONE
     TYPE(Element_t) :: Element
     INTEGER, INTENT(IN) :: ngp, evals1, evals2
+    INTEGER :: nd
     REAL(kind=dp), INTENT(IN) :: t_n1, t_n2
 
     WRITE (*,'(A,I0)') 'Element type=', Element % TYPE % ElementCode
@@ -559,8 +565,9 @@ CONTAINS
     END IF
     WRITE (*,'(A,L1)') 'Active P element=', isActivePElement(Element)
     WRITE (*,'(A,I0)') 'Element number of nodes=', Element % TYPE % NumberOfNodes
-    WRITE (*,'(A,I0)') 'Element number of nonnodal dofs=', GetElementNOFDOFs(Element)
-    WRITE (*,'(A,I0)') 'Element number of bubble dofs=', GetElementNOFBDOFs()
+    nd = GetElementNOFDOFs(Element, Solver) - Element % TYPE % NumberOfNodes
+    WRITE (*,'(A,I0)') 'Element number of nonnodal dofs=', nd
+    WRITE (*,'(A,I0)') 'Element number of bubble dofs for static condensation=', GetElementNOFBDOFs()
     WRITE (*,'(A,I0)') 'Number of Gauss points=', ngp
     WRITE (*,'(A,I0)') 'Nodal basis, number of local matrix evaluations=', evals1
     WRITE (*,'(A,F12.9)') 'Nodal  basis, local matrix assembly t(s):', t_n1
@@ -577,7 +584,7 @@ CONTAINS
     TYPE(Mesh_t), POINTER :: Mesh
     INTEGER, INTENT(IN) :: ElementCode, P
     TYPE(Element_t), POINTER :: PElement
-    INTEGER :: node, edge, face, astat
+    INTEGER :: node, edge, face, bubble, astat
 
     ! Allocate a mesh with a single element
     Mesh => AllocateMesh()
@@ -586,6 +593,7 @@ CONTAINS
       CALL Fatal('AllocateMeshAndElement','Allocation of mesh element failed')
     END IF
     Mesh % NumberOfBulkElements = 1
+    Mesh % MaxNDOFs = 1
 
     ! Construct P element
     PElement => AllocateElement()
@@ -673,6 +681,9 @@ CONTAINS
           CALL Fatal('AllocateMeshAndElement','Unknown element type')
         END SELECT
         CALL AllocatePDefinitions(Mesh % Faces(face))
+        ALLOCATE(Mesh % Faces(face) % BoundaryInfo)
+        Mesh % Faces(face) % BoundaryInfo % Right => NULL()
+        Mesh % Faces(face) % BoundaryInfo % Left => NULL()
         Mesh % Faces(face) % PDefs % P = P
         Mesh % Faces(face) % PDefs % isEdge = .TRUE.
         Mesh % Faces(face) % PDefs % GaussPoints = (P+1) ** Mesh % Faces(face) % Type % DIMENSION
@@ -684,6 +695,14 @@ CONTAINS
     END IF 
 
     PElement % BDofs = GetBubbleDofs( PElement, P )
+    IF (PElement % BDofs >0) THEN
+      ALLOCATE(PElement % BubbleIndexes(PElement % BDOFs), STAT=astat)
+      IF (astat /= 0) THEN
+        CALL Fatal('AllocateMeshAndElement','Allocation of bubble indices failed')
+      END IF
+      PElement % BubbleIndexes(:) = [(bubble, bubble=1,PElement % BDofs)]
+    END IF
+
     PElement % PDefs % P = P
     IF (ElementCode == 504) THEN
       PElement % PDefs % TetraType = 1
@@ -756,6 +775,10 @@ CONTAINS
       ALLOCATE(ClonedElement % FaceIndexes( SIZE(Element % FaceIndexes)))
       ClonedElement % FaceIndexes(:) = Element % FaceIndexes(:)
     END IF
+    IF (ASSOCIATED( Element % BubbleIndexes )) THEN
+      ALLOCATE(ClonedElement % BubbleIndexes( SIZE(Element % BubbleIndexes)))
+      ClonedElement % BubbleIndexes(:) = Element % BubbleIndexes(:)
+    END IF
   END FUNCTION ClonePElement
   
   SUBROUTINE DeallocatePElement(PElement)
@@ -767,6 +790,7 @@ CONTAINS
     IF (ASSOCIATED(PElement % NodeIndexes)) DEALLOCATE(PElement % NodeIndexes)
     IF (ASSOCIATED(PElement % EdgeIndexes)) DEALLOCATE(PElement % EdgeIndexes)
     IF (ASSOCIATED(PElement % FaceIndexes)) DEALLOCATE(PElement % FaceIndexes)
+    IF (ASSOCIATED(PElement % BubbleIndexes)) DEALLOCATE(PElement % BubbleIndexes)
     DEALLOCATE(PElement)
   END SUBROUTINE DeallocatePElement
 

--- a/fem/tests/MixedPoisson3D_Brick/mixed.sif
+++ b/fem/tests/MixedPoisson3D_Brick/mixed.sif
@@ -54,7 +54,7 @@ Solver 1
   ! constructing the piecewise constant approximation of the
   ! variable of the Poisson equation in the standard form.
   !-------------------------------------------------------
-  Element = "n:1 b:25 f:4"
+  Element = "n:1 b:25 -quad_face b:4"
   Optimize Bandwidth = True
   Bubbles in Global System = Logical True
   Linear System Solver = Iterative

--- a/fem/tests/SecondOrderEdgeElement3D/convergencetest.sif
+++ b/fem/tests/SecondOrderEdgeElement3D/convergencetest.sif
@@ -55,7 +55,7 @@ Solver 1
   Variable DOFs = 1
   Procedure = "EdgeElementTest" "EdgeElementSolver"
 
-  Element = "n:0 e:2 f:2"
+  Element = "n:0 e:2 -tri_face b:2"
 
   Optimize Bandwidth = True
   Bubbles in Global System = Logical True

--- a/fem/tests/p-FEM_two_solvers/BenchmarkShell.F90
+++ b/fem/tests/p-FEM_two_solvers/BenchmarkShell.F90
@@ -1,0 +1,352 @@
+!/*****************************************************************************/
+! *
+! *  Elmer, A Finite Element Software for Multiphysical Problems
+! *
+! *  Copyright 1st April 1995 - , CSC - IT Center for Science Ltd., Finland
+! * 
+! *  This program is free software; you can redistribute it and/or
+! *  modify it under the terms of the GNU General Public License
+! *  as published by the Free Software Foundation; either version 2
+! *  of the License, or (at your option) any later version.
+! * 
+! *  This program is distributed in the hope that it will be useful,
+! *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+! *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+! *  GNU General Public License for more details.
+! *
+! *  You should have received a copy of the GNU General Public License
+! *  along with this program (in file fem/GPL-2); if not, write to the 
+! *  Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, 
+! *  Boston, MA 02110-1301, USA.
+! *
+! *****************************************************************************/
+!
+!/******************************************************************************
+! *
+! *  A test case for solving the two-dimensional Reissner-Naghdi shell equations 
+! *  over a straight cylindrical shell parametrized in (exact) lines of curvature 
+! *  coordinates. 
+! *
+! *  Authors: Mika Malinen
+! *  Email:   mika.malinen@csc.fi
+! *  Web:     http://www.csc.fi/elmer
+! *  Address: CSC - IT Center for Science Ltd.
+! *           Keilaranta 14
+! *           02101 Espoo, Finland 
+! *
+! *  Original Date: Feb 6, 2019
+! *
+! *****************************************************************************/
+
+!------------------------------------------------------------------------------
+SUBROUTINE ShellSolver( Model,Solver,dt,TransientSimulation )
+!------------------------------------------------------------------------------
+  USE DefUtils
+  USE ElementDescription
+
+  IMPLICIT NONE
+!------------------------------------------------------------------------------
+  TYPE(Solver_t) :: Solver
+  TYPE(Model_t) :: Model
+
+  REAL(KIND=dp) :: dt
+  LOGICAL :: TransientSimulation
+!------------------------------------------------------------------------------
+! Local variables:
+!------------------------------------------------------------------------------
+  TYPE(Mesh_t), POINTER :: Mesh
+  TYPE(ValueList_t), POINTER :: SolverPars
+  TYPE(Element_t), POINTER :: Element
+
+  INTEGER :: ShellModelPar, csize
+  INTEGER :: n, nb, nd, k, active 
+  INTEGER :: ElementSought
+
+  REAL(KIND=dp) :: t, RefWork, Work, Norm
+  REAL(KIND=dp) :: Energy(5), ResVec(20)
+  REAL(KIND=dp) :: LocalSol(6,9)
+
+  REAL(KIND=dp) :: e1(3), e2(3), e3(3)
+!------------------------------------------------------------------------------  
+  SolverPars => GetSolverParams()
+  Mesh => GetMesh()
+
+  ShellModelPar = ListGetInteger(SolverPars, 'Variable DOFs', minv=5, maxv=6)
+  IF (ShellModelPar == 6) THEN
+    csize = 4
+  ELSE
+    csize = 3
+  END IF
+
+  ! ------------------------------------------------------------------------------
+  ! Assembly loop for generating the shell stiffness matrix:
+  ! ------------------------------------------------------------------------------
+  CALL DefaultInitialize()
+  Active = GetNOFActive()
+  DO k=1,Active
+    Element => GetActiveElement(k)
+
+    n  = GetElementNOFNodes()
+    nd = GetElementNOFDOFs()
+    nb = GetElementNOFBDOFs()
+
+    ! ------------------------------------------------------------------------------
+    ! Generate the element stiffness matrix and assemble the local contribution:
+    ! -----------------------------------------------------------------------------
+    CALL ShellLocalMatrix(Element, n, nd+nb, ShellModelPar, csize)
+
+  END DO
+
+  CALL DefaultFinishBulkAssembly() 
+  CALL DefaultFinishAssembly()
+
+  CALL DefaultDirichletBCs()
+
+  ! And finally, solve:
+  !--------------------
+  Norm = DefaultSolve()
+
+  Work = 8.0d0*SUM(Solver % Variable % Values(:) * Solver % Matrix % RHS(:))
+  t = 1.0d-1
+!  RefWork = 12.0d0*(1.0d0-(1.0d0/3.0d0)**2)*(1.0d9)**2/7.0d10 * 2.688287959059254*t ! t=0.01
+  RefWork = 12.0d0*(1.0d0-(1.0d0/3.0d0)**2)*(1.0d9)**2/7.0d10 * 1.828629366566552*t ! t=0.1
+  PRINT *, 'Relative energy error = ', SQRT(ABS(RefWork-Work)/RefWork)
+
+CONTAINS
+
+!------------------------------------------------------------------------------
+  SUBROUTINE ShellLocalMatrix(Element, n, nd, m, csize)
+!------------------------------------------------------------------------------
+    IMPLICIT NONE
+
+    TYPE(Element_t), POINTER :: Element
+    INTEGER :: n, nd, m, csize 
+    !------------------------------------------------------------------------------
+    TYPE(ValueList_t), POINTER :: BodyForce
+    TYPE(Nodes_t) :: Nodes
+    TYPE(GaussIntegrationPoints_t) :: IP
+
+    LOGICAL :: Stat, Found
+    INTEGER :: i, k, p, t
+
+    REAL(KIND=dp) :: MASS(m*nd,m*nd), STIFF(m*nd,m*nd), FORCE(m*nd), LOAD(n)
+    REAL(KIND=dp) :: BM(csize,m*nd), BS(2,m*nd), BB(3,m*nd)
+    REAL(KIND=dp) :: PoissonRatio(n), YoungsMod(n), ShellThickness(n)
+    REAL(KIND=dp) :: CMat(4,4), GMat(2,2)
+    REAL(KIND=dp) :: nu, E, h, NormalTraction
+    REAL(KIND=dp) :: R
+    REAL(KIND=dp) :: Basis(nd), dBasisdx(nd,3), DetJ, LoadAtIP, Weight
+
+    REAL(KIND=dp) :: y1, y2
+
+    SAVE Nodes
+    !------------------------------------------------------------------------------
+    R = 1.0d0   ! R = principal radius of curvature, y1 = angular dir, y2 = axial dir  
+
+    CALL GetElementNodes(Nodes)
+
+    ! --------------------------------------------------------------------------
+    ! Body forces, material parameters and the shell thickness:
+    ! --------------------------------------------------------------------------
+    PoissonRatio(1:n) = GetReal(GetMaterial(),'Poisson Ratio')
+    YoungsMod(1:n) = GetReal(GetMaterial(),'Youngs Modulus')
+    ShellThickness(1:n) = GetReal(GetMaterial(),'Shell Thickness')
+    LOAD = 0.0_dp
+    BodyForce => GetBodyForce()
+    IF ( ASSOCIATED(BodyForce) ) &
+        Load(1:n) = GetReal( BodyForce, 'Normal Pressure', Found )
+
+    MASS = 0.0d0
+    STIFF = 0.0d0
+    FORCE = 0.0d0
+    BM = 0.0d0
+    BS = 0.0d0
+    BB = 0.0d0
+
+    IP = GaussPoints( Element )
+
+    DO t=1,IP % n
+
+      stat = ElementInfo( Element, Nodes, IP % U(t), IP % V(t), &
+          IP % W(t), detJ, Basis, dBasisdx )
+
+      ! ------------------------------------------------
+      ! Data interpolation:
+      ! ------------------------------------------------
+      nu = SUM( PoissonRatio(1:n) * Basis(1:n) )
+      E = SUM( YoungsMod(1:n) * Basis(1:n) )
+      h = SUM( ShellThickness(1:n) * Basis(1:n) )
+      NormalTraction = SUM( Load(1:n) * Basis(1:n) )
+      !
+      ! Use a hard-coded load to avoid errors from representing the load: 
+      !
+      y1 = SUM( Nodes % x(1:n) * Basis(1:n) )
+      NormalTraction = h * 1.0d9 * cos(2.0d0*y1)
+
+      CALL ElasticityMatrix(CMat, GMat, 1.0D0, 1.0D0, E, nu)
+
+      !---------------------------------------------------------------
+      ! The part corresponding to the membrane strains:
+      !---------------------------------------------------------------
+      Weight = h * detJ * IP % s(t)
+      DO p=1,nd
+        BM(1,(p-1)*m+1) = dBasisdx(p,1) 
+        BM(1,(p-1)*m+3) = Basis(p)/R 
+
+        BM(2,(p-1)*m+2) = dBasisdx(p,2)
+
+        BM(3,(p-1)*m+1) = dBasisdx(p,2)
+        BM(3,(p-1)*m+2) = dBasisdx(p,1)
+
+        IF (m==6) THEN
+        !IF (.FALSE.) THEN
+          !----------------------------------------------------------------
+          ! Determine the thickness-stretch parameter via augmented energy:
+          !----------------------------------------------------------------
+          BM(4,(p-1)*m+6) = Basis(p)
+          BM(4,(p-1)*m+1) = -nu/(1.0d0-nu) * dBasisdx(p,1)
+          BM(4,(p-1)*m+2) = -nu/(1.0d0-nu) * dBasisdx(p,2)
+          BM(4,(p-1)*m+3) = -nu/(1.0d0-nu) * Basis(p)/R
+        END IF
+
+      END DO
+      CALL StrainEnergyDensity(Stiff, CMat(1:csize,1:csize), BM, csize, m*nd, Weight)
+
+      !---------------------------------------------------------------
+      ! The part corresponding to the shear strains:
+      !---------------------------------------------------------------      
+      DO p=1,nd       
+        BS(1,(p-1)*m+1) = -Basis(p)/R        
+        BS(1,(p-1)*m+3) = dBasisdx(p,1)
+        BS(1,(p-1)*m+4) = -Basis(p) 
+
+        BS(2,(p-1)*m+3) = dBasisdx(p,2)
+        BS(2,(p-1)*m+5) = -Basis(p) 
+      END DO
+      CALL StrainEnergyDensity(Stiff, GMat, BS, 2, m*nd, Weight)
+
+      !---------------------------------------------------------------
+      ! The part corresponding to the bending strains (terms depending
+      ! on the membrane strains dropped at the moment):
+      !---------------------------------------------------------------      
+      Weight = h**3/12.0d0 * detJ * IP % s(t)
+      DO p=1,nd
+        BB(1,(p-1)*m+4) = dBasisdx(p,1) 
+
+        BB(2,(p-1)*m+5) = dBasisdx(p,2)
+
+        BB(3,(p-1)*m+4) = dBasisdx(p,2)
+        BB(3,(p-1)*m+5) = dBasisdx(p,1)
+        BB(3,(p-1)*m+1) = -1.0d0/R * dBasisdx(p,2)
+      END DO
+      CALL StrainEnergyDensity(Stiff, CMat(1:3,1:3), BB, 3, m*nd, Weight)
+
+      !IF (m==6) THEN
+      IF (.FALSE.) THEN
+        !----------------------------------------------------------------
+        ! Determine the thickness-stretch parameter corresponding to the
+        ! state of vanishing normal stress:
+        !----------------------------------------------------------------
+        Weight = detJ * IP % s(t)
+        DO p=1,nd
+          DO k=1,nd
+            Stiff(p*6,k*6) = Basis(p) * Basis(k) * Weight
+            Stiff(p*6,(k-1)*m+1) = -nu/(1.0d0-nu) * Basis(p) * dBasisdx(k,1) * Weight
+            Stiff(p*6,(k-1)*m+3) = -nu/(1.0d0-nu) * Basis(p) * Basis(k)/R * Weight
+            Stiff(p*6,(k-1)*m+2) = -nu/(1.0d0-nu) * Basis(p) * dBasisdx(k,2)  * Weight
+          END DO
+        END DO
+      END IF
+
+      !----------------------------------------------------------------
+      ! RHS vector:
+      !--------------------------------------------------------
+      Weight = detJ * IP % s(t)
+      DO p=1,nd
+        i = m*(p-1)+3
+        Force(i) = Force(i) + NormalTraction * Basis(p) * Weight
+      END DO
+
+    END DO
+
+    CALL DefaultUpdateEquations(STIFF,FORCE)  
+
+!------------------------------------------------------------------------------
+  END SUBROUTINE ShellLocalMatrix
+!------------------------------------------------------------------------------
+
+
+!------------------------------------------------------------------------------
+  SUBROUTINE ElasticityMatrix(CMat, GMat, A1, A2, E, nu)
+!------------------------------------------------------------------------------
+! The matrix representation of the elasticity tensor with respect an orthogonal
+! basis. The case A1 = A2 = 1 corresponds to an orthonormal basis.     
+!------------------------------------------------------------------------------    
+    IMPLICIT NONE
+
+    REAL(KIND=dp) :: CMat(4,4), GMat(2,2), A1, A2, E, nu  
+!------------------------------------------------------------------------------
+    CMat = 0.0d0
+    GMat = 0.0d0
+
+    CMat = 0.0d0
+    CMat(1,1) = 1.0d0    
+    CMat(1,2) = nu
+    CMat(2,1) = nu
+    CMat(2,2) = 1.0d0
+    CMat(3,3) = (1.0d0-nu)/2.0d0
+    CMat = CMat * E / (1.0d0-nu**2)
+
+    CMat(1,1) = CMat(1,1)/A1**4
+    CMat(1,2) = CMat(1,2)/(A1**2 * A2**2)
+    CMat(2,1) = CMat(2,1)/(A1**2 * A2**2)
+    CMat(2,2) = CMat(2,2)/A2**4   
+    CMat(3,3) = CMat(3,3)/(A1**2 * A2**2)
+
+    ! The row corresponding to the normal stress:
+    CMat(4,4) = (1.0d0-nu) * E /( (1.0d0+nu) * (1.0d0-2.0d0*nu) )
+    !CMat(4,1) = nu * E /(A1**2*(1.0d0+nu)*(1.0d0-2.0d0*nu))
+    !CMat(4,2) = CMat(4,1) 
+    !CMat(4,4) = (1.0d0-nu) * E /(A1**2*(1.0d0+nu)*(1.0d0-2.0d0*nu))
+
+    GMat(1,1) = E/(2.0d0*(1.0d0 + nu)*A1**2)
+    GMat(2,2) = E/(2.0d0*(1.0d0 + nu)*A2**2)
+!------------------------------------------------------------------------------
+  END SUBROUTINE ElasticityMatrix
+!------------------------------------------------------------------------------    
+
+!------------------------------------------------------------------------------
+  SUBROUTINE StrainEnergyDensity(A, B, C, m, n, s)
+!------------------------------------------------------------------------------
+! Performs the operation
+!
+!    A = A + C' * B * C * s
+!
+! with
+!
+!    Size( A ) = n x n
+!    Size( B ) = m x m
+!    Size( C ) = m x n
+!------------------------------------------------------------------------------
+    IMPLICIT NONE
+    REAL(KIND=dp) :: A(n,n), B(m,m), C(m,n), s
+    INTEGER :: m, n
+!------------------------------------------------------------------------------
+    INTEGER :: i,j,k,l
+!------------------------------------------------------------------------------
+    DO i=1,n
+       DO j=1,n
+          DO k=1,m
+             DO l=1,m
+                A(i,j) = A(i,j) + C(k,i)*B(k,l)*C(l,j) * s
+             END DO
+          END DO
+       END DO
+    END DO
+!------------------------------------------------------------------------------
+  END SUBROUTINE StrainEnergyDensity
+!------------------------------------------------------------------------------
+
+!------------------------------------------------------------------------------
+END SUBROUTINE ShellSolver
+!------------------------------------------------------------------------------

--- a/fem/tests/p-FEM_two_solvers/CMakeLists.txt
+++ b/fem/tests/p-FEM_two_solvers/CMakeLists.txt
@@ -1,0 +1,9 @@
+INCLUDE(test_macros)
+INCLUDE_DIRECTORIES(${CMAKE_BINARY_DIR}/fem/src)
+
+CONFIGURE_FILE( two_solvers.sif two_solvers.sif COPYONLY)
+ADD_ELMERTEST_MODULE(p-FEM_two_solvers BenchmarkShell BenchmarkShell.F90)
+
+file(COPY ELMERSOLVER_STARTINFO eighth.grd BenchmarkShell.F90 DESTINATION "${CMAKE_CURRENT_BINARY_DIR}/")
+
+ADD_ELMER_TEST(p-FEM_two_solvers LABELS quick p-fem)

--- a/fem/tests/p-FEM_two_solvers/ELMERSOLVER_STARTINFO
+++ b/fem/tests/p-FEM_two_solvers/ELMERSOLVER_STARTINFO
@@ -1,0 +1,1 @@
+two_solvers.sif

--- a/fem/tests/p-FEM_two_solvers/README.txt
+++ b/fem/tests/p-FEM_two_solvers/README.txt
@@ -1,0 +1,2 @@
+Here the principal purpose is to test the ability to use different p-basis 
+functions independently in different solvers.

--- a/fem/tests/p-FEM_two_solvers/eighth.grd
+++ b/fem/tests/p-FEM_two_solvers/eighth.grd
@@ -1,0 +1,30 @@
+***** ElmerGrid input file for structured grid generation *****
+Version = 210903
+Coordinate System = Cartesian 2D
+Subcell Divisions in 2D = 3 4
+Subcell Limits 1 = -10.0 0.0 1.570796327 10
+Subcell Limits 2 =  -10 0.0 0.75 1.0 10
+Material Structure in 2D
+  4 4 4
+  5 2 0
+  5 1 0
+  3 3 3
+End
+Materials Interval = 1 2
+Boundary Definitions
+! type     out      int
+  1         -1       1        1
+  2         -2       1        1
+  3         -2       2        1
+  4         -3       2        1
+  5         -4       2        1
+  6         -4       1        1    
+End
+Numbering = Horizontal
+Decimals = 12
+Element Degree = 1
+Element Innernodes = True
+Element Ratios 1 = 1 1 1
+Element Ratios 2 = 1 1 1
+Element Divisions 1 = 1 2 1  
+Element Divisions 2 = 1 1 1 1

--- a/fem/tests/p-FEM_two_solvers/runtest.cmake
+++ b/fem/tests/p-FEM_two_solvers/runtest.cmake
@@ -1,0 +1,3 @@
+include(test_macros)
+execute_process(COMMAND ${ELMERGRID_BIN} 1 2 eighth)
+RUN_ELMER_TEST()

--- a/fem/tests/p-FEM_two_solvers/two_solvers.sif
+++ b/fem/tests/p-FEM_two_solvers/two_solvers.sif
@@ -1,0 +1,123 @@
+
+Check Keywords "Warn"
+
+Header
+  Mesh DB "." "eighth"
+End
+
+Simulation
+  Max Output Level = 5
+  Coordinate System = Cartesian 2D
+  Simulation Type = Steady
+  Output Intervals(1) = 1
+  Steady State Max Iterations = 1
+End
+
+Body 1
+  Equation = 1
+  Material = 1
+  Body Force = 1
+End
+
+Body 2
+  Equation = 1
+  Material = 1
+  Body Force = 1
+End
+
+Material 1
+ Poisson Ratio = Real $1.0/3.0
+ Youngs Modulus = Real 7.0e+10
+ Shell Thickness = Real 0.1
+
+  Convection Velocity 1 = 0
+  Convection Velocity 2 = 0
+
+  diffusion coefficient = 1.0
+  convection coefficient = 0.0
+  time derivative coefficient = 0.0
+End
+
+Body Force 1 
+  Field Source = Real 1
+  !
+  ! The solver code has a hard-coded load that is equivalent to the following
+  ! specification in order to avoid FE errors from presenting the load.
+  !
+  Normal Pressure = Variable Coordinate
+     Real MATC "1.0e-1 * 1.0e+9 * cos(2.0*tx(0))"
+End
+
+Equation 1 
+  Active Solvers(2) = 1 2
+End
+
+Solver 1
+  Equation = "Shell equation"
+
+  Variable = "U"
+  Variable DOFs = 5
+  Procedure = "BenchmarkShell" "ShellSolver"
+
+  Element = p:4
+
+  Linear System Solver = "Iterative"
+  Linear System Preconditioning = ILU2
+  Linear System Max Iterations = 1000
+  Linear System Convergence Tolerance = 1e-7
+  Linear System Iterative Method = GCR
+  Linear System GCR Restart = 100
+  Linear System Abort Not Converged = False
+  Steady State Convergence Tolerance = 1e-09
+End
+
+Solver 2
+  Equation = "ModelPDE"
+  Variable = "Field"
+  Procedure = "ModelPDE" "AdvDiffSolver"
+  Element = "p:2"
+  Linear System Solver = Direct
+  Steady State Convergence Tolerance = 1e-9
+End
+
+! Symmetry at y2 = 0:
+! --------------------
+Boundary Condition 1
+  Target Boundaries(1) = 1
+  U 2 = Real 0
+  U 5 = Real 0
+End
+
+! Symmetry at y1 = pi/2:
+! --------------------
+Boundary Condition 2
+  Target Boundaries(2) = 2 3
+  U 1 = Real 0
+  U 4 = Real 0
+End
+
+! Fixed end at y2 = L:
+! --------------------
+Boundary Condition 3
+  Target Boundaries(1) = 4
+  Field = 0
+  U 1 = Real 0
+  U 2 = Real 0
+  U 3 = Real 0
+  U 4 = Real 0
+  U 5 = Real 0 
+End
+
+! Symmetry at y1 = 0:
+! --------------------
+Boundary Condition 4
+  Target Boundaries(2) = 5 6
+  U 1 = Real 0
+  U 4 = Real 0
+End
+
+Solver 1 :: Reference Norm = Real 1.72402774E-02
+Solver 1 :: Reference Norm Tolerance = Real 1.0E-5
+
+Solver 2 :: Reference Norm = Real 2.10847920E-01
+Solver 2 :: Reference Norm Tolerance = Real 1.0E-5

--- a/fem/tests/p-FEM_with_varying_p/README.txt
+++ b/fem/tests/p-FEM_with_varying_p/README.txt
@@ -31,11 +31,4 @@ The energy norm of the error for different p-element definitions (over the
 same 2 X 2 mesh, with p being fixed as p=8 in the boundary layer and p varying
 elsewhere) is found to be as follows (the shell thickness d=0.1): 
 
-p=1  Relative energy error =    0.80299745294707536
-p=2  Relative energy error =    0.21996131107911385
-p=3  Relative energy error =    0.14832093405769983
-p=4  Relative energy error =    2.9071622043103682E-002
-p=5  Relative energy error =    7.0387548946027100E-003
-p=6  Relative energy error =    2.3735430471359740E-003
-p=7  Relative energy error =    5.8687310435069976E-004
-p=8: Relative energy error =    1.3339513082990932E-004
+p=4  Relative energy error =    2.8912002775000799E-002

--- a/fem/tests/p-FEM_with_varying_p/README.txt
+++ b/fem/tests/p-FEM_with_varying_p/README.txt
@@ -31,4 +31,11 @@ The energy norm of the error for different p-element definitions (over the
 same 2 X 2 mesh, with p being fixed as p=8 in the boundary layer and p varying
 elsewhere) is found to be as follows (the shell thickness d=0.1): 
 
-p=4  Relative energy error =    2.8912002775000799E-002
+p=1  Relative energy error =   0.85396972358657408
+p=2  Relative energy error =   0.23800207437997356
+p=3  Relative energy error =   0.14558431573734487
+p=4  Relative energy error =   2.8912002775000799E-002
+p=5  Relative energy error =   7.0313590547632018E-003
+p=6  Relative energy error =   2.3734217622063724E-003
+p=7  Relative energy error =   5.8687216090359958E-004
+p=8  Relative energy error =   1.3339512982768768E-004

--- a/fem/tests/p-FEM_with_varying_p/cylindrical_shell.sif
+++ b/fem/tests/p-FEM_with_varying_p/cylindrical_shell.sif
@@ -34,7 +34,14 @@
 ! same 2 X 2 mesh, with p being fixed as p=8 in the boundary layer and p varying
 ! elsewhere) is found to be as follows (the shell thickness d=0.1): 
 ! 
-! p=4  Relative energy error =    2.8912002775000799E-002
+! p=1  Relative energy error =   0.85396972358657408
+! p=2  Relative energy error =   0.23800207437997356
+! p=3  Relative energy error =   0.14558431573734487
+! p=4  Relative energy error =   2.8912002775000799E-002
+! p=5  Relative energy error =   7.0313590547632018E-003
+! p=6  Relative energy error =   2.3734217622063724E-003
+! p=7  Relative energy error =   5.8687216090359958E-004
+! p=8  Relative energy error =   1.3339512982768768E-004
 !
 !
 ! The original author of this test: Mika Malinen 

--- a/fem/tests/p-FEM_with_varying_p/cylindrical_shell.sif
+++ b/fem/tests/p-FEM_with_varying_p/cylindrical_shell.sif
@@ -34,14 +34,7 @@
 ! same 2 X 2 mesh, with p being fixed as p=8 in the boundary layer and p varying
 ! elsewhere) is found to be as follows (the shell thickness d=0.1): 
 ! 
-! p=1  Relative energy error =    0.80299745294707536
-! p=2  Relative energy error =    0.21996131107911385
-! p=3  Relative energy error =    0.14832093405769983
-! p=4  Relative energy error =    2.9071622043103682E-002
-! p=5  Relative energy error =    7.0387548946027100E-003
-! p=6  Relative energy error =    2.3735430471359740E-003
-! p=7  Relative energy error =    5.8687310435069976E-004
-! p=8: Relative energy error =    1.3339513082990932E-004
+! p=4  Relative energy error =    2.8912002775000799E-002
 !
 !
 ! The original author of this test: Mika Malinen 
@@ -172,5 +165,5 @@ Boundary Condition 4
   U 4 = Real 0
 End
 
-Solver 1 :: Reference Norm = Real 1.17389899E-02
+Solver 1 :: Reference Norm = Real 1.17434024E-02
 Solver 1 :: Reference Norm Tolerance = Real 1.0E-5


### PR DESCRIPTION
These changes have been done to fix inconsistencies which have occurred when solver-wise element definitions are used over the same mesh. The earlier implementation was based on using the structured data Element % BDOFs and Element % PDefs, which do not suit well to the case of solver-wise element definitions as the structured data object Element is not treated as a solver-wise entity. Now the structured data Solver % Def_Dofs is used for this purpose.

A known issue with the version after these changes is that a high-order approximation with element-wise changing p cannot treat "hanging DOFs" at element interfaces in the best possible way to respect the continuity. Improving this needs re-thinking and is left as a future task. 