### PR TITLE
Build with ParaView in CI on Ubuntu.

### DIFF
--- a/.github/workflows/build-macos-homebrew.yaml
+++ b/.github/workflows/build-macos-homebrew.yaml
@@ -61,6 +61,7 @@ jobs:
             -DWITH_Zoltan=OFF \
             -DWITH_Mumps=OFF \
             -DWITH_ELMERGUI=ON \
+            -DWITH_PARAVIEW=ON \
             -DQWT_INCLUDE_DIR="${HOMEBREW_PREFIX}/opt/qwt-qt5/lib/qwt.framework/Headers" \
             -DCREATE_PKGCONFIG_FILE=ON \
             ..

--- a/.github/workflows/build-windows-mingw.yaml
+++ b/.github/workflows/build-windows-mingw.yaml
@@ -88,6 +88,7 @@ jobs:
             -DParMetis_INCLUDE_DIR="$(pkg-config --cflags parmetis)" \
             -DWITH_Mumps=OFF \
             -DWITH_ELMERGUI=ON \
+            -DWITH_PARAVIEW=ON \
             -DCREATE_PKGCONFIG_FILE=ON \
             ${{ matrix.umfpack-cmake-flags }} \
             ..

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -84,6 +84,7 @@ jobs:
             -DWITH_VTK=ON \
             -DWITH_OCC=ON \
             -DWITH_MATC=ON \
+            -DWITH_PARAVIEW=ON \
             -DCREATE_PKGCONFIG_FILE=ON \
             -DWITH_MPI=ON \
             -DMPI_TEST_MAXPROC=2 \

--- a/.github/workflows/ubuntu-clang-full.yaml
+++ b/.github/workflows/ubuntu-clang-full.yaml
@@ -63,6 +63,7 @@ jobs:
             -DWITH_Mumps=ON \
             -DWITH_ElmerIce=ON \
             -DWITH_ELMERGUI=ON \
+            -DWITH_PARAVIEW=ON \
             -DCREATE_PKGCONFIG_FILE=ON \
             -DWITH_MPI=ON \
             -DMPI_TEST_MAXPROC=2 \

--- a/.github/workflows/ubuntu-elmerice.yaml
+++ b/.github/workflows/ubuntu-elmerice.yaml
@@ -64,6 +64,7 @@ jobs:
             -DWITH_ElmerIce=ON \
             -DWITH_ELMERGUI=ON \
             -DWITH_MATC=ON \
+            -DWITH_PARAVIEW=ON \
             -DCREATE_PKGCONFIG_FILE=ON \
             -DWITH_MPI=ON \
             -DMPI_TEST_MAXPROC=2 \

--- a/.github/workflows/ubuntu-gcc-full.yaml
+++ b/.github/workflows/ubuntu-gcc-full.yaml
@@ -63,6 +63,7 @@ jobs:
             -DWITH_Mumps=ON \
             -DWITH_ElmerIce=ON \
             -DWITH_ELMERGUI=ON \
+            -DWITH_PARAVIEW=ON \
             -DCREATE_PKGCONFIG_FILE=ON \
             -DWITH_MPI=ON \
             -DMPI_TEST_MAXPROC=2 \

--- a/.github/workflows/ubuntu-parallel.yaml
+++ b/.github/workflows/ubuntu-parallel.yaml
@@ -60,6 +60,7 @@ jobs:
             -DWITH_Hypre=ON \
             -DHypre_INCLUDE_DIR="/usr/include/hypre" \
             -DWITH_ELMERGUI=ON \
+            -DWITH_PARAVIEW=ON \
             -DWITH_ELMERICE=ON \
             -DCREATE_PKGCONFIG_FILE=ON \
             -DWITH_MPI=ON \


### PR DESCRIPTION
This enables ParaView in the CI on Ubuntu.

The `ubuntu-latest` label is still pointing to Ubuntu 22.04. Unfortunately, there is a package conflict that prevents installing ParaView on the runner:
```
Some packages could not be installed. This may mean that you have
requested an impossible situation or if you are using the unstable
distribution that some required packages have not yet been created
or been moved out of Incoming.
The following information may help to resolve the situation:

The following packages have unmet dependencies:
 python3-paraview : Conflicts: python3-vtk9 but 9.1.0+really9.1.0+dfsg2-3build1 is to be installed
E: Error, pkgProblemResolver::Resolve generated breaks, this may be caused by held packages.
Error: Process completed with exit code 100.
```

That package conflict is resolved in Ubuntu 24.04. Runner images with that version of Ubuntu are already hosted as a beta by GitHub: https://github.com/actions/runner-images/issues/9848

For the time being, pin the runner image to `ubuntu-24.04`. That part of the change should be reverted some time after the `ubuntu-latest` label starts pointing to `ubuntu-24.04` (so the CI won't be stuck at an eventually old version of Ubuntu).
