### PR TITLE
Defer initialization of `listheaders` to later with OpenMP.

### DIFF
--- a/ElmerGUI/Application/vtkpost/mc.h
+++ b/ElmerGUI/Application/vtkpost/mc.h
@@ -2,12 +2,19 @@
 #define MC_H
 
 extern "C" {
+
 typedef struct list {
   struct list *next;              /* pointer to next item in list */
   char *name;                     /* name of list item            */
 } LIST;
 
+#ifdef _OPENMP
+/* Move initialization to matc.c::mtc_init() for thread safety */
+extern LIST *listheaders;
+#pragma omp threadprivate(listheaders)
+#else
 extern LIST listheaders[];
+#endif /* _OPENMP */
 
 #define ALLOCATIONS 0
 #define CONSTANTS   1


### PR DESCRIPTION
When building ElmerGUI with support for OpenMP, defer initialization of `listheaders` to `mtc_init()` (in libmatc) for thread safety. This is equivalent to what is done in `matc.h` of `libmatc`.

It looks like not doing that became an error with newer versions of GCC or binutils.

This fixes the second part of #532.