### PR TITLE
Fix METIS compilation error on MinGW (gettimeofday issue)

### DIFF
--- a/elmergrid/src/metis-5.1.0/GKlib/gk_arch.h
+++ b/elmergrid/src/metis-5.1.0/GKlib/gk_arch.h
@@ -10,6 +10,11 @@
 #ifndef _GK_ARCH_H_
 #define _GK_ARCH_H_
 
+#ifdef __MINGW32__
+#include <sys/time.h>
+#define gettimeofday mingw_gettimeofday
+#endif
+
 /*************************************************************************
 * Architecture-specific differences in header files
 **************************************************************************/

--- a/elmergrid/src/metis-5.1.0/GKlib/timers.c
+++ b/elmergrid/src/metis-5.1.0/GKlib/timers.c
@@ -9,7 +9,7 @@
 
 
 #include <GKlib.h>
-
+#include "gk_arch.h"
 
 
 


### PR DESCRIPTION
This commit resolves the compilation error in the METIS library when building Elmer FEM on Windows using MinGW. The error was caused by the use of the POSIX function `gettimeofday`, which is not directly available in Windows.

Changes made:
1. Modified `elmergrid/src/metis-5.1.0/GKlib/gk_arch.h` to define `gettimeofday` as `mingw_gettimeofday` when compiling with MinGW.
2. Updated `elmergrid/src/metis-5.1.0/GKlib/timers.c` to include `gk_arch.h`.

These changes allow the METIS library to compile successfully on Windows with MinGW, resolving the "implicit declaration of function 'gettimeofday'" error.

Fixes #489