### PR TITLE
GUI multi selection

### DIFF
--- a/ElmerGUI/Application/src/glwidget.cpp
+++ b/ElmerGUI/Application/src/glwidget.cpp
@@ -195,10 +195,6 @@ GLWidget::GLWidget(QWidget *parent)
   helpers = new Helpers;
   meshutils = new Meshutils;
 
-  ctrlPressed = false;
-  shiftPressed = false;
-  altPressed = false;
-
   // Coordinate axis:
   quadric_axis = gluNewQuadric();
 
@@ -641,15 +637,7 @@ void GLWidget::focusInEvent(QFocusEvent *event)
 //-----------------------------------------------------------------------------
 void GLWidget::keyPressEvent(QKeyEvent *event)
 {
-  if(event->key() == Qt::Key_Control)
-    ctrlPressed = true;
-
   if(event->key() == Qt::Key_Shift)
-    shiftPressed = true;
-
-  if((event->key() == Qt::Key_Alt) || (event->key() == Qt::Key_AltGr))
-    altPressed = true;
-
   if(event->key() == Qt::Key_Escape)
     emit(escPressed());
 }
@@ -659,14 +647,6 @@ void GLWidget::keyPressEvent(QKeyEvent *event)
 //-----------------------------------------------------------------------------
 void GLWidget::keyReleaseEvent(QKeyEvent *event)
 {
-  if(event->key() == Qt::Key_Control)
-    ctrlPressed = false;
-
-  if(event->key() == Qt::Key_Shift)
-    shiftPressed = false;
-
-  if(event->key() == Qt::Key_Alt)
-    altPressed = false;
 }
 
 
@@ -895,7 +875,7 @@ void GLWidget::mouseDoubleClickEvent(QMouseEvent *event)
       l = getList(l->getParent());
 
     // if not ctrl pressed, rebuild all selected lists except this one:
