### PR TITLE
Material loss exponent

### DIFF
--- a/fem/src/MagnetoDynamicsUtils.F90
+++ b/fem/src/MagnetoDynamicsUtils.F90
@@ -566,6 +566,69 @@
   END SUBROUTINE GetPermittivityC
 !------------------------------------------------------------------------------
 
+
+!------------------------------------------------------------------------------
+!> This gets keywords for a loss model that is needed by FourierLossSolver and
+!> MagnetoDynamicsCalcFields. There is an old and new format. 
+!------------------------------------------------------------------------------
+  SUBROUTINE GetLossExponents(vList,FreqPower,FieldPower,Ncomp,OldKeywords)
+!------------------------------------------------------------------------------
+    TYPE(ValueList_t),POINTER :: vList
+    REAL(KIND=dp) :: FreqPower(:), FieldPower(:)
+    INTEGER :: Ncomp
+    LOGICAL, OPTIONAL :: OldKeywords
+    
+    REAL(KIND=dp), POINTER :: WrkArray(:,:)
+    LOGICAL :: Found
+    INTEGER :: icomp
+    CHARACTER(*), PARAMETER :: Caller = 'GetLossExponents'
+
+    IF( PRESENT(OldKeywords) ) THEN
+      IF( OldKeywords ) THEN      
+        FreqPower(1) = GetCReal( vList,'Harmonic Loss Linear Frequency Exponent',Found )
+        IF( .NOT. Found ) FreqPower(1) = 1.0_dp
+        
+        FreqPower(2) = GetCReal( vList,'Harmonic Loss Quadratic Frequency Exponent',Found )
+        IF( .NOT. Found ) FreqPower(2) = 2.0_dp
+        
+        FieldPower(1) = GetCReal( vList,'Harmonic Loss Linear Exponent',Found ) 
+        IF( .NOT. Found ) FieldPower(1) = 2.0_dp
+        FieldPower(1) = FieldPower(1) / 2.0_dp
+        
+        FieldPower(2) = GetCReal( vList,'Harmonic Loss Quadratic Exponent',Found ) 
+        IF( .NOT. Found ) FieldPower(2) = 2.0_dp
+        FieldPower(2) = FieldPower(2) / 2.0_dp    
+        RETURN
+      END IF
+    END IF
+    
+    WrkArray => ListGetConstRealArray( vList,'Harmonic Loss Frequency Exponent',Found )    
+    IF( Found ) THEN 
+      IF( SIZE( WrkArray,1 ) < Ncomp ) THEN
+        CALL Fatal(Caller,'> Harmonic Loss Frequency Exponent < too small')
+      END IF
+      FreqPower(1:Ncomp) = WrkArray(1:Ncomp,1)
+    ELSE       
+      DO icomp = 1, Ncomp
+        FreqPower(icomp) = GetCReal( vList,'Harmonic Loss Frequency Exponent '//I2S(icomp) )
+      END DO
+    END IF
+
+    WrkArray => ListGetConstRealArray( vList,'Harmonic Loss Field Exponent',Found )
+    IF( Found ) THEN
+      IF( SIZE( WrkArray,1 ) < Ncomp ) THEN
+        CALL Fatal(Caller,'> Harmonic Loss Field Exponent < too small')
+      END IF
+      FieldPower(1:Ncomp) = WrkArray(1:Ncomp,1)        
+    ELSE
+      DO icomp = 1, Ncomp
+        FieldPower(icomp) = GetCReal( vList,'Harmonic Loss Field Exponent '//I2S(icomp) )
+      END DO
+    END IF    
+    
+  END SUBROUTINE GetLossExponents
+
+  
 !------------------------------------------------------------------------------
  END MODULE MGDynMaterialUtils
 !------------------------------------------------------------------------------

--- a/fem/src/modules/FourierLoss.F90
+++ b/fem/src/modules/FourierLoss.F90
@@ -830,8 +830,8 @@ CONTAINS
 
     DG = GetLogical(SolverParams,'Discontinuous Galerkin',Found )
 
-    MaterialExponents = GetLogical( SolverParams,'Use Material Loss Exponents', Found ) 
-
+    
+    MaterialExponents = ListCheckPrefixAnyMaterial( Model,'Harmonic Loss Frequency Exponent') 
     IF(.NOT. MaterialExponents) THEN
       CALL GetLossExponents(SolverParams,FreqPower,FieldPower)
     END IF

--- a/fem/src/modules/FourierLoss.F90
+++ b/fem/src/modules/FourierLoss.F90
@@ -754,6 +754,40 @@ CONTAINS
   END SUBROUTINE LocalFourierTransform
 
 
+  SUBROUTINE GetLossExponents(vList,FreqPower,FieldPower)
+    TYPE(ValueList_t),POINTER :: vList
+    REAL(KIND=dp) :: FreqPower(:), FieldPower(:)
+
+    REAL(KIND=dp), POINTER :: WrkArray(:,:)
+    INTEGER :: icomp
+        
+    WrkArray => ListGetConstRealArray( vList,'Harmonic Loss Frequency Exponent',Found )
+    IF( Found ) THEN 
+      IF( SIZE( WrkArray,1 ) < Ncomp ) THEN
+        CALL Fatal(Caller,'> Harmonic Loss Frequency Exponent < too small')
+      END IF
+      FreqPower(1:Ncomp) = WrkArray(1:Ncomp,1)
+    ELSE       
+      DO icomp = 1, Ncomp
+        FreqPower(icomp) = GetCReal( vList,'Harmonic Loss Frequency Exponent '//I2S(icomp) )
+      END DO
+    END IF
+
+    WrkArray => ListGetConstRealArray( vList,'Harmonic Loss Field Exponent',Found )
+    IF( Found ) THEN
+      IF( SIZE( WrkArray,1 ) < Ncomp ) THEN
+        CALL Fatal(Caller,'> Harmonic Loss Field Exponent < too small')
+      END IF
+      FieldPower(1:Ncomp) = WrkArray(1:Ncomp,1)        
+    ELSE
+      DO icomp = 1, Ncomp
+        FieldPower(icomp) = GetCReal( vList,'Harmonic Loss Field Exponent '//I2S(icomp) )
+      END DO
+    END IF
+    
+  END SUBROUTINE GetLossExponents
+  
+
   !------------------------------------------------------------------------------
   ! Assembly the mass matrix and r.h.s. for computing the losses using the 
   ! Galerkin method.
@@ -776,7 +810,7 @@ CONTAINS
     REAL(KIND=dp), ALLOCATABLE :: Basis(:), dBasisdx(:,:)
     REAL(KIND=dp), ALLOCATABLE :: WBasis(:,:), RotWBasis(:,:)
     INTEGER, ALLOCATABLE :: Indeces(:), Pivot(:)
-    LOGICAL :: DG, Erroneous
+    LOGICAL :: DG, Erroneous, MaterialExponents
     
     SAVE Nodes
     
@@ -795,31 +829,13 @@ CONTAINS
     Freq = Omega / (2*PI)
 
     DG = GetLogical(SolverParams,'Discontinuous Galerkin',Found )
-    
-    WrkArray => ListGetConstRealArray( SolverParams,'Harmonic Loss Frequency Exponent',Found )
-    IF( Found ) THEN 
-      IF( SIZE( WrkArray,1 ) < Ncomp ) THEN
-        CALL Fatal(Caller,'> Harmonic Loss Frequency Exponent < too small')
-      END IF
-      FreqPower(1:Ncomp) = WrkArray(1:Ncomp,1)
-    ELSE       
-      DO icomp = 1, Ncomp
-        FreqPower(icomp) = GetCReal( SolverParams,'Harmonic Loss Frequency Exponent '//I2S(icomp) )
-      END DO
-    END IF
 
-    WrkArray => ListGetConstRealArray( SolverParams,'Harmonic Loss Field Exponent',Found )
-    IF( Found ) THEN
-      IF( SIZE( WrkArray,1 ) < Ncomp ) THEN
-        CALL Fatal(Caller,'> Harmonic Loss Field Exponent < too small')
-      END IF
-      FieldPower(1:Ncomp) = WrkArray(1:Ncomp,1)        
-    ELSE
-      DO icomp = 1, Ncomp
-        FieldPower(icomp) = GetCReal( SolverParams,'Harmonic Loss Field Exponent '//I2S(icomp) )
-      END DO
-    END IF
+    MaterialExponents = GetLogical( SolverParams,'Use Material Loss Exponents', Found ) 
 
+    IF(.NOT. MaterialExponents) THEN
+      CALL GetLossExponents(SolverParams,FreqPower,FieldPower)
+    END IF
+      
     ! Sum over the loss for each frequency, each body, and for the combined effect
     SeriesLoss = 0.0_dp
     BodyLoss = 0.0_dp
@@ -855,7 +871,10 @@ CONTAINS
       BodyId = Element % BodyId
       Material => GetMaterial()
 
-      
+      IF(MaterialExponents) THEN
+        CALL GetLossExponents(Material,FreqPower,FieldPower)
+      END IF
+
       DO t=1,IntegStuff % n
         IF( DirectField ) THEN
           ! For direct field we don't need the curl i.e. no dBasisdx needed

--- a/fem/src/modules/MagnetoDynamics/CalcFields.F90
+++ b/fem/src/modules/MagnetoDynamics/CalcFields.F90
@@ -970,7 +970,7 @@ END SUBROUTINE MagnetoDynamicsCalcFields_Init
      LossN = 2 
           
      IF(.NOT. MaterialExponents) THEN
-       OldLossKeywords = ListCheckPresent(SolverParams,'Harmonic Linear Frequency Exponent')
+       OldLossKeywords = ListCheckPresent(SolverParams,'Harmonic Loss Linear Frequency Exponent')
        CALL GetLossExponents(SolverParams,FreqPower,FieldPower,LossN,OldLossKeywords)
      END IF
 
@@ -984,8 +984,10 @@ END SUBROUTINE MagnetoDynamicsCalcFields_Init
          CALL Warn('MagnetoDynamicsCalcFields',&
              'Harmonic loss requires > Harmonic Loss Quadratic Coefficient < in material section!')
        END IF       
-     END IF
 
+       CALL Info('MagnetoDynamicsCalcFields','Consider using more generic keywords for loss computation!')
+     END IF
+     
      ComponentLoss = 0.0_dp
      ALLOCATE( BodyLoss(3,Model % NumberOfBodies) )
      BodyLoss = 0.0_dp

--- a/fem/src/modules/MagnetoDynamics/CalcFields.F90
+++ b/fem/src/modules/MagnetoDynamics/CalcFields.F90
@@ -962,7 +962,7 @@ END SUBROUTINE MagnetoDynamicsCalcFields_Init
        .OR. ASSOCIATED( ML2 ) .OR. ASSOCIATED( EL_ML2 ) 
 
    IF (LossEstimation) THEN
-     MaterialExponents = GetLogical( SolverParams,'Use Material Loss Exponents', Found ) 
+     MaterialExponents = ListCheckPrefixAnyMaterial( Model,'Harmonic Loss Linear Frequency Exponent') 
      IF(.NOT. MaterialExponents) THEN
        CALL GetLossExponents(SolverParams,FreqPower,FieldPower)
      END IF

--- a/fem/src/modules/MagnetoDynamics/CalcFields.F90
+++ b/fem/src/modules/MagnetoDynamics/CalcFields.F90
@@ -2002,7 +2002,7 @@ END SUBROUTINE MagnetoDynamicsCalcFields_Init
            END IF
            
            ! No losses to add if loss coefficient is not given
-           IF( Found ) THEN
+           IF( Found .OR. MaterialsExponents ) THEN
              ElemLoss = 0.0_dp
              DO l=1,2
                ValAtIP = SUM( B(l,1:3) ** 2 )


### PR DESCRIPTION
This PR enables loss models to have different exponent in different regions. Also allows new keyword format for the harmonic losses (that was already used in FourierLoss). Already tested by Juris.