### PR TITLE
B field fix in the gap

### DIFF
--- a/fem/src/modules/MagnetoDynamics/CalcFields.F90
+++ b/fem/src/modules/MagnetoDynamics/CalcFields.F90
@@ -3047,7 +3047,7 @@ CONTAINS
               B(k,3) = 0._dp
             END IF
           CASE(3)
-            B(k,:) = normal*sum( SOL(k,np+1:nd)* RotWBasis(1:nd-np,3) )
+            B(k,:) = normal*MATMUL( SOL(k,np+1:nd), RotWBasis(1:nd-np,:) )
           END SELECT
         END DO
 


### PR DESCRIPTION
The current implementation considers that the gap should be oriented in the z-direction. B field was 0 for all other directions therefore magnetic field energy stored in the gap too. With the fix we allow it to be oriented in any direction.