### PR TITLE
VTKpost widget size adjustment and also fixed bug of color selection in ElmerGUI

### DIFF
--- a/ElmerGUI/Application/src/mainwindow.cpp
+++ b/ElmerGUI/Application/src/mainwindow.cpp
@@ -4957,6 +4957,7 @@ void MainWindow::colorizeBodySlot() {
 //-----------------------------------------------------------------------------
 void MainWindow::backgroundColorSlot() {
   QColor newColor = QColorDialog::getColor(glWidget->backgroundColor, this);
+  if(!newColor.isValid()) return;
   glWidget->qglClearColor(newColor);
   glWidget->backgroundColor = newColor;
 }
@@ -4970,6 +4971,7 @@ void MainWindow::surfaceColorSlot() {
   }
 
   QColor newColor = QColorDialog::getColor(glWidget->surfaceColor, this);
+  if(!newColor.isValid()) return;
   glWidget->surfaceColor = newColor;
   glWidget->rebuildLists();
 }
@@ -4983,6 +4985,7 @@ void MainWindow::edgeColorSlot() {
   }
 
   QColor newColor = QColorDialog::getColor(glWidget->edgeColor, this);
+  if(!newColor.isValid()) return;
   glWidget->edgeColor = newColor;
   glWidget->rebuildLists();
 }
@@ -4996,6 +4999,7 @@ void MainWindow::surfaceMeshColorSlot() {
   }
 
   QColor newColor = QColorDialog::getColor(glWidget->surfaceMeshColor, this);
+  if(!newColor.isValid()) return;
   glWidget->surfaceMeshColor = newColor;
   glWidget->rebuildLists();
 }
@@ -5009,6 +5013,7 @@ void MainWindow::sharpEdgeColorSlot() {
   }
 
   QColor newColor = QColorDialog::getColor(glWidget->sharpEdgeColor, this);
+  if(!newColor.isValid()) return;
   glWidget->sharpEdgeColor = newColor;
   glWidget->rebuildLists();
 }
@@ -5022,6 +5027,7 @@ void MainWindow::selectionColorSlot() {
   }
 
   QColor newColor = QColorDialog::getColor(glWidget->selectionColor, this);
+  if(!newColor.isValid()) return;
   glWidget->selectionColor = newColor;
   glWidget->rebuildLists();
 }

--- a/ElmerGUI/Application/vtkpost/colorbar.ui
+++ b/ElmerGUI/Application/vtkpost/colorbar.ui
@@ -27,12 +27,6 @@
        <layout class="QHBoxLayout" >
         <item>
          <widget class="QLabel" name="colorLabel" >
-          <property name="maximumSize" >
-           <size>
-            <width>70</width>
-            <height>16777215</height>
-           </size>
-          </property>
           <property name="text" >
            <string>Color map:</string>
           </property>
@@ -40,18 +34,12 @@
         </item>
         <item>
          <widget class="QComboBox" name="colorCombo" >
-          <property name="minimumSize" >
-           <size>
-            <width>280</width>
-            <height>0</height>
-           </size>
-          </property>
-          <property name="maximumSize" >
-           <size>
-            <width>16777215</width>
-            <height>24</height>
-           </size>
-          </property>
+  <property name="sizePolicy">
+   <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+    <horstretch>0</horstretch>
+    <verstretch>0</verstretch>
+   </sizepolicy>
+  </property>
          </widget>
         </item>
        </layout>
@@ -86,12 +74,6 @@
         </item>
         <item row="0" column="3" >
          <widget class="QSpinBox" name="labelsSpin" >
-          <property name="maximumSize" >
-           <size>
-            <width>70</width>
-            <height>24</height>
-           </size>
-          </property>
           <property name="value" >
            <number>5</number>
           </property>
@@ -116,12 +98,6 @@
         </item>
         <item row="1" column="3" >
          <widget class="QLineEdit" name="widthEdit" >
-          <property name="maximumSize" >
-           <size>
-            <width>70</width>
-            <height>24</height>
-           </size>
-          </property>
           <property name="text" >
            <string>0.1</string>
           </property>
@@ -146,12 +122,6 @@
         </item>
         <item row="2" column="3" >
          <widget class="QLineEdit" name="heightEdit" >
-          <property name="maximumSize" >
-           <size>
-            <width>70</width>
-            <height>24</height>
-           </size>
-          </property>
           <property name="text" >
            <string>0.9</string>
           </property>

--- a/ElmerGUI/Application/vtkpost/isocontour.ui
+++ b/ElmerGUI/Application/vtkpost/isocontour.ui
@@ -26,18 +26,6 @@
        <layout class="QHBoxLayout" >
         <item>
          <widget class="QLabel" name="variableLabel" >
-          <property name="minimumSize" >
-           <size>
-            <width>55</width>
-            <height>0</height>
-           </size>
-          </property>
-          <property name="maximumSize" >
-           <size>
-            <width>55</width>
-            <height>16777215</height>
-           </size>
-          </property>
           <property name="text" >
            <string>Variable:</string>
           </property>
@@ -45,18 +33,12 @@
         </item>
         <item>
          <widget class="QComboBox" name="contoursCombo" >
-          <property name="minimumSize" >
-           <size>
-            <width>280</width>
-            <height>0</height>
-           </size>
-          </property>
-          <property name="maximumSize" >
-           <size>
-            <width>16777215</width>
-            <height>24</height>
-           </size>
-          </property>
+  <property name="sizePolicy">
+   <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+    <horstretch>0</horstretch>
+    <verstretch>0</verstretch>
+   </sizepolicy>
+  </property>
          </widget>
         </item>
        </layout>
@@ -65,12 +47,6 @@
        <layout class="QGridLayout" >
         <item row="0" column="0" >
          <widget class="QLabel" name="contoursMinLabel" >
-          <property name="maximumSize" >
-           <size>
-            <width>70</width>
-            <height>16777215</height>
-           </size>
-          </property>
           <property name="text" >
            <string>Min:</string>
           </property>
@@ -78,12 +54,6 @@
         </item>
         <item row="0" column="1" >
          <widget class="QLineEdit" name="contoursMinEdit" >
-          <property name="maximumSize" >
-           <size>
-            <width>16777215</width>
-            <height>24</height>
-           </size>
-          </property>
           <property name="text" >
            <string>0.0</string>
           </property>
@@ -98,12 +68,6 @@
         </item>
         <item row="0" column="3" >
          <widget class="QLineEdit" name="contoursMaxEdit" >
-          <property name="maximumSize" >
-           <size>
-            <width>16777215</width>
-            <height>24</height>
-           </size>
-          </property>
           <property name="text" >
            <string>1.0</string>
           </property>
@@ -111,18 +75,6 @@
         </item>
         <item row="1" column="0" >
          <widget class="QLabel" name="contoursLabel" >
-          <property name="minimumSize" >
-           <size>
-            <width>55</width>
-            <height>0</height>
-           </size>
-          </property>
-          <property name="maximumSize" >
-           <size>
-            <width>55</width>
-            <height>16777215</height>
-           </size>
-          </property>
           <property name="text" >
            <string>Contours:</string>
           </property>
@@ -130,18 +82,6 @@
         </item>
         <item row="1" column="1" >
          <widget class="QSpinBox" name="contoursSpin" >
-          <property name="minimumSize" >
-           <size>
-            <width>0</width>
-            <height>0</height>
-           </size>
-          </property>
-          <property name="maximumSize" >
-           <size>
-            <width>16777215</width>
-            <height>24</height>
-           </size>
-          </property>
           <property name="minimum" >
            <number>1</number>
           </property>
