### PR TITLE
Fix saveline

### DIFF
--- a/fem/src/modules/SaveData/SaveLine.F90
+++ b/fem/src/modules/SaveData/SaveLine.F90
@@ -1463,7 +1463,7 @@ CONTAINS
         END DO
       END IF
 
-      DgVar = ASSOCIATED( Mesh % Elements(1) % DGIndexes ) 
+      !DgVar = ASSOCIATED( Mesh % Elements(1) % DGIndexes ) 
       
       ! Go through the elements and register the boundary index and fluxes if asked
       DO t = 1,  Mesh % NumberOfBulkElements + Mesh % NumberOfBoundaryElements        


### PR DESCRIPTION
Fix for two issues in SaveLine;
First, do not use DGVar output mode if there is no DG variable to save; 
Second, fix issues with column order not preserved if one of the variable is not defined on a given boundary.