### PR TITLE
Fix Homogenization 3D

### DIFF
--- a/fem/src/modules/MagnetoDynamics/WhitneyAVHarmonicSolver.F90
+++ b/fem/src/modules/MagnetoDynamics/WhitneyAVHarmonicSolver.F90
@@ -1254,7 +1254,9 @@ END BLOCK
                      RotMLoc(3,3), velo(3), omega_velo(3,n), &
                      lorentz_velo(3,n), RotWJ(3)
     REAL(KIND=dp) :: LocalLamThick, skind, babs, muder, AlocR(2,nd)
-    REAL(KIND=dp) :: nu_11(nd), nuim_11(nd), nu_22(nd), nuim_22(nd)
+    REAL(KIND=dp) :: nu_11(nd), nuim_11(nd),  &
+                     nu_22(nd), nuim_22(nd),  &
+                     nu_33(nd), nuim_33(nd)
     REAL(KIND=dp) :: nu_val, nuim_val
     REAL(KIND=dp) :: sigma_33(nd), sigmaim_33(nd)
 
@@ -1339,7 +1341,13 @@ END BLOCK
           nuim_22 = 0._dp
           nu_22 = GetReal(CompParams, 'nu 22', Found)
           nuim_22 = GetReal(CompParams, 'nu 22 im', FoundIm)
-          IF ( .NOT. Found .AND. .NOT. FoundIm ) CALL Fatal ('LocalMatrix', 'Homogenization Model nu 11 not found!')
+          IF ( .NOT. Found .AND. .NOT. FoundIm ) CALL Fatal ('LocalMatrix', 'Homogenization Model nu 22 not found!')
+
+          nu_33 = 0._dp
+          nuim_33 = 0._dp
+          nu_33 = GetReal(CompParams, 'nu 33', Found)
+          nuim_33 = GetReal(CompParams, 'nu 33 im', FoundIm)
+          IF ( .NOT. Found .AND. .NOT. FoundIm ) CALL Fatal ('LocalMatrix', 'Homogenization Model nu 33 not found!')
 
           ! Sigma 33 is not needed in because it does not exist in stranded coil
           ! Its contribution is taken into account in the circuit module if explicit coil resistance is not used!
@@ -1459,6 +1467,9 @@ END BLOCK
            nu_val = SUM( Basis(1:n) * nu_22(1:n) ) 
            nuim_val = SUM( Basis(1:n) * nuim_22(1:n) ) 
            Nu(2,2) = CMPLX(nu_val, nuim_val, KIND=dp)
+           nu_val = SUM( Basis(1:n) * nu_33(1:n) ) 
+           nuim_val = SUM( Basis(1:n) * nuim_33(1:n) ) 
+           Nu(3,3) = CMPLX(nu_val, nuim_val, KIND=dp)
            Nu = MATMUL(MATMUL(RotMLoc, Nu),TRANSPOSE(RotMLoc))
          END IF
        END IF

--- a/fem/tests/circuits_harmonic_homogenization_coil_solver/sif/2241.sif
+++ b/fem/tests/circuits_harmonic_homogenization_coil_solver/sif/2241.sif
@@ -227,6 +227,8 @@ Component 1
    Nu 11 im = Real $ 259371
    Nu 22 = Real $ 773655 
    Nu 22 im = Real $ 259371
+   Nu 33 = Real $ 773655      ! these are not physical
+   Nu 33 im = Real $ 259371   ! 
    Sigma 33 = Real 9e7
    Number of Turns = Real 144
    Electrode Area = Real 0.000185614878383
@@ -265,7 +267,7 @@ End
 
 Solver 4 :: Reference Norm = Real 4.01153162E-07
 Solver 4 :: Reference Norm Tolerance = Real 1E-03
-Solver 5 :: Reference Norm = Real 6.02057030E+03
+Solver 5 :: Reference Norm = Real 6.03834682E+03
 Solver 5 :: Reference Norm Tolerance = Real 1E-03
 
 $fprintf( stderr, "TEST CASE 1\n");

--- a/fem/tests/circuits_harmonic_stranded_homogenization/sif/2241.sif
+++ b/fem/tests/circuits_harmonic_stranded_homogenization/sif/2241.sif
@@ -198,6 +198,8 @@ Component 1
    Nu 11 im = Real $ 259371
    Nu 22 = Real $ 773655 
    Nu 22 im = Real $ 259371
+   Nu 33 = Real $ 773655      ! these are not physical
+   Nu 33 im = Real $ 259371   ! 
    Sigma 33 = Real 9e7
    Number of Turns = Real 144
    Electrode Area = Real 0.000185614878383
@@ -251,7 +253,7 @@ End
 
 Solver 4 :: Reference Norm = Real 5.88944303E-01 
 Solver 4 :: Reference Norm Tolerance = Real 1E-03
-Solver 6 :: Reference Norm = Real 4.09497893E-07 
+Solver 6 :: Reference Norm = Real 4.09225331E-07
 Solver 6 :: Reference Norm Tolerance = Real 1E-03
 !Solver 7 :: Reference Norm = Real 1.63166208E-09
 !Solver 7 :: Reference Norm Tolerance = Real 1E-03


### PR DESCRIPTION
* Don't require homogenization for all coils
* Add missing nu component (homog)

  By convention, we are using the 2D approximation in 2D stranded homogenization parameters: in local coordinates they are xx and yy. But, the third one (zz) has been missing, causing some strange tensors as output. In this commit the third is added. Note that now the third has to be declared in the sif:

  ```sif Component: Nu 33 Component: Nu 33 im ```

  Had to touch these: `fem/tests/circuits_harmonic_homogenization_coil_solver/sif/2241.sif` `fem/tests/circuits_harmonic_stranded_homogenization/sif/2241.sif`

TODO:
  * we need to hack coil solver such that we don't have the problem shown in: https://github.com/ElmerCSC/elmerfem/issues/460#issuecomment-2059231516 This should be fixed soon! @raback