@@ -166,18 +106,6 @@
        <layout class="QHBoxLayout" >
         <item>
          <widget class="QLabel" name="listLabel" >
-          <property name="minimumSize" >
-           <size>
-            <width>55</width>
-            <height>0</height>
-           </size>
-          </property>
-          <property name="maximumSize" >
-           <size>
-            <width>55</width>
-            <height>16777215</height>
-           </size>
-          </property>
           <property name="text" >
            <string>List:</string>
           </property>
@@ -185,12 +113,6 @@
         </item>
         <item>
          <widget class="QLineEdit" name="contourList" >
-          <property name="maximumSize" >
-           <size>
-            <width>16777215</width>
-            <height>24</height>
-           </size>
-          </property>
          </widget>
         </item>
        </layout>
@@ -208,18 +130,6 @@
        <layout class="QHBoxLayout" >
         <item>
          <widget class="QLabel" name="colorLabel" >
-          <property name="minimumSize" >
-           <size>
-            <width>55</width>
-            <height>0</height>
-           </size>
-          </property>
-          <property name="maximumSize" >
-           <size>
-            <width>50</width>
-            <height>16777215</height>
-           </size>
-          </property>
           <property name="text" >
            <string>Color:</string>
           </property>
@@ -227,18 +137,12 @@
         </item>
         <item>
          <widget class="QComboBox" name="colorCombo" >
-          <property name="minimumSize" >
-           <size>
-            <width>180</width>
-            <height>0</height>
-           </size>
-          </property>
-          <property name="maximumSize" >
-           <size>
-            <width>16777215</width>
-            <height>24</height>
-           </size>
-          </property>
+  <property name="sizePolicy">
+   <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+    <horstretch>0</horstretch>
+    <verstretch>0</verstretch>
+   </sizepolicy>
+  </property>
          </widget>
         </item>
 		<item>
@@ -261,18 +165,6 @@
        <layout class="QGridLayout" >
         <item row="0" column="0" >
          <widget class="QLabel" name="colorMinLabel" >
-          <property name="minimumSize" >
-           <size>
-            <width>55</width>
-            <height>0</height>
-           </size>
-          </property>
-          <property name="maximumSize" >
-           <size>
-            <width>50</width>
-            <height>16777215</height>
-           </size>
-          </property>
           <property name="text" >
            <string>Min:</string>
           </property>
@@ -328,12 +220,6 @@
         </item>
         <item row="0" column="3" >
          <widget class="QSpinBox" name="lineWidthSpin" >
-          <property name="maximumSize" >
-           <size>
-            <width>16777215</width>
-            <height>24</height>
-           </size>
-          </property>
           <property name="minimum" >
            <number>1</number>
           </property>
@@ -355,12 +241,6 @@
         </item>
         <item row="1" column="3" >
          <widget class="QSpinBox" name="tubeQuality" >
-          <property name="maximumSize" >
-           <size>
-            <width>16777215</width>
-            <height>24</height>
-           </size>
-          </property>
           <property name="minimum" >
            <number>3</number>
           </property>
@@ -385,12 +265,6 @@
         </item>
         <item row="2" column="3" >
          <widget class="QSpinBox" name="tubeRadius" >
-          <property name="maximumSize" >
-           <size>
-            <width>16777215</width>
-            <height>24</height>
-           </size>
-          </property>
           <property name="minimum" >
            <number>1</number>
           </property>

--- a/ElmerGUI/Application/vtkpost/isosurface.ui
+++ b/ElmerGUI/Application/vtkpost/isosurface.ui
@@ -26,18 +26,6 @@
        <layout class="QHBoxLayout" >
         <item>
          <widget class="QLabel" name="variableLabel" >
-          <property name="minimumSize" >
-           <size>
-            <width>55</width>
-            <height>0</height>
-           </size>
-          </property>
-          <property name="maximumSize" >
-           <size>
-            <width>50</width>
-            <height>16777215</height>
-           </size>
-          </property>
           <property name="text" >
            <string>Variable:</string>
           </property>
@@ -45,18 +33,12 @@
         </item>
         <item>
          <widget class="QComboBox" name="contoursCombo" >
-          <property name="minimumSize" >
-           <size>
-            <width>280</width>
-            <height>0</height>
-           </size>
-          </property>
-          <property name="maximumSize" >
-           <size>
-            <width>16777215</width>
-            <height>24</height>
-           </size>
-          </property>
+  <property name="sizePolicy">
+   <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+    <horstretch>0</horstretch>
+    <verstretch>0</verstretch>
+   </sizepolicy>
+  </property>
          </widget>
         </item>
        </layout>
@@ -72,12 +54,6 @@
         </item>
         <item row="0" column="1" >
          <widget class="QLineEdit" name="contoursMinEdit" >
-          <property name="maximumSize" >
-           <size>
-            <width>16777215</width>
-            <height>24</height>
-           </size>
-          </property>
           <property name="text" >
            <string>0.0</string>
           </property>
@@ -92,12 +68,6 @@
         </item>
         <item row="0" column="3" >
          <widget class="QLineEdit" name="contoursMaxEdit" >
-          <property name="maximumSize" >
-           <size>
-            <width>16777215</width>
-            <height>24</height>
-           </size>
-          </property>
           <property name="text" >
            <string>1.0</string>
           </property>
@@ -105,18 +75,6 @@
         </item>
         <item row="1" column="0" >
          <widget class="QLabel" name="contoursLabel" >
-          <property name="minimumSize" >
-           <size>
-            <width>55</width>
-            <height>0</height>
-           </size>
-          </property>
-          <property name="maximumSize" >
-           <size>
-            <width>16777215</width>
-            <height>16777215</height>
-           </size>
-          </property>
           <property name="text" >
            <string>Contours:</string>
           </property>
@@ -124,12 +82,6 @@
         </item>
         <item row="1" column="1" >
          <widget class="QSpinBox" name="contoursSpin" >
-          <property name="maximumSize" >
-           <size>
-            <width>16777215</width>
-            <height>24</height>
-           </size>
-          </property>
           <property name="minimum" >
            <number>1</number>
           </property>
@@ -154,12 +106,6 @@
        <layout class="QHBoxLayout" >
         <item>
          <widget class="QLabel" name="listLabel" >
-          <property name="minimumSize" >
-           <size>
-            <width>55</width>
-            <height>0</height>
-           </size>
-          </property>
           <property name="text" >
            <string>List:</string>
           </property>
@@ -167,12 +113,6 @@
         </item>
         <item>
          <widget class="QLineEdit" name="contourList" >
-          <property name="maximumSize" >
-           <size>
-            <width>16777215</width>
-            <height>24</height>
-           </size>
-          </property>
          </widget>
         </item>
        </layout>
@@ -190,18 +130,6 @@
        <layout class="QHBoxLayout" >
         <item>
          <widget class="QLabel" name="colorLabel" >
-          <property name="minimumSize" >
-           <size>
-            <width>55</width>
-            <height>0</height>
-           </size>
-          </property>
-          <property name="maximumSize" >
-           <size>
-            <width>50</width>
-            <height>16777215</height>
-           </size>
-          </property>
           <property name="text" >
            <string>Color:</string>
           </property>
@@ -209,18 +137,12 @@
         </item>
         <item>
          <widget class="QComboBox" name="colorCombo" >
