### PR TITLE
Avoid out-of-bound index.

### DIFF
--- a/fem/src/SolverUtils.F90
+++ b/fem/src/SolverUtils.F90
@@ -852,7 +852,7 @@ CONTAINS
 
        np = mGetElementDOFs(pIndexes,Element)
        np = MIN(np,n)
-       Ind(1:np) = NT % BoundaryReorder(pIndexes(1:np))
+       Ind(1:np) = NT % BoundaryReorder(MIN(pIndexes(1:np),SIZE(NT % BoundaryReorder)))
        
        ! TODO: See that RotateMatrix is vectorized
        CALL RotateMatrix( Lmtr, Lvec, n, dim, NDOFs, Ind, NT % BoundaryNormals, &


### PR DESCRIPTION
This avoids the random crash of `rotflow` that was discussed in #507 for me.

My Fortran is pretty rusty. And I'm not familiar with the code base. So, please check if this change is sensible.

I'm not sure if I'm reading or understanding the code correctly. The "out-of-bound indices" might be coming from here:
https://github.com/ElmerCSC/elmerfem/blob/746b705c7452f2583e89b3839e3d74cf6d368530/fem/src/ElementUtils.F90#L3993-L4001
Maybe, they should be dealt with differently? Potentially, reduce `np` by the degrees of freedom of the solver somehow? (Does any of that even make sense?)

