### PR TITLE
Fix typo in CI rules for OpenMP on Ubuntu runners.

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -35,26 +35,26 @@ jobs:
             cc: "gcc"
             cxx: "g++"
             openmp: with
-            openmp-cmake-flags: "-WITH_OpenMP=ON"
+            openmp-cmake-flags: "-DWITH_OpenMP=ON"
           - compiler: gcc
             compiler-pkgs: "g++ gcc"
             cc: "gcc"
             cxx: "g++"
             mpi: without
             openmp: with
-            openmp-cmake-flags: "-WITH_OpenMP=ON"
+            openmp-cmake-flags: "-DWITH_OpenMP=ON"
           - compiler: gcc
             compiler-pkgs: "g++ gcc"
             cc: "gcc"
             cxx: "g++"
             mpi: with
             openmp: without
-            openmp-cmake-flags: "-WITH_OpenMP=OFF"
+            openmp-cmake-flags: "-DWITH_OpenMP=OFF"
           - compiler: clang
             compiler-pkgs: "clang"
             cc: "clang"
             cxx: "clang++"
-            openmp-cmake-flags: "-WITH_OpenMP=ON -DOpenMP_C_FLAGS=-fopenmp=libgomp -DOpenMP_CXX_FLAGS=-fopenmp=libgomp"
+            openmp-cmake-flags: "-DWITH_OpenMP=ON -DOpenMP_C_FLAGS=-fopenmp=libgomp -DOpenMP_CXX_FLAGS=-fopenmp=libgomp"
 
     env:
       CC: ${{ matrix.cc }}

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -121,7 +121,7 @@ jobs:
           CTEST_OUTPUT_ON_FAILURE: 1
         run: |
           cd ${GITHUB_WORKSPACE}/build
-          ctest -L quick -j$(nproc)
+          set -o pipefail && ctest -L quick -j$(nproc) . | tee ./ctest_output.log
 
       - name: Re-run tests
         if: always() && (steps.run-ctest.outcome == 'failure')
@@ -130,6 +130,21 @@ jobs:
           CTEST_OUTPUT_ON_FAILURE: 1
         run: |
           cd ${GITHUB_WORKSPACE}/build
+          failed_tests=($(sed -n 's/^.*#[0-9]*\:\s*\(\S*\).*Failed.*/\1/p' ./ctest_output.log))
+          for test in "${failed_tests[@]}"; do
+            echo "::group::Content of fem/tests/${test}"
+            echo ---- Files ----
+            ls -Rl fem/tests/${test}
+            if [ -f fem/tests/${test}/test-stderr*.log ]; then
+              echo ---- Content of test-stderr*.log ----
+              cat fem/tests/${test}/test-stderr*.log
+            fi
+            if [ -f fem/tests/${test}/test-stdout*.log ]; then
+              echo ---- Content of test-stdout*.log ----
+              cat fem/tests/${test}/test-stdout*.log
+            fi
+            echo "::endgroup::"
+          done
           echo "::group::Re-run failing tests"
           ctest --rerun-failed --output-on-failure || true
           echo "::endgroup::"

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -26,7 +26,7 @@ jobs:
       fail-fast: false
 
       matrix:
-        compiler: [gcc, clang]
+        compiler: [gcc]
         mpi: [with]
         openmp: [with]
         include:
@@ -51,12 +51,19 @@ jobs:
             openmp: without
             openmp-cmake-flags: "-DWITH_OpenMP=OFF"
           - compiler: clang
-            compiler-pkgs: "clang libomp-dev"
+            compiler-pkgs: "clang"
             cc: "clang"
             cxx: "clang++"
             mpi: with
-            openmp: with
-            openmp-cmake-flags: "-DWITH_OpenMP=ON -DOpenMP_C_FLAGS='-fopenmp=libgomp -D_OPENMP=201511' -DOpenMP_CXX_FLAGS='-fopenmp=libgomp -D_OPENMP=201511' -DOpenMP_C_LIB_NAMES='gomp;pthread' -DOpenMP_CXX_LIB_NAMES='gomp;pthread'"
+            openmp: without
+            openmp-cmake-flags: "-DWITH_OpenMP=OFF"
+          # - compiler: clang
+          #   compiler-pkgs: "clang libomp-dev"
+          #   cc: "clang"
+          #   cxx: "clang++"
+          #   mpi: with
+          #   openmp: with
+          #   openmp-cmake-flags: "-DWITH_OpenMP=ON -DOpenMP_C_FLAGS='-fopenmp=libgomp -D_OPENMP=201511' -DOpenMP_CXX_FLAGS='-fopenmp=libgomp -D_OPENMP=201511' -DOpenMP_C_LIB_NAMES='gomp;pthread' -DOpenMP_CXX_LIB_NAMES='gomp;pthread'"
 
     env:
       CC: ${{ matrix.cc }}

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -51,10 +51,12 @@ jobs:
             openmp: without
             openmp-cmake-flags: "-DWITH_OpenMP=OFF"
           - compiler: clang