-          <property name="minimumSize" >
-           <size>
-            <width>180</width>
-            <height>0</height>
-           </size>
-          </property>
-          <property name="maximumSize" >
-           <size>
-            <width>16777215</width>
-            <height>24</height>
-           </size>
-          </property>
+  <property name="sizePolicy">
+   <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+    <horstretch>0</horstretch>
+    <verstretch>0</verstretch>
+   </sizepolicy>
+  </property>
          </widget>
         </item>
 		<item>
@@ -243,12 +165,6 @@
        <layout class="QGridLayout" >
         <item row="0" column="0" >
          <widget class="QLabel" name="colorMinLabel" >
-          <property name="minimumSize" >
-           <size>
-            <width>55</width>
-            <height>0</height>
-           </size>
-          </property>
           <property name="text" >
            <string>Min:</string>
           </property>
@@ -256,12 +172,6 @@
         </item>
         <item row="0" column="1" >
          <widget class="QLineEdit" name="colorMinEdit" >
-          <property name="maximumSize" >
-           <size>
-            <width>16777215</width>
-            <height>24</height>
-           </size>
-          </property>
           <property name="text" >
            <string>0.0</string>
           </property>
@@ -276,12 +186,6 @@
         </item>
         <item row="0" column="3" >
          <widget class="QLineEdit" name="colorMaxEdit" >
-          <property name="maximumSize" >
-           <size>
-            <width>16777215</width>
-            <height>24</height>
-           </size>
-          </property>
           <property name="text" >
            <string>1.0</string>
           </property>
@@ -326,12 +230,6 @@
         </item>
         <item row="0" column="3" >
          <widget class="QSpinBox" name="featureAngle" >
-          <property name="maximumSize" >
-           <size>
-            <width>16777215</width>
-            <height>24</height>
-           </size>
-          </property>
           <property name="maximum" >
            <number>90</number>
           </property>
@@ -349,12 +247,6 @@
         </item>
         <item row="1" column="3" >
          <widget class="QSpinBox" name="opacitySpin" >
-          <property name="maximumSize" >
-           <size>
-            <width>16777215</width>
-            <height>24</height>
-           </size>
-          </property>
           <property name="maximum" >
            <number>100</number>
           </property>

--- a/ElmerGUI/Application/vtkpost/matc.ui
+++ b/ElmerGUI/Application/vtkpost/matc.ui
@@ -20,12 +20,6 @@
     <layout class="QHBoxLayout" >
      <item>
       <widget class="QLabel" name="mathLabel" >
-       <property name="maximumSize" >
-        <size>
-         <width>45</width>
-         <height>24</height>
-        </size>
-       </property>
        <property name="text" >
         <string>math:</string>
        </property>
@@ -33,18 +27,6 @@
      </item>
      <item>
       <widget class="QLineEdit" name="mcEdit" >
-       <property name="minimumSize" >
-        <size>
-         <width>0</width>
-         <height>24</height>
-        </size>
-       </property>
-       <property name="maximumSize" >
-        <size>
-         <width>16777215</width>
-         <height>24</height>
-        </size>
-       </property>
       </widget>
      </item>
     </layout>

--- a/ElmerGUI/Application/vtkpost/preferences.ui
+++ b/ElmerGUI/Application/vtkpost/preferences.ui
@@ -42,12 +42,6 @@
         </item>
         <item row="0" column="2" >
          <widget class="QLabel" name="sizeLabel" >
-          <property name="minimumSize" >
-           <size>
-            <width>80</width>
-            <height>0</height>
-           </size>
-          </property>
           <property name="text" >
            <string>Size:</string>
           </property>
@@ -55,12 +49,6 @@
         </item>
         <item row="0" column="3" >
          <widget class="QSpinBox" name="pointSize" >
-          <property name="maximumSize" >
-           <size>
-            <width>16777215</width>
-            <height>24</height>
-           </size>
-          </property>
           <property name="minimum" >
            <number>1</number>
           </property>
@@ -91,12 +79,6 @@
         </item>
         <item row="1" column="2" >
          <widget class="QLabel" name="qualityLabel" >
-          <property name="minimumSize" >
-           <size>
-            <width>80</width>
-            <height>0</height>
-           </size>
-          </property>
           <property name="text" >
            <string>Quality:</string>
           </property>
@@ -104,12 +86,6 @@
         </item>
         <item row="1" column="3" >
          <widget class="QSpinBox" name="pointQuality" >
-          <property name="maximumSize" >
-           <size>
-            <width>16777215</width>
-            <height>24</height>
-           </size>
-          </property>
           <property name="minimum" >
            <number>2</number>
           </property>
@@ -204,18 +180,6 @@
         </item>
         <item row="0" column="2" >
          <widget class="QLabel" name="meshLineWidthLabel" >
-          <property name="minimumSize" >
-           <size>
-            <width>80</width>
-            <height>0</height>
-           </size>
-          </property>
-          <property name="maximumSize" >
-           <size>
-            <width>90</width>
-            <height>16777215</height>
-           </size>
-          </property>
           <property name="text" >
            <string>Line width:</string>
           </property>
@@ -223,18 +187,6 @@
         </item>
         <item row="0" column="3" >
          <widget class="QSpinBox" name="meshLineWidth" >
-          <property name="minimumSize" >
-           <size>
-            <width>0</width>
-            <height>24</height>
-           </size>
-          </property>
-          <property name="maximumSize" >
-           <size>
-            <width>70</width>
-            <height>24</height>
-           </size>
-          </property>
           <property name="minimum" >
            <number>1</number>
           </property>
@@ -256,12 +208,6 @@
         </item>
         <item row="1" column="3" >
          <widget class="QSpinBox" name="meshEdgeTubeQuality" >
-          <property name="maximumSize" >
-           <size>
-            <width>16777215</width>
-            <height>24</height>
-           </size>
-          </property>
           <property name="minimum" >
            <number>3</number>
           </property>
@@ -279,12 +225,6 @@
         </item>
         <item row="2" column="3" >
          <widget class="QSpinBox" name="meshEdgeTubeRadius" >
-          <property name="maximumSize" >
-           <size>
-            <width>16777215</width>
-            <height>24</height>
-           </size>
-          </property>
           <property name="minimum" >
            <number>1</number>
           </property>
@@ -328,18 +268,6 @@
         </item>
         <item row="0" column="2" >
          <widget class="QLabel" name="angleLabel" >
-          <property name="minimumSize" >
-           <size>
-            <width>80</width>
-            <height>0</height>
-           </size>
-          </property>
-          <property name="maximumSize" >
-           <size>
-            <width>90</width>
-            <height>16777215</height>
-           </size>
-          </property>
           <property name="text" >
            <string>Feature angle:</string>
           </property>
@@ -347,18 +275,6 @@
         </item>
         <item row="0" column="3" >
          <widget class="QSpinBox" name="angleSpin" >
-          <property name="minimumSize" >
-           <size>
-            <width>0</width>
-            <height>24</height>
-           </size>
-          </property>
-          <property name="maximumSize" >
-           <size>
-            <width>70</width>
-            <height>24</height>
-           </size>
-          </property>
           <property name="minimum" >
            <number>0</number>
           </property>
@@ -379,18 +295,6 @@
         </item>
         <item row="1" column="2" >
          <widget class="QLabel" name="lineWidthLabel_2" >
-          <property name="minimumSize" >
-           <size>
-            <width>80</width>
-            <height>0</height>
-           </size>
-          </property>
-          <property name="maximumSize" >
-           <size>
-            <width>90</width>
-            <height>16777215</height>
-           </size>
-          </property>
           <property name="text" >
            <string>Line width:</string>
           </property>
