### PR TITLE
Implement post processing for homogenization

### DIFF
--- a/fem/src/modules/CircuitsAndDynamics.F90
+++ b/fem/src/modules/CircuitsAndDynamics.F90
@@ -1703,10 +1703,11 @@ SUBROUTINE CircuitsAndDynamicsHarmonic( Model,Solver,dt,TransientSimulation )
       CASE ('stranded')
         StrandedHomogenization = GetLogical(CompParams, 'Homogenization Model', Found)
         IF ( StrandedHomogenization ) THEN 
-          sigma_33 = 0._dp
-          sigmaim_33 = 0._dp
           sigma_33 = GetReal(CompParams, 'sigma 33', Found)
+          IF ( .NOT. Found ) sigma_33 = 0._dp
           sigmaim_33 = GetReal(CompParams, 'sigma 33 im', FoundIm)
+          IF ( .NOT. FoundIm ) sigmaim_33 = 0._dp
+          IF ( .NOT. Found .AND. .NOT. FoundIm ) CALL Fatal ('LocalMatrix', 'Homogenization Model sigma 33 not found!')
           IF ( .NOT. Found .AND. .NOT. FoundIm ) CALL Fatal ('AddComponentEquationsAndCouplings', &
               'Homogenization Model Sigma 33 not found!')
           Tcoef = CMPLX(0._dp, 0._dp, KIND=dp)

--- a/fem/src/modules/MagnetoDynamics/WhitneyAVHarmonicSolver.F90
+++ b/fem/src/modules/MagnetoDynamics/WhitneyAVHarmonicSolver.F90
@@ -1288,6 +1288,7 @@ END BLOCK
     REAL(KIND=dp) :: LocalLamThick, skind, babs, muder, AlocR(2,nd)
     REAL(KIND=dp) :: nu_11(nd), nuim_11(nd), nu_22(nd), nuim_22(nd)
     REAL(KIND=dp) :: nu_val, nuim_val
+    REAL(KIND=dp) :: sigma_33(nd), sigmaim_33(nd)
 
     COMPLEX(KIND=dp) :: mu, C(3,3), L(3), G(3), M(3), JfixPot(n), Nu(3,3)
     COMPLEX(KIND=dp) :: LocalLamCond, JAC(nd,nd), B_ip(3), Aloc(nd), &
@@ -1365,11 +1366,16 @@ END BLOCK
           nu_11 = GetReal(CompParams, 'nu 11', Found)
           nuim_11 = GetReal(CompParams, 'nu 11 im', FoundIm)
           IF ( .NOT. Found .AND. .NOT. FoundIm ) CALL Fatal ('LocalMatrix', 'Homogenization Model nu 11 not found!')
+
           nu_22 = 0._dp
           nuim_22 = 0._dp
           nu_22 = GetReal(CompParams, 'nu 22', Found)
           nuim_22 = GetReal(CompParams, 'nu 22 im', FoundIm)
-          IF ( .NOT. Found .AND. .NOT. FoundIm ) CALL Fatal ('LocalMatrix', 'Homogenization Model nu 22 not found!')
+          IF ( .NOT. Found .AND. .NOT. FoundIm ) CALL Fatal ('LocalMatrix', 'Homogenization Model nu 11 not found!')
+
+          ! Sigma 33 is not needed in because it does not exist in stranded coil
+          ! Its contribution is taken into account in the circuit module if explicit coil resistance is not used!
+
           UseRotM = .TRUE.
         END IF
       ELSE IF( CoilType == 'foil winding') THEN

--- a/fem/tests/circuits_harmonic_stranded_homogenization/sif/2241.sif
+++ b/fem/tests/circuits_harmonic_stranded_homogenization/sif/2241.sif
@@ -20,7 +20,7 @@ Simulation 1
    Steady State Max Iterations = 1
    BDF Order = 1
    Output Intervals = 1
-   Angular Frequency = $ 2*pi*10000
+   Angular Frequency = 376.991118431
 End
 Solver 1
    Exec Solver = Before all
@@ -104,6 +104,8 @@ Solver 7
    Potential Variable = String "A"
    Calculate Current Density = Logical True
    Loss Estimation = Logical True
+   Calculate Homogenization Loss = Logical True
+   Calculate Joule Heating = Logical True
    Steady State Convergence Tolerance = 0
    Linear System Solver = "Iterative"
    Linear System Preconditioning = None
@@ -117,7 +119,7 @@ Solver 8
    Exec Solver = After timestep
    Equation = "ResultOutput"
    Procedure = "ResultOutputSolve" "ResultOutputSolver"
-   Output File Name = 2241-results2
+   Output File Name = 2241-results
    Vtu format = Logical True
    Save Geometry Ids = Logical True
 End


### PR DESCRIPTION
Here we implement post processing for homogenization model. New field, called the "proximity loss", is created and it contains the proximity losses caused by the homogenization parameter `nu`. Skin losses are added to the existing joule losses.

@juharu could you check if this is OK. I ran tests, they seem fine.

FYI @raback 