### PR TITLE
Set minimum C and C++ standard versions.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -66,6 +66,12 @@ SET(CMAKE_MODULE_PATH "${PROJECT_SOURCE_DIR}/cmake/Modules;${CMAKE_ROOT}/Modules
 SET(CMAKE_Fortran_MODULE_DIRECTORY
   ${PROJECT_BINARY_DIR}/fmodules CACHE PATH "Directory for Fortran modules")
 
+# Require minimum standard version
+SET(CMAKE_C_STANDARD 99)
+SET(CMAKE_C_STANDARD_REQUIRED ON)
+SET(CMAKE_CXX_STANDARD 11)
+SET(CMAKE_CXX_STANDARD_REQUIRED ON)
+
 # Defaults to cache variables
 SET(WITH_MPI TRUE CACHE BOOL "Use MPI parallelization")
 SET(MPI_TEST_MAXPROC 8 CACHE STRING "Maximum number of tasks used in parallel tests")


### PR DESCRIPTION
Fixed width integer types (like `int64_t`) are currently used in C and in C++ source files. These types were added in C99 or C++11, respectively.

Most compilers default to newer versions of the standard by now. But some compilers that are old or follow a more conservative approach (like Apple Clang that still defaults to C++98 iiuc) might need extra flags to enable features from newer standards.

Set the minimum C and C++ standard versions to C99 and C++11 in the CMake build rules, respectively.
