### PR TITLE
Add nix flake

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,7 @@ run_mgdyn_tests.sh
 fem/tests/CircuitsAndDynamics
 slurm*out
 ElmerGUI/CMakeLists.txt
+result
 
 # Test-generated files
 fem/tests/**/TEST.PASSED

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,367 @@
+{
+  "nodes": {
+    "csa": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1718358396,
+        "narHash": "sha256-TCNBlx6RVRFZhkZ2NghacuLVRsH6eLZTOJ70p/a9lcA=",
+        "owner": "mk3z",
+        "repo": "csa-c",
+        "rev": "36f99e3eb589f4c9c6dce657a0eb73f263521e85",
+        "type": "github"
+      },
+      "original": {
+        "owner": "mk3z",
+        "repo": "csa-c",
+        "type": "github"
+      }
+    },
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1710146030,
+        "narHash": "sha256-SZ5L6eA7HJ/nmkzGG7/ISclqe6oZdOZTNoesiInkXPQ=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "b1d9ab70662946ef0850d488da1c9019f3a9752a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "flake-utils_2": {
+      "inputs": {
+        "systems": "systems_2"
+      },
+      "locked": {
+        "lastModified": 1710146030,
+        "narHash": "sha256-SZ5L6eA7HJ/nmkzGG7/ISclqe6oZdOZTNoesiInkXPQ=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "b1d9ab70662946ef0850d488da1c9019f3a9752a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "flake-utils_3": {
+      "inputs": {
+        "systems": "systems_3"
+      },
+      "locked": {
+        "lastModified": 1710146030,
+        "narHash": "sha256-SZ5L6eA7HJ/nmkzGG7/ISclqe6oZdOZTNoesiInkXPQ=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "b1d9ab70662946ef0850d488da1c9019f3a9752a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "flake-utils_4": {
+      "inputs": {
+        "systems": "systems_4"
+      },
+      "locked": {
+        "lastModified": 1710146030,
+        "narHash": "sha256-SZ5L6eA7HJ/nmkzGG7/ISclqe6oZdOZTNoesiInkXPQ=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "b1d9ab70662946ef0850d488da1c9019f3a9752a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "flake-utils_5": {
+      "inputs": {
+        "systems": "systems_5"
+      },
+      "locked": {
+        "lastModified": 1710146030,
+        "narHash": "sha256-SZ5L6eA7HJ/nmkzGG7/ISclqe6oZdOZTNoesiInkXPQ=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "b1d9ab70662946ef0850d488da1c9019f3a9752a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "flake-utils_6": {
+      "inputs": {
+        "systems": "systems_6"
+      },
+      "locked": {
+        "lastModified": 1710146030,
+        "narHash": "sha256-SZ5L6eA7HJ/nmkzGG7/ISclqe6oZdOZTNoesiInkXPQ=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "b1d9ab70662946ef0850d488da1c9019f3a9752a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "hypre": {
+      "inputs": {
+        "flake-utils": "flake-utils_3",
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1718358069,
+        "narHash": "sha256-DP7/t6SMPu1oyfyPdAgS9Q/EyFeiEWAJfYIMLun97yE=",
+        "owner": "mk3z",
+        "repo": "hypre",
+        "rev": "bf04b0275e70160d8a888ef6f80ce0352883ff4d",
+        "type": "github"
+      },
+      "original": {
+        "owner": "mk3z",
+        "repo": "hypre",
+        "type": "github"
+      }
+    },
+    "mmg": {
+      "inputs": {
+        "flake-utils": "flake-utils_4",
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1718359975,
+        "narHash": "sha256-/HCAPrGEdt6HwTeMlPcZz4AO55PJrBwjP93leg+K4m8=",
+        "owner": "mk3z",
+        "repo": "mmg",
+        "rev": "ef183bf3dbc4525c85faf66e4c0312d4ae58696f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "mk3z",
+        "ref": "develop",
+        "repo": "mmg",
+        "type": "github"
+      }
+    },
+    "mumps": {
+      "inputs": {
+        "flake-utils": "flake-utils_5",
+        "mumps-src": "mumps-src",
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1718266354,
+        "narHash": "sha256-GMHo1/w57kIQZf24peiG39sGL8R0sJOANlC9layL70A=",
+        "owner": "mk3z",
+        "repo": "mumps",
+        "rev": "5f7074574c1328f5eead9ad5358cdf7916b2fce1",
+        "type": "github"
+      },
+      "original": {
+        "owner": "mk3z",
+        "repo": "mumps",
+        "type": "github"
+      }
+    },
+    "mumps-src": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1714644934,
+        "narHash": "sha256-X+eX4SBoiA9akp3zPk0niO/mjh4lUbBAJTMG8cBEi6M=",
+        "type": "tarball",
+        "url": "https://mumps-solver.org/MUMPS_5.7.1.tar.gz"
+      },
+      "original": {
+        "type": "tarball",
+        "url": "https://mumps-solver.org/MUMPS_5.7.1.tar.gz"
+      }
+    },
+    "nix-filter": {
+      "locked": {
+        "lastModified": 1710156097,
+        "narHash": "sha256-1Wvk8UP7PXdf8bCCaEoMnOT1qe5/Duqgj+rL8sRQsSM=",
+        "owner": "numtide",
+        "repo": "nix-filter",
+        "rev": "3342559a24e85fc164b295c3444e8a139924675b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "nix-filter",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1718208800,
+        "narHash": "sha256-US1tAChvPxT52RV8GksWZS415tTS7PV42KTc2PNDBmc=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "cc54fb41d13736e92229c21627ea4f22199fee6b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-24.05",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nn": {
+      "inputs": {
+        "flake-utils": "flake-utils_6",
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1718360021,
+        "narHash": "sha256-2Mr/W2rkbF+FYK4Cw8MeEsMcLfGD2oxXXWMCmohBv5A=",
+        "owner": "mk3z",
+        "repo": "nn-c",
+        "rev": "f05a7b3fbd99dcd720af639351caf8aa6334847b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "mk3z",
+        "repo": "nn-c",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "csa": "csa",
+        "flake-utils": "flake-utils_2",
+        "hypre": "hypre",
+        "mmg": "mmg",
+        "mumps": "mumps",
+        "nix-filter": "nix-filter",
+        "nixpkgs": "nixpkgs",
+        "nn": "nn"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    },
+    "systems_2": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    },
+    "systems_3": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    },
+    "systems_4": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    },
+    "systems_5": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    },
+    "systems_6": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,232 @@
+{
+  description = "Elmer FEM";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-24.05";
+
+    flake-utils.url = "github:numtide/flake-utils";
+
+    nix-filter.url = "github:numtide/nix-filter";
+
+    mumps = {
+      url = "github:mk3z/mumps";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+
+    hypre = {
+      url = "github:mk3z/hypre";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+
+    csa = {
+      url = "github:mk3z/csa-c";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+
+    nn = {
+      url = "github:mk3z/nn-c";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+
+    mmg = {
+      url = "github:mk3z/mmg/develop";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+  };
+
+  outputs = {
+    self,
+    nixpkgs,
+    flake-utils,
+    nix-filter,
+    ...
+  } @ inputs:
+    flake-utils.lib.eachDefaultSystem (
+      system: let
+        pkgs = nixpkgs.legacyPackages.${system};
+        mumps = inputs.mumps.packages.${system}.default;
+        hypre = inputs.hypre.packages.${system}.default;
+        csa = inputs.csa.packages.${system}.default;
+        nn = inputs.nn.packages.${system}.default;
+        mmg = inputs.mmg.packages.${system}.default;
+
+        basePkg = {
+          name,
+          nativeBuildInputs,
+          buildInputs,
+          cmakeFlags,
+          doCheck,
+          checkPhase ? ''
+            runHook preCheckPhase
+            ctest -j $NIX_BUILD_CORES -L fast
+            runHook postCheckPhase
+          '',
+        } @ inputs: let
+          storepath = placeholder "out";
+        in
+          pkgs.stdenv.mkDerivation {
+            inherit name doCheck checkPhase storepath;
+
+            pname = "elmerfem";
+
+            src = nix-filter {
+              root = self;
+              exclude = [
+                (nix-filter.lib.matchExt "nix")
+                "flake.lock"
+                ".git"
+                ".gitignore"
+                ".gitmodules"
+              ];
+            };
+
+            hardeningDisable = ["format"];
+
+            nativeBuildInputs = with pkgs;
+              [
+                cmake
+                gfortran
+                pkg-config
+                autoPatchelfHook
+              ]
+              ++ inputs.nativeBuildInputs;
+
+            buildInputs = with pkgs;
+              [
+                mpi
+                blas
+                liblapack
+                tbb
+              ]
+              ++ inputs.buildInputs;
+
+            cmakeFlags =
+              [
+                "-DELMER_INSTALL_LIB_DIR=${storepath}/lib"
+                "-DCMAKE_INSTALL_LIBDIR=lib"
+                "-DCMAKE_INSTALL_INCLUDEDIR=include"
+                "-DWITH_LUA:BOOL=TRUE"
+
+                "-DWITH_OpenMP:BOOLEAN=TRUE"
+                "-DWITH_MPI:BOOLEAN=TRUE"
+
+                "-Wno-dev"
+              ]
+              ++ inputs.cmakeFlags;
+
+            autoPatchelfIgnoreMissingDeps = ["libmpi_stubs.so"];
+
+            preConfigure = ''
+              patchShebangs ./
+            '';
+
+            nativeCheckInputs = with pkgs; [
+              mpiCheckPhaseHook
+              openssh
+            ];
+          };
+
+        nogui = {doCheck ? false}:
+          basePkg {
+            inherit doCheck;
+            name = "elmerfem";
+            nativeBuildInputs = [];
+            buildInputs = [];
+            cmakeFlags = [];
+          };
+
+        gui = {doCheck ? false}:
+          basePkg {
+            inherit doCheck;
+            name = "elmerfem-gui";
+
+            nativeBuildInputs = [pkgs.libsForQt5.wrapQtAppsHook];
+
+            buildInputs = with pkgs; [
+              libsForQt5.qtbase
+              libsForQt5.qtscript
+              libsForQt5.qwt
+              libGL
+              libGLU
+              opencascade-occt_7_6
+              vtkWithQt5
+            ];
+
+            cmakeFlags = [
+              "-DWITH_ELMERGUI:BOOLEAN=TRUE"
+              "-DWITH_QT5:BOOLEAN=TRUE"
+              "-DWITH_OCC:BOOLEAN=TRUE"
+              "-DWITH_VTK:BOOLEAN=TRUE"
+              "-DCMAKE_OpenGL_GL_PREFERENCE=GLVND"
+            ];
+          };
+
+        ice = {doCheck ? false}:
+          basePkg {
+            inherit doCheck;
+            name = "elmerice";
+
+            nativeBuildInputs = [];
+
+            buildInputs = with pkgs;
+              [
+                hdf5-mpi
+                scalapack
+              ]
+              ++ [
+                csa
+                hypre
+                mumps
+                nn
+              ];
+
+            cmakeFlags = [
+              "-DWITH_ElmerIce:BOOL=TRUE"
+
+              "-DWITH_NETCDF:BOOL=TRUE"
+              "-DNETCDF_LIBRARY=${pkgs.netcdf-mpi}/lib/libnetcdf.so"
+              "-DNETCDFF_LIBRARY=${pkgs.netcdffortran}/lib/libnetcdff.so"
+              "-DNETCDF_INCLUDE_DIR=${pkgs.netcdf-mpi}/include"
+              "-DCMAKE_Fortran_FLAGS=-I${pkgs.netcdffortran}/include"
+
+              "-DWITH_Hypre:BOOL=TRUE"
+
+              "-DWITH_Mumps:BOOL=TRUE"
+
+              "-DWITH_ScatteredDataInterpolator:BOOL=TRUE"
+              "-DCSA_LIBRARY=${csa}/lib/libcsa.a"
+              "-DCSA_INCLUDE_DIR=${csa}/include"
+              "-DNN_INCLUDE_DIR=${nn}/include"
+              "-DNN_LIBRARY=${nn}/lib/libnn.a"
+
+              "-DWITH_MMG:BOOL=TRUE"
+              "-DMMG_INCLUDE_DIR=${mmg}/include"
+              "-DMMG_LIBRARY=${mmg}/lib/libmmg.so"
+
+              "-DWITH_GridDataReader:BOOL=TRUE"
+
+              "-DWITH_Trilinos:BOOL=FALSE"
+            ];
+
+            checkPhase = ''
+              runHook preCheckPhase
+              ctest -j $NIX_BUILD_CORES -L fast -E "(Hydro_Coupled)|(Hydro_SedOnly)|(Proj_South)"
+              runHook postCheckPhase
+            '';
+          };
+      in {
+        checks = {
+          nogui = nogui {doCheck = true;};
+          gui = gui {doCheck = true;};
+          ice = ice {doCheck = true;};
+        };
+
+        packages = {
+          default = nogui {};
+          nogui = nogui {};
+          gui = gui {};
+          ice = ice {};
+        };
+      }
+    );
+}


### PR DESCRIPTION
This PR adds a nix flake which can be used to build Elmer on systems with the nix package manager. Currently the flake contains three packages.