### PR TITLE
Optionally build with external (P)ARPACK in CI on Windows/MinGW.

### DIFF
--- a/.github/workflows/build-windows-mingw.yaml
+++ b/.github/workflows/build-windows-mingw.yaml
@@ -18,7 +18,7 @@ jobs:
 
     runs-on: windows-latest
 
-    name: MSYS2 (${{ matrix.umfpack }} UMFPACK, ${{ matrix.msystem }})
+    name: MSYS2 (${{ matrix.dependencies }} dependencies, ${{ matrix.msystem }})
 
     defaults:
       run:
@@ -31,10 +31,11 @@ jobs:
       matrix:
         # msystem: [MINGW64, CLANG64]
         msystem: [MINGW64]
-        umfpack: [internal, external]
+        dependencies: [bundled, external]
         include:
-          - umfpack: external
-            umfpack-cmake-flags: "-DEXTERNAL_UMFPACK=ON"
+          - dependencies: external
+            external-packages: parpack:p
+            external-cmake-flags: -DEXTERNAL_UMFPACK=ON -DEXTERNAL_ARPACK=ON -DEXTERNAL_PARPACK=ON
 
     steps:
       - name: get CPU name
@@ -83,6 +84,7 @@ jobs:
             unixodbc:p
             utf8cpp:p
             opencascade:p
+            ${{ matrix.external-packages }}
 
       - name: install MSMPI
         uses: mpi4py/setup-mpi@v1
@@ -121,7 +123,7 @@ jobs:
             -DWITH_MATC=ON \
             -DWITH_PARAVIEW=ON \
             -DCREATE_PKGCONFIG_FILE=ON \
-            ${{ matrix.umfpack-cmake-flags }} \
+            ${{ matrix.external-cmake-flags }} \
             ..
 
       - name: build


### PR DESCRIPTION
PARPACK is distributed by MSYS2 now.
Use the runner that already builds against an external UMFPACK library to also test building against external ARPACK and PARPACK libraries.