-            compiler-pkgs: "clang"
+            compiler-pkgs: "clang libomp-dev"
             cc: "clang"
             cxx: "clang++"
-            openmp-cmake-flags: "-DWITH_OpenMP=ON -DOpenMP_C_FLAGS=-fopenmp=libgomp -DOpenMP_CXX_FLAGS=-fopenmp=libgomp"
+            mpi: with
+            openmp: with
+            openmp-cmake-flags: "-DWITH_OpenMP=ON -DOpenMP_C_FLAGS='-fopenmp=libgomp -D_OPENMP=201511' -DOpenMP_CXX_FLAGS='-fopenmp=libgomp -D_OPENMP=201511' -DOpenMP_C_LIB_NAMES='gomp;pthread' -DOpenMP_CXX_LIB_NAMES='gomp;pthread'"
 
     env:
       CC: ${{ matrix.cc }}

--- a/ElmerGUI/matc/src/eval.c
+++ b/ElmerGUI/matc/src/eval.c
@@ -722,27 +722,27 @@ VARIABLE *evalclause(root) CLAUSE *root;
       {
         VARIABLE *var;
         char *r;
-  
+
         /*
          *  VARIABLE name
          */
         r = SDATA(root->this);
-  
+
         /*
-         *  check for name conflicts 
+         *  check for name conflicts
          */
         if (fnc_check(r) || com_check(r) || lst_find(CONSTANTS, r))
         {
           error( "VARIABLE not created [%s], identifier in use.\n ", r);
         }
-  
-        if ((res = evaltree(LINK(root->this))) != NULL) 
+
+        if ((res = evaltree(LINK(root->this))) != NULL)
         {
-          var_delete(r);
-          var = var_new(r,TYPE(res),1,1);
-  
+          if ((var = var_check(r)) == NULL)
+            var = var_new(r,TYPE(res),1,1);
+
           d = MATR(res);
-          for(i = 0; i < NCOL(res)*NROW(res); i++) 
+          for(i = 0; i < NCOL(res)*NROW(res); i++)
           {
             *MATR(var) = *d++;
             ptr = evalclause(LINK(root));
@@ -753,7 +753,7 @@ VARIABLE *evalclause(root) CLAUSE *root;
         root = root->jmp;
       break;
       }
-    } 
+    }
     root = LINK(root);
   }
   return ptr;

--- a/matc/src/eval.c
+++ b/matc/src/eval.c
@@ -723,27 +723,27 @@ VARIABLE *evalclause(root) CLAUSE *root;
       {
         VARIABLE *var;
         char *r;
-  
+
         /*
          *  VARIABLE name
          */
         r = SDATA(root->this);
-  
+
         /*
-         *  check for name conflicts 
+         *  check for name conflicts
          */
         if (fnc_check(r) || com_check(r) || lst_find(CONSTANTS, r))
         {
           error( "VARIABLE not created [%s], identifier in use.\n ", r);
         }
-  
-        if ((res = evaltree(LINK(root->this))) != NULL) 
+
+        if ((res = evaltree(LINK(root->this))) != NULL)
         {
-          var_delete(r);
-          var = var_new(r,TYPE(res),1,1);
-  
+          if ((var = var_check(r)) == NULL)
+            var = var_new(r,TYPE(res),1,1);
+
           d = MATR(res);
-          for(i = 0; i < NCOL(res)*NROW(res); i++) 
+          for(i = 0; i < NCOL(res)*NROW(res); i++)
           {
             *MATR(var) = *d++;
             ptr = evalclause(LINK(root));
@@ -754,7 +754,7 @@ VARIABLE *evalclause(root) CLAUSE *root;
         root = root->jmp;
       break;
       }
-    } 
+    }
     root = LINK(root);
   }
   return ptr;


### PR DESCRIPTION
There was a typo in the flags to enable OpenMP in the CI on Ubuntu. That meant that these runners never actually used OpenMP. (That's my bad. Sorry for that.)

Fixing that typo revealed that some additional flags were missing for using libgomp as the OpenMP implementation when building with LLVM Clang.

This PR fixes that typo and adds those flags.

