### PR TITLE
Simplify using newer versions of external UMFPACK or CHOLMOD libraries

### DIFF
--- a/cmake/Modules/FindCHOLMOD.cmake
+++ b/cmake/Modules/FindCHOLMOD.cmake
@@ -8,7 +8,7 @@
 
 # his module returns these variables for the rest of the project to use.
 #
-#  CHOLMOD_FOUND             - True if CHOLMOD found 
+#  CHOLMOD_FOUND             - True if CHOLMOD found
 #  CHOLMOD_INCLUDE_DIR       - CHOLMOD include dir.
 #  CHOLMOD_LIBRARIES         - needed cuda libraries
 
@@ -32,17 +32,17 @@ SET(CHOLMODINCLUDE
   "$ENV{CHOLMOD_ROOT}/include"
   "${CHOLMOD_ROOT}/include/suitesparse"
   "$ENV{CHOLMOD_ROOT}/include/suitesparse"
-  "${CMAKE_SOURCE_DIR}/umfpack/include"
+  "${CMAKE_SOURCE_DIR}/cholmod/include"
   INTERNAL
   )
 # Try to find CHOLMOD
-FIND_PATH(CHOLMOD_INCLUDE_DIR 
-  umfpack.h
-  HINTS 
+FIND_PATH(CHOLMOD_INCLUDE_DIR
+  cholmod.h
+  HINTS
   ${CHOLMODINCLUDE}
   )
 
-SET(CHOLMODLIB 
+SET(CHOLMODLIB
   "${CHOLMODROOT}/lib"
   "$ENV{CHOLMODROOT}/lib"
   "${CHOLMODROOT}/lib64"
@@ -51,10 +51,10 @@ SET(CHOLMODLIB
   "$ENV{CHOLMOD_ROOT}/lib"
   "${CHOLMOD_ROOT}/lib64"
   "$ENV{CHOLMOD_ROOT}/lib64"
-  "${CMAKE_SOURCE_DIR}/umfpack/lib"
+  "${CMAKE_SOURCE_DIR}/cholmod/lib"
   INTERNAL)
 
-FIND_LIBRARY(CHOLMOD_LIB umfpack HINTS ${CHOLMODLIB})
+FIND_LIBRARY(CHOLMOD_LIB cholmod HINTS ${CHOLMODLIB})
 
 IF (CHOLMOD_INCLUDE_DIR AND CHOLMOD_LIB)
   UNSET(CHOLMOD_FAILMSG)
@@ -63,7 +63,7 @@ IF (CHOLMOD_INCLUDE_DIR AND CHOLMOD_LIB)
 ELSE()
   SET(CHOLMOD_FAILMSG "CHOLMOD library not found.")
 ENDIF()
-   
+
 IF (NOT CHOLMOD_FAILMSG)
   SET(CHOLMOD_FOUND TRUE)
 ENDIF()
@@ -85,5 +85,5 @@ MARK_AS_ADVANCED(
   CHOLMODLIB
   CHOLMOD_FAILMSG
   CHOLMOD_FOUND
-  CHOLMOD_INCLUDE_DIR 
+  CHOLMOD_INCLUDE_DIR
   CHOLMOD_LIBRARIES)

--- a/cmake/Modules/FindCHOLMOD.cmake
+++ b/cmake/Modules/FindCHOLMOD.cmake
@@ -12,13 +12,21 @@
 #  CHOLMOD_INCLUDE_DIR       - CHOLMOD include dir.
 #  CHOLMOD_LIBRARIES         - needed cuda libraries
 
-INCLUDE(${CMAKE_ROOT}/Modules/FindPackageHandleStandardArgs.cmake)
-
 # If CHOLMOD libraries are already defined, do nothing
 IF(CHOLMOD_LIBRARIES AND CHOLMOD_INCLUDE_DIR)
    SET(CHOLMOD_FOUND TRUE)
    RETURN()
 ENDIF()
+
+# Try to find with CMake config file of upstream UMFPACK.
+FIND_PACKAGE(CHOLMOD CONFIG)
+
+IF(UMFPACK_LIBRARIES AND UMFPACK_INCLUDE_DIR)
+  RETURN()
+ENDIF()
+
+# Fall back to manual search
+INCLUDE(${CMAKE_ROOT}/Modules/FindPackageHandleStandardArgs.cmake)
 
 SET(CHOLMOD_FOUND FALSE)
 MESSAGE(STATUS "Finding CHOLMOD")

--- a/cmake/Modules/FindUMFPACK.cmake
+++ b/cmake/Modules/FindUMFPACK.cmake
@@ -8,17 +8,25 @@
 
 # his module returns these variables for the rest of the project to use.
 #
-#  UMFPACK_FOUND             - True if UMFPACK found 
+#  UMFPACK_FOUND             - True if UMFPACK found
 #  UMFPACK_INCLUDE_DIR       - UMFPACK include dir.
 #  UMFPACK_LIBRARIES         - needed cuda libraries
-
-INCLUDE(${CMAKE_ROOT}/Modules/FindPackageHandleStandardArgs.cmake)
 
 # If UMFPACK libraries are already defined, do nothing
 IF(UMFPACK_LIBRARIES AND UMFPACK_INCLUDE_DIR)
    SET(UMFPACK_FOUND TRUE)
    RETURN()
 ENDIF()
+
+# Try to find with CMake config file of upstream UMFPACK.
+FIND_PACKAGE(UMFPACK CONFIG)
+
+IF(UMFPACK_LIBRARIES AND UMFPACK_INCLUDE_DIR)
+  RETURN()
+ENDIF()
+
+# Fall back to manual search
+INCLUDE(${CMAKE_ROOT}/Modules/FindPackageHandleStandardArgs.cmake)
 
 SET(UMFPACK_FOUND FALSE)
 MESSAGE(STATUS "Finding UMFPACK")
@@ -36,13 +44,13 @@ SET(UMFPACKINCLUDE
   INTERNAL
   )
 # Try to find UMFPACK
-FIND_PATH(UMFPACK_INCLUDE_DIR 
+FIND_PATH(UMFPACK_INCLUDE_DIR
   umfpack.h
-  HINTS 
+  HINTS
   ${UMFPACKINCLUDE}
   )
 
-SET(UMFPACKLIB 
+SET(UMFPACKLIB
   "${UMFPACKROOT}/lib"
   "$ENV{UMFPACKROOT}/lib"
   "${UMFPACKROOT}/lib64"
@@ -63,7 +71,7 @@ IF (UMFPACK_INCLUDE_DIR AND UMFPACK_LIB)
 ELSE()
   SET(UMFPACK_FAILMSG "UMFPACK library not found.")
 ENDIF()
-   
+
 IF (NOT UMFPACK_FAILMSG)
   SET(UMFPACK_FOUND TRUE)
 ENDIF()
@@ -85,5 +93,5 @@ MARK_AS_ADVANCED(
   UMFPACKLIB
   UMFPACK_FAILMSG
   UMFPACK_FOUND
-  UMFPACK_INCLUDE_DIR 
+  UMFPACK_INCLUDE_DIR
   UMFPACK_LIBRARIES)

--- a/fem/src/CMakeLists.txt
+++ b/fem/src/CMakeLists.txt
@@ -177,22 +177,24 @@ IF(HAVE_ZOLTAN)
 ENDIF()
 
 # ElmerSolver libraries
+SET(ELMERSOLVER_LIBRARIES matc fhuti binio arpack)
+
 IF(UMFPACK_FOUND)
-  SET(ELMERSOLVER_LIBRARIES matc fhuti binio arpack
-                          ${UMFPACK_LIBRARIES}
-                          ${LAPACK_LIBRARIES} ${BLAS_LIBRARIES}
-                          ${CMAKE_DL_LIBS})
+  # external implementation of UMFPACK
+  LIST(APPEND ELMERSOLVER_LIBRARIES ${UMFPACK_LIBRARIES})
 
   TARGET_INCLUDE_DIRECTORIES(elmersolver PRIVATE ${UMFPACK_INCLUDE_DIR})
   #LIST(APPEND ELMERSOLVER_LIBRARIES ${UMFPACK_LIBRARIES})
   #TARGET_LINK_LIBRARIES(elmersolver "${UMFPACK_LIBRARIES}")
 ELSE()
-  SET(ELMERSOLVER_LIBRARIES matc fhuti binio arpack
-                          umfpack amd
-                          ${LAPACK_LIBRARIES} ${BLAS_LIBRARIES}
-                          ${CMAKE_DL_LIBS})
+  # bundled UMFPACK
+  LIST(APPEND ELMERSOLVER_LIBRARIES umfpack amd)
   TARGET_INCLUDE_DIRECTORIES(elmersolver PRIVATE ${PROJECT_SOURCE_DIR}/umfpack/src/umfpack/include)
 ENDIF()
+
+LIST(APPEND ELMERSOLVER_LIBRARIES
+  ${LAPACK_LIBRARIES} ${BLAS_LIBRARIES}
+  ${CMAKE_DL_LIBS})
 
 IF(WITH_LUA)
   LIST(APPEND ELMERSOLVER_LIBRARIES ${LUA_LIBRARIES})
@@ -215,7 +217,6 @@ IF(NOT(WITH_MPI))
   TARGET_LINK_LIBRARIES(Solver_TGT elmersolver)
 ENDIF()
 
-# ElmerSolver libraries 
 IF(WITH_MPI)
   #ADD_LIBRARY(elmersolver_mpi SHARED ${solverlib_SOURCES})
 
@@ -305,7 +306,7 @@ ENDIF()
 
 IF (WITH_CHOLMOD)
   SET(CURR_CFLAGS "-DHAVE_CHOLMOD ${MPI_Fortran_COMPILE_FLAGS}")
-  TARGET_LINK_LIBRARIES(elmersolver "${CHOLMOD_LIBRARIES};")
+  TARGET_LINK_LIBRARIES(elmersolver "${CHOLMOD_LIBRARIES}")
 ENDIF()    
 
 # elmersolver -library
@@ -329,10 +330,7 @@ SET_TARGET_PROPERTIES(ViewFactors PROPERTIES LINKER_LANGUAGE Fortran)
 # TARGET_INCLUDE_DIRECTORIES(ViewFactors PUBLIC ${CMAKE_BINARY_DIR}/fem/src/viewfactors)
 # FIND_LIBRARY(VIEW3D_LIBRARIES PATHS ${CMAKE_CURRENT_BINARY_DIR}/view3d)
 # FIND_LIBRARY(VIEWAXIS_LIBRARIES PATHS ${CMAKE_CURRENT_BINARY_DIR}/viewaxis)
-TARGET_LINK_LIBRARIES(ViewFactors ${ELMERSOLVER_LIBRARIES} 
-                                  mpi_stubs
-				  view3d
-				  viewaxis elmersolver)
+TARGET_LINK_LIBRARIES(ViewFactors view3d viewaxis elmersolver)
 INSTALL(TARGETS ViewFactors RUNTIME DESTINATION "bin")
 
 IF(NOT(WIN32))
@@ -346,10 +344,7 @@ SET_TARGET_PROPERTIES(Radiators PROPERTIES LINKER_LANGUAGE Fortran)
 # TARGET_INCLUDE_DIRECTORIES(Radiators PUBLIC ${CMAKE_BINARY_DIR}/fem/src/viewfactors)
 # FIND_LIBRARY(VIEW3D_LIBRARIES PATHS ${CMAKE_CURRENT_BINARY_DIR}/view3d)
 # FIND_LIBRARY(VIEWAXIS_LIBRARIES PATHS ${CMAKE_CURRENT_BINARY_DIR}/viewaxis)
-TARGET_LINK_LIBRARIES(Radiators ${ELMERSOLVER_LIBRARIES} 
-                                  mpi_stubs
-				  view3d
-				  viewaxis elmersolver)
+TARGET_LINK_LIBRARIES(Radiators view3d viewaxis elmersolver)
 INSTALL(TARGETS Radiators RUNTIME DESTINATION "bin")
 
 IF(NOT(WIN32))


### PR DESCRIPTION
Newer versions of SuiteSparse install CMake files. Use those files if they are available. Only fall back to guessing
installation locations if they are not available.
