### PR TITLE
Enable building with Zoltan in CI.

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -41,6 +41,8 @@ jobs:
 
       - name: checkout repository
         uses: actions/checkout@v4
+        with:
+          submodules: recursive
 
       - name: install dependencies
         run: |
@@ -59,7 +61,7 @@ jobs:
             -DBLA_VENDOR="OpenBLAS" \
             -DWITH_OpenMP=ON \
             -DWITH_LUA=ON \
-            -DWITH_Zoltan=OFF \
+            -DWITH_Zoltan=ON \
             -DWITH_Mumps=ON \
             -DWITH_ELMERGUI=ON \
             -DCREATE_PKGCONFIG_FILE=ON \

--- a/.github/workflows/full-test.yaml
+++ b/.github/workflows/full-test.yaml
@@ -72,7 +72,7 @@ jobs:
       - name: build
         run: |
           cd ${GITHUB_WORKSPACE}/build
-          cmake --build .
+          cmake --build . -j$(nproc)
 
       - name: install
         run: |
@@ -84,7 +84,7 @@ jobs:
         timeout-minutes: 150
         run: |
           cd ${GITHUB_WORKSPACE}/build
-          ctest .
+          ctest . -j$(nproc)
 
       - name: Re-run tests
         if: always() && (steps.run-ctest.outcome == 'failure')

--- a/.github/workflows/full-test.yaml
+++ b/.github/workflows/full-test.yaml
@@ -42,6 +42,8 @@ jobs:
 
       - name: checkout repository
         uses: actions/checkout@v4
+        with:
+          submodules: recursive
 
       - name: install dependencies
         run: |
@@ -59,7 +61,7 @@ jobs:
             -DBLA_VENDOR="OpenBLAS" \
             -DWITH_OpenMP=ON \
             -DWITH_LUA=ON \
-            -DWITH_Zoltan=OFF \
+            -DWITH_Zoltan=ON \
             -DWITH_Mumps=ON \
             -DCREATE_PKGCONFIG_FILE=ON \
             -DWITH_MPI=ON \


### PR DESCRIPTION
I didn't realize before that Zoltan was a Git submodule.

Check out with all submodules and activate Zoltan in the "normal" and the weekly CI rules.

Also, use parallel processes in build and test steps during the weekly (full-test) CI runs.