### PR TITLE
Fix parallel boundary statistics in SaveScalars

### DIFF
--- a/fem/src/modules/SaveData/SaveScalars.F90
+++ b/fem/src/modules/SaveData/SaveScalars.F90
@@ -2916,6 +2916,7 @@ CONTAINS
     TYPE(ValueList_t), POINTER :: Material
     LOGICAL :: Stat, Permutated, NodalVar    
     INTEGER :: i,j,j2,k,p,q,t,DIM,bc,n,nd,hits,istat
+    INTEGER :: tmpDofs
     INTEGER, TARGET :: Indexes(100)
 
     IF( ASSOCIATED( Var % Perm ) ) THEN
@@ -2993,7 +2994,8 @@ CONTAINS
           IF( .NOT. FindMinMax .AND. IsParallel ) THEN
             IF(ASSOCIATED( Var % Solver) ) THEN
               IF( ASSOCIATED( Var % SOlver % Matrix ) ) THEN
-                IF( Var % Solver % Matrix % ParallelInfo % NeighbourList(NoDofs*(j2-1)+1) % Neighbours(1) /= ParEnv % MyPE ) CYCLE
+                tmpDofs=Var % Solver % Variable % Dofs
+                IF( Var % Solver % Matrix % ParallelInfo % NeighbourList(tmpDofs*(j2-1)+1) % Neighbours(1) /= ParEnv % MyPE ) CYCLE
               END IF
             END IF
           END IF


### PR DESCRIPTION
Fix bug reported in http://elmerfem.org/forum/viewtopic.php?t=8290

Issue is that the solver % Matrix structure is related to the main solver variable; If statistics are done on a given component  the number of DOFs is 1, and not the DOFs of the solver % variable.

Maybe we could still rely on the old test :
IF( Mesh % ParallelInfo % NeighbourList(j) % Neighbours(1) /= ParEnv % MyPE ) CYCLE to skip nodes that are ot owned by the current PE?