### PR TITLE
umat nt modification

### DIFF
--- a/fem/src/modules/ElasticSolve.F90
+++ b/fem/src/modules/ElasticSolve.F90
@@ -324,7 +324,8 @@ SUBROUTINE ElasticSolver( Model, Solver, dt, TransientSimulation )
        LocalTemperature(:),ElasticModulus(:,:,:),PoissonRatio(:), Density(:), &
        Damping(:), HeatExpansionCoeff(:,:,:),Alpha(:,:),Beta(:), &
        ReferenceTemperature(:),BoundaryDispl(:),LocalDisplacement(:,:), PrevSOL(:), &
-       PrevLocalDisplacement(:,:), SpringCoeff(:,:,:), LocalExternalForce(:)
+       PrevLocalDisplacement(:,:), SpringCoeff(:,:,:), LocalExternalForce(:), &
+       DisplacementRot(:), LocalForceSaved(:)
          
   REAL(KIND=dp) :: UNorm, TransformMatrix(3,3), Tdiff, Normal(3), s, UnitNorm, DragCoeff
   REAL(KIND=dp) :: Norm, NonlinTol, NonlinRes0, NonlinRes, time 
@@ -676,6 +677,9 @@ SUBROUTINE ElasticSolver( Model, Solver, dt, TransientSimulation )
   END IF
 
   ALLOCATE( PrevSOL(SIZE(Displacement)) )
+  ALLOCATE(DisplacementRot(SIZE(Displacement)))
+  ALLOCATE(LocalForceSaved(STDOFs*N))
+
   PrevSOL = Displacement
   IF (UseUMAT) THEN
     IF (.NOT. ASSOCIATED(StiffMatrix % BulkRHS)) &
@@ -1167,7 +1171,9 @@ SUBROUTINE ElasticSolver( Model, Solver, dt, TransientSimulation )
              ! ---------------------------------------------------------------------------
              ValuesSaved => StiffMatrix % RHS
              StiffMatrix % RHS => StiffMatrix % BulkRHS
+             LocalForceSaved = LocalForce
              CALL DefaultUpdateForce(LocalForce)
+             LocalForce = LocalForceSaved
              Solver % Matrix % RHS => ValuesSaved
            END IF
 
@@ -1204,10 +1210,13 @@ SUBROUTINE ElasticSolver( Model, Solver, dt, TransientSimulation )
        ! the Dirichlet BCs for the complete field. Modify BCs so that the right BC
        ! is obtained for the solution increment.
        ! ---------------------------------------------------------------------------------
+       DisplacementRot = Displacement
+       CALL RotateNTSystemAll(DisplacementRot, StressPerm, STDOFs)
+       
        IF (ALLOCATED(StiffMatrix % ConstrainedDOF)) THEN
          DO i=1,StiffMatrix % NumberOfRows
            IF (StiffMatrix % ConstrainedDOF(i)) THEN
-             StiffMatrix % DValues(i) = StiffMatrix % DValues(i) - Displacement(i)
+             StiffMatrix % DValues(i) = StiffMatrix % DValues(i) - DisplacementRot(i)
            END IF
          END DO
          CALL EnforceDirichletConditions(Solver, StiffMatrix, ForceVector)
@@ -1369,6 +1378,9 @@ SUBROUTINE ElasticSolver( Model, Solver, dt, TransientSimulation )
   END IF
 
   DEALLOCATE( PrevSOL )
+  DEALLOCATE(DisplacementRot)
+  DEALLOCATE(LocalForceSaved)
+
 
   CALL DefaultFinish()
   


### PR DESCRIPTION
ElasticSolve UMAT and Normal-Tangential Displacement = True didn't give correct results. Proposed modification:
DValues at line 1219 refer to the NT-rotated coords while Displacement refers to cartesian. Thus Displacement should be rotated. Using DisplacementRot instead of Displacement.

CALL DefaultUpdateForce(LocalForce) at line 1175 is rotating LocalForce. Later, DefaultUpdateEquations is also rotating LocalForce so it must be sent in "unrotated".
This feels like a "quick fix". Maybe, preferably,  DefaultUpdateForce(LocalForce) should not change LocalForce. However, it is used in other modules and I cant overview if that would cause problems there. 

Please verify that the new variables DisplacementRot and LocalForceSaved are properly defined, allocated and deallocated.

There is a simple test case at https://github.com/RFredrik/elmer/tree/main/UMAT_NT to test with and without NT boundary