### PR TITLE
Fix solver specific option in ElmerGUI, here are the before and after…

### DIFF
--- a/ElmerGUI/Application/src/sifgenerator.cpp
+++ b/ElmerGUI/Application/src/sifgenerator.cpp
@@ -905,7 +905,7 @@ bool SifGenerator::parseSolverSpecificTab(DynamicEditor *solEditor, const QStrin
       if( entry.elem.attribute("Widget", "") != "Edit") continue;
 
       QLineEdit *l = static_cast<QLineEdit*>(entry.widget);
-      QString varName = l->text().trimmed();
+      QString varName = l->text().simplified();
 
       if ( varName == "" ) continue;
 
@@ -929,8 +929,12 @@ bool SifGenerator::parseSolverSpecificTab(DynamicEditor *solEditor, const QStrin
           if (i>1) varName = varName + " ";
           varName = varName + subVarName + ":" + QString::number(dofs);
 
-          if ( subDofSplit.count() > 1 )
+          if ( subDofSplit.count() > 1 ) {
             subVarName = subDofSplit.at(1).trimmed();
+            if ( subDofSplit.count() > 2 ) {
+               subVarName = subVarName + " " + subDofSplit.at(2);
+            }
+          }
         }
         varName = varName + "]";
         addSifLine( "  " + labelName + " = ", varName );


### PR DESCRIPTION
… cases

before:
Variable = Potential[Potential Re:1 Potential:1]
after:
Variable = Potential[Potential Re:1 Potential Im:1]

Based on the bug report in the forums:
[http://www.elmerfem.org/forum/viewtopic.php?p=27916#p27916](url)

