### PR TITLE
Fix for Output var name longer than Var name

### DIFF
--- a/fem/src/ModelDescription.F90
+++ b/fem/src/ModelDescription.F90
@@ -3776,6 +3776,7 @@ CONTAINS
               VarName = ListGetString( ResList,'Output Variable '//I2S(j), Found )
               IF( .NOT. Found ) EXIT
               k2 = LEN_TRIM(VarName)
+	      IF (len(Var % Name) < k2) CYCLE
               IF( VarName(1:k2) == Var % Name(1:k2) ) THEN
                 SaveThis = .TRUE.
                 ! This makes it possible to request saving of vectors


### PR DESCRIPTION
Fix for the case when the Output variable name is longer than the Variable name.

Example:

Simulation
...
   Output variable 4 = "relative permeability re e"
...
End

Causes the following error
SingleSolver: Solver Equation string is: post process data SaveResult: ----------------------------------------- SaveResult: Saving results to file: mesh/h1.result At line 3779 of file /home/vencels/Projects/Elmer/elmerfem-orig/fem/src/ModelDescription.F90 Fortran runtime error: Substring out of bounds: upper bound (26) of 'var' exceeds string length (19)