@@ -398,18 +302,6 @@
         </item>
         <item row="1" column="3" >
          <widget class="QSpinBox" name="lineWidthSpin" >
-          <property name="minimumSize" >
-           <size>
-            <width>0</width>
-            <height>24</height>
-           </size>
-          </property>
-          <property name="maximumSize" >
-           <size>
-            <width>70</width>
-            <height>24</height>
-           </size>
-          </property>
           <property name="minimum" >
            <number>1</number>
           </property>
@@ -431,12 +323,6 @@
         </item>
         <item row="2" column="3" >
          <widget class="QSpinBox" name="featureEdgeTubeQuality" >
-          <property name="maximumSize" >
-           <size>
-            <width>16777215</width>
-            <height>24</height>
-           </size>
-          </property>
           <property name="minimum" >
            <number>3</number>
           </property>
@@ -461,12 +347,6 @@
         </item>
         <item row="3" column="3" >
          <widget class="QSpinBox" name="featureEdgeTubeRadius" >
-          <property name="maximumSize" >
-           <size>
-            <width>16777215</width>
-            <height>24</height>
-           </size>
-          </property>
           <property name="minimum" >
            <number>1</number>
           </property>
@@ -531,12 +411,6 @@
         </item>
         <item row="0" column="1" >
          <widget class="QLineEdit" name="clipPointX" >
-          <property name="maximumSize" >
-           <size>
-            <width>16777215</width>
-            <height>24</height>
-           </size>
-          </property>
           <property name="text" >
            <string>0.0</string>
           </property>
@@ -551,12 +425,6 @@
         </item>
         <item row="0" column="3" >
          <widget class="QLineEdit" name="clipNormalX" >
-          <property name="maximumSize" >
-           <size>
-            <width>16777215</width>
-            <height>24</height>
-           </size>
-          </property>
           <property name="text" >
            <string>1.0</string>
           </property>
@@ -571,12 +439,6 @@
         </item>
         <item row="1" column="1" >
          <widget class="QLineEdit" name="clipPointY" >
-          <property name="maximumSize" >
-           <size>
-            <width>16777215</width>
-            <height>24</height>
-           </size>
-          </property>
           <property name="text" >
            <string>0.0</string>
           </property>
@@ -591,12 +453,6 @@
         </item>
         <item row="1" column="3" >
          <widget class="QLineEdit" name="clipNormalY" >
-          <property name="maximumSize" >
-           <size>
-            <width>16777215</width>
-            <height>24</height>
-           </size>
-          </property>
           <property name="text" >
            <string>0.0</string>
           </property>
@@ -611,12 +467,6 @@
         </item>
         <item row="2" column="1" >
          <widget class="QLineEdit" name="clipPointZ" >
-          <property name="maximumSize" >
-           <size>
-            <width>16777215</width>
-            <height>24</height>
-           </size>
-          </property>
           <property name="text" >
            <string>0.0</string>
           </property>
@@ -631,12 +481,6 @@
         </item>
         <item row="2" column="3" >
          <widget class="QLineEdit" name="clipNormalZ" >
-          <property name="maximumSize" >
-           <size>
-            <width>16777215</width>
-            <height>24</height>
-           </size>
-          </property>
           <property name="text" >
            <string>0.0</string>
           </property>

--- a/ElmerGUI/Application/vtkpost/readepfile.ui
+++ b/ElmerGUI/Application/vtkpost/readepfile.ui
@@ -26,22 +26,10 @@
        <layout class="QHBoxLayout" >
         <item>
          <widget class="QLineEdit" name="fileName" >
-          <property name="maximumSize" >
-           <size>
-            <width>16777215</width>
-            <height>24</height>
-           </size>
-          </property>
          </widget>
         </item>
         <item>
          <widget class="QPushButton" name="browseButton" >
-          <property name="maximumSize" >
-           <size>
-            <width>16777215</width>
-            <height>24</height>
-           </size>
-          </property>
           <property name="text" >
            <string>Browse</string>
           </property>
@@ -62,12 +50,6 @@
        <layout class="QGridLayout" >
         <item row="0" column="0" >
          <widget class="QLabel" name="nodesLabel" >
-          <property name="maximumSize" >
-           <size>
-            <width>16777215</width>
-            <height>24</height>
-           </size>
-          </property>
           <property name="text" >
            <string>Nodes:</string>
           </property>
@@ -75,12 +57,6 @@
         </item>
         <item row="0" column="1" >
          <widget class="QLineEdit" name="nodesEdit" >
-          <property name="maximumSize" >
-           <size>
-            <width>16777215</width>
-            <height>24</height>
-           </size>
-          </property>
          </widget>
         </item>
         <item row="0" column="2" >
@@ -92,22 +68,10 @@
         </item>
         <item row="0" column="3" >
          <widget class="QLineEdit" name="timestepsEdit" >
-          <property name="maximumSize" >
-           <size>
-            <width>16777215</width>
-            <height>24</height>
-           </size>
-          </property>
          </widget>
         </item>
         <item row="1" column="0" >
          <widget class="QLabel" name="elementsLabel" >
-          <property name="minimumSize" >
-           <size>
-            <width>60</width>
-            <height>0</height>
-           </size>
-          </property>
           <property name="text" >
            <string>Elements:</string>
           </property>
@@ -115,12 +79,6 @@
         </item>
         <item row="1" column="1" >
          <widget class="QLineEdit" name="elementsEdit" >
-          <property name="maximumSize" >
-           <size>
-            <width>16777215</width>
-            <height>24</height>
-           </size>
-          </property>
          </widget>
         </item>
         <item row="1" column="2" >
@@ -132,12 +90,6 @@
         </item>
         <item row="1" column="3" >
          <widget class="QLineEdit" name="dofsEdit" >
-          <property name="maximumSize" >
-           <size>
-            <width>16777215</width>
-            <height>24</height>
-           </size>
-          </property>
          </widget>
         </item>
        </layout>
@@ -155,12 +107,6 @@
        <layout class="QGridLayout" >
         <item row="0" column="0" >
          <widget class="QLabel" name="startLabel" >
-          <property name="minimumSize" >
-           <size>
-            <width>60</width>
-            <height>0</height>
-           </size>
-          </property>
           <property name="text" >
            <string>Start:</string>
           </property>
@@ -168,18 +114,6 @@
         </item>
         <item row="0" column="1" >
          <widget class="QSpinBox" name="start" >
-          <property name="minimumSize" >
-           <size>
-            <width>120</width>
-            <height>0</height>
-           </size>
-          </property>
-          <property name="maximumSize" >
-           <size>
-            <width>16777215</width>
-            <height>24</height>
-           </size>
-          </property>
           <property name="minimum" >
            <number>1</number>
           </property>
@@ -203,12 +137,6 @@
         </item>
         <item row="0" column="3" >
          <widget class="QPushButton" name="allButton" >
-          <property name="maximumSize" >
-           <size>
-            <width>16777215</width>
-            <height>24</height>
-           </size>
-          </property>
           <property name="text" >
            <string>All</string>
           </property>
@@ -223,12 +151,6 @@
         </item>
         <item row="1" column="1" >
          <widget class="QSpinBox" name="end" >
-          <property name="maximumSize" >
-           <size>
-            <width>16777215</width>
-            <height>24</height>
-           </size>
-          </property>
           <property name="minimum" >
            <number>1</number>
           </property>

