### PR TITLE
Add actions for mesh pieces to ElmerGUI Simulation section.

### DIFF
--- a/ElmerGUI/Application/forms/generalsetup.ui
+++ b/ElmerGUI/Application/forms/generalsetup.ui
@@ -471,13 +471,34 @@
            </widget>
           </item>
           <item row="7" column="0">
+           <widget class="QCheckBox" name="calculateMeshPiecesCheck">
+            <property name="text">
+             <string>Calculate Mesh Pieces</string>
+            </property>
+           </widget>
+          </item>
+          <item row="7" column="2">
+           <widget class="QLabel" name="desiredMeshPiecesLabel">
+            <property name="text">
+             <string>Desired Mesh Pieces</string>
+            </property>
+           </widget>
+          </item>
+          <item row="7" column="3">
+           <widget class="QLineEdit" name="desiredMeshPiecesEdit">
+            <property name="text">
+             <string></string>
+            </property>
+           </widget>
+          </item>
+          <item row="8" column="0">
            <widget class="QLabel" name="simulationFreeTextLabel">
             <property name="text">
              <string>Free text</string>
             </property>
            </widget>
           </item>
-          <item row="7" column="1" colspan="3">
+          <item row="8" column="1" colspan="3">
            <widget class="QTextEdit" name="simulationFreeTextEdit">
             <property name="minimumSize">
              <size>

--- a/ElmerGUI/Application/src/sifgenerator.cpp
+++ b/ElmerGUI/Application/src/sifgenerator.cpp
@@ -207,8 +207,8 @@ void SifGenerator::makeSimulationBlock()
 	     ui.postFileEdit->text().trimmed());
 
   if(ui.calculateMeshPiecesCheck->isChecked())
-       te->append("  Calculate Mesh Pieces = Logical True");
-  addSifLine("  Desired Mesh Pieces = Integer ", 
+       te->append("  Calculate Mesh Pieces = True");
+  addSifLine("  Desired Mesh Pieces = ", 
 	     ui.desiredMeshPiecesEdit->text().trimmed());
 
   qs = ui.simulationFreeTextEdit->toPlainText();

--- a/ElmerGUI/Application/src/sifgenerator.cpp
+++ b/ElmerGUI/Application/src/sifgenerator.cpp
@@ -206,6 +206,11 @@ void SifGenerator::makeSimulationBlock()
   addSifLine("  Post File = ", 
 	     ui.postFileEdit->text().trimmed());
 
+  if(ui.calculateMeshPiecesCheck->isChecked())
+       te->append("  Calculate Mesh Pieces = Logical True");
+  addSifLine("  Desired Mesh Pieces = Integer ", 
+	     ui.desiredMeshPiecesEdit->text().trimmed());
+
   qs = ui.simulationFreeTextEdit->toPlainText();
 
   if(!qs.isEmpty())

--- a/fem/tests/MortarAndPeriodicPoisson2D/case.sif
+++ b/fem/tests/MortarAndPeriodicPoisson2D/case.sif
@@ -27,6 +27,7 @@ Simulation
 !  Post File = mortar.vtu
 
   Simulation Timing = Logical True
+  Calculate Mesh Pieces = Logical True
 End 
 
 Constants

--- a/fem/tests/MortarMixedDimensions/case.sif
+++ b/fem/tests/MortarMixedDimensions/case.sif
@@ -19,6 +19,7 @@ Simulation
   
   Output Intervals = 0
   Simulation Timing = Logical True
+  Desired Mesh Pieces = Integer 2
 End 
 
 Constants

--- a/fem/tests/MortarPoisson2D/case.sif
+++ b/fem/tests/MortarPoisson2D/case.sif
@@ -19,6 +19,8 @@ Simulation
   Post File = mortar.vtu
 
   Simulation Timing = Logical True
+  Calculate Mesh Pieces = Logical True
+  Desired Mesh Pieces = Integer 3
 End 
 
 Constants


### PR DESCRIPTION
New ElmerGUI check box for 'Calculate Mesh Pieces', and new ElmerGUI text box to enter the number of 'Desired Mesh Pieces'.  
By default, if the check box is unchecked and the text box is empty, then nothing is added to the Simulation section of the sif file.  Checking the check box will add 'Calculate Mesh Pieces = Logical True'.  Likewise, if a number is entered into the text box, such as a '1', then 'Desired Mesh Pieces = Integer 1' will be added to the Simulation section.  If both the check box is checked and a number is added to the text box, then both statements will be added to the sif file.