### PR TITLE
Use unique Fortran module names

### DIFF
--- a/.github/workflows/build-windows-mingw.yaml
+++ b/.github/workflows/build-windows-mingw.yaml
@@ -65,7 +65,6 @@ jobs:
           mkdir ${GITHUB_WORKSPACE}/build
           cd ${GITHUB_WORKSPACE}/build
           cmake \
-            -G "MSYS Makefiles" \
             -DCMAKE_BUILD_TYPE="Release" \
             -DCMAKE_INSTALL_PREFIX="${GITHUB_WORKSPACE}/usr" \
             -DCPACK_BUNDLE_EXTRA_WINDOWS_DLLS=OFF \

--- a/fem/tests/mgdyn_anisotropic_cond/currents.f90
+++ b/fem/tests/mgdyn_anisotropic_cond/currents.f90
@@ -1,18 +1,18 @@
 
-module ToroidCurrents
-  contains 
+module ToroidCurrents1
+  contains
 
     function rho(r, r0, y)
-      USE Types 
+      USE Types
       real(kind=dp) :: rho, r, r0, y
-      
+
        rho = sqrt((r-r0)**2+y**2)
     end function rho
 
     function currentInToroidR(r, r0, y, turns, I) result (curr)
-      USE Types 
+      USE Types
       real(kind=dp) :: r, r0, y, curr, rho1, rho2, turns, I
-   
+
       rho1 = rho(8d-3, r0, y)
       rho2 = rho(10d-3, r0, y)
 
@@ -21,9 +21,9 @@ module ToroidCurrents
     end function currentInToroidR
 
     function currentInToroidY(r, r0, y, turns, I) result (curr)
-      USE Types 
+      USE Types
       real(kind=dp) :: r, r0, y, curr, rho1, rho2, turns, I
-   
+
       rho1 = rho(8d-3, r0, y)
       rho2 = rho(10d-3, r0, y)
 
@@ -31,11 +31,11 @@ module ToroidCurrents
 
     end function currentInToroidY
 
-End module ToroidCurrents
+End module ToroidCurrents1
 
 FUNCTION currdens1( model, n, args) RESULT(curr)
   USE DefUtils
-  Use ToroidCurrents
+  Use ToroidCurrents1
   IMPLICIT None
   TYPE(Model_t) :: model
   INTEGER :: n
@@ -65,7 +65,7 @@ END FUNCTION currdens1
 
 FUNCTION currdens2( model, n, args) RESULT(curr)
   USE DefUtils
-  Use ToroidCurrents
+  Use ToroidCurrents1
   IMPLICIT None
   TYPE(Model_t) :: model
   INTEGER :: n
@@ -95,7 +95,7 @@ END FUNCTION currdens2
 
 FUNCTION currdens3( model, n, args) RESULT(curr)
   USE DefUtils
-  Use ToroidCurrents
+  Use ToroidCurrents1
   IMPLICIT None
   TYPE(Model_t) :: model
   INTEGER :: n
@@ -122,4 +122,3 @@ FUNCTION currdens3( model, n, args) RESULT(curr)
   curr = currentInToroidR(r, r0, y, turns, I) * cos(theta)
 
 END FUNCTION currdens3
-

--- a/fem/tests/mgdyn_lamstack_lowfreq_transient/currents.f90
+++ b/fem/tests/mgdyn_lamstack_lowfreq_transient/currents.f90
@@ -1,18 +1,18 @@
 
-module ToroidCurrents
-  contains 
+module ToroidCurrents2
+  contains
 
     function rho(r, r0, y)
-      USE Types 
+      USE Types
       real(kind=dp) :: rho, r, r0, y
-      
+
        rho = sqrt((r-r0)**2+y**2)
     end function rho
 
     function currentInToroidR(r, r0, y, turns, I) result (curr)
-      USE Types 
+      USE Types
       real(kind=dp) :: r, r0, y, curr, rho1, rho2, turns, I
-   
+
       rho1 = rho(8d-3, r0, y)
       rho2 = rho(10d-3, r0, y)
 
@@ -21,9 +21,9 @@ module ToroidCurrents
     end function currentInToroidR
 
     function currentInToroidY(r, r0, y, turns, I) result (curr)
-      USE Types 
+      USE Types
       real(kind=dp) :: r, r0, y, curr, rho1, rho2, turns, I
-   
+
       rho1 = rho(8d-3, r0, y)
       rho2 = rho(10d-3, r0, y)
 
@@ -31,11 +31,11 @@ module ToroidCurrents
 
     end function currentInToroidY
 
-End module ToroidCurrents
+End module ToroidCurrents2
 
 FUNCTION currdens1( model, n, args) RESULT(curr)
   USE DefUtils
-  Use ToroidCurrents
+  Use ToroidCurrents2
   IMPLICIT None
   TYPE(Model_t) :: model
   INTEGER :: n
@@ -65,7 +65,7 @@ END FUNCTION currdens1
 
 FUNCTION currdens2( model, n, args) RESULT(curr)
   USE DefUtils
-  Use ToroidCurrents
+  Use ToroidCurrents2
   IMPLICIT None
   TYPE(Model_t) :: model
   INTEGER :: n
@@ -95,7 +95,7 @@ END FUNCTION currdens2
 
 FUNCTION currdens3( model, n, args) RESULT(curr)
   USE DefUtils
-  Use ToroidCurrents
+  Use ToroidCurrents2
   IMPLICIT None
   TYPE(Model_t) :: model
   INTEGER :: n
@@ -122,5 +122,3 @@ FUNCTION currdens3( model, n, args) RESULT(curr)
   curr = currentInToroidR(r, r0, y, turns, I) * cos(theta)
 
 END FUNCTION currdens3
-
-


### PR DESCRIPTION
Some CMake generators (e.g., Ninja) require that Fortran modules have unique names. That is because these generators create `.mod` files for these modules in a common folder (`fmodules` in the build tree).

Two files in `fem/tests` define Fortran modules named `ToroidCurrents`. Append numbers to these module names to work around the issue with some CMake generators (like Ninja).

Fixes #491.

Also, use Ninja on Windows now that it works.
