### PR TITLE
Avoid out-of-bound index.

### DIFF
--- a/fem/src/SolverUtils.F90
+++ b/fem/src/SolverUtils.F90
@@ -760,10 +760,10 @@ CONTAINS
      IF ( Rotate ) THEN
        NormalIndexes = 0
 
-       np = mGetElementDOFs(pIndexes,Element)
-       np = MIN(np, n)
+       np = mGetElementDOFs(pIndexes,Element,NotBubble=.TRUE.)
+       np = MIN(np,n)
        NormalIndexes(1:np) = NT % BoundaryReorder(pIndexes(1:np))
-       
+
        CALL RotateMatrix( LocalStiffMatrix, LocalForce, n, dim, NDOFs, &
           NormalIndexes, NT % BoundaryNormals, NT % BoundaryTangent1, NT % BoundaryTangent2 )
      END IF
@@ -850,18 +850,10 @@ CONTAINS
      IF ( Rotate ) THEN
        Ind = 0
 
-       np = mGetElementDOFs(pIndexes,Element)
+       np = mGetElementDOFs(pIndexes,Element,NotBubble=.TRUE.)
        np = MIN(np,n)
+       Ind(1:np) = NT % BoundaryReorder(pIndexes(1:np))
 
-       DO i=1,np
-         j = pIndexes(i)
-         IF(j > 0 .AND. j <= SIZE(NT % BoundaryReorder) ) THEN
-           Ind(i) = NT % BoundaryReorder(j)
-         ELSE
-           Ind(i) = j
-         END IF
-       END DO
-       
        ! TODO: See that RotateMatrix is vectorized
        CALL RotateMatrix( Lmtr, Lvec, n, dim, NDOFs, Ind, NT % BoundaryNormals, &
                     NT % BoundaryTangent1, NT % BoundaryTangent2 )
@@ -14491,7 +14483,7 @@ END FUNCTION SearchNodeL
           END IF
         END DO
       END IF
-      
+
       ! This is temporal (?) fix for a glitch where the complex eigen vector
       ! is expanded to one where real and complex parts follow each other. 
       IF( ListGetLogical( Solver % Values,'Expand Eigen Vectors', Stat ) ) THEN
@@ -19713,7 +19705,7 @@ CONTAINS
                 MAXVAL(f(i::dofs,iControl)),SUM(f(i::dofs,iControl))
           END DO
         END  IF
-       
+
         IF( ABS(cAmp(iControl)) > 1.0e-20 ) THEN
           b(1:nsize) = b(1:nsize) + cAmp(iControl) * f(1:nsize,iControl)
         END IF


### PR DESCRIPTION
This is another attempt at fixing the random crashes of `rotflow` that was discussed in #507. (Hopefully, an improvement over #514.)

The test `rotflow` occasionally fails and valgrind flags an out-of-range error when running that test.

That error occurs because bubble degrees of freedom with indices larger than the number of nodes are used. Avoid that error by optionally not including the indices of bubble degrees of freedom in `mGetElementDOFs`. Only use non-bubble DOFs in `UpdateGlobalEquations`.

I'm still not entirely sure how bubble DOFs should be handled in this case. But I *think* that they can be ignored. (Please, check if that is actually the case.)
In any case, the proposed changes make that `valgrind` doesn't trigger during the test `rotflow` any more for me.

PS: There were a couple of merge conflicts when I tried to rebase on a current head. I hope I resolved them correctly.
