### PR TITLE
Build ElmerGUI with Qt6 in CI on macOS.

### DIFF
--- a/.github/workflows/build-macos-homebrew.yaml
+++ b/.github/workflows/build-macos-homebrew.yaml
@@ -40,7 +40,9 @@ jobs:
         run: |
           brew update
           brew reinstall gcc
-          brew install cmake libomp openblas open-mpi qwt-qt5
+          brew install \
+            cmake libomp openblas open-mpi \
+            qwt
           echo "HOMEBREW_PREFIX=$(brew --prefix)" >> $GITHUB_ENV
 
       - name: configure
@@ -56,7 +58,7 @@ jobs:
             -DCMAKE_Fortran_COMPILER=gfortran \
             -DCMAKE_INSTALL_PREFIX="${GITHUB_WORKSPACE}/usr" \
             -DBLA_VENDOR="OpenBLAS" \
-            -DCMAKE_PREFIX_PATH="${HOMEBREW_PREFIX}/opt/libomp;${HOMEBREW_PREFIX}/opt/openblas;${HOMEBREW_PREFIX}/opt/qt@5;${HOMEBREW_PREFIX}/opt/qwt-qt5" \
+            -DCMAKE_PREFIX_PATH="${HOMEBREW_PREFIX}/opt/libomp;${HOMEBREW_PREFIX}/opt/openblas;${HOMEBREW_PREFIX}/opt/qt;${HOMEBREW_PREFIX}/opt/qwt" \
             -DWITH_OpenMP=ON \
             -DOpenMP_C_FLAGS="-Xclang -fopenmp -I${HOMEBREW_PREFIX}/opt/libomp/include" \
             -DOpenMP_CXX_FLAGS="-Xclang -fopenmp -I${HOMEBREW_PREFIX}/opt/libomp/include" \
@@ -67,8 +69,9 @@ jobs:
             -DWITH_Zoltan=OFF \
             -DWITH_Mumps=OFF \
             -DWITH_ELMERGUI=ON \
+            -DWITH_QT6=ON \
             -DWITH_PARAVIEW=ON \
-            -DQWT_INCLUDE_DIR="${HOMEBREW_PREFIX}/opt/qwt-qt5/lib/qwt.framework/Headers" \
+            -DQWT_INCLUDE_DIR="${HOMEBREW_PREFIX}/opt/qwt/lib/qwt.framework/Headers" \
             -DCREATE_PKGCONFIG_FILE=ON \
             ..
 

--- a/ElmerGUI/Application/src/convergenceview.cpp
+++ b/ElmerGUI/Application/src/convergenceview.cpp
@@ -43,6 +43,12 @@
 #include "convergenceview.h"
 #include "mainwindow.h"
 
+#if defined(__cplusplus) && __cplusplus >= 201703L
+#  define REGISTER
+#else
+#  define REGISTER register
+#endif
+
 using namespace std;
 
 //-----------------------------------------------------------------------------
@@ -59,7 +65,7 @@ void CurveData::append(double *x, double *y, int count)
     d_y.resize(newSize);
   }
   
-  for(register int i = 0; i < count; i++) {
+  for(REGISTER int i = 0; i < count; i++) {
     d_x[d_count + i] = x[i];
     d_y[d_count + i] = y[i];
   }


### PR DESCRIPTION
Qt6 requires a C++ compiler that supports at least C++17.
C++17 removed the storage class specifier `register`. Clang seems to be more restrictive than GCC when it comes to extensions to the standard. Trying to use `register` with C++17 results in a compilation error like the following with `clang++`:
```
/Users/runner/work/elmerfem/elmerfem/ElmerGUI/Application/src/convergenceview.cpp:62:7: error: ISO C++17 does not allow 'register' storage class specifier [-Wregister]
  for(register int i = 0; i < count; i++) {
      ^~~~~~~~~
```

Only use the storage class specifier `register` if the used standard supports it.

This is an initial step towards potentially building ElmerGUI with VTK in CI on macOS. (Homebrew provides a version of VTK that is build with Qt6 - but no version of VTK with Qt5.)
