### PR TITLE
Avoid compiler warnings about implicit function declarations.

### DIFF
--- a/fem/src/CMakeLists.txt
+++ b/fem/src/CMakeLists.txt
@@ -179,18 +179,19 @@ ENDIF()
 # ElmerSolver libraries
 IF(UMFPACK_FOUND)
   SET(ELMERSOLVER_LIBRARIES matc fhuti binio arpack
+                          ${UMFPACK_LIBRARIES}
                           ${LAPACK_LIBRARIES} ${BLAS_LIBRARIES}
-			  ${UMFPACK_LIBRARIES}
                           ${CMAKE_DL_LIBS})
-			
-  INCLUDE_DIRECTORIES(${UMFPACK_INCLUDE_DIR})
+
+  TARGET_INCLUDE_DIRECTORIES(elmersolver PRIVATE ${UMFPACK_INCLUDE_DIR})
   #LIST(APPEND ELMERSOLVER_LIBRARIES ${UMFPACK_LIBRARIES})
   #TARGET_LINK_LIBRARIES(elmersolver "${UMFPACK_LIBRARIES}")
 ELSE()
-  SET(ELMERSOLVER_LIBRARIES matc umfpack 
-                          amd fhuti binio arpack
-                          ${LAPACK_LIBRARIES} ${BLAS_LIBRARIES} 
+  SET(ELMERSOLVER_LIBRARIES matc fhuti binio arpack
+                          umfpack amd
+                          ${LAPACK_LIBRARIES} ${BLAS_LIBRARIES}
                           ${CMAKE_DL_LIBS})
+  TARGET_INCLUDE_DIRECTORIES(elmersolver PRIVATE ${PROJECT_SOURCE_DIR}/umfpack/src/umfpack/include)
 ENDIF()
 
 IF(WITH_LUA)

--- a/fem/src/umf4_f77wrapper.c
+++ b/fem/src/umf4_f77wrapper.c
@@ -80,6 +80,8 @@
 
 #include "../config.h"
 
+#include "umfpack.h"
+
 #ifdef NULL
 #undef NULL
 #endif


### PR DESCRIPTION
Include header that declares functions from the UMFPACK library before using them. Add path to that header to the preprocessor flags. 
Also keep similar order of linker flags independent of whether the bundled or an external UMFPACK library is used.

This warning is elevated to an error in LLVM Clang 18 (with default compiler flags). This also errors for GCC 14.
