### PR TITLE
Increase size of buffer to accommodate maximum number of read characters

### DIFF
--- a/ElmerGUI/matc/src/eval.c
+++ b/ElmerGUI/matc/src/eval.c
@@ -449,12 +449,12 @@ VARIABLE *evalclause(root) CLAUSE *root;
 #else
            FILE *fp = popen( SDATA(root->this), "r" );
 #endif
-           static char s[101];
+           static char s[121];
 
            if ( !fp ) error( "systemcall: open failure: [%s].\n", SDATA(root->this) );
 
            while( fgets( s, 120, fp ) ) PrintOut( s );
-  
+
 #if defined(WIN32) || defined(MINGW32)
            _pclose( fp );
 #else

--- a/matc/src/eval.c
+++ b/matc/src/eval.c
@@ -449,13 +449,13 @@ VARIABLE *evalclause(root) CLAUSE *root;
 #else
            FILE *fp = popen( SDATA(root->this), "r" );
 #endif
-           static char s[101];
+           static char s[121];
 #pragma omp threadprivate (s)
 
            if ( !fp ) error( "systemcall: open failure: [%s].\n", SDATA(root->this) );
 
            while( fgets( s, 120, fp ) ) PrintOut( s );
-  
+
 #if defined(WIN32) || defined(MINGW32)
            _pclose( fp );
 #else

--- a/post/matc/src/eval.c
+++ b/post/matc/src/eval.c
@@ -449,13 +449,13 @@ VARIABLE *evalclause(root) CLAUSE *root;
 #else
            FILE *fp = popen( SDATA(root->this), "r" );
 #endif
-           static char s[101];
+           static char s[121];
 #pragma omp threadprivate (s)
 
            if ( !fp ) error( "systemcall: open failure: [%s].\n", SDATA(root->this) );
 
            while( fgets( s, 120, fp ) ) PrintOut( s );
-  
+
 #if defined(WIN32) || defined(MINGW32)
            _pclose( fp );
 #else


### PR DESCRIPTION
`fgets` is set to read up to 120 characters. Increase the size of the buffer `s` to 121.