-    if(!ctrlPressed) {
+    if(!(event->modifiers() & Qt::ControlModifier)) {
       for(i = 0; i < getLists(); i++) {
 	list_t *l2 = getList(i);
 	if(l2->isSelected() && (l2->getIndex() != l->getIndex())) {
@@ -953,7 +933,7 @@ void GLWidget::mouseDoubleClickEvent(QMouseEvent *event)
     // body selection:
     //----------------
     currentlySelectedBody = -1;
-    if(shiftPressed || bodyEditActive) {
+    if( (event->modifiers() & Qt::ShiftModifier) || bodyEditActive) {
 
       // determine the max bulk index
       int MAX_BULK_INDEX = -1;
@@ -1057,7 +1037,7 @@ void GLWidget::mouseDoubleClickEvent(QMouseEvent *event)
   body_selection_finished:
     
     // Emit result to mainwindow:
-    emit(signalBoundarySelected(l));
+    emit(signalBoundarySelected(l, event->modifiers()));
 
   } else {
 
@@ -1065,7 +1045,7 @@ void GLWidget::mouseDoubleClickEvent(QMouseEvent *event)
     dummylist.setNature(-1);
     dummylist.setType(-1);
     dummylist.setIndex(-1);
-    emit(signalBoundarySelected(&dummylist));
+    emit(signalBoundarySelected(&dummylist, event->modifiers()));
 
   }
 

--- a/ElmerGUI/Application/src/glwidget.cpp
+++ b/ElmerGUI/Application/src/glwidget.cpp
@@ -637,7 +637,6 @@ void GLWidget::focusInEvent(QFocusEvent *event)
 //-----------------------------------------------------------------------------
 void GLWidget::keyPressEvent(QKeyEvent *event)
 {
-  if(event->key() == Qt::Key_Shift)
   if(event->key() == Qt::Key_Escape)
     emit(escPressed());
 }

--- a/ElmerGUI/Application/src/glwidget.h
+++ b/ElmerGUI/Application/src/glwidget.h
@@ -159,9 +159,6 @@ public:
   bool stateDrawBodyIndex;
   bool stateBcColors;
   bool stateBodyColors;
-  bool ctrlPressed;
-  bool shiftPressed;
-  bool altPressed;
   bool bodyEditActive;
   bool stateUseBgImage;
   bool stateStretchBgImage;
@@ -182,7 +179,7 @@ public:
 public slots:
 
 signals:
-  void signalBoundarySelected(list_t*);
+  void signalBoundarySelected(list_t*, Qt::KeyboardModifiers);
   void escPressed();
 
 protected:

--- a/ElmerGUI/Application/src/mainwindow.cpp
+++ b/ElmerGUI/Application/src/mainwindow.cpp
@@ -202,8 +202,8 @@ MainWindow::MainWindow() {
           SLOT(menuBarTriggeredSlot(QAction *)));
 
   // glWidget emits (list_t*) when a boundary is selected by double clicking:
-  connect(glWidget, SIGNAL(signalBoundarySelected(list_t *)), this,
-          SLOT(boundarySelectedSlot(list_t *)));
+  connect(glWidget, SIGNAL(signalBoundarySelected(list_t *, Qt::KeyboardModifiers)), this,
+          SLOT(boundarySelectedSlot(list_t *, Qt::KeyboardModifiers)));
 
   // glWidget emits (void) when esc has been pressed:
   connect(glWidget, SIGNAL(escPressed()), this, SLOT(viewNormalModeSlot()));
@@ -6099,7 +6099,7 @@ void MainWindow::generateSifSlot() {
 
 // Boundary selected by double clicking (signaled by glWidget::select):
 //-----------------------------------------------------------------------------
-void MainWindow::boundarySelectedSlot(list_t *l) {
+void MainWindow::boundarySelectedSlot(list_t *l, Qt::KeyboardModifiers modifiers) {
   QString qs;
 
   if (l->getIndex() < 0) {
@@ -6131,10 +6131,7 @@ void MainWindow::boundarySelectedSlot(list_t *l) {
 
   // Open bc property sheet for selected boundary:
   //-----------------------------------------------
-  if (l->isSelected() && (glWidget->altPressed || bcEditActive)) {
-    glWidget->ctrlPressed = false;
-    glWidget->shiftPressed = false;
-    glWidget->altPressed = false;
+  if (l->isSelected() && ((modifiers & Qt::AltModifier) || bcEditActive)) {
 
     if (l->getNature() != PDE_BOUNDARY) {
       /*Ignore when double clicking a body of 2D geometry under boundary
@@ -6186,7 +6183,7 @@ void MainWindow::boundarySelectedSlot(list_t *l) {
 
   // boundary as a body treatment
   // ----------------------------
-  if (l->isSelected() && glWidget->ctrlPressed) {
+  if (l->isSelected() && (modifiers & Qt::ControlModifier)) {
 
     // renumbering:
     int n = glWidget->boundaryMap.value(l->getIndex());
@@ -6206,9 +6203,6 @@ void MainWindow::boundarySelectedSlot(list_t *l) {
     bodyEdit = boundaryEdit->bodyProperties;
 
     if (bodyEdit) {
-      glWidget->ctrlPressed = false;
-      glWidget->shiftPressed = false;
-      glWidget->altPressed = false;
 
       bodyEdit->setWindowTitle("Properties for body " +
                                QString::number(current));
@@ -6224,11 +6218,7 @@ void MainWindow::boundarySelectedSlot(list_t *l) {
   // Open body property sheet for selected body:
   //---------------------------------------------
   if ((glWidget->currentlySelectedBody >= 0) &&
-      (glWidget->shiftPressed || bodyEditActive)) {
-
-    glWidget->ctrlPressed = false;
-    glWidget->shiftPressed = false;
-    glWidget->altPressed = false;
+      ( (modifiers & Qt::ShiftModifier) || bodyEditActive)) {
 
     current = glWidget->currentlySelectedBody;
 

--- a/ElmerGUI/Application/src/mainwindow.h
+++ b/ElmerGUI/Application/src/mainwindow.h
@@ -205,7 +205,7 @@ private slots:
   void meshingTerminatedSlot(); // signal emitted by meshingThread
   void meshingFinishedSlot();   // signal emitted by meshingThread
 
-  void boundarySelectedSlot(list_t *); // signal emitted by glWidget
+  void boundarySelectedSlot(list_t *, Qt::KeyboardModifiers); // signal emitted by glWidget
   void doDivideSurfaceSlot(double);    // signal emitted by boundaryDivide
   void doDivideEdgeSlot(double);       // signal emitted by boundaryDivide
 

--- a/ElmerGUI/Application/src/objectbrowser.cpp
+++ b/ElmerGUI/Application/src/objectbrowser.cpp
@@ -175,8 +175,8 @@ ObjectBrowser::ObjectBrowser(QMainWindow *parent, Qt::WindowFlags flags)
   connect(mainwindow->edgeUnifyAct, SIGNAL(triggered()), this,
           SLOT(boundaryUnifiedSlot()));
 
-  connect(mainwindow->glWidget, SIGNAL(signalBoundarySelected(list_t *)), this,
-          SLOT(boundarySelectedSlot(list_t *)));
+  connect(mainwindow->glWidget, SIGNAL(signalBoundarySelected(list_t *, Qt::KeyboardModifiers)), this,
+          SLOT(boundarySelectedSlot(list_t *, Qt::KeyboardModifiers)));
 
   connect(mainwindow->meshingThread, SIGNAL(started()), this,
           SLOT(meshingStartedSlot()));
@@ -407,7 +407,7 @@ void ObjectBrowser::treeItemDoubleClickedSlot(QTreeWidgetItem *item,
     mainwindow->glWidget->bodyEditActive = false;
     mainwindow->bcEditAct->setChecked(true);
     mainwindow->bodyEditAct->setChecked(false);
-    mainwindow->boundarySelectedSlot(l);
+    mainwindow->boundarySelectedSlot(l, Qt::NoModifier);
     // mainwindow->bcEditActive = bcEditActive;
     // mainwindow->bodyEditActive = bodyEditActive;
     connect1(
@@ -437,7 +437,7 @@ void ObjectBrowser::treeItemDoubleClickedSlot(QTreeWidgetItem *item,
     mainwindow->glWidget->bodyEditActive = false;
     mainwindow->bcEditAct->setChecked(true);
     mainwindow->bodyEditAct->setChecked(false);
-    mainwindow->boundarySelectedSlot(l);
+    mainwindow->boundarySelectedSlot(l, Qt::NoModifier);
     // mainwindow->bcEditActive = bcEditActive;
     // mainwindow->bodyEditActive = bodyEditActive;
     connect1(
@@ -465,7 +465,7 @@ void ObjectBrowser::treeItemDoubleClickedSlot(QTreeWidgetItem *item,
     mainwindow->glWidget->bodyEditActive = true;
     mainwindow->bcEditAct->setChecked(false);
     mainwindow->bodyEditAct->setChecked(true);
-    mainwindow->boundarySelectedSlot(l);
+    mainwindow->boundarySelectedSlot(l, Qt::NoModifier);
     // mainwindow->bcEditActive = bcEditActive;
     // mainwindow->bodyEditActive = bodyEditActive;
     connect1(pe,
@@ -503,7 +503,7 @@ void ObjectBrowser::treeItemDoubleClickedSlot(QTreeWidgetItem *item,
     mainwindow->glWidget->bodyEditActive = true;
     mainwindow->bcEditAct->setChecked(false);
     mainwindow->bodyEditAct->setChecked(true);
-    mainwindow->boundarySelectedSlot(l);
+    mainwindow->boundarySelectedSlot(l, Qt::NoModifier);
     // mainwindow->bcEditActive = bcEditActive;
     // mainwindow->bodyEditActive = bodyEditActive;
     connect1(pe,
@@ -1016,7 +1016,7 @@ void ObjectBrowser::boundaryDividedSlot(double d) {
   boundaryPropertyParentTreeItem->addChild(new QTreeWidgetItem()); // dummy
 }
 
-void ObjectBrowser::boundarySelectedSlot(list_t *l) {
+void ObjectBrowser::boundarySelectedSlot(list_t *l, Qt::KeyboardModifiers modifiers) {
 
   bodyPropertyParentTreeItem->setExpanded(true);
   boundaryPropertyParentTreeItem->setExpanded(true);
@@ -1059,7 +1059,7 @@ void ObjectBrowser::boundarySelectedSlot(list_t *l) {
 
   if (dialog == NULL) {
     cout << " could not find selected body/boundary in "
-            "ObjectBrowser::boundarySelectedSlot(list_t*).  list_t:"
+            "ObjectBrowser::boundarySelectedSlot(list_t*, Qt::KeyboardModifiers).  list_t:"
          << (qulonglong)l << endl;
     return;
   }
@@ -1067,7 +1067,7 @@ void ObjectBrowser::boundarySelectedSlot(list_t *l) {
   for (int i = 0; i < boundaryPropertyParentTreeItem->childCount(); i++) {
     QTreeWidgetItem *child = boundaryPropertyParentTreeItem->child(i);
     if (child->data(0, Qt::UserRole) == (qulonglong)dialog) {
-      tree->setCurrentItem(child);
+      if( !(modifiers & Qt::ControlModifier) )tree->setCurrentItem(child);
       BoundaryPropertyEditor *pe = (BoundaryPropertyEditor *)dialog;
       connect1(
           pe, SIGNAL(BoundaryComboChanged(BoundaryPropertyEditor *, QString)),
@@ -1083,7 +1083,7 @@ void ObjectBrowser::boundarySelectedSlot(list_t *l) {
   for (int i = 0; i < bodyPropertyParentTreeItem->childCount(); i++) {
     QTreeWidgetItem *child = bodyPropertyParentTreeItem->child(i);
     if (child->data(0, Qt::UserRole) == (qulonglong)dialog) {
-      tree->setCurrentItem(child);
+      if( !(modifiers & Qt::ControlModifier)) tree->setCurrentItem(child);
       BodyPropertyEditor *pe = (BodyPropertyEditor *)dialog;
       connect1(pe,
                SIGNAL(BodyMaterialComboChanged(BodyPropertyEditor *, QString)),
@@ -1747,9 +1747,7 @@ void ObjectBrowser::treeItemSelectionChangedSlot() {
   MainWindow *mainwindow = (MainWindow *)mainWindow;
   if (mainwindow->glWidget->getMesh() == NULL)
     return;
-  if (mainwindow->glWidget->ctrlPressed)
-    return; // ignore if selecting multiple surfaces/edges in glWidget to
-            // maintain the selection at glWidget
+
   QTreeWidgetItem *item = tree->currentItem();
 
   // select boundaries/bodies checked in DyanmicEditor

--- a/ElmerGUI/Application/src/objectbrowser.h
+++ b/ElmerGUI/Application/src/objectbrowser.h
@@ -89,7 +89,7 @@ private slots:
   void boundaryDividedSlot(double);
   void boundaryUnifiedSlot();
  
-  void boundarySelectedSlot(list_t*);
+  void boundarySelectedSlot(list_t*, Qt::KeyboardModifiers);
   
   void boundaryComboChanged(BoundaryPropertyEditor *,QString);
   void bodyComboChanged(BodyPropertyEditor *,QString);  


### PR DESCRIPTION
This PR aims to mitigate #411.  Three bool variables ctrlPressed, shiftPressed and altPressed were eliminated from GLWidget class. Instead,  MouseEvent::modifiers()  is directly referred during mouse event slots. Unfortunately I couldn't reproduce the issue maybe because my computer is cheap one. So I can't confirm this fix works, but hopefully solve the issue.