--- a/ElmerGUI/Application/vtkpost/streamline.ui
+++ b/ElmerGUI/Application/vtkpost/streamline.ui
@@ -30,18 +30,6 @@
          <layout class="QHBoxLayout">
           <item>
            <widget class="QLabel" name="vectorLabel">
-            <property name="minimumSize">
-             <size>
-              <width>50</width>
-              <height>0</height>
-             </size>
-            </property>
-            <property name="maximumSize">
-             <size>
-              <width>50</width>
-              <height>16777215</height>
-             </size>
-            </property>
             <property name="text">
              <string>Vector:</string>
             </property>
@@ -49,18 +37,12 @@
           </item>
           <item>
            <widget class="QComboBox" name="vectorCombo">
-            <property name="minimumSize">
-             <size>
-              <width>280</width>
-              <height>0</height>
-             </size>
-            </property>
-            <property name="maximumSize">
-             <size>
-              <width>16777215</width>
-              <height>24</height>
-             </size>
-            </property>
+  <property name="sizePolicy">
+   <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+    <horstretch>0</horstretch>
+    <verstretch>0</verstretch>
+   </sizepolicy>
+  </property>
            </widget>
           </item>
          </layout>
@@ -76,12 +58,6 @@
           </item>
           <item row="0" column="1">
            <widget class="QLineEdit" name="propagationTime">
-            <property name="maximumSize">
-             <size>
-              <width>90</width>
-              <height>24</height>
-             </size>
-            </property>
             <property name="text">
              <string>1.0</string>
             </property>
@@ -96,18 +72,6 @@
           </item>
           <item row="0" column="4">
            <widget class="QLineEdit" name="stepLength">
-            <property name="minimumSize">
-             <size>
-              <width>90</width>
-              <height>0</height>
-             </size>
-            </property>
-            <property name="maximumSize">
-             <size>
-              <width>90</width>
-              <height>24</height>
-             </size>
-            </property>
             <property name="text">
              <string>0.05</string>
             </property>
@@ -139,12 +103,6 @@
           </item>
           <item row="1" column="4">
            <widget class="QLineEdit" name="integStepLength">
-            <property name="maximumSize">
-             <size>
-              <width>90</width>
-              <height>24</height>
-             </size>
-            </property>
             <property name="text">
              <string>0.005</string>
             </property>
@@ -242,18 +200,6 @@
          <layout class="QHBoxLayout">
           <item>
            <widget class="QLabel" name="lengthLabel">
-            <property name="minimumSize">
-             <size>
-              <width>50</width>
-              <height>0</height>
-             </size>
-            </property>
-            <property name="maximumSize">
-             <size>
-              <width>50</width>
-              <height>16777215</height>
-             </size>
-            </property>
             <property name="text">
              <string>Color:</string>
             </property>
@@ -261,18 +207,12 @@
           </item>
           <item>
            <widget class="QComboBox" name="colorCombo">
-            <property name="minimumSize">
-             <size>
-              <width>180</width>
-              <height>0</height>
-             </size>
-            </property>
-            <property name="maximumSize">
-             <size>
-              <width>16777215</width>
-              <height>24</height>
-             </size>
-            </property>
+  <property name="sizePolicy">
+   <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+    <horstretch>0</horstretch>
+    <verstretch>0</verstretch>
+   </sizepolicy>
+  </property>
            </widget>
           </item>
 		  <item>
@@ -295,18 +235,6 @@
          <layout class="QGridLayout">
           <item row="0" column="0">
            <widget class="QLabel" name="minLabel">
-            <property name="minimumSize">
-             <size>
-              <width>50</width>
-              <height>0</height>
-             </size>
-            </property>
-            <property name="maximumSize">
-             <size>
-              <width>50</width>
-              <height>16777215</height>
-             </size>
-            </property>
             <property name="text">
              <string>Min:</string>
             </property>
@@ -314,28 +242,10 @@
           </item>
           <item row="0" column="1">
            <widget class="QLineEdit" name="minVal">
-            <property name="maximumSize">
-             <size>
-              <width>90</width>
-              <height>24</height>
-             </size>
-            </property>
            </widget>
           </item>
           <item row="0" column="3">
            <widget class="QLabel" name="maxLabel">
-            <property name="minimumSize">
-             <size>
-              <width>70</width>
-              <height>0</height>
-             </size>
-            </property>
-            <property name="maximumSize">
-             <size>
-              <width>50</width>
-              <height>16777215</height>
-             </size>
-            </property>
             <property name="text">
              <string>Max:</string>
             </property>
@@ -343,12 +253,6 @@
           </item>
           <item row="0" column="4">
            <widget class="QLineEdit" name="maxVal">
-            <property name="maximumSize">
-             <size>
-              <width>90</width>
-              <height>24</height>
-             </size>
-            </property>
            </widget>
           </item>
           <item row="1" column="4">
@@ -403,12 +307,6 @@
           </item>
           <item row="0" column="3">
            <widget class="QSpinBox" name="lineWidth">
-            <property name="maximumSize">
-             <size>
-              <width>16777215</width>
-              <height>24</height>
-             </size>
-            </property>
             <property name="minimum">
              <number>1</number>
             </property>
@@ -507,18 +405,6 @@
          <layout class="QGridLayout">
           <item row="0" column="0">
            <widget class="QLabel" name="xPointStartLabel">
-            <property name="minimumSize">
-             <size>
-              <width>50</width>
-              <height>0</height>
-             </size>
-            </property>
-            <property name="maximumSize">
-             <size>
-              <width>50</width>
-              <height>16777215</height>
-             </size>
-            </property>
             <property name="text">
              <string>Center X:</string>
             </property>
@@ -526,18 +412,6 @@
           </item>
           <item row="0" column="1">
            <widget class="QLineEdit" name="centerX">
-            <property name="minimumSize">
-             <size>
-              <width>90</width>
-              <height>0</height>
-             </size>
-            </property>
-            <property name="maximumSize">
-             <size>
-              <width>90</width>
-              <height>24</height>
-             </size>
-            </property>
             <property name="text">
              <string>0.0</string>
             </property>
@@ -545,12 +419,6 @@
           </item>
           <item row="0" column="3">
            <widget class="QLabel" name="radiusLabel">
-            <property name="minimumSize">
-             <size>
-              <width>55</width>
-              <height>0</height>
-             </size>
-            </property>
             <property name="text">
              <string>Radius:</string>
             </property>
@@ -558,18 +426,6 @@
           </item>
           <item row="0" column="4">
            <widget class="QLineEdit" name="radius">
-            <property name="minimumSize">
-             <size>
-              <width>90</width>
-              <height>0</height>
-             </size>
-            </property>
-            <property name="maximumSize">
-             <size>
-              <width>90</width>
-              <height>24</height>
-             </size>
-            </property>
             <property name="text">
              <string>0.0</string>
             </property>
@@ -584,12 +440,6 @@
           </item>
           <item row="1" column="1">
            <widget class="QLineEdit" name="centerY">
-            <property name="maximumSize">
-             <size>
-              <width>90</width>
-              <height>24</height>
-             </size>
-            </property>
             <property name="text">
              <string>0.0</string>
             </property>
@@ -610,12 +460,6 @@
           </item>
           <item row="1" column="3">
            <widget class="QLabel" name="pointsLabel">
-            <property name="minimumSize">
-             <size>
-              <width>50</width>
-              <height>0</height>
-             </size>
-            </property>
             <property name="text">
              <string>Points:</string>
             </property>
