### PR TITLE
Add CI rules for GitHub hosted Ubuntu runners.

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,0 +1,97 @@
+name: build
+on:
+  workflow_dispatch:
+  push:
+  pull_request:
+
+concurrency: ci-${{ github.ref }}
+
+jobs:
+
+  ubuntu:
+    # For available GitHub-hosted runners, see:
+    # https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners
+    runs-on: ubuntu-latest
+
+    name: ubuntu (${{ matrix.compiler }})
+
+    strategy:
+      # Allow other runners in the matrix to continue if some fail
+      fail-fast: false
+
+      matrix:
+        compiler: [gcc]
+        include:
+          - compiler: gcc
+            compiler-pkgs: "g++ gcc"
+            cc: "gcc"
+            cxx: "g++"
+          #- compiler: clang
+          #  compiler-pkgs: "clang libomp-dev"
+          #  cc: "clang"
+          #  cxx: "clang++"
+
+    env:
+      CC: ${{ matrix.cc }}
+      CXX: ${{ matrix.cxx }}
+
+    steps:
+      - name: get CPU information
+        run: lscpu
+
+      - name: checkout repository
+        uses: actions/checkout@v4
+
+      - name: install dependencies
+        run: |
+          sudo apt -qq update
+          sudo apt install -y ${{ matrix.compiler-pkgs }} cmake gfortran \
+            libopenblas-dev libopenmpi-dev libmumps-dev libparmetis-dev
+
+      - name: configure
+        run: |
+          mkdir ${GITHUB_WORKSPACE}/build
+          cd ${GITHUB_WORKSPACE}/build
+          cmake \
+            -DCMAKE_BUILD_TYPE="Release" \
+            -DCMAKE_INSTALL_PREFIX="${GITHUB_WORKSPACE}/usr" \
+            -DCMAKE_Fortran_FLAGS="-Wno-argument-mismatch" \
+            -DBLA_VENDOR="OpenBLAS" \
+            -DWITH_OpenMP=ON \
+            -DWITH_LUA=ON \
+            -DWITH_Zoltan=OFF \
+            -DWITH_Mumps=ON \
+            -DCREATE_PKGCONFIG_FILE=ON \
+            -DWITH_MPI=ON \
+            -DMPI_TEST_MAXPROC=2 \
+            -DMPIEXEC_PREFLAGS="--allow-run-as-root" \
+            ..
+
+      - name: build
+        run: |
+          cd ${GITHUB_WORKSPACE}/build
+          cmake --build .
+
+      - name: install
+        run: |
+          cd ${GITHUB_WORKSPACE}/build
+          cmake --install .
+
+      - name: check
+        id: run-ctest
+        timeout-minutes: 150
+        run: |
+          cd ${GITHUB_WORKSPACE}/build
+          ctest .
+
+      - name: Re-run tests
+        if: always() && (steps.run-ctest.outcome == 'failure')
+        timeout-minutes: 60
+        run: |
+          cd ${GITHUB_WORKSPACE}/build
+          echo "::group::Re-run ctest"
+          ctest --rerun-failed --output-on-failure || true
+          echo "::endgroup::"
+          echo "::group::Log from these tests"
+          [ ! -f Testing/Temporary/LastTest.log ] || cat Testing/Temporary/LastTest.log
+          echo "::endgroup::"


### PR DESCRIPTION
These rules are heavily inspired by the existing CI scripts (apart from Zoltan that didn't build for me).

Building with LLVM Clang and libomp is currently failing with a linking error. That might be caused by how the CMake targets link to OpenMP in the build rules. (But I haven't looked into it any further. Might try to dig into that later.)
I left that part of the build matrix commented out for the time being.

Additionally, some tests were failing for me. I don't know whether those test failures are expected or if that's because of a configuration error in the proposed CI rules.

I was looking into using `ccache` to potentially speed up compilation time. But there are three main reasons why I opted against that:
* A large portion of the code of ElmerFEM is written in Fortran for which current versions of `ccache` don't have support.
* Even for the remaining parts of the code (written in C or C++) a large portion can't be cached because `config.h` includes the Git revision. So, almost every compilation unit changes on every push which would invalidate the compiler cache.
* The CI time is dominated by the test suite anyway. (Don't get me wrong: Having good coverage is actually a good thing.)

The proposed rules would trigger on each change of a PR and whenever a change is pushed to the repository. Additionally, it would be possible to trigger the CI manually for maintainers of this repository. The same rules are run in either case. Is that agreeable?

Are you interested in having CI running on the GitHub-hosted runners? If you are, GitHub also hosts runners with macOS and Windows that are free (as in free beer) to use for open source projects. So, once the CI rules are sorted out for the Ubuntu runners, we could look into adding rules for the other OSs if that is something you are interested in.
