### PR TITLE
CI rules for MinGW with packages and tools from MSYS2

### DIFF
--- a/.github/workflows/build-windows-mingw.yaml
+++ b/.github/workflows/build-windows-mingw.yaml
@@ -4,7 +4,7 @@ on:
   push:
   pull_request:
 
-concurrency: ci-${{ github.ref }}
+concurrency: ci-windows-mingw-${{ github.ref }}
 
 jobs:
 

--- a/.github/workflows/build-windows-mingw.yaml
+++ b/.github/workflows/build-windows-mingw.yaml
@@ -9,47 +9,83 @@ concurrency: ci-windows-mingw-${{ github.ref }}
 jobs:
 
   windows-mingw:
+
     runs-on: windows-latest
+
     defaults:
       run:
         shell: msys2 {0}
-    
+
+    strategy:
+      # Allow other runners in the matrix to continue if some fail
+      fail-fast: false
+
+      matrix:
+        # msystem: [MINGW64, CLANG64]
+        msystem: [MINGW64]
+
     steps:
-      - uses: actions/checkout@v4
-      
-      - uses: msys2/setup-msys2@v2
+      - name: checkout repository
+        uses: actions/checkout@v4
+
+      - name: install dependencies
+        uses: msys2/setup-msys2@v2
         with:
-          msystem: MINGW64
+          msystem: ${{ matrix.msystem }}
           update: true
           install: >-
-            git
-            mingw-w64-x86_64-gcc
-            mingw-w64-x86_64-gcc-fortran
-            mingw-w64-x86_64-cmake
-            mingw-w64-x86_64-openblas
-            mingw-w64-x86_64-parmetis
             base-devel
-      
-      - name: Configure
+            git
+          pacboy: >-
+            cc:p
+            fc:p
+            cmake:p
+            openblas:p
+            parmetis:p
+
+      - name: configure
         run: |
-          mkdir build
-          cd build
-          cmake .. -G "MSYS Makefiles" \
+          mkdir ${GITHUB_WORKSPACE}/build
+          cd ${GITHUB_WORKSPACE}/build
+          cmake \
+            -G "MSYS Makefiles" \
             -DCMAKE_BUILD_TYPE="Release" \
+            -DCMAKE_INSTALL_PREFIX="${GITHUB_WORKSPACE}/usr" \
+            -DCPACK_BUNDLE_EXTRA_WINDOWS_DLLS=OFF \
             -DBLA_VENDOR="OpenBLAS" \
             -DWITH_OpenMP=ON \
             -DWITH_LUA=ON \
             -DWITH_Zoltan=OFF \
             -DWITH_Mumps=OFF \
             -DCREATE_PKGCONFIG_FILE=ON \
-            -DWITH_MPI=OFF
-      
-      - name: Build
+            -DWITH_MPI=OFF \
+            ..
+
+      - name: build
         run: |
-          cd build
-          cmake --build .
-      
-      - name: Test
+          cd ${GITHUB_WORKSPACE}/build
+          cmake --build . -j$(nproc)
+
+      - name: install
         run: |
-          cd build
-          ctest -L quick
+          cd ${GITHUB_WORKSPACE}/build
+          cmake --install .
+
+      - name: check
+        id: run-ctest
+        timeout-minutes: 150
+        run: |
+          cd ${GITHUB_WORKSPACE}/build
+          ctest -L quick -j$(nproc)
+
+      - name: re-run tests
+        if: always() && (steps.run-ctest.outcome == 'failure')
+        timeout-minutes: 60
+        run: |
+          cd ${GITHUB_WORKSPACE}/build
+          echo "::group::Re-run failing tests"
+          ctest --rerun-failed --output-on-failure || true
+          echo "::endgroup::"
+          echo "::group::Log from these tests"
+          [ ! -f Testing/Temporary/LastTest.log ] || cat Testing/Temporary/LastTest.log
+          echo "::endgroup::"

--- a/.github/workflows/build-windows-mingw.yaml
+++ b/.github/workflows/build-windows-mingw.yaml
@@ -42,6 +42,8 @@ jobs:
             cmake:p
             openblas:p
             parmetis:p
+            qwt-qt5:p
+            qt5-script:p
 
       - name: configure
         run: |
@@ -57,6 +59,7 @@ jobs:
             -DWITH_LUA=ON \
             -DWITH_Zoltan=OFF \
             -DWITH_Mumps=OFF \
+            -DWITH_ELMERGUI=ON \
             -DCREATE_PKGCONFIG_FILE=ON \
             -DWITH_MPI=OFF \
             ..

--- a/.github/workflows/build-windows-mingw.yaml
+++ b/.github/workflows/build-windows-mingw.yaml
@@ -25,6 +25,11 @@ jobs:
         msystem: [MINGW64]
 
     steps:
+      - name: get CPU name
+        shell: pwsh
+        run : |
+          Get-CIMInstance -Class Win32_Processor | Select-Object -Property Name
+
       - name: checkout repository
         uses: actions/checkout@v4
 

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -4,7 +4,7 @@ on:
   push:
   pull_request:
 
-concurrency: ci-${{ github.ref }}
+concurrency: ci-ubuntu-${{ github.ref }}
 
 jobs:
 

--- a/.github/workflows/ubuntu-clang-full.yaml
+++ b/.github/workflows/ubuntu-clang-full.yaml
@@ -5,7 +5,7 @@ on:
     # Run job every Thursday at 09:50 UTC
     - cron: '50 09 * * 4'
 
-concurrency: ci-${{ github.ref }}
+concurrency: ci-ubuntu-clang-full-${{ github.ref }}
 
 jobs:
 

--- a/.github/workflows/ubuntu-gcc-full.yaml
+++ b/.github/workflows/ubuntu-gcc-full.yaml
@@ -5,7 +5,7 @@ on:
     # Run job every Tuesday at 09:50 UTC
     - cron: '50 09 * * 2'
 
-concurrency: ci-${{ github.ref }}
+concurrency: ci-ubuntu-gcc-full-${{ github.ref }}
 
 jobs:
 


### PR DESCRIPTION
This overhauls the CI rules for MinGW a bit to make it easier to potentially expand the build matrix in the future.

It also tries to make it more comparable with the CI rules for Ubuntu (e.g., by using the same names for the respective build steps).

I tried to have it build using the [CLANG64 environment](https://www.msys2.org/docs/environments/) of MSYS2. But that currently fails because LLVM Flang hasn't support for some feature (yet?). Maybe, we can try again after LLVM Flang 19 has been released and MSYS2 started distributing it (maybe, some time this fall).

I also tried to build with MSMPI. But a couple of test are failing. I plan on opening a (draft) PR with that on top of this one if that is ok with you.

I'm also thinking about potentially using the UMFPACK library from MSYS2 for this workflow. Potentially by adding a build matrix with the internal and the MSYS2 UMFPACK. Would that be ok?
