### PR TITLE
Fix building with VTK 9.3 or newer

### DIFF
--- a/.github/workflows/build-windows-mingw.yaml
+++ b/.github/workflows/build-windows-mingw.yaml
@@ -61,10 +61,27 @@ jobs:
             fc:p
             cmake:p
             msmpi:p
+            opencascade:p
             openblas:p
             parmetis:p
             qt6-declarative:p
             qwt-qt6:p
+            vtk:p
+            adios2:p
+            boost:p
+            cgns:p
+            cli11:p
+            eigen3:p
+            fast_float:p
+            ffmpeg:p
+            gl2ps:p
+            liblas:p
+            libmariadbclient:p
+            openslide:p
+            openvdb:p
+            pdal:p
+            unixodbc:p
+            utf8cpp:p
             ${{ matrix.umfpack-package }}
 
       - name: install MSMPI
@@ -95,6 +112,7 @@ jobs:
             -DWITH_Mumps=OFF \
             -DWITH_ELMERGUI=ON \
             -DWITH_QT6=ON \
+            -DWITH_VTK=ON \
             -DWITH_PARAVIEW=ON \
             -DCREATE_PKGCONFIG_FILE=ON \
             ${{ matrix.umfpack-cmake-flags }} \

--- a/.github/workflows/build-windows-mingw.yaml
+++ b/.github/workflows/build-windows-mingw.yaml
@@ -61,7 +61,6 @@ jobs:
             fc:p
             cmake:p
             msmpi:p
-            opencascade:p
             openblas:p
             parmetis:p
             qt6-declarative:p
@@ -82,6 +81,7 @@ jobs:
             pdal:p
             unixodbc:p
             utf8cpp:p
+            opencascade:p
             ${{ matrix.umfpack-package }}
 
       - name: install MSMPI
@@ -113,6 +113,7 @@ jobs:
             -DWITH_ELMERGUI=ON \
             -DWITH_QT6=ON \
             -DWITH_VTK=ON \
+            -DWITH_OCC=ON \
             -DWITH_PARAVIEW=ON \
             -DCREATE_PKGCONFIG_FILE=ON \
             ${{ matrix.umfpack-cmake-flags }} \

--- a/.github/workflows/build-windows-mingw.yaml
+++ b/.github/workflows/build-windows-mingw.yaml
@@ -63,8 +63,8 @@ jobs:
             msmpi:p
             openblas:p
             parmetis:p
-            qwt-qt5:p
-            qt5-script:p
+            qt6-declarative:p
+            qwt-qt6:p
             ${{ matrix.umfpack-package }}
 
       - name: install MSMPI
@@ -94,6 +94,7 @@ jobs:
             -DParMetis_INCLUDE_DIR="$(pkg-config --cflags parmetis)" \
             -DWITH_Mumps=OFF \
             -DWITH_ELMERGUI=ON \
+            -DWITH_QT6=ON \
             -DWITH_PARAVIEW=ON \
             -DCREATE_PKGCONFIG_FILE=ON \
             ${{ matrix.umfpack-cmake-flags }} \

--- a/ElmerGUI/Application/cad/cadview.h
+++ b/ElmerGUI/Application/cad/cadview.h
@@ -58,7 +58,6 @@ namespace nglib {
 #include <BRepMesh_IncrementalMesh.hxx>
 #endif
 
-#include "vtkConfigure.h"
 #ifndef VTK_MAJOR_VERSION
 #include "vtkVersionMacros.h"
 #endif

--- a/ElmerGUI/Application/vtkpost/vtkpost.h
+++ b/ElmerGUI/Application/vtkpost/vtkpost.h
@@ -57,7 +57,6 @@
 #include <gui/PythonQtScriptingConsole.h>
 #endif
 
-#include "vtkConfigure.h"
 #ifndef VTK_MAJOR_VERSION
 #include "vtkVersionMacros.h"
 #endif


### PR DESCRIPTION
MSYS2 distributes VTK version 9.3. However, they only distribute a version that is linked against Qt6.
Switch the Windows/MinGW CI runners to building ElmerGUI with Qt6. (That also increases coverage because the Ubuntu runners still build with Qt5.)
Additionally, install packages that are needed as build dependencies for VTK. (They aren't needed as runtime dependencies. So, MSYS2 doesn't install them automatically when installing VTK.)
Among those dependencies, OpenCascade needs to be installed on the runner. Take advantage of that and build ElmerGUI also against OpenCascade on that platform in CI.

Most importantly: The header `vtkConfigure.h` was deprecated in VTK 9.1 and was removed in VTK 9.3:
https://gitlab.kitware.com/vtk/vtk/-/blob/master/Documentation/release/9.1.md#filters-2
It looks like no symbol that was defined in [that header](https://vtk.org/doc/release/6.3/html/vtkConfigure_8h_source.html) is used in ElmerGUI. So, no longer include the header in the sources.

That fixes the first part of #532.