@@ -623,12 +467,6 @@
           </item>
           <item row="1" column="4">
            <widget class="QSpinBox" name="points">
-            <property name="maximumSize">
-             <size>
-              <width>90</width>
-              <height>24</height>
-             </size>
-            </property>
             <property name="minimum">
              <number>1</number>
             </property>
@@ -643,12 +481,6 @@
           </item>
           <item row="2" column="1">
            <widget class="QLineEdit" name="centerZ">
-            <property name="maximumSize">
-             <size>
-              <width>90</width>
-              <height>24</height>
-             </size>
-            </property>
             <property name="text">
              <string>0.0</string>
             </property>
@@ -669,18 +501,6 @@
          <layout class="QGridLayout">
           <item row="0" column="0">
            <widget class="QLabel" name="xStartLabel">
-            <property name="minimumSize">
-             <size>
-              <width>50</width>
-              <height>0</height>
-             </size>
-            </property>
-            <property name="maximumSize">
-             <size>
-              <width>50</width>
-              <height>16777215</height>
-             </size>
-            </property>
             <property name="text">
              <string>Start X:</string>
             </property>
@@ -688,18 +508,6 @@
           </item>
           <item row="0" column="1">
            <widget class="QLineEdit" name="startX">
-            <property name="minimumSize">
-             <size>
-              <width>90</width>
-              <height>0</height>
-             </size>
-            </property>
-            <property name="maximumSize">
-             <size>
-              <width>90</width>
-              <height>24</height>
-             </size>
-            </property>
             <property name="text">
              <string>0.0</string>
             </property>
@@ -707,18 +515,6 @@
           </item>
           <item row="0" column="3">
            <widget class="QLabel" name="xEndLabel">
-            <property name="minimumSize">
-             <size>
-              <width>55</width>
-              <height>0</height>
-             </size>
-            </property>
-            <property name="maximumSize">
-             <size>
-              <width>50</width>
-              <height>16777215</height>
-             </size>
-            </property>
             <property name="text">
              <string>End X:</string>
             </property>
@@ -726,18 +522,6 @@
           </item>
           <item row="0" column="4" colspan="2">
            <widget class="QLineEdit" name="endX">
-            <property name="minimumSize">
-             <size>
-              <width>90</width>
-              <height>0</height>
-             </size>
-            </property>
-            <property name="maximumSize">
-             <size>
-              <width>90</width>
-              <height>24</height>
-             </size>
-            </property>
             <property name="text">
              <string>0.0</string>
             </property>
@@ -752,12 +536,6 @@
           </item>
           <item row="1" column="1">
            <widget class="QLineEdit" name="startY">
-            <property name="maximumSize">
-             <size>
-              <width>90</width>
-              <height>24</height>
-             </size>
-            </property>
             <property name="text">
              <string>0.0</string>
             </property>
@@ -772,12 +550,6 @@
           </item>
           <item row="1" column="4" colspan="2">
            <widget class="QLineEdit" name="endY">
-            <property name="maximumSize">
-             <size>
-              <width>90</width>
-              <height>24</height>
-             </size>
-            </property>
             <property name="text">
              <string>0.0</string>
             </property>
@@ -792,12 +564,6 @@
           </item>
           <item row="2" column="1">
            <widget class="QLineEdit" name="startZ">
-            <property name="maximumSize">
-             <size>
-              <width>90</width>
-              <height>24</height>
-             </size>
-            </property>
             <property name="text">
              <string>0.0</string>
             </property>
@@ -812,12 +578,6 @@
           </item>
           <item row="2" column="4" colspan="2">
            <widget class="QLineEdit" name="endZ">
-            <property name="maximumSize">
-             <size>
-              <width>90</width>
-              <height>24</height>
-             </size>
-            </property>
             <property name="text">
              <string>0.0</string>
             </property>
@@ -832,12 +592,6 @@
           </item>
           <item row="3" column="1">
            <widget class="QSpinBox" name="lines">
-            <property name="maximumSize">
-             <size>
-              <width>90</width>
-              <height>24</height>
-             </size>
-            </property>
             <property name="minimum">
              <number>1</number>
             </property>

--- a/ElmerGUI/Application/vtkpost/surface.ui
+++ b/ElmerGUI/Application/vtkpost/surface.ui
@@ -24,18 +24,6 @@
        <layout class="QHBoxLayout">
         <item>
          <widget class="QLabel" name="surfaceLabel">
-          <property name="minimumSize">
-           <size>
-            <width>50</width>
-            <height>0</height>
-           </size>
-          </property>
-          <property name="maximumSize">
-           <size>
-            <width>50</width>
-            <height>16777215</height>
-           </size>
-          </property>
           <property name="text">
            <string>Surface:</string>
           </property>
@@ -43,18 +31,12 @@
         </item>
         <item>
          <widget class="QComboBox" name="surfaceCombo">
-          <property name="minimumSize">
-           <size>
-            <width>180</width>
-            <height>0</height>
-           </size>
-          </property>
-          <property name="maximumSize">
-           <size>
-            <width>16777215</width>
-            <height>24</height>
-           </size>
-          </property>
+  <property name="sizePolicy">
+   <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+    <horstretch>0</horstretch>
+    <verstretch>0</verstretch>
+   </sizepolicy>
+  </property>
          </widget>
         </item>
         <item>
@@ -77,12 +59,6 @@
        <layout class="QGridLayout">
         <item row="0" column="0">
          <widget class="QLabel" name="minLabel">
-          <property name="minimumSize">
-           <size>
-            <width>50</width>
-            <height>0</height>
-           </size>
-          </property>
           <property name="text">
            <string>Min:</string>
           </property>
@@ -90,12 +66,6 @@
         </item>
         <item row="0" column="1">
          <widget class="QLineEdit" name="minEdit">
-          <property name="maximumSize">
-           <size>
-            <width>16777215</width>
-            <height>24</height>
-           </size>
-          </property>
          </widget>
         </item>
         <item row="0" column="2">
@@ -107,12 +77,6 @@
         </item>
         <item row="0" column="3">
          <widget class="QLineEdit" name="maxEdit">
-          <property name="maximumSize">
-           <size>
-            <width>16777215</width>
-            <height>24</height>
-           </size>
-          </property>
          </widget>
         </item>
         <item row="1" column="3">

--- a/ElmerGUI/Application/vtkpost/text.ui
+++ b/ElmerGUI/Application/vtkpost/text.ui
@@ -26,12 +26,6 @@
        <layout class="QHBoxLayout" >
         <item>
          <widget class="QLabel" name="textLabel" >
-          <property name="minimumSize" >
-           <size>
-            <width>50</width>
-            <height>0</height>
-           </size>
-          </property>
           <property name="text" >
            <string>Text:</string>
           </property>
@@ -39,12 +33,6 @@
         </item>
         <item>
          <widget class="QLineEdit" name="textEdit" >
-          <property name="maximumSize" >
-           <size>
-            <width>16777215</width>
-            <height>24</height>
-           </size>
-          </property>
           <property name="text" >
            <string>Message</string>
           </property>
@@ -56,12 +44,6 @@
        <layout class="QHBoxLayout" >
         <item>
          <widget class="QLabel" name="posXLabel" >
-          <property name="minimumSize" >
-           <size>
-            <width>50</width>
-            <height>0</height>
-           </size>
-          </property>
           <property name="text" >
            <string>PosX:</string>
           </property>
@@ -69,12 +51,6 @@
         </item>
         <item>
          <widget class="QLineEdit" name="posxEdit" >
