### PR TITLE
Run more tests regularly in CI.

### DIFF
--- a/.github/workflows/build-macos-homebrew.yaml
+++ b/.github/workflows/build-macos-homebrew.yaml
@@ -98,9 +98,9 @@ jobs:
         run: |
           cd ${GITHUB_WORKSPACE}/build
           ctest . \
-            -L "quick|elmerice-fast" \
+            -LE slow \
             -j$(sysctl -n hw.logicalcpu) \
-            --timeout 180
+            --timeout 300
 
       - name: re-run tests
         if: always() && (steps.run-ctest.outcome == 'failure')

--- a/.github/workflows/build-windows-mingw.yaml
+++ b/.github/workflows/build-windows-mingw.yaml
@@ -144,9 +144,9 @@ jobs:
         run: |
           cd ${GITHUB_WORKSPACE}/build
           ctest . \
-            -L "quick|elmerice-fast" \
+            -LE slow \
             -j$(nproc) \
-            --timeout 180
+            --timeout 300
 
       - name: re-run tests
         if: always() && (steps.run-ctest.outcome == 'failure')

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -141,9 +141,9 @@ jobs:
         run: |
           cd ${GITHUB_WORKSPACE}/build
           ctest . \
-            -L "quick|elmerice-fast" \
+            -LE slow \
             -j$(nproc) \
-            --timeout 180
+            --timeout 300
 
       - name: Re-run tests
         if: always() && (steps.run-ctest.outcome == 'failure')


### PR DESCRIPTION
The nix workflow takes approx. 30 minutes anyway. So, there is probably little harm in running more tests without extending the overall duration of a CI run by too much.