### PR TITLE
Build ElmerIce and run its ctests in CI on macOS

### DIFF
--- a/.github/workflows/build-macos-homebrew.yaml
+++ b/.github/workflows/build-macos-homebrew.yaml
@@ -69,6 +69,7 @@ jobs:
             -DWITH_Zoltan=OFF \
             -DWITH_Mumps=OFF \
             -DWITH_CHOLMOD=ON \
+            -DWITH_ElmerIce=ON \
             -DWITH_ELMERGUI=ON \
             -DWITH_QT6=ON \
             -DQWT_INCLUDE_DIR="${HOMEBREW_PREFIX}/opt/qwt/lib/qwt.framework/Headers" \
@@ -97,7 +98,7 @@ jobs:
         run: |
           cd ${GITHUB_WORKSPACE}/build
           ctest . \
-            -L quick \
+            -L "quick|elmerice-fast" \
             -j$(sysctl -n hw.logicalcpu) \
             --timeout 180
 


### PR DESCRIPTION
This is mainly thought to show the work-in-progress for ElmerIce on macOS.

Some of its tests seem to be stuck indefinitely on macOS 14.
Reduce the timeout for a single test from 1500 seconds (25 minutes is the default for ctest) to 180 seconds. None of the tests in the "quick" set should be taking longer than that. And it isn't worth blocking the CI runners for any longer in this case.

Additionally, this shows more output for failed tests in the CI log on macOS. It turned out that the approach that is working on Ubuntu and Windows uses bash-isms that don't work on macOS.
After trying different approaches, I'm liking the one that is working here better than the one that we are using currently for the other platforms. Maybe, we could use the approach from this PR also in the other workflows (untested as of now).

Anyway, the same set of tests fail on macOS 13 and macOS 14. While they fail more or less immediately on macOS 13, they are stuck indefinitely(?) on macOS 14.
The `test-stderr.log` file contains errors like the following in this case:
```
[Mac-1725527155906.local:38011] shmem: mmap: an error occurred while determining whether or not /var/folders/72/1_pq_fmd68z11lwcbjh9cyj00000gn/T//ompi.Mac-1725527155906.501/jf.0/1864564736/sm_segment.Mac-1725527155906.501.6f230000.0 could be created.
  
  Program received signal SIGILL: Illegal instruction.
  
  Backtrace for this error:
  
  Could not print backtrace: executable file is not an executable
  
  Could not print backtrace: executable file is not an executable
  
  Could not print backtrace: executable file is not an executable
  
  Could not print backtrace: executable file is not an executable
  #0  0x10c1a0a0e
  #1  0x10c19fb1d
  #2  0x7ff8048135ec
  #3  0x7ff80470ad4b
  #4  0x7ff804695391
```

The last lines in `test-stdout.log` are:
```
  CheckKeyword: Found keyword type assuming suffix 1 for: operator 4
  Operator 5 = String "cpu time"
   String "cpu time"
  CheckKeyword: Found keyword type assuming suffix 1 for: operator 5
  Loading user function library: [ElmerIceUSF]...[SeaPressure]
```

Does anyone have an idea what could be causing that?