-          <property name="maximumSize" >
-           <size>
-            <width>16777215</width>
-            <height>24</height>
-           </size>
-          </property>
           <property name="text" >
            <string>10</string>
           </property>
@@ -82,12 +58,6 @@
         </item>
         <item>
          <widget class="QLabel" name="posYLabel" >
-          <property name="minimumSize" >
-           <size>
-            <width>50</width>
-            <height>0</height>
-           </size>
-          </property>
           <property name="text" >
            <string>PosY:</string>
           </property>
@@ -95,12 +65,6 @@
         </item>
         <item>
          <widget class="QLineEdit" name="posyEdit" >
-          <property name="maximumSize" >
-           <size>
-            <width>16777215</width>
-            <height>24</height>
-           </size>
-          </property>
           <property name="text" >
            <string>10</string>
           </property>
@@ -149,12 +113,6 @@
        <layout class="QHBoxLayout" >
         <item>
          <widget class="QLabel" name="fontLabel" >
-          <property name="maximumSize" >
-           <size>
-            <width>50</width>
-            <height>16777215</height>
-           </size>
-          </property>
           <property name="text" >
            <string>Type:</string>
           </property>
@@ -162,12 +120,12 @@
         </item>
         <item>
          <widget class="QComboBox" name="comboBox" >
-          <property name="maximumSize" >
-           <size>
-            <width>16777215</width>
-            <height>24</height>
-           </size>
-          </property>
+  <property name="sizePolicy">
+   <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+    <horstretch>0</horstretch>
+    <verstretch>0</verstretch>
+   </sizepolicy>
+  </property>
           <item>
            <property name="text" >
             <string>Arial</string>
@@ -177,12 +135,6 @@
         </item>
         <item>
          <widget class="QLabel" name="label" >
-          <property name="maximumSize" >
-           <size>
-            <width>50</width>
-            <height>16777215</height>
-           </size>
-          </property>
           <property name="text" >
            <string>Size:</string>
           </property>
@@ -190,12 +142,6 @@
         </item>
         <item>
          <widget class="QSpinBox" name="size" >
-          <property name="maximumSize" >
-           <size>
-            <width>75</width>
-            <height>24</height>
-           </size>
-          </property>
           <property name="minimum" >
            <number>1</number>
           </property>

--- a/ElmerGUI/Application/vtkpost/timestep.ui
+++ b/ElmerGUI/Application/vtkpost/timestep.ui
@@ -26,12 +26,6 @@
        <layout class="QHBoxLayout" >
         <item>
          <widget class="QLabel" name="timeStepLabel" >
-          <property name="minimumSize" >
-           <size>
-            <width>50</width>
-            <height>0</height>
-           </size>
-          </property>
           <property name="text" >
            <string>Step:</string>
           </property>
@@ -39,18 +33,6 @@
         </item>
         <item>
          <widget class="QSpinBox" name="timeStep" >
-          <property name="minimumSize" >
-           <size>
-            <width>80</width>
-            <height>0</height>
-           </size>
-          </property>
-          <property name="maximumSize" >
-           <size>
-            <width>16777215</width>
-            <height>24</height>
-           </size>
-          </property>
           <property name="minimum" >
            <number>1</number>
           </property>
@@ -74,12 +56,6 @@
         </item>
         <item>
          <widget class="QPushButton" name="applyButton" >
-          <property name="maximumSize" >
-           <size>
-            <width>16777215</width>
-            <height>24</height>
-           </size>
-          </property>
           <property name="text" >
            <string>Apply</string>
           </property>
@@ -110,18 +86,6 @@
         </item>
         <item row="0" column="1" >
          <widget class="QSpinBox" name="start" >
-          <property name="minimumSize" >
-           <size>
-            <width>80</width>
-            <height>0</height>
-           </size>
-          </property>
-          <property name="maximumSize" >
-           <size>
-            <width>16777215</width>
-            <height>24</height>
-           </size>
-          </property>
           <property name="minimum" >
            <number>1</number>
           </property>
@@ -158,12 +122,6 @@
         </item>
         <item row="0" column="4" >
          <widget class="QSpinBox" name="increment" >
-          <property name="maximumSize" >
-           <size>
-            <width>16777215</width>
-            <height>24</height>
-           </size>
-          </property>
           <property name="minimum" >
            <number>1</number>
           </property>
@@ -174,12 +132,6 @@
         </item>
         <item row="1" column="0" >
          <widget class="QLabel" name="stopLabel" >
-          <property name="minimumSize" >
-           <size>
-            <width>50</width>
-            <height>0</height>
-           </size>
-          </property>
           <property name="text" >
            <string>Stop:</string>
           </property>
@@ -187,18 +139,6 @@
         </item>
         <item row="1" column="1" >
          <widget class="QSpinBox" name="stop" >
-          <property name="minimumSize" >
-           <size>
-            <width>70</width>
-            <height>0</height>
-           </size>
-          </property>
-          <property name="maximumSize" >
-           <size>
-            <width>16777215</width>
-            <height>24</height>
-           </size>
-          </property>
           <property name="minimum" >
            <number>1</number>
           </property>
@@ -209,12 +149,6 @@
         </item>
         <item row="1" column="4" >
          <widget class="QPushButton" name="loopButton" >
-          <property name="maximumSize" >
-           <size>
-            <width>16777215</width>
-            <height>24</height>
-           </size>
-          </property>
           <property name="text" >
            <string>Loop</string>
           </property>
@@ -238,12 +172,6 @@
        <layout class="QGridLayout" >
         <item row="0" column="0" >
          <widget class="QLabel" name="doBeforeLabel" >
-          <property name="minimumSize" >
-           <size>
-            <width>50</width>
-            <height>0</height>
-           </size>
-          </property>
           <property name="text" >
            <string>Cmd:</string>
           </property>
@@ -251,18 +179,6 @@
         </item>
         <item row="0" column="1" >
          <widget class="QLineEdit" name="doBefore" >
-          <property name="minimumSize" >
-           <size>
-            <width>305</width>
-            <height>0</height>
-           </size>
-          </property>
-          <property name="maximumSize" >
-           <size>
-            <width>16777215</width>
-            <height>24</height>
-           </size>
-          </property>
          </widget>
         </item>
         <item row="1" column="1" >
@@ -294,12 +210,6 @@
         </item>
         <item row="1" column="0" >
          <widget class="QLabel" name="label_2" >
-          <property name="minimumSize" >
-           <size>
-            <width>50</width>
-            <height>0</height>
-           </size>
-          </property>
           <property name="text" >
            <string>Directory:</string>
           </property>
@@ -307,12 +217,6 @@
         </item>
         <item row="1" column="1" >
          <widget class="QLineEdit" name="saveDirectory" >
-          <property name="maximumSize" >
-           <size>
-            <width>16777215</width>
-            <height>24</height>
-           </size>
-          </property>
           <property name="text" >
            <string>.</string>
           </property>

--- a/ElmerGUI/Application/vtkpost/vector.ui
+++ b/ElmerGUI/Application/vtkpost/vector.ui
@@ -26,18 +26,6 @@
        <layout class="QHBoxLayout" >
         <item>
          <widget class="QLabel" name="vectorLabel" >
-          <property name="minimumSize" >
-           <size>
-            <width>50</width>
-            <height>0</height>
-           </size>
-          </property>
-          <property name="maximumSize" >
-           <size>
-            <width>50</width>
-            <height>16777215</height>
-           </size>
-          </property>
           <property name="text" >
            <string>Vector:</string>
           </property>
