### PR TITLE
Fix STOP statement to make it compatible with oldish ifort versions.

### DIFF
--- a/fem/tests/P2ndDerivatives/P2ndDerivativesTest.f90
+++ b/fem/tests/P2ndDerivatives/P2ndDerivativesTest.f90
@@ -266,7 +266,7 @@ CONTAINS
      scal = MAX(ABS(f1),ABS(f2))
      IF(ABS(f1-f2)>scal*eps) THEN
        PRINT*,f1,f2,ABS(f1-f2), '>', scal*eps, str
-       STOP str 
+       STOP "Test failed."
      END IF
 !------------------------------------------------------------------------------
    END SUBROUTINE CheckValue


### PR DESCRIPTION
In pre-2008 FORTRAN, the STOP statement could not be followed by a variable that represented a variable-length character string (character string literals were allowed though). For example, the following was allowed:

```
STOP
STOP 1234
STOP "Exiting now"
```

but the following was not allowed:

```
SUBROUTINE MyStop(str)
  CHARACTER (len=*) :: str
  STOP str
END SUBROUTINE MyStop
```

In more recent FORTRAN standards, all of the above are valid. However, while the newest versions of Intel FORTRAN accept all of the above, somewhat older versions (which are still in use in some supercomputing environments) do not accept the last syntax.

In order to make the code as compatible as possible with the Intel compilers, I suggest to replace every occurrence of the last syntax (I found only one) with another, more-universal, one.