### PR TITLE
Add CI rule that triggers once a week with the full test suite. 

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -55,7 +55,6 @@ jobs:
           cmake \
             -DCMAKE_BUILD_TYPE="Release" \
             -DCMAKE_INSTALL_PREFIX="${GITHUB_WORKSPACE}/usr" \
-            -DCMAKE_Fortran_FLAGS="-Wno-argument-mismatch" \
             -DBLA_VENDOR="OpenBLAS" \
             -DWITH_OpenMP=ON \
             -DWITH_LUA=ON \
@@ -89,7 +88,7 @@ jobs:
         timeout-minutes: 60
         run: |
           cd ${GITHUB_WORKSPACE}/build
-          echo "::group::Re-run ctest"
+          echo "::group::Re-run failing tests"
           ctest --rerun-failed --output-on-failure || true
           echo "::endgroup::"
           echo "::group::Log from these tests"

--- a/.github/workflows/full-test.yaml
+++ b/.github/workflows/full-test.yaml
@@ -1,0 +1,97 @@
+name: full-test
+on:
+  workflow_dispatch:
+  schedule:
+    # Run job every Tuesday at 09:50 UTC
+    - cron: '50 09 * * 2'
+
+concurrency: ci-${{ github.ref }}
+
+jobs:
+
+  ubuntu:
+    # For available GitHub-hosted runners, see:
+    # https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners
+    runs-on: ubuntu-latest
+
+    name: ubuntu (${{ matrix.compiler }})
+
+    strategy:
+      # Allow other runners in the matrix to continue if some fail
+      fail-fast: false
+
+      matrix:
+        compiler: [gcc]
+        include:
+          - compiler: gcc
+            compiler-pkgs: "g++ gcc"
+            cc: "gcc"
+            cxx: "g++"
+          #- compiler: clang
+          #  compiler-pkgs: "clang libomp-dev"
+          #  cc: "clang"
+          #  cxx: "clang++"
+
+    env:
+      CC: ${{ matrix.cc }}
+      CXX: ${{ matrix.cxx }}
+
+    steps:
+      - name: get CPU information
+        run: lscpu
+
+      - name: checkout repository
+        uses: actions/checkout@v4
+
+      - name: install dependencies
+        run: |
+          sudo apt -qq update
+          sudo apt install -y ${{ matrix.compiler-pkgs }} cmake gfortran \
+            libopenblas-dev libopenmpi-dev libmumps-dev libparmetis-dev
+
+      - name: configure
+        run: |
+          mkdir ${GITHUB_WORKSPACE}/build
+          cd ${GITHUB_WORKSPACE}/build
+          cmake \
+            -DCMAKE_BUILD_TYPE="Release" \
+            -DCMAKE_INSTALL_PREFIX="${GITHUB_WORKSPACE}/usr" \
+            -DBLA_VENDOR="OpenBLAS" \
+            -DWITH_OpenMP=ON \
+            -DWITH_LUA=ON \
+            -DWITH_Zoltan=OFF \
+            -DWITH_Mumps=ON \
+            -DCREATE_PKGCONFIG_FILE=ON \
+            -DWITH_MPI=ON \
+            -DMPI_TEST_MAXPROC=2 \
+            -DMPIEXEC_PREFLAGS="--allow-run-as-root" \
+            ..
+
+      - name: build
+        run: |
+          cd ${GITHUB_WORKSPACE}/build
+          cmake --build .
+
+      - name: install
+        run: |
+          cd ${GITHUB_WORKSPACE}/build
+          cmake --install .
+
+      - name: check
+        id: run-ctest
+        timeout-minutes: 150
+        run: |
+          cd ${GITHUB_WORKSPACE}/build
+          ctest .
+
+      - name: Re-run tests
+        if: always() && (steps.run-ctest.outcome == 'failure')
+        timeout-minutes: 60
+        run: |
+          cd ${GITHUB_WORKSPACE}/build
+          echo "::group::Re-run failing tests"
+          ctest --rerun-failed --output-on-failure || true
+          echo "::endgroup::"
+          echo "::group::Log from these tests"
+          [ ! -f Testing/Temporary/LastTest.log ] || cat Testing/Temporary/LastTest.log
+          echo "::endgroup::"


### PR DESCRIPTION
Currently, this is basically a copy of the build rules that trigger on pull requests or pushes. The only difference is that the trigger is on a weekly schedule and the full set of tests are run.

Mid-term, more tests could be run for different configurations on PRs or pushes (e.g., build tests with bundled or external dependencies, with some enabled or disabled features, with different compilers, on different platforms, ...) while the full test suite is only run with one or a different subset of configurations.

That will be easier if we start with two sets of (currently basically identical) rules and let them spread in different directions from here without having to care about the other rules.


I don't know what "activating the "elmerice" capabilities/tests" means. So, I didn't touch anything in the existing configuration.
Could you please let me know if something should be changed?