@@ -45,18 +33,12 @@
         </item>
         <item>
          <widget class="QComboBox" name="vectorCombo" >
-          <property name="minimumSize" >
-           <size>
-            <width>280</width>
-            <height>0</height>
-           </size>
-          </property>
-          <property name="maximumSize" >
-           <size>
-            <width>16777215</width>
-            <height>24</height>
-           </size>
-          </property>
+  <property name="sizePolicy">
+   <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+    <horstretch>0</horstretch>
+    <verstretch>0</verstretch>
+   </sizepolicy>
+  </property>
          </widget>
         </item>
        </layout>
@@ -65,18 +47,6 @@
        <layout class="QHBoxLayout" >
         <item>
          <widget class="QLabel" name="scaleLabel" >
-          <property name="minimumSize" >
-           <size>
-            <width>50</width>
-            <height>0</height>
-           </size>
-          </property>
-          <property name="maximumSize" >
-           <size>
-            <width>50</width>
-            <height>16777215</height>
-           </size>
-          </property>
           <property name="text" >
            <string>Length:</string>
           </property>
@@ -84,18 +54,6 @@
         </item>
         <item>
          <widget class="QSpinBox" name="scaleSpin" >
-          <property name="minimumSize" >
-           <size>
-            <width>50</width>
-            <height>0</height>
-           </size>
-          </property>
-          <property name="maximumSize" >
-           <size>
-            <width>16777215</width>
-            <height>24</height>
-           </size>
-          </property>
           <property name="minimum" >
            <number>1</number>
           </property>
@@ -119,12 +77,6 @@
         </item>
         <item>
          <widget class="QSpinBox" name="qualitySpin" >
-          <property name="maximumSize" >
-           <size>
-            <width>16777215</width>
-            <height>24</height>
-           </size>
-          </property>
           <property name="minimum" >
            <number>2</number>
           </property>
@@ -155,18 +107,6 @@
         </item>
         <item>
          <widget class="QSpinBox" name="everyNth" >
-          <property name="minimumSize" >
-           <size>
-            <width>50</width>
-            <height>0</height>
-           </size>
-          </property>
-          <property name="maximumSize" >
-           <size>
-            <width>16777215</width>
-            <height>24</height>
-           </size>
-          </property>
           <property name="minimum" >
            <number>1</number>
           </property>
@@ -264,18 +204,6 @@
        <layout class="QHBoxLayout" >
         <item>
          <widget class="QLabel" name="lengthLabel" >
-          <property name="minimumSize" >
-           <size>
-            <width>50</width>
-            <height>0</height>
-           </size>
-          </property>
-          <property name="maximumSize" >
-           <size>
-            <width>50</width>
-            <height>16777215</height>
-           </size>
-          </property>
           <property name="text" >
            <string>Color:</string>
           </property>
@@ -283,18 +211,12 @@
         </item>
         <item>
          <widget class="QComboBox" name="colorCombo" >
-          <property name="minimumSize" >
-           <size>
-            <width>180</width>
-            <height>0</height>
-           </size>
-          </property>
-          <property name="maximumSize" >
-           <size>
-            <width>16777215</width>
-            <height>24</height>
-           </size>
-          </property>
+  <property name="sizePolicy">
+   <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+    <horstretch>0</horstretch>
+    <verstretch>0</verstretch>
+   </sizepolicy>
+  </property>
          </widget>
         </item>
 		<item>
@@ -317,12 +239,6 @@
        <layout class="QGridLayout" >
         <item row="0" column="0" >
          <widget class="QLabel" name="minLabel" >
-          <property name="minimumSize" >
-           <size>
-            <width>50</width>
-            <height>0</height>
-           </size>
-          </property>
           <property name="text" >
            <string>Min:</string>
           </property>
@@ -330,22 +246,10 @@
         </item>
         <item row="0" column="1" >
          <widget class="QLineEdit" name="minVal" >
-          <property name="maximumSize" >
-           <size>
-            <width>16777215</width>
-            <height>24</height>
-           </size>
-          </property>
          </widget>
         </item>
         <item row="0" column="2" >
          <widget class="QLabel" name="maxLabel" >
-          <property name="minimumSize" >
-           <size>
-            <width>50</width>
-            <height>0</height>
-           </size>
-          </property>
           <property name="text" >
            <string>Max:</string>
           </property>
@@ -353,12 +257,6 @@
         </item>
         <item row="0" column="3" >
          <widget class="QLineEdit" name="maxVal" >
-          <property name="maximumSize" >
-           <size>
-            <width>16777215</width>
-            <height>24</height>
-           </size>
-          </property>
          </widget>
         </item>
         <item row="1" column="3" >
@@ -383,18 +281,6 @@
        <layout class="QHBoxLayout" >
         <item>
          <widget class="QLabel" name="thresholdVariableLabel" >
-          <property name="minimumSize" >
-           <size>
-            <width>50</width>
-            <height>0</height>
-           </size>
-          </property>
-          <property name="maximumSize" >
-           <size>
-            <width>50</width>
-            <height>16777215</height>
-           </size>
-          </property>
           <property name="text" >
            <string>Variable:</string>
           </property>
@@ -402,12 +288,12 @@
         </item>
         <item>
          <widget class="QComboBox" name="thresholdCombo" >
-          <property name="maximumSize" >
-           <size>
-            <width>16777215</width>
-            <height>24</height>
-           </size>
-          </property>
+  <property name="sizePolicy">
+   <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+    <horstretch>0</horstretch>
+    <verstretch>0</verstretch>
+   </sizepolicy>
+  </property>
          </widget>
         </item>
        </layout>
@@ -416,12 +302,6 @@
        <layout class="QGridLayout" >
         <item row="0" column="0" >
          <widget class="QLabel" name="thresholdMinLabel" >
-          <property name="minimumSize" >
-           <size>
-            <width>50</width>
-            <height>0</height>
-           </size>
-          </property>
           <property name="text" >
            <string>Min:</string>
           </property>
@@ -429,22 +309,10 @@
         </item>
         <item row="0" column="1" >
          <widget class="QLineEdit" name="thresholdMin" >
-          <property name="maximumSize" >
-           <size>
-            <width>16777215</width>
-            <height>24</height>
-           </size>
-          </property>
          </widget>
         </item>
         <item row="0" column="2" >
          <widget class="QLabel" name="thresholdMaxlabel" >
-          <property name="minimumSize" >
-           <size>
-            <width>50</width>
-            <height>0</height>
-           </size>
-          </property>
           <property name="text" >
            <string>Max:</string>
           </property>
@@ -452,12 +320,6 @@
         </item>
         <item row="0" column="3" >
          <widget class="QLineEdit" name="thresholdMax" >
-          <property name="maximumSize" >
-           <size>
-            <width>16777215</width>
-            <height>24</height>
-           </size>
-          </property>
          </widget>
         </item>
         <item row="1" column="0" colspan="2" >


### PR DESCRIPTION
This PR is to improve GUI:

- The size of widgets in VTKpost (Surfaces, Vectors, Isocontours, etc.) were adjusted to avoid collapsing in high scaling display setting as shown in the picture. This was done by deleting maximum widget size information from .ui file

![X250 (vectors window)](https://user-images.githubusercontent.com/53612710/215263015-00baa835-cd4e-4c34-9f15-ac595a68b2d8.png

- Fixed bug of unexpectedly selecting black color when color selection action was canceled in ElmerGUI.

Hope this helps. -Saeki