### PR TITLE
Release the elmergrid grd file lock after finished reading, just before

### DIFF
--- a/ElmerGUI/Application/plugins/egmain.cpp
+++ b/ElmerGUI/Application/plugins/egmain.cpp
@@ -851,7 +851,7 @@ int main(int argc, char *argv[])
   static Real mergeeps;
   long ii;
 
-  if(info) printf("\nStarting program Elmergrid\n");
+  if(info) printf("\nStarting program Elmergrid, compiled on %s\n", __DATE__ );
   
   InitParameters(&eg);
   grids = (struct GridType*)malloc((size_t) (MAXCASES)*sizeof(struct GridType));     

--- a/ElmerGUI/Application/plugins/egnative.cpp
+++ b/ElmerGUI/Application/plugins/egnative.cpp
@@ -4891,7 +4891,7 @@ int LoadCommands(char *prefix,struct ElmergridType *eg,
 
 end:
   printf("Read commands from a file\n");
-
+  fclose(in);
   return(0);
 }
 

--- a/elmergrid/src/egnative.c
+++ b/elmergrid/src/egnative.c
@@ -4891,7 +4891,7 @@ int LoadCommands(char *prefix,struct ElmergridType *eg,
 
 end:
   printf("Read commands from a file\n");
-
+  fclose(in);
   return(0);
 }
 

--- a/elmergrid/src/fempre.c
+++ b/elmergrid/src/fempre.c
@@ -78,7 +78,7 @@ int main(int argc, char *argv[])
 
   showmem = TRUE;
 
-  printf("\nStarting program Elmergrid\n");
+  printf("\nStarting program Elmergrid, compiled on %s\n", __DATE__ );
 
   InitParameters(&eg);
 


### PR DESCRIPTION
exiting LoadCommands.  Refer to Issue #377 for more details.