### PR TITLE
Build with Trilinos in CI on Ubuntu.

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -17,7 +17,7 @@ jobs:
   ubuntu:
     # For available GitHub-hosted runners, see:
     # https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
 
     name: ubuntu (${{ matrix.compiler }} ${{ matrix.openmp }} OpenMP)
 
@@ -72,7 +72,8 @@ jobs:
             libopenblas-dev libopenmpi-dev libmumps-dev libparmetis-dev \
             libqwt-qt5-dev qtscript5-dev libqt5svg5-dev \
             libvtk9-qt-dev libglvnd-dev \
-            occt-misc libocct-data-exchange-dev libocct-draw-dev
+            occt-misc libocct-data-exchange-dev libocct-draw-dev \
+            trilinos-all-dev libptscotch-dev
 
       - name: configure
         run: |
@@ -95,6 +96,7 @@ jobs:
             -DWITH_MPI=ON \
             -DMPI_TEST_MAXPROC=2 \
             -DMPIEXEC_PREFLAGS="--allow-run-as-root" \
+            -DWITH_Trilinos=ON \
             ..
 
       - name: build


### PR DESCRIPTION
There is a packaging conflict between vtk9 and trilinos on Ubuntu 22.04:
```
Some packages could not be installed. This may mean that you have
requested an impossible situation or if you are using the unstable
distribution that some required packages have not yet been created
or been moved out of Incoming.
The following information may help to resolve the situation:

The following packages have unmet dependencies:
 libvtk9-dev : Depends: libtbb-dev but it is not installable
E: Unable to correct problems, you have held broken packages.
```

It looks like that conflict has been resolved in Ubuntu 24.04. Pin the runner image to that version of Ubuntu for now.
