### PR TITLE
ARPACK/PARPACK: Avoid compiler error with GFortran 10 or newer. 

### DIFF
--- a/mathlibs/src/arpack/cgetv0.f
+++ b/mathlibs/src/arpack/cgetv0.f
@@ -2,13 +2,13 @@ c\BeginDoc
 c
 c\Name: cgetv0
 c
-c\Description: 
+c\Description:
 c  Generate a random initial residual vector for the Arnoldi process.
-c  Force the residual vector to be in the range of the operator OP.  
+c  Force the residual vector to be in the range of the operator OP.
 c
 c\Usage:
 c  call cgetv0
-c     ( IDO, BMAT, ITRY, INITV, N, J, V, LDV, RESID, RNORM, 
+c     ( IDO, BMAT, ITRY, INITV, N, J, V, LDV, RESID, RNORM,
 c       IPNTR, WORKD, IERR )
 c
 c\Arguments
@@ -35,7 +35,7 @@ c          B = 'I' -> standard eigenvalue problem A*x = lambda*x
 c          B = 'G' -> generalized eigenvalue problem A*x = lambda*B*x
 c
 c  ITRY    Integer.  (INPUT)
-c          ITRY counts the number of times that cgetv0 is called.  
+c          ITRY counts the number of times that cgetv0 is called.
 c          It should be set to 1 on the initial call to cgetv0.
 c
 c  INITV   Logical variable.  (INPUT)
@@ -54,11 +54,11 @@ c          The first J-1 columns of V contain the current Arnoldi basis
 c          if this is a "restart".
 c
 c  LDV     Integer.  (INPUT)
-c          Leading dimension of V exactly as declared in the calling 
+c          Leading dimension of V exactly as declared in the calling
 c          program.
 c
 c  RESID   Complex array of length N.  (INPUT/OUTPUT)
-c          Initial residual vector to be generated.  If RESID is 
+c          Initial residual vector to be generated.  If RESID is
 c          provided, force RESID into the range of the operator OP.
 c
 c  RNORM   Real scalar.  (OUTPUT)
@@ -91,19 +91,19 @@ c
 c\Routines called:
 c     second  ARPACK utility routine for timing.
 c     cvout   ARPACK utility routine that prints vectors.
-c     clarnv  LAPACK routine for generating a random vector. 
+c     clarnv  LAPACK routine for generating a random vector.
 c     cgemv   Level 2 BLAS routine for matrix vector multiplication.
 c     ccopy   Level 1 BLAS that copies one vector to another.
 c     cdotc   Level 1 BLAS that computes the scalar product of two vectors.
-c     scnrm2  Level 1 BLAS that computes the norm of a vector. 
+c     scnrm2  Level 1 BLAS that computes the norm of a vector.
 c
 c\Author
 c     Danny Sorensen               Phuong Vu
 c     Richard Lehoucq              CRPC / Rice University
 c     Dept. of Computational &     Houston, Texas
-c     Applied Mathematics 
-c     Rice University           
-c     Houston, Texas            
+c     Applied Mathematics
+c     Rice University
+c     Houston, Texas
 c
 c\SCCS Information: @(#)
 c FILE: getv0.F   SID: 2.3   DATE OF SID: 8/27/96   RELEASE: 2
@@ -112,10 +112,10 @@ c\EndLib
 c
 c-----------------------------------------------------------------------
 c
-      subroutine cgetv0 
-     &   ( ido, bmat, itry, initv, n, j, v, ldv, resid, rnorm, 
+      subroutine cgetv0
+     &   ( ido, bmat, itry, initv, n, j, v, ldv, resid, rnorm,
      &     ipntr, workd, ierr )
-c 
+c
 c     %----------------------------------------------------%
 c     | Include files for debugging and timing information |
 c     %----------------------------------------------------%
@@ -174,7 +174,7 @@ c     %--------------------%
 c     | External Functions |
 c     %--------------------%
 c
-      Real 
+      Real
      &           scnrm2, slapy2
       Complex
      &           cdotc
@@ -205,7 +205,7 @@ c
       end if
 c
       if (ido .eq.  0) then
-c 
+c
 c        %-------------------------------%
 c        | Initialize timing statistics  |
 c        | & message level for debugging |
@@ -213,7 +213,7 @@ c        %-------------------------------%
 c
          call second (t0)
          msglvl = mgetv0
-c 
+c
          ierr   = 0
          iter   = 0
          first  = .FALSE.
@@ -232,7 +232,7 @@ c
             idist = 2
             call clarnv (idist, iseed, n, resid)
          end if
-c 
+c
 c        %----------------------------------------------------------%
 c        | Force the starting vector into the range of OP to handle |
 c        | the generalized problem when B is possibly (singular).   |
@@ -248,7 +248,7 @@ c
             go to 9000
          end if
       end if
-c 
+c
 c     %----------------------------------------%
 c     | Back from computing B*(initial-vector) |
 c     %----------------------------------------%
@@ -260,10 +260,10 @@ c     | Back from computing B*(orthogonalized-vector) |
 c     %-----------------------------------------------%
 c
       if (orth)  go to 40
-c 
+c
       call second (t3)
       tmvopx = tmvopx + (t3 - t2)
-c 
+c
 c     %------------------------------------------------------%
 c     | Starting vector is now in the range of OP; r = OP*r; |
 c     | Compute B-norm of starting vector.                   |
@@ -281,14 +281,14 @@ c
       else if (bmat .eq. 'I') then
          call ccopy (n, resid, 1, workd, 1)
       end if
-c 
+c
    20 continue
 c
       if (bmat .eq. 'G') then
          call second (t3)
          tmvbx = tmvbx + (t3 - t2)
       end if
-c 
+c
       first = .FALSE.
       if (bmat .eq. 'G') then
           cnorm  = cdotc (n, resid, 1, workd, 1)
@@ -303,7 +303,7 @@ c     | Exit if this is the very first Arnoldi step |
 c     %---------------------------------------------%
 c
       if (j .eq. 1) go to 50
-c 
+c
 c     %----------------------------------------------------------------
 c     | Otherwise need to B-orthogonalize the starting vector against |
 c     | the current Arnoldi basis using Gram-Schmidt with iter. ref.  |
@@ -319,11 +319,11 @@ c
       orth = .TRUE.
    30 continue
 c
-      call cgemv ('C', n, j-1, one, v, ldv, workd, 1, 
+      call cgemv ('C', n, j-1, one, v, ldv, workd, 1,
      &            zero, workd(n+1), 1)
-      call cgemv ('N', n, j-1, -one, v, ldv, workd(n+1), 1, 
+      call cgemv ('N', n, j-1, -one, v, ldv, workd(n+1), 1,
      &            one, resid, 1)
-c 
+c
 c     %----------------------------------------------------------%
 c     | Compute the B-norm of the orthogonalized starting vector |
 c     %----------------------------------------------------------%
@@ -339,14 +339,14 @@ c
       else if (bmat .eq. 'I') then
          call ccopy (n, resid, 1, workd, 1)
       end if
-c 
+c
    40 continue
 c
       if (bmat .eq. 'G') then
          call second (t3)
          tmvbx = tmvbx + (t3 - t2)
       end if
-c 
+c
       if (bmat .eq. 'G') then
          cnorm = cdotc (n, resid, 1, workd, 1)
          rnorm = sqrt(slapy2(real(cnorm),aimag(cnorm)))
@@ -359,14 +359,14 @@ c     | Check for further orthogonalization. |
 c     %--------------------------------------%
 c
       if (msglvl .gt. 2) then
-          call svout (logfil, 1, [rnorm0], ndigit, 
+          call svout (logfil, 1, [rnorm0], ndigit,
      &                '_getv0: re-orthonalization ; rnorm0 is')
-          call svout (logfil, 1, [rnorm], ndigit, 
+          call svout (logfil, 1, [rnorm], ndigit,
      &                '_getv0: re-orthonalization ; rnorm is')
       end if
 c
       if (rnorm .gt. 0.717*rnorm0) go to 50
-c 
+c
       iter = iter + 1
       if (iter .le. 1) then
 c
@@ -388,7 +388,7 @@ c
          rnorm = rzero
          ierr = -1
       end if
-c 
+c
    50 continue
 c
       if (msglvl .gt. 0) then
@@ -400,10 +400,10 @@ c
      &        '_getv0: initial / restarted starting vector')
       end if
       ido = 99
-c 
+c
       call second (t1)
       tgetv0 = tgetv0 + (t1 - t0)
-c 
+c
  9000 continue
       return
 c

--- a/mathlibs/src/arpack/cgetv0.f
+++ b/mathlibs/src/arpack/cgetv0.f
@@ -359,9 +359,9 @@ c     | Check for further orthogonalization. |
 c     %--------------------------------------%
 c
       if (msglvl .gt. 2) then
-          call svout (logfil, 1, rnorm0, ndigit, 
+          call svout (logfil, 1, [rnorm0], ndigit, 
      &                '_getv0: re-orthonalization ; rnorm0 is')
-          call svout (logfil, 1, rnorm, ndigit, 
+          call svout (logfil, 1, [rnorm], ndigit, 
      &                '_getv0: re-orthonalization ; rnorm is')
       end if
 c
@@ -392,7 +392,7 @@ c
    50 continue
 c
       if (msglvl .gt. 0) then
-         call svout (logfil, 1, rnorm, ndigit,
+         call svout (logfil, 1, [rnorm], ndigit,
      &        '_getv0: B-norm of initial / restarted starting vector')
       end if
       if (msglvl .gt. 2) then

--- a/mathlibs/src/arpack/cnaitr.f
+++ b/mathlibs/src/arpack/cnaitr.f
@@ -2,8 +2,8 @@ c\BeginDoc
 c
 c\Name: cnaitr
 c
-c\Description: 
-c  Reverse communication interface for applying NP additional steps to 
+c\Description:
+c  Reverse communication interface for applying NP additional steps to
 c  a K step nonsymmetric Arnoldi factorization.
 c
 c  Input:  OP*V_{k}  -  V_{k}*H = r_{k}*e_{k}^T
@@ -19,7 +19,7 @@ c  computed and returned.
 c
 c\Usage:
 c  call cnaitr
-c     ( IDO, BMAT, N, K, NP, NB, RESID, RNORM, V, LDV, H, LDH, 
+c     ( IDO, BMAT, N, K, NP, NB, RESID, RNORM, V, LDV, H, LDH,
 c       IPNTR, WORKD, INFO )
 c
 c\Arguments
@@ -61,8 +61,8 @@ c  NP      Integer.  (INPUT)
 c          Number of additional Arnoldi steps to take.
 c
 c  NB      Integer.  (INPUT)
-c          Blocksize to be used in the recurrence.          
-c          Only work for NB = 1 right now.  The goal is to have a 
+c          Blocksize to be used in the recurrence.
+c          Only work for NB = 1 right now.  The goal is to have a
 c          program that implement both the block and non-block method.
 c
 c  RESID   Complex array of length N.  (INPUT/OUTPUT)
@@ -74,37 +74,37 @@ c          B-norm of the starting residual on input.
 c          B-norm of the updated residual r_{k+p} on output.
 c
 c  V       Complex N by K+NP array.  (INPUT/OUTPUT)
-c          On INPUT:  V contains the Arnoldi vectors in the first K 
+c          On INPUT:  V contains the Arnoldi vectors in the first K
 c          columns.
 c          On OUTPUT: V contains the new NP Arnoldi vectors in the next
 c          NP columns.  The first K columns are unchanged.
 c
 c  LDV     Integer.  (INPUT)
-c          Leading dimension of V exactly as declared in the calling 
+c          Leading dimension of V exactly as declared in the calling
 c          program.
 c
 c  H       Complex (K+NP) by (K+NP) array.  (INPUT/OUTPUT)
 c          H is used to store the generated upper Hessenberg matrix.
 c
 c  LDH     Integer.  (INPUT)
-c          Leading dimension of H exactly as declared in the calling 
+c          Leading dimension of H exactly as declared in the calling
 c          program.
 c
 c  IPNTR   Integer array of length 3.  (OUTPUT)
-c          Pointer to mark the starting locations in the WORK for 
+c          Pointer to mark the starting locations in the WORK for
 c          vectors used by the Arnoldi iteration.
 c          -------------------------------------------------------------
 c          IPNTR(1): pointer to the current operand vector X.
 c          IPNTR(2): pointer to the current result vector Y.
-c          IPNTR(3): pointer to the vector B * X when used in the 
+c          IPNTR(3): pointer to the vector B * X when used in the
 c                    shift-and-invert mode.  X is the current operand.
 c          -------------------------------------------------------------
-c          
+c
 c  WORKD   Complex work array of length 3*N.  (REVERSE COMMUNICATION)
 c          Distributed array to be used in the basic Arnoldi iteration
-c          for reverse communication.  The calling program should not 
+c          for reverse communication.  The calling program should not
 c          use WORKD as temporary workspace during the iteration !!!!!!
-c          On input, WORKD(1:N) = B*RESID and is used to save some 
+c          On input, WORKD(1:N) = B*RESID and is used to save some
 c          computation at the first step.
 c
 c  INFO    Integer.  (OUTPUT)
@@ -124,7 +124,7 @@ c\References:
 c  1. D.C. Sorensen, "Implicit Application of Polynomial Filters in
 c     a k-Step Arnoldi Method", SIAM J. Matr. Anal. Apps., 13 (1992),
 c     pp 357-385.
-c  2. R.B. Lehoucq, "Analysis and Implementation of an Implicitly 
+c  2. R.B. Lehoucq, "Analysis and Implementation of an Implicitly
 c     Restarted Arnoldi Iteration", Rice University Technical Report
 c     TR95-13, Department of Computational and Applied Mathematics.
 c
@@ -143,29 +143,29 @@ c     slapy2  LAPACK routine to compute sqrt(x**2+y**2) carefully.
 c     cgemv   Level 2 BLAS routine for matrix vector multiplication.
 c     caxpy   Level 1 BLAS that computes a vector triad.
 c     ccopy   Level 1 BLAS that copies one vector to another .
-c     cdotc   Level 1 BLAS that computes the scalar product of two vectors. 
+c     cdotc   Level 1 BLAS that computes the scalar product of two vectors.
 c     cscal   Level 1 BLAS that scales a vector.
-c     csscal  Level 1 BLAS that scales a complex vector by a real number. 
+c     csscal  Level 1 BLAS that scales a complex vector by a real number.
 c     scnrm2  Level 1 BLAS that computes the norm of a vector.
 c
 c\Author
 c     Danny Sorensen               Phuong Vu
 c     Richard Lehoucq              CRPC / Rice University
-c     Dept. of Computational &     Houston, Texas 
-c     Applied Mathematics 
-c     Rice University           
-c     Houston, Texas 
-c 
+c     Dept. of Computational &     Houston, Texas
+c     Applied Mathematics
+c     Rice University
+c     Houston, Texas
+c
 c\SCCS Information: @(#)
 c FILE: naitr.F   SID: 2.3   DATE OF SID: 8/27/96   RELEASE: 2
 c
 c\Remarks
 c  The algorithm implemented is:
-c  
+c
 c  restart = .false.
-c  Given V_{k} = [v_{1}, ..., v_{k}], r_{k}; 
+c  Given V_{k} = [v_{1}, ..., v_{k}], r_{k};
 c  r_{k} contains the initial residual vector even for k = 0;
-c  Also assume that rnorm = || B*r_{k} || and B*r_{k} are already 
+c  Also assume that rnorm = || B*r_{k} || and B*r_{k} are already
 c  computed by the calling program.
 c
 c  betaj = rnorm ; p_{k+1} = B*r_{k} ;
@@ -173,7 +173,7 @@ c  For  j = k+1, ..., k+np  Do
 c     1) if ( betaj < tol ) stop or restart depending on j.
 c        ( At present tol is zero )
 c        if ( restart ) generate a new starting vector.
-c     2) v_{j} = r(j-1)/betaj;  V_{j} = [V_{j-1}, v_{j}];  
+c     2) v_{j} = r(j-1)/betaj;  V_{j} = [V_{j-1}, v_{j}];
 c        p_{j} = p_{j}/betaj
 c     3) r_{j} = OP*v_{j} where OP is defined as in cnaupd
 c        For shift-invert mode p_{j} = B*v_{j} is already available.
@@ -188,7 +188,7 @@ c        If (rnorm > 0.717*wnorm) accept step and go back to 1)
 c     5) Re-orthogonalization step:
 c        s = V_{j}'*B*r_{j}
 c        r_{j} = r_{j} - V_{j}*s;  rnorm1 = || r_{j} ||
-c        alphaj = alphaj + s_{j};   
+c        alphaj = alphaj + s_{j};
 c     6) Iterative refinement step:
 c        If (rnorm1 > 0.717*rnorm) then
 c           rnorm = rnorm1
@@ -198,7 +198,7 @@ c           rnorm = rnorm1
 c           If this is the first time in step 6), go to 5)
 c           Else r_{j} lies in the span of V_{j} numerically.
 c              Set r_{j} = 0 and rnorm = 0; go to 1)
-c        EndIf 
+c        EndIf
 c  End Do
 c
 c\EndLib
@@ -206,7 +206,7 @@ c
 c-----------------------------------------------------------------------
 c
       subroutine cnaitr
-     &   (ido, bmat, n, k, np, nb, resid, rnorm, v, ldv, h, ldh, 
+     &   (ido, bmat, n, k, np, nb, resid, rnorm, v, ldv, h, ldh,
      &    ipntr, workd, info)
 c
 c     %----------------------------------------------------%
@@ -241,7 +241,7 @@ c
      &           one, zero
       Real
      &           rone, rzero
-      parameter (one = (1.0E+0, 0.0E+0), zero = (0.0E+0, 0.0E+0), 
+      parameter (one = (1.0E+0, 0.0E+0), zero = (0.0E+0, 0.0E+0),
      &           rone = 1.0E+0, rzero = 0.0E+0)
 c
 c     %--------------%
@@ -258,7 +258,7 @@ c
       logical    first, orth1, orth2, rstart, step3, step4
       integer    ierr, i, infol, ipj, irj, ivj, iter, itry, j, msglvl,
      &           jj
-      Real            
+      Real
      &           ovfl, smlnum, tst1, ulp, unfl, betaj,
      &           temp1, rnorm1, wnorm
       Complex
@@ -272,7 +272,7 @@ c     %----------------------%
 c     | External Subroutines |
 c     %----------------------%
 c
-      external   caxpy, ccopy, cscal, csscal, cgemv, cgetv0, 
+      external   caxpy, ccopy, cscal, csscal, cgemv, cgetv0,
      &           slabad, cvout, cmout, ivout, second
 c
 c     %--------------------%
@@ -280,8 +280,8 @@ c     | External Functions |
 c     %--------------------%
 c
       Complex
-     &           cdotc 
-      Real            
+     &           cdotc
+      Real
      &           slamch,  scnrm2, clanhs, slapy2
       external   cdotc, scnrm2, clanhs, slamch, slapy2
 c
@@ -289,7 +289,7 @@ c     %---------------------%
 c     | Intrinsic Functions |
 c     %---------------------%
 c
-      intrinsic  aimag, real, max, sqrt 
+      intrinsic  aimag, real, max, sqrt
 c
 c     %-----------------%
 c     | Data statements |
@@ -320,7 +320,7 @@ c
       end if
 c
       if (ido .eq. 0) then
-c 
+c
 c        %-------------------------------%
 c        | Initialize timing statistics  |
 c        | & message level for debugging |
@@ -328,7 +328,7 @@ c        %-------------------------------%
 c
          call second (t0)
          msglvl = mcaitr
-c 
+c
 c        %------------------------------%
 c        | Initial call to this routine |
 c        %------------------------------%
@@ -344,7 +344,7 @@ c
          irj    = ipj   + n
          ivj    = irj   + n
       end if
-c 
+c
 c     %-------------------------------------------------%
 c     | When in reverse communication mode one of:      |
 c     | STEP3, STEP4, ORTH1, ORTH2, RSTART              |
@@ -374,16 +374,16 @@ c     |        A R N O L D I     I T E R A T I O N     L O O P       |
 c     |                                                              |
 c     | Note:  B*r_{j-1} is already in WORKD(1:N)=WORKD(IPJ:IPJ+N-1) |
 c     %--------------------------------------------------------------%
- 
+
  1000 continue
 c
          if (msglvl .gt. 1) then
-            call ivout (logfil, 1, [j], ndigit, 
+            call ivout (logfil, 1, [j], ndigit,
      &                  '_naitr: generating Arnoldi vector number')
-            call svout (logfil, 1, [rnorm], ndigit, 
+            call svout (logfil, 1, [rnorm], ndigit,
      &                  '_naitr: B-norm of the current residual is')
          end if
-c 
+c
 c        %---------------------------------------------------%
 c        | STEP 1: Check if the B norm of j-th residual      |
 c        | vector is zero. Equivalent to determine whether   |
@@ -403,13 +403,13 @@ c
                call ivout (logfil, 1, [j], ndigit,
      &                     '_naitr: ****** RESTART AT STEP ******')
             end if
-c 
+c
 c           %---------------------------------------------%
 c           | ITRY is the loop variable that controls the |
 c           | maximum amount of times that a restart is   |
 c           | attempted. NRSTRT is used by stat.h         |
 c           %---------------------------------------------%
-c 
+c
             betaj  = rzero
             nrstrt = nrstrt + 1
             itry   = 1
@@ -423,7 +423,7 @@ c           | If in reverse communication mode and |
 c           | RSTART = .true. flow returns here.   |
 c           %--------------------------------------%
 c
-            call cgetv0 (ido, bmat, itry, .false., n, j, v, ldv, 
+            call cgetv0 (ido, bmat, itry, .false., n, j, v, ldv,
      &                   resid, rnorm, ipntr, workd, ierr)
             if (ido .ne. 99) go to 9000
             if (ierr .lt. 0) then
@@ -442,7 +442,7 @@ c
                ido = 99
                go to 9000
             end if
-c 
+c
    40    continue
 c
 c        %---------------------------------------------------------%
@@ -466,7 +466,7 @@ c            %-----------------------------------------%
 c
              call clascl ('General', i, i, rnorm, rone,
      &                    n, 1, v(1,j), n, infol)
-             call clascl ('General', i, i, rnorm, rone,  
+             call clascl ('General', i, i, rnorm, rone,
      &                    n, 1, workd(ipj), n, infol)
          end if
 c
@@ -483,14 +483,14 @@ c
          ipntr(2) = irj
          ipntr(3) = ipj
          ido = 1
-c 
+c
 c        %-----------------------------------%
 c        | Exit in order to compute OP*v_{j} |
 c        %-----------------------------------%
-c 
-         go to 9000 
+c
+         go to 9000
    50    continue
-c 
+c
 c        %----------------------------------%
 c        | Back from reverse communication; |
 c        | WORKD(IRJ:IRJ+N-1) := OP*v_{j}   |
@@ -499,7 +499,7 @@ c        %----------------------------------%
 c
          call second (t3)
          tmvopx = tmvopx + (t3 - t2)
- 
+
          step3 = .false.
 c
 c        %------------------------------------------%
@@ -507,7 +507,7 @@ c        | Put another copy of OP*v_{j} into RESID. |
 c        %------------------------------------------%
 c
          call ccopy (n, workd(irj), 1, resid, 1)
-c 
+c
 c        %---------------------------------------%
 c        | STEP 4:  Finish extending the Arnoldi |
 c        |          factorization to length j.   |
@@ -520,17 +520,17 @@ c
             ipntr(1) = irj
             ipntr(2) = ipj
             ido = 2
-c 
+c
 c           %-------------------------------------%
 c           | Exit in order to compute B*OP*v_{j} |
 c           %-------------------------------------%
-c 
+c
             go to 9000
          else if (bmat .eq. 'I') then
             call ccopy (n, resid, 1, workd(ipj), 1)
          end if
    60    continue
-c 
+c
 c        %----------------------------------%
 c        | Back from reverse communication; |
 c        | WORKD(IPJ:IPJ+N-1) := B*OP*v_{j} |
@@ -541,7 +541,7 @@ c
             call second (t3)
             tmvbx = tmvbx + (t3 - t2)
          end if
-c 
+c
          step4 = .false.
 c
 c        %-------------------------------------%
@@ -549,7 +549,7 @@ c        | The following is needed for STEP 5. |
 c        | Compute the B-norm of OP*v_{j}.     |
 c        %-------------------------------------%
 c
-         if (bmat .eq. 'G') then  
+         if (bmat .eq. 'G') then
              cnorm = cdotc (n, resid, 1, workd(ipj), 1)
              wnorm = sqrt( slapy2(real(cnorm),aimag(cnorm)) )
          else if (bmat .eq. 'I') then
@@ -569,13 +569,13 @@ c        %------------------------------------------%
 c        | Compute the j Fourier coefficients w_{j} |
 c        | WORKD(IPJ:IPJ+N-1) contains B*OP*v_{j}.  |
 c        %------------------------------------------%
-c 
+c
          call cgemv ('C', n, j, one, v, ldv, workd(ipj), 1,
      &               zero, h(1,j), 1)
 c
 c        %--------------------------------------%
 c        | Orthogonalize r_{j} against V_{j}.   |
-c        | RESID contains OP*v_{j}. See STEP 3. | 
+c        | RESID contains OP*v_{j}. See STEP 3. |
 c        %--------------------------------------%
 c
          call cgemv ('N', n, j, -one, v, ldv, h(1,j), 1,
@@ -584,9 +584,9 @@ c
          if (j .gt. 1) h(j,j-1) = cmplx(betaj, rzero)
 c
          call second (t4)
-c 
+c
          orth1 = .true.
-c 
+c
          call second (t2)
          if (bmat .eq. 'G') then
             nbx = nbx + 1
@@ -594,17 +594,17 @@ c
             ipntr(1) = irj
             ipntr(2) = ipj
             ido = 2
-c 
+c
 c           %----------------------------------%
 c           | Exit in order to compute B*r_{j} |
 c           %----------------------------------%
-c 
+c
             go to 9000
          else if (bmat .eq. 'I') then
             call ccopy (n, resid, 1, workd(ipj), 1)
-         end if 
+         end if
    70    continue
-c 
+c
 c        %---------------------------------------------------%
 c        | Back from reverse communication if ORTH1 = .true. |
 c        | WORKD(IPJ:IPJ+N-1) := B*r_{j}.                    |
@@ -614,20 +614,20 @@ c
             call second (t3)
             tmvbx = tmvbx + (t3 - t2)
          end if
-c 
+c
          orth1 = .false.
 c
 c        %------------------------------%
 c        | Compute the B-norm of r_{j}. |
 c        %------------------------------%
 c
-         if (bmat .eq. 'G') then         
+         if (bmat .eq. 'G') then
             cnorm = cdotc (n, resid, 1, workd(ipj), 1)
             rnorm = sqrt( slapy2(real(cnorm),aimag(cnorm)) )
          else if (bmat .eq. 'I') then
             rnorm = scnrm2(n, resid, 1)
          end if
-c 
+c
 c        %-----------------------------------------------------------%
 c        | STEP 5: Re-orthogonalization / Iterative refinement phase |
 c        | Maximum NITER_ITREF tries.                                |
@@ -650,20 +650,20 @@ c
 c
          iter  = 0
          nrorth = nrorth + 1
-c 
+c
 c        %---------------------------------------------------%
 c        | Enter the Iterative refinement phase. If further  |
 c        | refinement is necessary, loop back here. The loop |
 c        | variable is ITER. Perform a step of Classical     |
 c        | Gram-Schmidt using all the Arnoldi vectors V_{j}  |
 c        %---------------------------------------------------%
-c 
+c
    80    continue
 c
          if (msglvl .gt. 2) then
             rtemp(1) = wnorm
             rtemp(2) = rnorm
-            call svout (logfil, 2, rtemp, ndigit, 
+            call svout (logfil, 2, rtemp, ndigit,
      &      '_naitr: re-orthogonalization; wnorm and rnorm are')
             call cvout (logfil, j, h(1,j), ndigit,
      &                  '_naitr: j-th column of H')
@@ -674,7 +674,7 @@ c        | Compute V_{j}^T * B * r_{j}.                       |
 c        | WORKD(IRJ:IRJ+J-1) = v(:,1:J)'*WORKD(IPJ:IPJ+N-1). |
 c        %----------------------------------------------------%
 c
-         call cgemv ('C', n, j, one, v, ldv, workd(ipj), 1, 
+         call cgemv ('C', n, j, one, v, ldv, workd(ipj), 1,
      &               zero, workd(irj), 1)
 c
 c        %---------------------------------------------%
@@ -684,10 +684,10 @@ c        | The correction to H is v(:,1:J)*H(1:J,1:J)  |
 c        | + v(:,1:J)*WORKD(IRJ:IRJ+J-1)*e'_j.         |
 c        %---------------------------------------------%
 c
-         call cgemv ('N', n, j, -one, v, ldv, workd(irj), 1, 
+         call cgemv ('N', n, j, -one, v, ldv, workd(irj), 1,
      &               one, resid, 1)
          call caxpy (j, one, workd(irj), 1, h(1,j), 1)
-c 
+c
          orth2 = .true.
          call second (t2)
          if (bmat .eq. 'G') then
@@ -696,16 +696,16 @@ c
             ipntr(1) = irj
             ipntr(2) = ipj
             ido = 2
-c 
+c
 c           %-----------------------------------%
 c           | Exit in order to compute B*r_{j}. |
 c           | r_{j} is the corrected residual.  |
 c           %-----------------------------------%
-c 
+c
             go to 9000
          else if (bmat .eq. 'I') then
             call ccopy (n, resid, 1, workd(ipj), 1)
-         end if 
+         end if
    90    continue
 c
 c        %---------------------------------------------------%
@@ -715,19 +715,19 @@ c
          if (bmat .eq. 'G') then
             call second (t3)
             tmvbx = tmvbx + (t3 - t2)
-         end if 
+         end if
 c
 c        %-----------------------------------------------------%
 c        | Compute the B-norm of the corrected residual r_{j}. |
 c        %-----------------------------------------------------%
-c 
-         if (bmat .eq. 'G') then         
+c
+         if (bmat .eq. 'G') then
              cnorm  = cdotc (n, resid, 1, workd(ipj), 1)
              rnorm1 = sqrt( slapy2(real(cnorm),aimag(cnorm)) )
          else if (bmat .eq. 'I') then
              rnorm1 = scnrm2(n, resid, 1)
          end if
-c 
+c
          if (msglvl .gt. 0 .and. iter .gt. 0 ) then
             call ivout (logfil, 1, [j], ndigit,
      &           '_naitr: Iterative refinement for Arnoldi residual')
@@ -757,7 +757,7 @@ c           | angle of less than arcCOS(0.717)      |
 c           %---------------------------------------%
 c
             rnorm = rnorm1
-c 
+c
          else
 c
 c           %-------------------------------------------%
@@ -776,24 +776,24 @@ c           %-------------------------------------------------%
 c
             do 95 jj = 1, n
                resid(jj) = zero
-  95        continue 
+  95        continue
             rnorm = rzero
          end if
-c 
+c
 c        %----------------------------------------------%
 c        | Branch here directly if iterative refinement |
 c        | wasn't necessary or after at most NITER_REF  |
 c        | steps of iterative refinement.               |
 c        %----------------------------------------------%
-c 
+c
   100    continue
-c 
+c
          rstart = .false.
          orth2  = .false.
-c 
+c
          call second (t5)
          titref = titref + (t5 - t4)
-c 
+c
 c        %------------------------------------%
 c        | STEP 6: Update  j = j+1;  Continue |
 c        %------------------------------------%
@@ -804,27 +804,27 @@ c
             tcaitr = tcaitr + (t1 - t0)
             ido = 99
             do 110 i = max(1,k), k+np-1
-c     
+c
 c              %--------------------------------------------%
 c              | Check for splitting and deflation.         |
 c              | Use a standard test as in the QR algorithm |
 c              | REFERENCE: LAPACK subroutine clahqr        |
 c              %--------------------------------------------%
-c     
+c
                tst1 = slapy2(real(h(i,i)),aimag(h(i,i)))
      &              + slapy2(real(h(i+1,i+1)), aimag(h(i+1,i+1)))
                if( tst1.eq.real(zero) )
      &              tst1 = clanhs( '1', k+np, h, ldh, workd(n+1) )
-               if( slapy2(real(h(i+1,i)),aimag(h(i+1,i))) .le. 
-     &                    max( ulp*tst1, smlnum ) ) 
+               if( slapy2(real(h(i+1,i)),aimag(h(i+1,i))) .le.
+     &                    max( ulp*tst1, smlnum ) )
      &             h(i+1,i) = zero
  110        continue
-c     
+c
             if (msglvl .gt. 2) then
-               call cmout (logfil, k+np, k+np, h, ldh, ndigit, 
+               call cmout (logfil, k+np, k+np, h, ldh, ndigit,
      &          '_naitr: Final upper Hessenberg matrix H of order K+NP')
             end if
-c     
+c
             go to 9000
          end if
 c
@@ -833,7 +833,7 @@ c        | Loop back to extend the factorization by another step. |
 c        %--------------------------------------------------------%
 c
       go to 1000
-c 
+c
 c     %---------------------------------------------------------------%
 c     |                                                               |
 c     |  E N D     O F     M A I N     I T E R A T I O N     L O O P  |

--- a/mathlibs/src/arpack/cnaitr.f
+++ b/mathlibs/src/arpack/cnaitr.f
@@ -378,9 +378,9 @@ c     %--------------------------------------------------------------%
  1000 continue
 c
          if (msglvl .gt. 1) then
-            call ivout (logfil, 1, j, ndigit, 
+            call ivout (logfil, 1, [j], ndigit, 
      &                  '_naitr: generating Arnoldi vector number')
-            call svout (logfil, 1, rnorm, ndigit, 
+            call svout (logfil, 1, [rnorm], ndigit, 
      &                  '_naitr: B-norm of the current residual is')
          end if
 c 
@@ -400,7 +400,7 @@ c           | basis and continue the iteration.                 |
 c           %---------------------------------------------------%
 c
             if (msglvl .gt. 0) then
-               call ivout (logfil, 1, j, ndigit,
+               call ivout (logfil, 1, [j], ndigit,
      &                     '_naitr: ****** RESTART AT STEP ******')
             end if
 c 
@@ -729,7 +729,7 @@ c
          end if
 c 
          if (msglvl .gt. 0 .and. iter .gt. 0 ) then
-            call ivout (logfil, 1, j, ndigit,
+            call ivout (logfil, 1, [j], ndigit,
      &           '_naitr: Iterative refinement for Arnoldi residual')
             if (msglvl .gt. 2) then
                 rtemp(1) = rnorm

--- a/mathlibs/src/arpack/cnapps.f
+++ b/mathlibs/src/arpack/cnapps.f
@@ -268,9 +268,9 @@ c
          sigma = shift(jj)
 c
          if (msglvl .gt. 2 ) then
-            call ivout (logfil, 1, jj, ndigit, 
+            call ivout (logfil, 1, [jj], ndigit, 
      &               '_napps: shift number.')
-            call cvout (logfil, 1, sigma, ndigit, 
+            call cvout (logfil, 1, [sigma], ndigit, 
      &               '_napps: Value of the shift ')
          end if
 c
@@ -291,9 +291,9 @@ c
             if ( abs(real(h(i+1,i))) 
      &           .le. max(ulp*tst1, smlnum) )  then
                if (msglvl .gt. 0) then
-                  call ivout (logfil, 1, i, ndigit, 
+                  call ivout (logfil, 1, [i], ndigit, 
      &                 '_napps: matrix splitting at row/column no.')
-                  call ivout (logfil, 1, jj, ndigit, 
+                  call ivout (logfil, 1, [jj], ndigit, 
      &                 '_napps: matrix splitting with shift number.')
                   call cvout (logfil, 1, h(i+1,i), ndigit, 
      &                 '_napps: off diagonal element.')
@@ -307,9 +307,9 @@ c
    40    continue
 c
          if (msglvl .gt. 2) then
-             call ivout (logfil, 1, istart, ndigit, 
+             call ivout (logfil, 1, [istart], ndigit, 
      &                   '_napps: Start of current block ')
-             call ivout (logfil, 1, iend, ndigit, 
+             call ivout (logfil, 1, [iend], ndigit, 
      &                   '_napps: End of current block ')
          end if
 c
@@ -485,7 +485,7 @@ c
      &        '_napps: sigmak = (e_{kev+p}^T*Q)*e_{kev}')
          call cvout (logfil, 1, h(kev+1,kev), ndigit,
      &        '_napps: betak = e_{kev+1}^T*H*e_{kev}')
-         call ivout (logfil, 1, kev, ndigit, 
+         call ivout (logfil, 1, [kev], ndigit, 
      &               '_napps: Order of the final Hessenberg matrix ')
          if (msglvl .gt. 2) then
             call cmout (logfil, kev, kev, h, ldh, ndigit,

--- a/mathlibs/src/arpack/cnapps.f
+++ b/mathlibs/src/arpack/cnapps.f
@@ -19,7 +19,7 @@ c     A*VNEW_{k} - VNEW_{k}*HNEW_{k} = rnew_{k}*e_{k}^T.
 c
 c\Usage:
 c  call cnapps
-c     ( N, KEV, NP, SHIFT, V, LDV, H, LDH, RESID, Q, LDQ, 
+c     ( N, KEV, NP, SHIFT, V, LDV, H, LDH, RESID, Q, LDQ,
 c       WORKL, WORKD )
 c
 c\Arguments
@@ -28,7 +28,7 @@ c          Problem size, i.e. size of matrix A.
 c
 c  KEV     Integer.  (INPUT/OUTPUT)
 c          KEV+NP is the size of the input matrix H.
-c          KEV is the size of the updated matrix HNEW. 
+c          KEV is the size of the updated matrix HNEW.
 c
 c  NP      Integer.  (INPUT)
 c          Number of implicit shifts to be applied.
@@ -46,7 +46,7 @@ c          Leading dimension of V exactly as declared in the calling
 c          program.
 c
 c  H       Complex (KEV+NP) by (KEV+NP) array.  (INPUT/OUTPUT)
-c          On INPUT, H contains the current KEV+NP by KEV+NP upper 
+c          On INPUT, H contains the current KEV+NP by KEV+NP upper
 c          Hessenberg matrix of the Arnoldi factorization.
 c          On OUTPUT, H contains the updated KEV by KEV upper Hessenberg
 c          matrix in the KEV leading submatrix.
@@ -57,7 +57,7 @@ c          program.
 c
 c  RESID   Complex array of length N.  (INPUT/OUTPUT)
 c          On INPUT, RESID contains the the residual vector r_{k+p}.
-c          On OUTPUT, RESID is the update residual vector rnew_{k} 
+c          On OUTPUT, RESID is the update residual vector rnew_{k}
 c          in the first KEV locations.
 c
 c  Q       Complex KEV+NP by KEV+NP work array.  (WORKSPACE)
@@ -112,9 +112,9 @@ c\Author
 c     Danny Sorensen               Phuong Vu
 c     Richard Lehoucq              CRPC / Rice University
 c     Dept. of Computational &     Houston, Texas
-c     Applied Mathematics 
-c     Rice University           
-c     Houston, Texas 
+c     Applied Mathematics
+c     Rice University
+c     Houston, Texas
 c
 c\SCCS Information: @(#)
 c FILE: napps.F   SID: 2.2   DATE OF SID: 4/20/96   RELEASE: 2
@@ -132,7 +132,7 @@ c
 c-----------------------------------------------------------------------
 c
       subroutine cnapps
-     &   ( n, kev, np, shift, v, ldv, h, ldh, resid, q, ldq, 
+     &   ( n, kev, np, shift, v, ldv, h, ldh, resid, q, ldq,
      &     workl, workd )
 c
 c     %----------------------------------------------------%
@@ -153,7 +153,7 @@ c     | Array Arguments |
 c     %-----------------%
 c
       Complex
-     &           h(ldh,kev+np), resid(n), shift(np), 
+     &           h(ldh,kev+np), resid(n), shift(np),
      &           v(ldv,kev+np), q(ldq,kev+np), workd(2*n), workl(kev+np)
 c
 c     %------------%
@@ -175,22 +175,22 @@ c
       logical    first
       Complex
      &           cdum, f, g, h11, h21, r, s, sigma, t
-      Real             
+      Real
      &           c,  ovfl, smlnum, ulp, unfl, tst1
-      save       first, ovfl, smlnum, ulp, unfl 
+      save       first, ovfl, smlnum, ulp, unfl
 c
 c     %----------------------%
 c     | External Subroutines |
 c     %----------------------%
 c
-      external   caxpy, ccopy, cgemv, cscal, clacpy, clartg, 
+      external   caxpy, ccopy, cgemv, cscal, clacpy, clartg,
      &           cvout, claset, slabad, cmout, second, ivout
 c
 c     %--------------------%
 c     | External Functions |
 c     %--------------------%
 c
-      Real                 
+      Real
      &           clanhs, slamch, slapy2
       external   clanhs, slamch, slapy2
 c
@@ -204,7 +204,7 @@ c     %---------------------%
 c     | Statement Functions |
 c     %---------------------%
 c
-      Real     
+      Real
      &           cabs1
       cabs1( cdum ) = abs( real( cdum ) ) + abs( aimag( cdum ) )
 c
@@ -242,9 +242,9 @@ c     %-------------------------------%
 c
       call second (t0)
       msglvl = mcapps
-c 
-      kplusp = kev + np 
-c 
+c
+      kplusp = kev + np
+c
 c     %--------------------------------------------%
 c     | Initialize Q to the identity to accumulate |
 c     | the rotations and reflections              |
@@ -268,9 +268,9 @@ c
          sigma = shift(jj)
 c
          if (msglvl .gt. 2 ) then
-            call ivout (logfil, 1, [jj], ndigit, 
+            call ivout (logfil, 1, [jj], ndigit,
      &               '_napps: shift number.')
-            call cvout (logfil, 1, [sigma], ndigit, 
+            call cvout (logfil, 1, [sigma], ndigit,
      &               '_napps: Value of the shift ')
          end if
 c
@@ -288,14 +288,14 @@ c
             tst1 = cabs1( h( i, i ) ) + cabs1( h( i+1, i+1 ) )
             if( tst1.eq.rzero )
      &         tst1 = clanhs( '1', kplusp-jj+1, h, ldh, workl )
-            if ( abs(real(h(i+1,i))) 
+            if ( abs(real(h(i+1,i)))
      &           .le. max(ulp*tst1, smlnum) )  then
                if (msglvl .gt. 0) then
-                  call ivout (logfil, 1, [i], ndigit, 
+                  call ivout (logfil, 1, [i], ndigit,
      &                 '_napps: matrix splitting at row/column no.')
-                  call ivout (logfil, 1, [jj], ndigit, 
+                  call ivout (logfil, 1, [jj], ndigit,
      &                 '_napps: matrix splitting with shift number.')
-                  call cvout (logfil, 1, h(i+1,i), ndigit, 
+                  call cvout (logfil, 1, h(i+1,i), ndigit,
      &                 '_napps: off diagonal element.')
                end if
                iend = i
@@ -307,9 +307,9 @@ c
    40    continue
 c
          if (msglvl .gt. 2) then
-             call ivout (logfil, 1, [istart], ndigit, 
+             call ivout (logfil, 1, [istart], ndigit,
      &                   '_napps: Start of current block ')
-             call ivout (logfil, 1, [iend], ndigit, 
+             call ivout (logfil, 1, [iend], ndigit,
      &                   '_napps: End of current block ')
          end if
 c
@@ -325,7 +325,7 @@ c
          h21 = h(istart+1,istart)
          f = h11 - sigma
          g = h21
-c 
+c
          do 80 i = istart, iend-1
 c
 c           %------------------------------------------------------%
@@ -345,7 +345,7 @@ c
             do 50 j = i, kplusp
                t        =  c*h(i,j) + s*h(i+1,j)
                h(i+1,j) = -conjg(s)*h(i,j) + c*h(i+1,j)
-               h(i,j)   = t   
+               h(i,j)   = t
    50       continue
 c
 c           %---------------------------------------------%
@@ -355,7 +355,7 @@ c
             do 60 j = 1, min(i+2,iend)
                t        =  c*h(j,i) + conjg(s)*h(j,i+1)
                h(j,i+1) = -s*h(j,i) + c*h(j,i+1)
-               h(j,i)   = t   
+               h(j,i)   = t
    60       continue
 c
 c           %-----------------------------------------------------%
@@ -365,7 +365,7 @@ c
             do 70 j = 1, min(j+jj, kplusp)
                t        =   c*q(j,i) + conjg(s)*q(j,i+1)
                q(j,i+1) = - s*q(j,i) + c*q(j,i+1)
-               q(j,i)   = t   
+               q(j,i)   = t
    70       continue
 c
 c           %---------------------------%
@@ -381,7 +381,7 @@ c
 c        %-------------------------------%
 c        | Finished applying the shift.  |
 c        %-------------------------------%
-c 
+c
   100    continue
 c
 c        %---------------------------------------------------------%
@@ -428,7 +428,7 @@ c
          tst1 = cabs1( h( i, i ) ) + cabs1( h( i+1, i+1 ) )
          if( tst1 .eq. rzero )
      &       tst1 = clanhs( '1', kev, h, ldh, workl )
-         if( real( h( i+1,i ) ) .le. max( ulp*tst1, smlnum ) ) 
+         if( real( h( i+1,i ) ) .le. max( ulp*tst1, smlnum ) )
      &       h(i+1,i) = zero
  130  continue
 c
@@ -441,9 +441,9 @@ c     | of H would be zero as in exact arithmetic.      |
 c     %-------------------------------------------------%
 c
       if ( real( h(kev+1,kev) ) .gt. rzero )
-     &   call cgemv ('N', n, kplusp, one, v, ldv, q(1,kev+1), 1, zero, 
+     &   call cgemv ('N', n, kplusp, one, v, ldv, q(1,kev+1), 1, zero,
      &                workd(n+1), 1)
-c 
+c
 c     %----------------------------------------------------------%
 c     | Compute column 1 to kev of (V*Q) in backward order       |
 c     | taking advantage of the upper Hessenberg structure of Q. |
@@ -460,14 +460,14 @@ c     |  Move v(:,kplusp-kev+1:kplusp) into v(:,1:kev). |
 c     %-------------------------------------------------%
 c
       call clacpy ('A', n, kev, v(1,kplusp-kev+1), ldv, v, ldv)
-c 
+c
 c     %--------------------------------------------------------------%
 c     | Copy the (kev+1)-st column of (V*Q) in the appropriate place |
 c     %--------------------------------------------------------------%
 c
       if ( real( h(kev+1,kev) ) .gt. rzero )
      &   call ccopy (n, workd(n+1), 1, v(1,kev+1), 1)
-c 
+c
 c     %-------------------------------------%
 c     | Update the residual vector:         |
 c     |    r <- sigmak*r + betak*v(:,kev+1) |
@@ -485,7 +485,7 @@ c
      &        '_napps: sigmak = (e_{kev+p}^T*Q)*e_{kev}')
          call cvout (logfil, 1, h(kev+1,kev), ndigit,
      &        '_napps: betak = e_{kev+1}^T*H*e_{kev}')
-         call ivout (logfil, 1, [kev], ndigit, 
+         call ivout (logfil, 1, [kev], ndigit,
      &               '_napps: Order of the final Hessenberg matrix ')
          if (msglvl .gt. 2) then
             call cmout (logfil, kev, kev, h, ldh, ndigit,
@@ -497,7 +497,7 @@ c
  9000 continue
       call second (t1)
       tcapps = tcapps + (t1 - t0)
-c 
+c
       return
 c
 c     %---------------%

--- a/mathlibs/src/arpack/cnaup2.f
+++ b/mathlibs/src/arpack/cnaup2.f
@@ -388,7 +388,7 @@ c
          iter = iter + 1
 c
          if (msglvl .gt. 0) then
-            call ivout (logfil, 1, iter, ndigit, 
+            call ivout (logfil, 1, [iter], ndigit, 
      &           '_naup2: **** Start of major iteration number ****')
          end if
 c 
@@ -401,9 +401,9 @@ c
          np  = kplusp - nev
 c
          if (msglvl .gt. 1) then
-            call ivout (logfil, 1, nev, ndigit, 
+            call ivout (logfil, 1, [nev], ndigit, 
      &     '_naup2: The length of the current Arnoldi factorization')
-            call ivout (logfil, 1, np, ndigit, 
+            call ivout (logfil, 1, [np], ndigit, 
      &           '_naup2: Extend the Arnoldi factorization by')
          end if
 c
@@ -429,7 +429,7 @@ c
          update = .false.
 c
          if (msglvl .gt. 1) then
-            call svout (logfil, 1, rnorm, ndigit, 
+            call svout (logfil, 1, [rnorm], ndigit, 
      &           '_naup2: Corresponding B-norm of the residual')
          end if
 c 
@@ -657,7 +657,7 @@ c
          end if              
 c     
          if (msglvl .gt. 0) then
-            call ivout (logfil, 1, nconv, ndigit, 
+            call ivout (logfil, 1, [nconv], ndigit, 
      &           '_naup2: no. of "converged" Ritz values at this iter.')
             if (msglvl .gt. 1) then
                kp(1) = nev
@@ -697,7 +697,7 @@ c
          end if
 c
          if (msglvl .gt. 2) then 
-            call ivout (logfil, 1, np, ndigit, 
+            call ivout (logfil, 1, [np], ndigit, 
      &                  '_naup2: The number of shifts to apply ')
             call cvout (logfil, np, ritz, ndigit,
      &                  '_naup2: values of the shifts')
@@ -761,7 +761,7 @@ c
          cnorm = .false.
 c
          if (msglvl .gt. 2) then
-            call svout (logfil, 1, rnorm, ndigit, 
+            call svout (logfil, 1, [rnorm], ndigit, 
      &      '_naup2: B-norm of residual for compressed factorization')
             call cmout (logfil, nev, nev, h, ldh, ndigit,
      &        '_naup2: Compressed upper Hessenberg matrix H')

--- a/mathlibs/src/arpack/cnaup2.f
+++ b/mathlibs/src/arpack/cnaup2.f
@@ -2,13 +2,13 @@ c\BeginDoc
 c
 c\Name: cnaup2
 c
-c\Description: 
+c\Description:
 c  Intermediate level interface called by cnaupd.
 c
 c\Usage:
 c  call cnaup2
 c     ( IDO, BMAT, N, WHICH, NEV, NP, TOL, RESID, MODE, IUPD,
-c       ISHIFT, MXITER, V, LDV, H, LDH, RITZ, BOUNDS, 
+c       ISHIFT, MXITER, V, LDV, H, LDH, RITZ, BOUNDS,
 c       Q, LDQ, WORKL, IPNTR, WORKD, RWORK, INFO )
 c
 c\Arguments
@@ -38,27 +38,27 @@ c          IUPD .EQ. 0: use explicit restart instead implicit update.
 c          IUPD .NE. 0: use implicit update.
 c
 c  V       Complex N by (NEV+NP) array.  (INPUT/OUTPUT)
-c          The Arnoldi basis vectors are returned in the first NEV 
+c          The Arnoldi basis vectors are returned in the first NEV
 c          columns of V.
 c
 c  LDV     Integer.  (INPUT)
-c          Leading dimension of V exactly as declared in the calling 
+c          Leading dimension of V exactly as declared in the calling
 c          program.
 c
 c  H       Complex (NEV+NP) by (NEV+NP) array.  (OUTPUT)
 c          H is used to store the generated upper Hessenberg matrix
 c
 c  LDH     Integer.  (INPUT)
-c          Leading dimension of H exactly as declared in the calling 
+c          Leading dimension of H exactly as declared in the calling
 c          program.
 c
 c  RITZ    Complex array of length NEV+NP.  (OUTPUT)
 c          RITZ(1:NEV)  contains the computed Ritz values of OP.
 c
 c  BOUNDS  Complex array of length NEV+NP.  (OUTPUT)
-c          BOUNDS(1:NEV) contain the error bounds corresponding to 
+c          BOUNDS(1:NEV) contain the error bounds corresponding to
 c          the computed Ritz values.
-c          
+c
 c  Q       Complex (NEV+NP) by (NEV+NP) array.  (WORKSPACE)
 c          Private (replicated) work array used to accumulate the
 c          rotation in the shift application step.
@@ -67,7 +67,7 @@ c  LDQ     Integer.  (INPUT)
 c          Leading dimension of Q exactly as declared in the calling
 c          program.
 c
-c  WORKL   Complex work array of length at least 
+c  WORKL   Complex work array of length at least
 c          (NEV+NP)**2 + 3*(NEV+NP).  (WORKSPACE)
 c          Private (replicated) array on each PE or array allocated on
 c          the front end.  It is used in shifts calculation, shifts
@@ -75,15 +75,15 @@ c          application and convergence checking.
 c
 c
 c  IPNTR   Integer array of length 3.  (OUTPUT)
-c          Pointer to mark the starting locations in the WORKD for 
+c          Pointer to mark the starting locations in the WORKD for
 c          vectors used by the Arnoldi iteration.
 c          -------------------------------------------------------------
 c          IPNTR(1): pointer to the current operand vector X.
 c          IPNTR(2): pointer to the current result vector Y.
-c          IPNTR(3): pointer to the vector B * X when used in the 
+c          IPNTR(3): pointer to the vector B * X when used in the
 c                    shift-and-invert mode.  X is the current operand.
 c          -------------------------------------------------------------
-c          
+c
 c  WORKD   Complex work array of length 3*N.  (WORKSPACE)
 c          Distributed array to be used in the basic Arnoldi iteration
 c          for reverse communication.  The user should not use WORKD
@@ -101,7 +101,7 @@ c                          possibly from a previous run.
 c          Error flag on output.
 c          =     0: Normal return.
 c          =     1: Maximum number of iterations taken.
-c                   All possible eigenvalues of OP has been found.  
+c                   All possible eigenvalues of OP has been found.
 c                   NP returns the number of converged Ritz values.
 c          =     2: No shifts could be applied.
 c          =    -8: Error return from LAPACK eigenvalue calculation;
@@ -123,15 +123,15 @@ c\References:
 c  1. D.C. Sorensen, "Implicit Application of Polynomial Filters in
 c     a k-Step Arnoldi Method", SIAM J. Matr. Anal. Apps., 13 (1992),
 c     pp 357-385.
-c  2. R.B. Lehoucq, "Analysis and Implementation of an Implicitly 
+c  2. R.B. Lehoucq, "Analysis and Implementation of an Implicitly
 c     Restarted Arnoldi Iteration", Rice University Technical Report
 c     TR95-13, Department of Computational and Applied Mathematics.
 c
 c\Routines called:
-c     cgetv0  ARPACK initial vector generation routine. 
+c     cgetv0  ARPACK initial vector generation routine.
 c     cnaitr  ARPACK Arnoldi factorization routine.
 c     cnapps  ARPACK application of implicit shifts routine.
-c     cneigh  ARPACK compute Ritz values and error bounds routine. 
+c     cneigh  ARPACK compute Ritz values and error bounds routine.
 c     cngets  ARPACK reorder Ritz values and error bounds routine.
 c     csortc  ARPACK sorting routine.
 c     ivout   ARPACK utility routine that prints integers.
@@ -142,7 +142,7 @@ c     svout   ARPACK utility routine that prints vectors.
 c     slamch  LAPACK routine that determines machine constants.
 c     slapy2  LAPACK routine to compute sqrt(x**2+y**2) carefully.
 c     ccopy   Level 1 BLAS that copies one vector to another .
-c     cdotc   Level 1 BLAS that computes the scalar product of two vectors. 
+c     cdotc   Level 1 BLAS that computes the scalar product of two vectors.
 c     cswap   Level 1 BLAS that swaps two vectors.
 c     scnrm2  Level 1 BLAS that computes the norm of a vector.
 c
@@ -151,10 +151,10 @@ c     Danny Sorensen               Phuong Vu
 c     Richard Lehoucq              CRPC / Rice Universitya
 c     Chao Yang                    Houston, Texas
 c     Dept. of Computational &
-c     Applied Mathematics 
-c     Rice University           
-c     Houston, Texas 
-c 
+c     Applied Mathematics
+c     Rice University
+c     Houston, Texas
+c
 c\SCCS Information: @(#)
 c FILE: naup2.F   SID: 2.5   DATE OF SID: 8/16/96   RELEASE: 2
 c
@@ -166,8 +166,8 @@ c
 c-----------------------------------------------------------------------
 c
       subroutine cnaup2
-     &   ( ido, bmat, n, which, nev, np, tol, resid, mode, iupd, 
-     &     ishift, mxiter, v, ldv, h, ldh, ritz, bounds, 
+     &   ( ido, bmat, n, which, nev, np, tol, resid, mode, iupd,
+     &     ishift, mxiter, v, ldv, h, ldh, ritz, bounds,
      &     q, ldq, workl, ipntr, workd, rwork, info )
 c
 c     %----------------------------------------------------%
@@ -184,7 +184,7 @@ c
       character  bmat*1, which*2
       integer    ido, info, ishift, iupd, mode, ldh, ldq, ldv, mxiter,
      &           n, nev, np
-      Real  
+      Real
      &           tol
 c
 c     %-----------------%
@@ -193,10 +193,10 @@ c     %-----------------%
 c
       integer    ipntr(13)
       Complex
-     &           bounds(nev+np), h(ldh,nev+np), q(ldq,nev+np), 
-     &           resid(n), ritz(nev+np),  v(ldv,nev+np), 
+     &           bounds(nev+np), h(ldh,nev+np), q(ldq,nev+np),
+     &           resid(n), ritz(nev+np),  v(ldv,nev+np),
      &           workd(3*n), workl( (nev+np)*(nev+np+3) )
-       Real  
+       Real
      &           rwork(nev+np)
 c
 c     %------------%
@@ -215,7 +215,7 @@ c     | Local Scalars |
 c     %---------------%
 c
       logical    cnorm, getv0, initv, update, ushift
-      integer    ierr, iter, i, j, kplusp, msglvl, nconv, nevbef, nev0, 
+      integer    ierr, iter, i, j, kplusp, msglvl, nconv, nevbef, nev0,
      &           np0, nptemp
       Complex
      &           cmpnorm
@@ -223,8 +223,8 @@ c
      &           rtemp, eps23, rnorm
       character  wprime*2
 c
-      save       cnorm, getv0, initv, update, ushift, 
-     &           iter, kplusp, msglvl, nconv, nev0, np0, 
+      save       cnorm, getv0, initv, update, ushift,
+     &           iter, kplusp, msglvl, nconv, nev0, np0,
      &           eps23
 c
 c
@@ -247,7 +247,7 @@ c     %--------------------%
 c
       Complex
      &           cdotc
-      Real  
+      Real
      &           scnrm2, slamch, slapy2
       external   cdotc, scnrm2, slamch, slapy2
 c
@@ -262,11 +262,11 @@ c     | Executable Statements |
 c     %-----------------------%
 c
       if (ido .eq. 0) then
-c 
+c
          call second (t0)
-c 
+c
          msglvl = mcaup2
-c 
+c
          nev0   = nev
          np0    = np
 c
@@ -282,7 +282,7 @@ c
          kplusp = nev + np
          nconv  = 0
          iter   = 0
-c 
+c
 c        %---------------------------------%
 c        | Get machine dependent constant. |
 c        %---------------------------------%
@@ -312,7 +312,7 @@ c
             initv = .false.
          end if
       end if
-c 
+c
 c     %---------------------------------------------%
 c     | Get a possibly random starting vector and   |
 c     | force it into the range of the operator OP. |
@@ -329,7 +329,7 @@ c
          if (rnorm .eq. rzero) then
 c
 c           %-----------------------------------------%
-c           | The initial vector is zero. Error exit. | 
+c           | The initial vector is zero. Error exit. |
 c           %-----------------------------------------%
 c
             info = -9
@@ -338,7 +338,7 @@ c
          getv0 = .false.
          ido  = 0
       end if
-c 
+c
 c     %-----------------------------------%
 c     | Back from reverse communication : |
 c     | continue with update step         |
@@ -358,12 +358,12 @@ c     | at the end of the current iteration |
 c     %-------------------------------------%
 c
       if (cnorm)  go to 100
-c 
+c
 c     %----------------------------------------------------------%
 c     | Compute the first NEV steps of the Arnoldi factorization |
 c     %----------------------------------------------------------%
 c
-      call cnaitr (ido, bmat, n, 0, nev, mode, resid, rnorm, v, ldv, 
+      call cnaitr (ido, bmat, n, 0, nev, mode, resid, rnorm, v, ldv,
      &             h, ldh, ipntr, workd, info)
 c
       if (ido .ne. 99) go to 9000
@@ -374,7 +374,7 @@ c
          info = -9999
          go to 1200
       end if
-c 
+c
 c     %--------------------------------------------------------------%
 c     |                                                              |
 c     |           M A I N  ARNOLDI  I T E R A T I O N  L O O P       |
@@ -382,16 +382,16 @@ c     |           Each iteration implicitly restarts the Arnoldi     |
 c     |           factorization in place.                            |
 c     |                                                              |
 c     %--------------------------------------------------------------%
-c 
+c
  1000 continue
 c
          iter = iter + 1
 c
          if (msglvl .gt. 0) then
-            call ivout (logfil, 1, [iter], ndigit, 
+            call ivout (logfil, 1, [iter], ndigit,
      &           '_naup2: **** Start of major iteration number ****')
          end if
-c 
+c
 c        %-----------------------------------------------------------%
 c        | Compute NP additional steps of the Arnoldi factorization. |
 c        | Adjust NP since NEV might have been updated by last call  |
@@ -401,9 +401,9 @@ c
          np  = kplusp - nev
 c
          if (msglvl .gt. 1) then
-            call ivout (logfil, 1, [nev], ndigit, 
+            call ivout (logfil, 1, [nev], ndigit,
      &     '_naup2: The length of the current Arnoldi factorization')
-            call ivout (logfil, 1, [np], ndigit, 
+            call ivout (logfil, 1, [np], ndigit,
      &           '_naup2: Extend the Arnoldi factorization by')
          end if
 c
@@ -429,10 +429,10 @@ c
          update = .false.
 c
          if (msglvl .gt. 1) then
-            call svout (logfil, 1, [rnorm], ndigit, 
+            call svout (logfil, 1, [rnorm], ndigit,
      &           '_naup2: Corresponding B-norm of the residual')
          end if
-c 
+c
 c        %--------------------------------------------------------%
 c        | Compute the eigenvalues and corresponding error bounds |
 c        | of the current upper Hessenberg matrix.                |
@@ -451,7 +451,7 @@ c        | Select the wanted Ritz values and their bounds    |
 c        | to be used in the convergence test.               |
 c        | The wanted part of the spectrum and corresponding |
 c        | error bounds are in the last NEV loc. of RITZ,    |
-c        | and BOUNDS respectively.                          | 
+c        | and BOUNDS respectively.                          |
 c        %---------------------------------------------------%
 c
          nev = nev0
@@ -474,7 +474,7 @@ c        | BOUNDS respectively.                              |
 c        %---------------------------------------------------%
 c
          call cngets (ishift, which, nev, np, ritz, bounds)
-c 
+c
 c        %------------------------------------------------------------%
 c        | Convergence test: currently we use the following criteria. |
 c        | The relative accuracy of a Ritz value is considered        |
@@ -488,22 +488,22 @@ c
 c
          do 25 i = 1, nev
             rtemp = max( eps23, slapy2( real(ritz(np+i)),
-     &                                  aimag(ritz(np+i)) ) ) 
-            if ( slapy2(real(bounds(np+i)),aimag(bounds(np+i))) 
+     &                                  aimag(ritz(np+i)) ) )
+            if ( slapy2(real(bounds(np+i)),aimag(bounds(np+i)))
      &                 .le. tol*rtemp ) then
                nconv = nconv + 1
             end if
    25    continue
-c 
+c
          if (msglvl .gt. 2) then
             kp(1) = nev
             kp(2) = np
             kp(3) = nconv
-            call ivout (logfil, 3, kp, ndigit, 
+            call ivout (logfil, 3, kp, ndigit,
      &                  '_naup2: NEV, NP, NCONV are')
             call cvout (logfil, kplusp, ritz, ndigit,
      &           '_naup2: The eigenvalues of H')
-            call cvout (logfil, kplusp, bounds, ndigit, 
+            call cvout (logfil, kplusp, bounds, ndigit,
      &          '_naup2: Ritz estimates of the current NCV Ritz values')
          end if
 c
@@ -524,8 +524,8 @@ c
                nev = nev + 1
             end if
  30      continue
-c     
-         if ( (nconv .ge. nev0) .or. 
+c
+         if ( (nconv .ge. nev0) .or.
      &        (iter .gt. mxiter) .or.
      &        (np .eq. 0) ) then
 c
@@ -536,7 +536,7 @@ c
      &                     ndigit,
      &             '_naup2: Ritz estimates computed by _neigh:')
             end if
-c     
+c
 c           %------------------------------------------------%
 c           | Prepare to exit. Put the converged Ritz values |
 c           | and corresponding bounds in RITZ(1:NCONV) and  |
@@ -572,7 +572,7 @@ c           | Scale the Ritz estimate of each Ritz value       |
 c           | by 1 / max(eps23, magnitude of the Ritz value).  |
 c           %--------------------------------------------------%
 c
-            do 35 j = 1, nev0 
+            do 35 j = 1, nev0
                 rtemp = max( eps23, slapy2( real(ritz(j)),
      &                                       aimag(ritz(j)) ) )
                 bounds(j) = bounds(j)/rtemp
@@ -615,13 +615,13 @@ c
             end if
 c
 c           %------------------------------------%
-c           | Max iterations have been exceeded. | 
+c           | Max iterations have been exceeded. |
 c           %------------------------------------%
 c
             if (iter .gt. mxiter .and. nconv .lt. nev0) info = 1
 c
 c           %---------------------%
-c           | No shifts to apply. | 
+c           | No shifts to apply. |
 c           %---------------------%
 c
             if (np .eq. 0 .and. nconv .lt. nev0)  info = 2
@@ -630,7 +630,7 @@ c
             go to 1100
 c
          else if ( (nconv .lt. nev0) .and. (ishift .eq. 1) ) then
-c     
+c
 c           %-------------------------------------------------%
 c           | Do not have all the requested eigenvalues yet.  |
 c           | To prevent possible stagnation, adjust the size |
@@ -645,24 +645,24 @@ c
                nev = 2
             end if
             np = kplusp - nev
-c     
+c
 c           %---------------------------------------%
 c           | If the size of NEV was just increased |
 c           | resort the eigenvalues.               |
 c           %---------------------------------------%
-c     
-            if (nevbef .lt. nev) 
+c
+            if (nevbef .lt. nev)
      &         call cngets (ishift, which, nev, np, ritz, bounds)
 c
-         end if              
-c     
+         end if
+c
          if (msglvl .gt. 0) then
-            call ivout (logfil, 1, [nconv], ndigit, 
+            call ivout (logfil, 1, [nconv], ndigit,
      &           '_naup2: no. of "converged" Ritz values at this iter.')
             if (msglvl .gt. 1) then
                kp(1) = nev
                kp(2) = np
-               call ivout (logfil, 2, kp, ndigit, 
+               call ivout (logfil, 2, kp, ndigit,
      &              '_naup2: NEV and NP are')
                call cvout (logfil, nev, ritz(np+1), ndigit,
      &              '_naup2: "wanted" Ritz values ')
@@ -686,7 +686,7 @@ c
          ushift = .false.
 c
          if ( ishift .ne. 1 ) then
-c 
+c
 c            %----------------------------------%
 c            | Move the NP shifts from WORKL to |
 c            | RITZ, to free up WORKL           |
@@ -696,12 +696,12 @@ c
              call ccopy (np, workl, 1, ritz, 1)
          end if
 c
-         if (msglvl .gt. 2) then 
-            call ivout (logfil, 1, [np], ndigit, 
+         if (msglvl .gt. 2) then
+            call ivout (logfil, 1, [np], ndigit,
      &                  '_naup2: The number of shifts to apply ')
             call cvout (logfil, np, ritz, ndigit,
      &                  '_naup2: values of the shifts')
-            if ( ishift .eq. 1 ) 
+            if ( ishift .eq. 1 )
      &          call cvout (logfil, np, bounds, ndigit,
      &                  '_naup2: Ritz estimates of the shifts')
          end if
@@ -713,7 +713,7 @@ c        | matrix H.                                               |
 c        | The first 2*N locations of WORKD are used as workspace. |
 c        %---------------------------------------------------------%
 c
-         call cnapps (n, nev, np, ritz, v, ldv, 
+         call cnapps (n, nev, np, ritz, v, ldv,
      &                h, ldh, resid, q, ldq, workl, workd)
 c
 c        %---------------------------------------------%
@@ -730,18 +730,18 @@ c
             ipntr(1) = n + 1
             ipntr(2) = 1
             ido = 2
-c 
+c
 c           %----------------------------------%
 c           | Exit in order to compute B*RESID |
 c           %----------------------------------%
-c 
+c
             go to 9000
          else if (bmat .eq. 'I') then
             call ccopy (n, resid, 1, workd, 1)
          end if
-c 
+c
   100    continue
-c 
+c
 c        %----------------------------------%
 c        | Back from reverse communication; |
 c        | WORKD(1:N) := B*RESID            |
@@ -751,8 +751,8 @@ c
             call second (t3)
             tmvbx = tmvbx + (t3 - t2)
          end if
-c 
-         if (bmat .eq. 'G') then         
+c
+         if (bmat .eq. 'G') then
             cmpnorm = cdotc (n, resid, 1, workd, 1)
             rnorm = sqrt(slapy2(real(cmpnorm),aimag(cmpnorm)))
          else if (bmat .eq. 'I') then
@@ -761,12 +761,12 @@ c
          cnorm = .false.
 c
          if (msglvl .gt. 2) then
-            call svout (logfil, 1, [rnorm], ndigit, 
+            call svout (logfil, 1, [rnorm], ndigit,
      &      '_naup2: B-norm of residual for compressed factorization')
             call cmout (logfil, nev, nev, h, ldh, ndigit,
      &        '_naup2: Compressed upper Hessenberg matrix H')
          end if
-c 
+c
       go to 1000
 c
 c     %---------------------------------------------------------------%
@@ -779,7 +779,7 @@ c
 c
       mxiter = iter
       nev = nconv
-c     
+c
  1200 continue
       ido = 99
 c
@@ -789,7 +789,7 @@ c     %------------%
 c
       call second (t1)
       tcaup2 = t1 - t0
-c     
+c
  9000 continue
 c
 c     %---------------%

--- a/mathlibs/src/arpack/cnaupd.f
+++ b/mathlibs/src/arpack/cnaupd.f
@@ -600,9 +600,9 @@ c
       if (info .eq. 2) info = 3
 c
       if (msglvl .gt. 0) then
-         call ivout (logfil, 1, mxiter, ndigit,
+         call ivout (logfil, 1, [mxiter], ndigit,
      &               '_naupd: Number of update iterations taken')
-         call ivout (logfil, 1, np, ndigit,
+         call ivout (logfil, 1, [np], ndigit,
      &               '_naupd: Number of wanted "converged" Ritz values')
          call cvout (logfil, np, workl(ritz), ndigit, 
      &               '_naupd: The final Ritz values')

--- a/mathlibs/src/arpack/cnaupd.f
+++ b/mathlibs/src/arpack/cnaupd.f
@@ -2,11 +2,11 @@ c\BeginDoc
 c
 c\Name: cnaupd
 c
-c\Description: 
+c\Description:
 c  Reverse communication interface for the Implicitly Restarted Arnoldi
-c  iteration. This is intended to be used to find a few eigenpairs of a 
-c  complex linear operator OP with respect to a semi-inner product defined 
-c  by a hermitian positive semi-definite real matrix B. B may be the identity 
+c  iteration. This is intended to be used to find a few eigenpairs of a
+c  complex linear operator OP with respect to a semi-inner product defined
+c  by a hermitian positive semi-definite real matrix B. B may be the identity
 c  matrix.  NOTE: if both OP and B are real, then ssaupd or snaupd should
 c  be used.
 c
@@ -14,7 +14,7 @@ c
 c  The computed approximate eigenvalues are called Ritz values and
 c  the corresponding approximate eigenvectors are called Ritz vectors.
 c
-c  cnaupd is usually called iteratively to solve one of the 
+c  cnaupd is usually called iteratively to solve one of the
 c  following problems:
 c
 c  Mode 1:  A*x = lambda*x.
@@ -25,10 +25,10 @@ c           ===> OP = inv[M]*A  and  B = M.
 c           ===> (If M can be factored see remark 3 below)
 c
 c  Mode 3:  A*x = lambda*M*x, M symmetric semi-definite
-c           ===> OP =  inv[A - sigma*M]*M   and  B = M. 
-c           ===> shift-and-invert mode 
+c           ===> OP =  inv[A - sigma*M]*M   and  B = M.
+c           ===> shift-and-invert mode
 c           If OP*x = amu*x, then lambda = sigma + 1/amu.
-c  
+c
 c
 c  NOTE: The action of w <- inv[A - sigma*M]*v or w <- inv[M]*v
 c        should be accomplished either by a direct method
@@ -49,7 +49,7 @@ c       IPNTR, WORKD, WORKL, LWORKL, RWORK, INFO )
 c
 c\Arguments
 c  IDO     Integer.  (INPUT/OUTPUT)
-c          Reverse communication flag.  IDO must be zero on the first 
+c          Reverse communication flag.  IDO must be zero on the first
 c          call to cnaupd.  IDO will be set internally to
 c          indicate the type of operation to be performed.  Control is
 c          then given back to the calling routine which has the
@@ -72,14 +72,14 @@ c                    need to be recomputed in forming OP * X.
 c          IDO =  2: compute  Y = M * X  where
 c                    IPNTR(1) is the pointer into WORKD for X,
 c                    IPNTR(2) is the pointer into WORKD for Y.
-c          IDO =  3: compute and return the shifts in the first 
+c          IDO =  3: compute and return the shifts in the first
 c                    NP locations of WORKL.
 c          IDO = 99: done
 c          -------------------------------------------------------------
-c          After the initialization phase, when the routine is used in 
-c          the "shift-and-invert" mode, the vector M * X is already 
+c          After the initialization phase, when the routine is used in
+c          the "shift-and-invert" mode, the vector M * X is already
 c          available and does not need to be recomputed in forming OP*X.
-c             
+c
 c  BMAT    Character*1.  (INPUT)
 c          BMAT specifies the type of the matrix B that defines the
 c          semi-inner product for the operator OP.
@@ -101,14 +101,14 @@ c  NEV     Integer.  (INPUT)
 c          Number of eigenvalues of OP to be computed. 0 < NEV < N-1.
 c
 c  TOL     Real  scalar.  (INPUT)
-c          Stopping criteria: the relative accuracy of the Ritz value 
+c          Stopping criteria: the relative accuracy of the Ritz value
 c          is considered acceptable if BOUNDS(I) .LE. TOL*ABS(RITZ(I))
 c          where ABS(RITZ(I)) is the magnitude when RITZ(I) is complex.
 c          DEFAULT = slamch('EPS')  (machine precision as computed
 c                    by the LAPACK auxiliary subroutine slamch).
 c
 c  RESID   Complex array of length N.  (INPUT/OUTPUT)
-c          On INPUT: 
+c          On INPUT:
 c          If INFO .EQ. 0, a random initial residual vector is used.
 c          If INFO .NE. 0, RESID contains the initial residual vector,
 c                          possibly from a previous run.
@@ -118,15 +118,15 @@ c
 c  NCV     Integer.  (INPUT)
 c          Number of columns of the matrix V. NCV must satisfy the two
 c          inequalities 1 <= NCV-NEV and NCV <= N.
-c          This will indicate how many Arnoldi vectors are generated 
-c          at each iteration.  After the startup phase in which NEV 
-c          Arnoldi vectors are generated, the algorithm generates 
-c          approximately NCV-NEV Arnoldi vectors at each subsequent update 
-c          iteration. Most of the cost in generating each Arnoldi vector is 
+c          This will indicate how many Arnoldi vectors are generated
+c          at each iteration.  After the startup phase in which NEV
+c          Arnoldi vectors are generated, the algorithm generates
+c          approximately NCV-NEV Arnoldi vectors at each subsequent update
+c          iteration. Most of the cost in generating each Arnoldi vector is
 c          in the matrix-vector operation OP*x. (See remark 4 below.)
 c
 c  V       Complex array N by NCV.  (OUTPUT)
-c          Contains the final set of Arnoldi basis vectors. 
+c          Contains the final set of Arnoldi basis vectors.
 c
 c  LDV     Integer.  (INPUT)
 c          Leading dimension of V exactly as declared in the calling program.
@@ -137,23 +137,23 @@ c          The shifts selected at each iteration are used to filter out
 c          the components of the unwanted eigenvector.
 c          -------------------------------------------------------------
 c          ISHIFT = 0: the shifts are to be provided by the user via
-c                      reverse communication.  The NCV eigenvalues of 
+c                      reverse communication.  The NCV eigenvalues of
 c                      the Hessenberg matrix H are returned in the part
 c                      of WORKL array corresponding to RITZ.
 c          ISHIFT = 1: exact shifts with respect to the current
-c                      Hessenberg matrix H.  This is equivalent to 
-c                      restarting the iteration from the beginning 
+c                      Hessenberg matrix H.  This is equivalent to
+c                      restarting the iteration from the beginning
 c                      after updating the starting vector with a linear
-c                      combination of Ritz vectors associated with the 
+c                      combination of Ritz vectors associated with the
 c                      "wanted" eigenvalues.
 c          ISHIFT = 2: other choice of internal shift to be defined.
 c          -------------------------------------------------------------
 c
-c          IPARAM(2) = No longer referenced 
+c          IPARAM(2) = No longer referenced
 c
 c          IPARAM(3) = MXITER
-c          On INPUT:  maximum number of Arnoldi update iterations allowed. 
-c          On OUTPUT: actual number of Arnoldi update iterations taken. 
+c          On INPUT:  maximum number of Arnoldi update iterations allowed.
+c          On OUTPUT: actual number of Arnoldi update iterations taken.
 c
 c          IPARAM(4) = NB: blocksize to be used in the recurrence.
 c          The code currently works only for NB = 1.
@@ -163,11 +163,11 @@ c          This represents the number of Ritz values that satisfy
 c          the convergence criterion.
 c
 c          IPARAM(6) = IUPD
-c          No longer referenced. Implicit restarting is ALWAYS used.  
+c          No longer referenced. Implicit restarting is ALWAYS used.
 c
 c          IPARAM(7) = MODE
 c          On INPUT determines what type of eigenproblem is being solved.
-c          Must be 1,2,3,4; See under \Description of cnaupd for the 
+c          Must be 1,2,3,4; See under \Description of cnaupd for the
 c          four modes available.
 c
 c          IPARAM(8) = NP
@@ -186,7 +186,7 @@ c          arrays for matrices/vectors used by the Arnoldi iteration.
 c          -------------------------------------------------------------
 c          IPNTR(1): pointer to the current operand vector X in WORKD.
 c          IPNTR(2): pointer to the current result vector Y in WORKD.
-c          IPNTR(3): pointer to the vector B * X in WORKD when used in 
+c          IPNTR(3): pointer to the vector B * X in WORKD when used in
 c                    the shift-and-invert mode.
 c          IPNTR(4): pointer to the next available location in WORKL
 c                    that is untouched by the program.
@@ -199,7 +199,7 @@ c          IPNTR(14): pointer to the NP shifts in WORKL. See Remark 5 below.
 c
 c          Note: IPNTR(9:13) is only referenced by cneupd. See Remark 2 below.
 c
-c          IPNTR(9): pointer to the NCV RITZ values of the 
+c          IPNTR(9): pointer to the NCV RITZ values of the
 c                    original system.
 c          IPNTR(10): Not Used
 c          IPNTR(11): pointer to the NCV corresponding error bounds.
@@ -210,12 +210,12 @@ c                     of the upper Hessenberg matrix H. Only referenced by
 c                     cneupd if RVEC = .TRUE. See Remark 2 below.
 c
 c          -------------------------------------------------------------
-c          
+c
 c  WORKD   Complex work array of length 3*N.  (REVERSE COMMUNICATION)
 c          Distributed array to be used in the basic Arnoldi iteration
-c          for reverse communication.  The user should not use WORKD 
+c          for reverse communication.  The user should not use WORKD
 c          as temporary workspace during the iteration !!!!!!!!!!
-c          See Data Distribution Note below.  
+c          See Data Distribution Note below.
 c
 c  WORKL   Complex work array of length LWORKL.  (OUTPUT/WORKSPACE)
 c          Private (replicated) array on each PE or array allocated on
@@ -236,18 +236,18 @@ c                          possibly from a previous run.
 c          Error flag on output.
 c          =  0: Normal exit.
 c          =  1: Maximum number of iterations taken.
-c                All possible eigenvalues of OP has been found. IPARAM(5)  
+c                All possible eigenvalues of OP has been found. IPARAM(5)
 c                returns the number of wanted converged Ritz values.
 c          =  2: No longer an informational error. Deprecated starting
 c                with release 2 of ARPACK.
-c          =  3: No shifts could be applied during a cycle of the 
-c                Implicitly restarted Arnoldi iteration. One possibility 
-c                is to increase the size of NCV relative to NEV. 
+c          =  3: No shifts could be applied during a cycle of the
+c                Implicitly restarted Arnoldi iteration. One possibility
+c                is to increase the size of NCV relative to NEV.
 c                See remark 4 below.
 c          = -1: N must be positive.
 c          = -2: NEV must be positive.
 c          = -3: NCV-NEV >= 2 and less than or equal to N.
-c          = -4: The maximum number of Arnoldi update iteration 
+c          = -4: The maximum number of Arnoldi update iteration
 c                must be greater than zero.
 c          = -5: WHICH must be one of 'LM', 'SM', 'LR', 'SR', 'LI', 'SI'
 c          = -6: BMAT must be one of 'I' or 'G'.
@@ -268,16 +268,16 @@ c  1. The computed Ritz values are approximate eigenvalues of OP. The
 c     selection of WHICH should be made with this in mind when using
 c     Mode = 3.  When operating in Mode = 3 setting WHICH = 'LM' will
 c     compute the NEV eigenvalues of the original problem that are
-c     closest to the shift SIGMA . After convergence, approximate eigenvalues 
+c     closest to the shift SIGMA . After convergence, approximate eigenvalues
 c     of the original problem may be obtained with the ARPACK subroutine cneupd.
 c
-c  2. If a basis for the invariant subspace corresponding to the converged Ritz 
-c     values is needed, the user must call cneupd immediately following 
+c  2. If a basis for the invariant subspace corresponding to the converged Ritz
+c     values is needed, the user must call cneupd immediately following
 c     completion of cnaupd. This is new starting with release 2 of ARPACK.
 c
 c  3. If M can be factored into a Cholesky factorization M = LL'
 c     then Mode = 2 should not be selected.  Instead one should use
-c     Mode = 1 with  OP = inv(L)*A*inv(L').  Appropriate triangular 
+c     Mode = 1 with  OP = inv(L)*A*inv(L').  Appropriate triangular
 c     linear systems should be solved with L and L' rather
 c     than computing inverses.  After convergence, an approximate
 c     eigenvector z of the original problem is recovered by solving
@@ -287,11 +287,11 @@ c  4. At present there is no a-priori analysis to guide the selection
 c     of NCV relative to NEV.  The only formal requrement is that NCV > NEV + 1.
 c     However, it is recommended that NCV .ge. 2*NEV.  If many problems of
 c     the same type are to be solved, one should experiment with increasing
-c     NCV while keeping NEV fixed for a given test problem.  This will 
+c     NCV while keeping NEV fixed for a given test problem.  This will
 c     usually decrease the required number of OP*x operations but it
 c     also increases the work and storage required to maintain the orthogonal
 c     basis vectors.  The optimal "cross-over" with respect to CPU time
-c     is problem dependent and must be determined empirically. 
+c     is problem dependent and must be determined empirically.
 c     See Chapter 8 of Reference 2 for further information.
 c
 c  5. When IPARAM(1) = 0, and IDO = 3, the user needs to provide the
@@ -305,7 +305,7 @@ c     WORKL(IPNTR(8)+NCV-1).
 c
 c-----------------------------------------------------------------------
 c
-c\Data Distribution Note: 
+c\Data Distribution Note:
 c
 c  Fortran-D syntax:
 c  ================
@@ -324,10 +324,10 @@ c  ===============
 c  Complex resid(n), v(ldv,ncv), workd(n,3), workl(lworkl)
 c  shared     resid(block), v(block,:), workd(block,:)
 c  replicated workl(lworkl)
-c  
+c
 c  CM2/CM5 syntax:
 c  ==============
-c  
+c
 c-----------------------------------------------------------------------
 c
 c     include   'ex-nonsym.doc'
@@ -343,7 +343,7 @@ c\References:
 c  1. D.C. Sorensen, "Implicit Application of Polynomial Filters in
 c     a k-Step Arnoldi Method", SIAM J. Matr. Anal. Apps., 13 (1992),
 c     pp 357-385.
-c  2. R.B. Lehoucq, "Analysis and Implementation of an Implicitly 
+c  2. R.B. Lehoucq, "Analysis and Implementation of an Implicitly
 c     Restarted Arnoldi Iteration", Rice University Technical Report
 c     TR95-13, Department of Computational and Applied Mathematics.
 c  3. B.N. Parlett & Y. Saad, "_Complex_ Shift and Invert Strategies for
@@ -363,10 +363,10 @@ c\Author
 c     Danny Sorensen               Phuong Vu
 c     Richard Lehoucq              CRPC / Rice University
 c     Dept. of Computational &     Houston, Texas
-c     Applied Mathematics 
-c     Rice University           
-c     Houston, Texas 
-c 
+c     Applied Mathematics
+c     Rice University
+c     Houston, Texas
+c
 c\SCCS Information: @(#)
 c FILE: naupd.F   SID: 2.4   DATE OF SID: 8/27/96   RELEASE: 2
 c
@@ -377,7 +377,7 @@ c
 c-----------------------------------------------------------------------
 c
       subroutine cnaupd
-     &   ( ido, bmat, n, which, nev, tol, resid, ncv, v, ldv, iparam, 
+     &   ( ido, bmat, n, which, nev, tol, resid, ncv, v, ldv, iparam,
      &     ipntr, workd, workl, lworkl, rwork, info )
 c
 c     %----------------------------------------------------%
@@ -393,7 +393,7 @@ c     %------------------%
 c
       character  bmat*1, which*2
       integer    ido, info, ldv, lworkl, n, ncv, nev
-      Real 
+      Real
      &           tol
 c
 c     %-----------------%
@@ -403,7 +403,7 @@ c
       integer    iparam(11), ipntr(14)
       Complex
      &           resid(n), v(ldv,ncv), workd(3*n), workl(lworkl)
-      Real  
+      Real
      &           rwork(ncv)
 c
 c     %------------%
@@ -418,7 +418,7 @@ c     %---------------%
 c     | Local Scalars |
 c     %---------------%
 c
-      integer    bounds, ierr, ih, iq, ishift, iupd, iw, 
+      integer    bounds, ierr, ih, iq, ishift, iupd, iw,
      &           ldh, ldq, levec, mode, msglvl, mxiter, nb,
      &           nev0, next, np, ritz, j
       save       bounds, ih, iq, ishift, iupd, iw,
@@ -435,16 +435,16 @@ c     %--------------------%
 c     | External Functions |
 c     %--------------------%
 c
-      Real 
+      Real
      &           slamch
       external   slamch
 c
 c     %-----------------------%
 c     | Executable Statements |
 c     %-----------------------%
-c 
+c
       if (ido .eq. 0) then
-c 
+c
 c        %-------------------------------%
 c        | Initialize timing statistics  |
 c        | & message level for debugging |
@@ -495,7 +495,7 @@ c
          else if (mode .eq. 1 .and. bmat .eq. 'G') then
                                                 ierr = -11
          end if
-c 
+c
 c        %------------%
 c        | Error Exit |
 c        %------------%
@@ -505,14 +505,14 @@ c
             ido  = 99
             go to 9000
          end if
-c 
+c
 c        %------------------------%
 c        | Set default parameters |
 c        %------------------------%
 c
          if (nb .le. 0)				nb = 1
          if (tol .le. 0.0E+0 )			tol = slamch('EpsMach')
-         if (ishift .ne. 0  .and.  
+         if (ishift .ne. 0  .and.
      &       ishift .ne. 1  .and.
      &       ishift .ne. 2) 			ishift = 1
 c
@@ -524,8 +524,8 @@ c        | size of the invariant subspace desired.      |
 c        %----------------------------------------------%
 c
          np     = ncv - nev
-         nev0   = nev 
-c 
+         nev0   = nev
+c
 c        %-----------------------------%
 c        | Zero out internal workspace |
 c        %-----------------------------%
@@ -533,7 +533,7 @@ c
          do 10 j = 1, 3*ncv**2 + 5*ncv
             workl(j) = zero
   10     continue
-c 
+c
 c        %-------------------------------------------------------------%
 c        | Pointer into WORKL for address of H, RITZ, BOUNDS, Q        |
 c        | etc... and the remaining workspace.                         |
@@ -571,12 +571,12 @@ c     %-------------------------------------------------------%
 c     | Carry out the Implicitly restarted Arnoldi Iteration. |
 c     %-------------------------------------------------------%
 c
-      call cnaup2 
+      call cnaup2
      &   ( ido, bmat, n, which, nev0, np, tol, resid, mode, iupd,
-     &     ishift, mxiter, v, ldv, workl(ih), ldh, workl(ritz), 
-     &     workl(bounds), workl(iq), ldq, workl(iw), 
+     &     ishift, mxiter, v, ldv, workl(ih), ldh, workl(ritz),
+     &     workl(bounds), workl(iq), ldq, workl(iw),
      &     ipntr, workd, rwork, info )
-c 
+c
 c     %--------------------------------------------------%
 c     | ido .ne. 99 implies use of reverse communication |
 c     | to compute operations involving OP.              |
@@ -584,7 +584,7 @@ c     %--------------------------------------------------%
 c
       if (ido .eq. 3) iparam(8) = np
       if (ido .ne. 99) go to 9000
-c 
+c
       iparam(3) = mxiter
       iparam(5) = np
       iparam(9) = nopx
@@ -604,9 +604,9 @@ c
      &               '_naupd: Number of update iterations taken')
          call ivout (logfil, 1, [np], ndigit,
      &               '_naupd: Number of wanted "converged" Ritz values')
-         call cvout (logfil, np, workl(ritz), ndigit, 
+         call cvout (logfil, np, workl(ritz), ndigit,
      &               '_naupd: The final Ritz values')
-         call cvout (logfil, np, workl(bounds), ndigit, 
+         call cvout (logfil, np, workl(bounds), ndigit,
      &               '_naupd: Associated Ritz estimates')
       end if
 c

--- a/mathlibs/src/arpack/cneigh.f
+++ b/mathlibs/src/arpack/cneigh.f
@@ -12,7 +12,7 @@ c     ( RNORM, N, H, LDH, RITZ, BOUNDS, Q, LDQ, WORKL, RWORK, IERR )
 c
 c\Arguments
 c  RNORM   Real scalar.  (INPUT)
-c          Residual norm corresponding to the current upper Hessenberg 
+c          Residual norm corresponding to the current upper Hessenberg
 c          matrix H.
 c
 c  N       Integer.  (INPUT)
@@ -30,8 +30,8 @@ c          On output, RITZ(1:N) contains the eigenvalues of H.
 c
 c  BOUNDS  Complex array of length N.  (OUTPUT)
 c          On output, BOUNDS contains the Ritz estimates associated with
-c          the eigenvalues held in RITZ.  This is equal to RNORM 
-c          times the last components of the eigenvectors corresponding 
+c          the eigenvalues held in RITZ.  This is equal to RNORM
+c          times the last components of the eigenvectors corresponding
 c          to the eigenvalues in RITZ.
 c
 c  Q       Complex N by N array.  (WORKSPACE)
@@ -48,7 +48,7 @@ c          of H and also in the calculation of the eigenvectors of H.
 c
 c  RWORK   Real  work array of length N (WORKSPACE)
 c          Private (replicated) array on each PE or array allocated on
-c          the front end. 
+c          the front end.
 c
 c  IERR    Integer.  (OUTPUT)
 c          Error exit flag from clahqr or ctrevc.
@@ -74,18 +74,18 @@ c             upper Hessenberg matrix.
 c     claset  LAPACK matrix initialization routine.
 c     ctrevc  LAPACK routine to compute the eigenvectors of a matrix
 c             in upper triangular form
-c     ccopy   Level 1 BLAS that copies one vector to another. 
+c     ccopy   Level 1 BLAS that copies one vector to another.
 c     csscal  Level 1 BLAS that scales a complex vector by a real number.
 c     scnrm2  Level 1 BLAS that computes the norm of a vector.
-c     
+c
 c
 c\Author
 c     Danny Sorensen               Phuong Vu
 c     Richard Lehoucq              CRPC / Rice University
 c     Dept. of Computational &     Houston, Texas
-c     Applied Mathematics 
-c     Rice University           
-c     Houston, Texas 
+c     Applied Mathematics
+c     Rice University
+c     Houston, Texas
 c
 c\SCCS Information: @(#)
 c FILE: neigh.F   SID: 2.2   DATE OF SID: 4/20/96   RELEASE: 2
@@ -97,7 +97,7 @@ c\EndLib
 c
 c-----------------------------------------------------------------------
 c
-      subroutine cneigh (rnorm, n, h, ldh, ritz, bounds, 
+      subroutine cneigh (rnorm, n, h, ldh, ritz, bounds,
      &                   q, ldq, workl, rwork, ierr)
 c
 c     %----------------------------------------------------%
@@ -112,37 +112,37 @@ c     | Scalar Arguments |
 c     %------------------%
 c
       integer    ierr, n, ldh, ldq
-      Real     
+      Real
      &           rnorm
 c
 c     %-----------------%
 c     | Array Arguments |
 c     %-----------------%
 c
-      Complex     
+      Complex
      &           bounds(n), h(ldh,n), q(ldq,n), ritz(n),
-     &           workl(n*(n+3)) 
-      Real 
+     &           workl(n*(n+3))
+      Real
      &           rwork(n)
-c 
+c
 c     %------------%
 c     | Parameters |
 c     %------------%
 c
-      Complex     
+      Complex
      &           one, zero
       Real
      &           rone
       parameter  (one = (1.0E+0, 0.0E+0), zero = (0.0E+0, 0.0E+0),
      &           rone = 1.0E+0)
-c 
+c
 c     %------------------------%
 c     | Local Scalars & Arrays |
 c     %------------------------%
 c
       logical    select(1)
       integer    j,  msglvl
-      Complex     
+      Complex
      &           vl(1)
       Real
      &           temp
@@ -151,14 +151,14 @@ c     %----------------------%
 c     | External Subroutines |
 c     %----------------------%
 c
-      external   clacpy, clahqr, ctrevc, ccopy, 
+      external   clacpy, clahqr, ctrevc, ccopy,
      &           csscal, cmout, cvout, second
 c
 c     %--------------------%
 c     | External Functions |
 c     %--------------------%
 c
-      Real 
+      Real
      &           scnrm2
       external   scnrm2
 c
@@ -173,17 +173,17 @@ c     %-------------------------------%
 c
       call second (t0)
       msglvl = mceigh
-c 
+c
       if (msglvl .gt. 2) then
-          call cmout (logfil, n, n, h, ldh, ndigit, 
+          call cmout (logfil, n, n, h, ldh, ndigit,
      &         '_neigh: Entering upper Hessenberg matrix H ')
       end if
-c 
+c
 c     %----------------------------------------------------------%
 c     | 1. Compute the eigenvalues, the last components of the   |
 c     |    corresponding Schur vectors and the full Schur form T |
 c     |    of the current upper Hessenberg matrix H.             |
-c     |    clahqr returns the full Schur form of H               | 
+c     |    clahqr returns the full Schur form of H               |
 c     |    in WORKL(1:N**2), and the Schur vectors in q.         |
 c     %----------------------------------------------------------%
 c
@@ -205,7 +205,7 @@ c     |    apply the Schur vectors to get the corresponding      |
 c     |    eigenvectors.                                         |
 c     %----------------------------------------------------------%
 c
-      call ctrevc ('Right', 'Back', select, n, workl, n, vl, n, q, 
+      call ctrevc ('Right', 'Back', select, n, workl, n, vl, n, q,
      &             ldq, n, n, workl(n*n+1), rwork, ierr)
 c
       if (ierr .ne. 0) go to 9000

--- a/mathlibs/src/arpack/cneupd.f
+++ b/mathlibs/src/arpack/cneupd.f
@@ -473,7 +473,7 @@ c
             thres = aimag(workl(ritz))
          end if
          if (msglvl .gt. 2) then
-            call svout(logfil, 1, thres, ndigit,
+            call svout(logfil, 1, [thres], ndigit,
      &           '_neupd: Threshold eigenvalue used for re-ordering')
          end if
 c
@@ -557,9 +557,9 @@ c
  10      continue
 c
          if (msglvl .gt. 2) then
-             call ivout(logfil, 1, ktrord, ndigit,
+             call ivout(logfil, 1, [ktrord], ndigit,
      &            '_neupd: Number of specified eigenvalues')
-             call ivout(logfil, 1, nconv, ndigit,
+             call ivout(logfil, 1, [nconv], ndigit,
      &            '_neupd: Number of "converged" eigenvalues')
          end if 
 c

--- a/mathlibs/src/arpack/cneupd.f
+++ b/mathlibs/src/arpack/cneupd.f
@@ -1,48 +1,48 @@
 c\BeginDoc
-c 
-c\Name: cneupd 
-c 
-c\Description: 
-c  This subroutine returns the converged approximations to eigenvalues 
-c  of A*z = lambda*B*z and (optionally): 
-c 
-c      (1) The corresponding approximate eigenvectors; 
-c 
-c      (2) An orthonormal basis for the associated approximate 
-c          invariant subspace; 
-c 
-c      (3) Both.  
 c
-c  There is negligible additional cost to obtain eigenvectors.  An orthonormal 
+c\Name: cneupd
+c
+c\Description:
+c  This subroutine returns the converged approximations to eigenvalues
+c  of A*z = lambda*B*z and (optionally):
+c
+c      (1) The corresponding approximate eigenvectors;
+c
+c      (2) An orthonormal basis for the associated approximate
+c          invariant subspace;
+c
+c      (3) Both.
+c
+c  There is negligible additional cost to obtain eigenvectors.  An orthonormal
 c  basis is always computed.  There is an additional storage cost of n*nev
-c  if both are requested (in this case a separate array Z must be supplied). 
+c  if both are requested (in this case a separate array Z must be supplied).
 c
 c  The approximate eigenvalues and eigenvectors of  A*z = lambda*B*z
 c  are derived from approximate eigenvalues and eigenvectors of
 c  of the linear operator OP prescribed by the MODE selection in the
 c  call to CNAUPD.  CNAUPD must be called before this routine is called.
 c  These approximate eigenvalues and vectors are commonly called Ritz
-c  values and Ritz vectors respectively.  They are referred to as such 
-c  in the comments that follow.   The computed orthonormal basis for the 
-c  invariant subspace corresponding to these Ritz values is referred to as a 
-c  Schur basis. 
-c 
+c  values and Ritz vectors respectively.  They are referred to as such
+c  in the comments that follow.   The computed orthonormal basis for the
+c  invariant subspace corresponding to these Ritz values is referred to as a
+c  Schur basis.
+c
 c  The definition of OP as well as other terms and the relation of computed
 c  Ritz values and vectors of OP with respect to the given problem
-c  A*z = lambda*B*z may be found in the header of CNAUPD.  For a brief 
+c  A*z = lambda*B*z may be found in the header of CNAUPD.  For a brief
 c  description, see definitions of IPARAM(7), MODE and WHICH in the
 c  documentation of CNAUPD.
 c
 c\Usage:
-c  call cneupd 
-c     ( RVEC, HOWMNY, SELECT, D, Z, LDZ, SIGMA, WORKEV, BMAT, 
-c       N, WHICH, NEV, TOL, RESID, NCV, V, LDV, IPARAM, IPNTR, WORKD, 
+c  call cneupd
+c     ( RVEC, HOWMNY, SELECT, D, Z, LDZ, SIGMA, WORKEV, BMAT,
+c       N, WHICH, NEV, TOL, RESID, NCV, V, LDV, IPARAM, IPNTR, WORKD,
 c       WORKL, LWORKL, RWORK, INFO )
 c
 c\Arguments:
 c  RVEC    LOGICAL  (INPUT)
 c          Specifies whether a basis for the invariant subspace corresponding
-c          to the converged Ritz value approximations for the eigenproblem 
+c          to the converged Ritz value approximations for the eigenproblem
 c          A*z = lambda*B*z is computed.
 c
 c             RVEC = .FALSE.     Compute Ritz values only.
@@ -51,7 +51,7 @@ c             RVEC = .TRUE.      Compute Ritz vectors or Schur vectors.
 c                                See Remarks below.
 c
 c  HOWMNY  Character*1  (INPUT)
-c          Specifies the form of the basis for the invariant subspace 
+c          Specifies the form of the basis for the invariant subspace
 c          corresponding to the converged Ritz values that is to be computed.
 c
 c          = 'A': Compute NEV Ritz vectors;
@@ -62,34 +62,34 @@ c
 c  SELECT  Logical array of dimension NCV.  (INPUT)
 c          If HOWMNY = 'S', SELECT specifies the Ritz vectors to be
 c          computed. To select the  Ritz vector corresponding to a
-c          Ritz value D(j), SELECT(j) must be set to .TRUE.. 
-c          If HOWMNY = 'A' or 'P', SELECT need not be initialized 
+c          Ritz value D(j), SELECT(j) must be set to .TRUE..
+c          If HOWMNY = 'A' or 'P', SELECT need not be initialized
 c          but it is used as internal workspace.
 c
 c  D       Complex array of dimension NEV+1.  (OUTPUT)
-c          On exit, D contains the  Ritz  approximations 
+c          On exit, D contains the  Ritz  approximations
 c          to the eigenvalues lambda for A*z = lambda*B*z.
 c
 c  Z       Complex N by NEV array    (OUTPUT)
-c          On exit, if RVEC = .TRUE. and HOWMNY = 'A', then the columns of 
-c          Z represents approximate eigenvectors (Ritz vectors) corresponding 
+c          On exit, if RVEC = .TRUE. and HOWMNY = 'A', then the columns of
+c          Z represents approximate eigenvectors (Ritz vectors) corresponding
 c          to the NCONV=IPARAM(5) Ritz values for eigensystem
 c          A*z = lambda*B*z.
 c
 c          If RVEC = .FALSE. or HOWMNY = 'P', then Z is NOT REFERENCED.
 c
-c          NOTE: If if RVEC = .TRUE. and a Schur basis is not required, 
-c          the array Z may be set equal to first NEV+1 columns of the Arnoldi 
-c          basis array V computed by CNAUPD.  In this case the Arnoldi basis 
+c          NOTE: If if RVEC = .TRUE. and a Schur basis is not required,
+c          the array Z may be set equal to first NEV+1 columns of the Arnoldi
+c          basis array V computed by CNAUPD.  In this case the Arnoldi basis
 c          will be destroyed and overwritten with the eigenvector basis.
 c
 c  LDZ     Integer.  (INPUT)
 c          The leading dimension of the array Z.  If Ritz vectors are
-c          desired, then  LDZ .ge.  max( 1, N ) is required.  
+c          desired, then  LDZ .ge.  max( 1, N ) is required.
 c          In any case,  LDZ .ge. 1 is required.
 c
 c  SIGMA   Complex  (INPUT)
-c          If IPARAM(7) = 3 then SIGMA represents the shift. 
+c          If IPARAM(7) = 3 then SIGMA represents the shift.
 c          Not referenced if IPARAM(7) = 1 or 2.
 c
 c  WORKEV  Complex work array of dimension 2*NCV.  (WORKSPACE)
@@ -97,12 +97,12 @@ c
 c  **** The remaining arguments MUST be the same as for the   ****
 c  **** call to CNAUPD that was just completed.               ****
 c
-c  NOTE: The remaining arguments 
+c  NOTE: The remaining arguments
 c
-c           BMAT, N, WHICH, NEV, TOL, RESID, NCV, V, LDV, IPARAM, IPNTR, 
-c           WORKD, WORKL, LWORKL, RWORK, INFO 
+c           BMAT, N, WHICH, NEV, TOL, RESID, NCV, V, LDV, IPARAM, IPNTR,
+c           WORKD, WORKL, LWORKL, RWORK, INFO
 c
-c         must be passed directly to CNEUPD following the last call 
+c         must be passed directly to CNEUPD following the last call
 c         to CNAUPD.  These arguments MUST NOT BE MODIFIED between
 c         the the last call to CNAUPD and the call to CNEUPD.
 c
@@ -128,7 +128,7 @@ c  WORKL   Real work array of length LWORKL.  (OUTPUT/WORKSPACE)
 c          WORKL(1:ncv*ncv+2*ncv) contains information obtained in
 c          cnaupd.  They are not changed by cneupd.
 c          WORKL(ncv*ncv+2*ncv+1:3*ncv*ncv+4*ncv) holds the
-c          untransformed Ritz values, the untransformed error estimates of 
+c          untransformed Ritz values, the untransformed error estimates of
 c          the Ritz values, the upper triangular matrix for H, and the
 c          associated matrix representation of the invariant subspace for H.
 c
@@ -182,18 +182,18 @@ c\References:
 c  1. D.C. Sorensen, "Implicit Application of Polynomial Filters in
 c     a k-Step Arnoldi Method", SIAM J. Matr. Anal. Apps., 13 (1992),
 c     pp 357-385.
-c  2. R.B. Lehoucq, "Analysis and Implementation of an Implicitly 
+c  2. R.B. Lehoucq, "Analysis and Implementation of an Implicitly
 c     Restarted Arnoldi Iteration", Rice University Technical Report
 c     TR95-13, Department of Computational and Applied Mathematics.
 c  3. B. Nour-Omid, B. N. Parlett, T. Ericsson and P. S. Jensen,
 c     "How to Implement the Spectral Transformation", Math Comp.,
-c     Vol. 48, No. 178, April, 1987 pp. 664-673. 
+c     Vol. 48, No. 178, April, 1987 pp. 664-673.
 c
 c\Routines called:
 c     ivout   ARPACK utility routine that prints integers.
 c     cmout   ARPACK utility routine that prints matrices
 c     cvout   ARPACK utility routine that prints vectors.
-c     cgeqr2  LAPACK routine that computes the QR factorization of 
+c     cgeqr2  LAPACK routine that computes the QR factorization of
 c             a matrix.
 c     clacpy  LAPACK matrix copy routine.
 c     clahqr  LAPACK routine that computes the Schur form of a
@@ -202,7 +202,7 @@ c     claset  LAPACK matrix initialization routine.
 c     ctrevc  LAPACK routine to compute the eigenvectors of a matrix
 c             in upper triangular form.
 c     ctrsen  LAPACK routine that re-orders the Schur form.
-c     cunm2r  LAPACK routine that applies an orthogonal matrix in 
+c     cunm2r  LAPACK routine that applies an orthogonal matrix in
 c             factored form.
 c     slamch  LAPACK routine that determines machine constants.
 c     ctrmm   Level 3 BLAS matrix times an upper triangular matrix.
@@ -214,23 +214,23 @@ c     scnrm2  Level 1 BLAS that computes the norm of a complex vector.
 c
 c\Remarks
 c
-c  1. Currently only HOWMNY = 'A' and 'P' are implemented. 
+c  1. Currently only HOWMNY = 'A' and 'P' are implemented.
 c
 c  2. Schur vectors are an orthogonal representation for the basis of
 c     Ritz vectors. Thus, their numerical properties are often superior.
 c     If RVEC = .true. then the relationship
 c             A * V(:,1:IPARAM(5)) = V(:,1:IPARAM(5)) * T, and
 c     V(:,1:IPARAM(5))' * V(:,1:IPARAM(5)) = I are approximately satisfied.
-c     Here T is the leading submatrix of order IPARAM(5) of the 
-c     upper triangular matrix stored workl(ipntr(12)). 
+c     Here T is the leading submatrix of order IPARAM(5) of the
+c     upper triangular matrix stored workl(ipntr(12)).
 c
 c\Authors
 c     Danny Sorensen               Phuong Vu
 c     Richard Lehoucq              CRPC / Rice University
-c     Chao Yang                    Houston, Texas 
-c     Dept. of Computational & 
-c     Applied Mathematics 
-c     Rice University 
+c     Chao Yang                    Houston, Texas
+c     Dept. of Computational &
+c     Applied Mathematics
+c     Rice University
 c     Houston, Texas
 c
 c\SCCS Information: @(#)
@@ -239,9 +239,9 @@ c
 c\EndLib
 c
 c-----------------------------------------------------------------------
-      subroutine cneupd (rvec, howmny, select, d, z, ldz, sigma, 
-     &                   workev, bmat, n, which, nev, tol, 
-     &                   resid, ncv, v, ldv, iparam, ipntr, workd, 
+      subroutine cneupd (rvec, howmny, select, d, z, ldz, sigma,
+     &                   workev, bmat, n, which, nev, tol,
+     &                   resid, ncv, v, ldv, iparam, ipntr, workd,
      &                   workl, lworkl, rwork, info)
 c
 c     %----------------------------------------------------%
@@ -258,9 +258,9 @@ c
       character  bmat, howmny, which*2
       logical    rvec
       integer    info, ldz, ldv, lworkl, n, ncv, nev
-      Complex     
+      Complex
      &           sigma
-      Real 
+      Real
      &           tol
 c
 c     %-----------------%
@@ -272,7 +272,7 @@ c
       Real
      &           rwork(ncv)
       Complex
-     &           d(nev), resid(n), v(ldv,ncv), z(ldz, nev), 
+     &           d(nev), resid(n), v(ldv,ncv), z(ldz, nev),
      &           workd(3*n), workl(lworkl), workev(2*ncv)
 c
 c     %------------%
@@ -288,8 +288,8 @@ c     | Local Scalars |
 c     %---------------%
 c
       character  type*6
-      integer    bounds, ierr, ih, ihbds, iheig, nconv, 
-     &           invsub, iuptri, iwev, j, 
+      integer    bounds, ierr, ih, ihbds, iheig, nconv,
+     &           invsub, iuptri, iwev, j,
      &           ldh, ldq, mode, msglvl, ritz, wr, k,
      &           irz, ibd, ktrord, outncv, iq
       Complex
@@ -305,7 +305,7 @@ c
       external   ccopy, cgeru, cgeqr2, clacpy, cmout,
      &           cunm2r, ctrmm, cvout, ivout,
      &           clahqr
-c  
+c
 c     %--------------------%
 c     | External Functions |
 c     %--------------------%
@@ -321,7 +321,7 @@ c
 c     %-----------------------%
 c     | Executable Statements |
 c     %-----------------------%
-c 
+c
 c     %------------------------%
 c     | Set default parameters |
 c     %------------------------%
@@ -372,12 +372,12 @@ c
       else if (howmny .eq. 'S' ) then
          ierr = -12
       end if
-c     
+c
       if (mode .eq. 1 .or. mode .eq. 2) then
          type = 'REGULR'
       else if (mode .eq. 3 ) then
          type = 'SHIFTI'
-      else 
+      else
                                               ierr = -10
       end if
       if (mode .eq. 1 .and. bmat .eq. 'G')    ierr = -11
@@ -390,7 +390,7 @@ c
          info = ierr
          go to 9000
       end if
-c 
+c
 c     %--------------------------------------------------------%
 c     | Pointer into WORKL for address of H, RITZ, WORKEV, Q   |
 c     | etc... and the remaining workspace.                    |
@@ -418,7 +418,7 @@ c     |                                      the invariant        |
 c     |                                      subspace for H.      |
 c     | GRAND total of NCV * ( 3 * NCV + 4 ) locations.           |
 c     %-----------------------------------------------------------%
-c     
+c
       ih     = ipntr(5)
       ritz   = ipntr(6)
       iq     = ipntr(7)
@@ -453,7 +453,7 @@ c     %------------------------------------%
 c
       rnorm = workl(ih+2)
       workl(ih+2) = zero
-c     
+c
       if (rvec) then
 c
 c        %-------------------------------------------%
@@ -479,13 +479,13 @@ c
 c
 c        %---------------------------------------------------------%
 c        | Check to see if all converged Ritz values appear at the |
-c        | at the top of the upper triangular matrix computed by   | 
-c        | _neigh in _naup2.  This is done in the following way:   | 
+c        | at the top of the upper triangular matrix computed by   |
+c        | _neigh in _naup2.  This is done in the following way:   |
 c        |                                                         |
 c        | 1) For each Ritz value from _neigh, compare it with the |
 c        |    threshold Ritz value computed above to determine     |
 c        |    whether it is a wanted one.                          |
-c        |                                                         | 
+c        |                                                         |
 c        | 2) If it is wanted, then check the corresponding Ritz   |
 c        |    estimate to see if it has converged.  If it has, set |
 c        |    correponding entry in the logical array SELECT to    |
@@ -509,7 +509,7 @@ c
                   if ( slapy2(real(workl(ibd+j)),
      &                 aimag(workl(ibd+j))) .le. tol*rtemp )
      &               select(j+1) = .true.
-               end if 
+               end if
             else if (which .eq. 'SM') then
                if ( slapy2(real(workl(irz+j)),
      &                      aimag(workl(irz+j))) .le. thres )  then
@@ -561,7 +561,7 @@ c
      &            '_neupd: Number of specified eigenvalues')
              call ivout(logfil, 1, [nconv], ndigit,
      &            '_neupd: Number of "converged" eigenvalues')
-         end if 
+         end if
 c
 c        if (ktrord .gt. nconv) then
 c
@@ -611,7 +611,7 @@ c           | Reorder the computed upper triangular matrix. |
 c           %-----------------------------------------------%
 c
             call ctrsen ('None', 'V', select, ncv, workl(iuptri), ldh,
-     &           workl(invsub), ldq, workl(iheig), nconv, conds, sep, 
+     &           workl(invsub), ldq, workl(iheig), nconv, conds, sep,
      &           workev, ncv, ierr)
 c
             if (ierr .eq. 1) then
@@ -639,7 +639,7 @@ c        | Ritz values.                                |
 c        %---------------------------------------------%
 c
          call ccopy (ncv, workl(invsub+ncv-1), ldq, workl(ihbds), 1)
-c 
+c
 c        %--------------------------------------------%
 c        | Place the computed eigenvalues of H into D |
 c        | if a spectral transformation was not used. |
@@ -664,14 +664,14 @@ c        | * Copy the first NCONV columns of VQ into Z.           |
 c        | * Postmultiply Z by R.                                 |
 c        | The N by NCONV matrix Z is now a matrix representation |
 c        | of the approximate invariant subspace associated with  |
-c        | the Ritz values in workl(iheig). The first NCONV       | 
+c        | the Ritz values in workl(iheig). The first NCONV       |
 c        | columns of V are now approximate Schur vectors         |
 c        | associated with the upper triangular matrix of order   |
 c        | NCONV in workl(iuptri).                                |
 c        %--------------------------------------------------------%
 c
-         call cunm2r ('Right', 'Notranspose', n, ncv, nconv, 
-     &        workl(invsub), ldq, workev, v, ldv, workd(n+1), 
+         call cunm2r ('Right', 'Notranspose', n, ncv, nconv,
+     &        workl(invsub), ldq, workev, v, ldv, workd(n+1),
      &        ierr)
          call clacpy ('All', n, nconv, v, ldv, z, ldz)
 c
@@ -686,7 +686,7 @@ c           | Note that since Q is orthogonal, R is a diagonal  |
 c           | matrix consisting of plus or minus ones.          |
 c           %---------------------------------------------------%
 c
-            if ( real( workl(invsub+(j-1)*ldq+j-1) ) .lt. 
+            if ( real( workl(invsub+(j-1)*ldq+j-1) ) .lt.
      &                  real(zero) ) then
                call cscal (nconv, -one, workl(iuptri+j-1), ldq)
                call cscal (nconv, -one, workl(iuptri+(j-1)*ldq), 1)
@@ -740,7 +740,7 @@ c                 | Note that the eigenvector matrix of T is |
 c                 | upper triangular, thus the length of the |
 c                 | inner product can be set to j.           |
 c                 %------------------------------------------%
-c 
+c
                   workev(j) = cdotc(j, workl(ihbds), 1,
      &                        workl(invsub+(j-1)*ldq), 1)
  40         continue
@@ -759,7 +759,7 @@ c
 c           %---------------------------------------%
 c           | Copy Ritz estimates into workl(ihbds) |
 c           %---------------------------------------%
-c 
+c
             call ccopy(nconv, workev, 1, workl(ihbds), 1)
 c
 c           %----------------------------------------------%
@@ -770,7 +770,7 @@ c
             call ctrmm ('Right', 'Upper', 'No transpose', 'Non-unit',
      &                  n, nconv, one, workl(invsub), ldq, z, ldz)
 c
-         end if 
+         end if
 c
       else
 c
@@ -793,25 +793,25 @@ c     %------------------------------------------------%
 c
       if (type .eq. 'REGULR') then
 c
-         if (rvec) 
+         if (rvec)
      &      call cscal(ncv, rnorm, workl(ihbds), 1)
-c      
+c
       else
-c     
+c
 c        %---------------------------------------%
 c        |   A spectral transformation was used. |
 c        | * Determine the Ritz estimates of the |
 c        |   Ritz values in the original system. |
 c        %---------------------------------------%
 c
-         if (rvec) 
+         if (rvec)
      &      call cscal(ncv, rnorm, workl(ihbds), 1)
-c    
+c
          do 50 k=1, ncv
             temp = workl(iheig+k-1)
             workl(ihbds+k-1) = workl(ihbds+k-1) / temp / temp
   50     continue
-c  
+c
       end if
 c
 c     %-----------------------------------------------------------%
@@ -821,7 +821,7 @@ c     |             lambda = 1/theta + sigma                      |
 c     | NOTES:                                                    |
 c     | *The Ritz vectors are not affected by the transformation. |
 c     %-----------------------------------------------------------%
-c    
+c
       if (type .eq. 'SHIFTI') then
          do 60 k=1, nconv
             d(k) = one / workl(iheig+k-1) + sigma
@@ -876,7 +876,7 @@ c
  9000 continue
 c
       return
-c     
+c
 c     %---------------%
 c     | End of cneupd |
 c     %---------------%

--- a/mathlibs/src/arpack/cngets.f
+++ b/mathlibs/src/arpack/cngets.f
@@ -2,9 +2,9 @@ c\BeginDoc
 c
 c\Name: cngets
 c
-c\Description: 
+c\Description:
 c  Given the eigenvalues of the upper Hessenberg matrix H,
-c  computes the NP shifts AMU that are zeros of the polynomial of 
+c  computes the NP shifts AMU that are zeros of the polynomial of
 c  degree NP which filters out components of the unwanted eigenvectors
 c  corresponding to the AMU's based on some given criteria.
 c
@@ -40,8 +40,8 @@ c  RITZ    Complex array of length KEV+NP.  (INPUT/OUTPUT)
 c          On INPUT, RITZ contains the the eigenvalues of H.
 c          On OUTPUT, RITZ are sorted so that the unwanted
 c          eigenvalues are in the first NP locations and the wanted
-c          portion is in the last KEV locations.  When exact shifts are 
-c          selected, the unwanted part corresponds to the shifts to 
+c          portion is in the last KEV locations.  When exact shifts are
+c          selected, the unwanted part corresponds to the shifts to
 c          be applied. Also, if ISHIFT .eq. 1, the unwanted eigenvalues
 c          are further sorted so that the ones with largest Ritz values
 c          are first.
@@ -49,7 +49,7 @@ c
 c  BOUNDS  Complex array of length KEV+NP.  (INPUT/OUTPUT)
 c          Error bounds corresponding to the ordering in RITZ.
 c
-c  
+c
 c
 c\EndDoc
 c
@@ -70,9 +70,9 @@ c\Author
 c     Danny Sorensen               Phuong Vu
 c     Richard Lehoucq              CRPC / Rice University
 c     Dept. of Computational &     Houston, Texas
-c     Applied Mathematics 
-c     Rice University           
-c     Houston, Texas 
+c     Applied Mathematics
+c     Rice University
+c     Houston, Texas
 c
 c\SCCS Information: @(#)
 c FILE: ngets.F   SID: 2.2   DATE OF SID: 4/20/96   RELEASE: 2
@@ -136,14 +136,14 @@ c     %-------------------------------%
 c     | Initialize timing statistics  |
 c     | & message level for debugging |
 c     %-------------------------------%
-c 
+c
       call second (t0)
       msglvl = mcgets
-c 
+c
       call csortc (which, .true., kev+np, ritz, bounds)
-c     
+c
       if ( ishift .eq. 1 ) then
-c     
+c
 c        %-------------------------------------------------------%
 c        | Sort the unwanted Ritz values used as shifts so that  |
 c        | the ones with largest Ritz estimates are first        |
@@ -152,11 +152,11 @@ c        | forward instability of the iteration when the shifts  |
 c        | are applied in subroutine cnapps.                     |
 c        | Be careful and use 'SM' since we want to sort BOUNDS! |
 c        %-------------------------------------------------------%
-c     
+c
          call csortc ( 'SM', .true., np, bounds, ritz )
 c
       end if
-c     
+c
       call second (t1)
       tcgets = tcgets + (t1 - t0)
 c
@@ -165,14 +165,14 @@ c
          call ivout (logfil, 1, [np], ndigit, '_ngets: NP is')
          call cvout (logfil, kev+np, ritz, ndigit,
      &        '_ngets: Eigenvalues of current H matrix ')
-         call cvout (logfil, kev+np, bounds, ndigit, 
+         call cvout (logfil, kev+np, bounds, ndigit,
      &      '_ngets: Ritz estimates of the current KEV+NP Ritz values')
       end if
-c     
+c
       return
-c     
+c
 c     %---------------%
 c     | End of cngets |
 c     %---------------%
-c     
+c
       end

--- a/mathlibs/src/arpack/cngets.f
+++ b/mathlibs/src/arpack/cngets.f
@@ -161,8 +161,8 @@ c
       tcgets = tcgets + (t1 - t0)
 c
       if (msglvl .gt. 0) then
-         call ivout (logfil, 1, kev, ndigit, '_ngets: KEV is')
-         call ivout (logfil, 1, np, ndigit, '_ngets: NP is')
+         call ivout (logfil, 1, [kev], ndigit, '_ngets: KEV is')
+         call ivout (logfil, 1, [np], ndigit, '_ngets: NP is')
          call cvout (logfil, kev+np, ritz, ndigit,
      &        '_ngets: Eigenvalues of current H matrix ')
          call cvout (logfil, kev+np, bounds, ndigit, 

--- a/mathlibs/src/arpack/dgetv0.f
+++ b/mathlibs/src/arpack/dgetv0.f
@@ -364,9 +364,9 @@ c     | Check for further orthogonalization. |
 c     %--------------------------------------%
 c
       if (msglvl .gt. 2) then
-          call dvout (logfil, 1, rnorm0, ndigit, 
+          call dvout (logfil, 1, [rnorm0], ndigit, 
      &                '_getv0: re-orthonalization ; rnorm0 is')
-          call dvout (logfil, 1, rnorm, ndigit, 
+          call dvout (logfil, 1, [rnorm], ndigit, 
      &                '_getv0: re-orthonalization ; rnorm is')
       end if
 c
@@ -397,7 +397,7 @@ c
    50 continue
 c
       if (msglvl .gt. 0) then
-         call dvout (logfil, 1, rnorm, ndigit,
+         call dvout (logfil, 1, [rnorm], ndigit,
      &        '_getv0: B-norm of initial / restarted starting vector')
       end if
       if (msglvl .gt. 2) then

--- a/mathlibs/src/arpack/dnaitr.f
+++ b/mathlibs/src/arpack/dnaitr.f
@@ -371,9 +371,9 @@ c     %--------------------------------------------------------------%
  1000 continue
 c
          if (msglvl .gt. 1) then
-            call ivout (logfil, 1, j, ndigit, 
+            call ivout (logfil, 1, [j], ndigit, 
      &                  '_naitr: generating Arnoldi vector number')
-            call dvout (logfil, 1, rnorm, ndigit, 
+            call dvout (logfil, 1, [rnorm], ndigit, 
      &                  '_naitr: B-norm of the current residual is')
          end if
 c 
@@ -393,7 +393,7 @@ c           | basis and continue the iteration.                 |
 c           %---------------------------------------------------%
 c
             if (msglvl .gt. 0) then
-               call ivout (logfil, 1, j, ndigit,
+               call ivout (logfil, 1, [j], ndigit,
      &                     '_naitr: ****** RESTART AT STEP ******')
             end if
 c 
@@ -721,7 +721,7 @@ c
          end if
 c
          if (msglvl .gt. 0 .and. iter .gt. 0) then
-            call ivout (logfil, 1, j, ndigit,
+            call ivout (logfil, 1, [j], ndigit,
      &           '_naitr: Iterative refinement for Arnoldi residual')
             if (msglvl .gt. 2) then
                 xtemp(1) = rnorm

--- a/mathlibs/src/arpack/dnaitr.f
+++ b/mathlibs/src/arpack/dnaitr.f
@@ -3,8 +3,8 @@ c\BeginDoc
 c
 c\Name: dnaitr
 c
-c\Description: 
-c  Reverse communication interface for applying NP additional steps to 
+c\Description:
+c  Reverse communication interface for applying NP additional steps to
 c  a K step nonsymmetric Arnoldi factorization.
 c
 c  Input:  OP*V_{k}  -  V_{k}*H = r_{k}*e_{k}^T
@@ -20,7 +20,7 @@ c  computed and returned.
 c
 c\Usage:
 c  call dnaitr
-c     ( IDO, BMAT, N, K, NP, NB, RESID, RNORM, V, LDV, H, LDH, 
+c     ( IDO, BMAT, N, K, NP, NB, RESID, RNORM, V, LDV, H, LDH,
 c       IPNTR, WORKD, INFO )
 c
 c\Arguments
@@ -62,8 +62,8 @@ c  NP      Integer.  (INPUT)
 c          Number of additional Arnoldi steps to take.
 c
 c  NB      Integer.  (INPUT)
-c          Blocksize to be used in the recurrence.          
-c          Only work for NB = 1 right now.  The goal is to have a 
+c          Blocksize to be used in the recurrence.
+c          Only work for NB = 1 right now.  The goal is to have a
 c          program that implement both the block and non-block method.
 c
 c  RESID   Double precision array of length N.  (INPUT/OUTPUT)
@@ -75,37 +75,37 @@ c          B-norm of the starting residual on input.
 c          B-norm of the updated residual r_{k+p} on output.
 c
 c  V       Double precision N by K+NP array.  (INPUT/OUTPUT)
-c          On INPUT:  V contains the Arnoldi vectors in the first K 
+c          On INPUT:  V contains the Arnoldi vectors in the first K
 c          columns.
 c          On OUTPUT: V contains the new NP Arnoldi vectors in the next
 c          NP columns.  The first K columns are unchanged.
 c
 c  LDV     Integer.  (INPUT)
-c          Leading dimension of V exactly as declared in the calling 
+c          Leading dimension of V exactly as declared in the calling
 c          program.
 c
 c  H       Double precision (K+NP) by (K+NP) array.  (INPUT/OUTPUT)
 c          H is used to store the generated upper Hessenberg matrix.
 c
 c  LDH     Integer.  (INPUT)
-c          Leading dimension of H exactly as declared in the calling 
+c          Leading dimension of H exactly as declared in the calling
 c          program.
 c
 c  IPNTR   Integer array of length 3.  (OUTPUT)
-c          Pointer to mark the starting locations in the WORK for 
+c          Pointer to mark the starting locations in the WORK for
 c          vectors used by the Arnoldi iteration.
 c          -------------------------------------------------------------
 c          IPNTR(1): pointer to the current operand vector X.
 c          IPNTR(2): pointer to the current result vector Y.
-c          IPNTR(3): pointer to the vector B * X when used in the 
+c          IPNTR(3): pointer to the vector B * X when used in the
 c                    shift-and-invert mode.  X is the current operand.
 c          -------------------------------------------------------------
-c          
+c
 c  WORKD   Double precision work array of length 3*N.  (REVERSE COMMUNICATION)
 c          Distributed array to be used in the basic Arnoldi iteration
-c          for reverse communication.  The calling program should not 
+c          for reverse communication.  The calling program should not
 c          use WORKD as temporary workspace during the iteration !!!!!!
-c          On input, WORKD(1:N) = B*RESID and is used to save some 
+c          On input, WORKD(1:N) = B*RESID and is used to save some
 c          computation at the first step.
 c
 c  INFO    Integer.  (OUTPUT)
@@ -125,7 +125,7 @@ c\References:
 c  1. D.C. Sorensen, "Implicit Application of Polynomial Filters in
 c     a k-Step Arnoldi Method", SIAM J. Matr. Anal. Apps., 13 (1992),
 c     pp 357-385.
-c  2. R.B. Lehoucq, "Analysis and Implementation of an Implicitly 
+c  2. R.B. Lehoucq, "Analysis and Implementation of an Implicitly
 c     Restarted Arnoldi Iteration", Rice University Technical Report
 c     TR95-13, Department of Computational and Applied Mathematics.
 c
@@ -143,7 +143,7 @@ c     dgemv   Level 2 BLAS routine for matrix vector multiplication.
 c     daxpy   Level 1 BLAS that computes a vector triad.
 c     dscal   Level 1 BLAS that scales a vector.
 c     dcopy   Level 1 BLAS that copies one vector to another .
-c     ddot    Level 1 BLAS that computes the scalar product of two vectors. 
+c     ddot    Level 1 BLAS that computes the scalar product of two vectors.
 c     dnrm2   Level 1 BLAS that computes the norm of a vector.
 c
 c\Author
@@ -151,22 +151,22 @@ c     Danny Sorensen               Phuong Vu
 c     Richard Lehoucq              CRPC / Rice University
 c     Dept. of Computational &     Houston, Texas
 c     Applied Mathematics
-c     Rice University           
-c     Houston, Texas    
-c 
+c     Rice University
+c     Houston, Texas
+c
 c\Revision history:
 c     xx/xx/92: Version ' 2.4'
 c
-c\SCCS Information: @(#) 
+c\SCCS Information: @(#)
 c FILE: naitr.F   SID: 2.4   DATE OF SID: 8/27/96   RELEASE: 2
 c
 c\Remarks
 c  The algorithm implemented is:
-c  
+c
 c  restart = .false.
-c  Given V_{k} = [v_{1}, ..., v_{k}], r_{k}; 
+c  Given V_{k} = [v_{1}, ..., v_{k}], r_{k};
 c  r_{k} contains the initial residual vector even for k = 0;
-c  Also assume that rnorm = || B*r_{k} || and B*r_{k} are already 
+c  Also assume that rnorm = || B*r_{k} || and B*r_{k} are already
 c  computed by the calling program.
 c
 c  betaj = rnorm ; p_{k+1} = B*r_{k} ;
@@ -174,7 +174,7 @@ c  For  j = k+1, ..., k+np  Do
 c     1) if ( betaj < tol ) stop or restart depending on j.
 c        ( At present tol is zero )
 c        if ( restart ) generate a new starting vector.
-c     2) v_{j} = r(j-1)/betaj;  V_{j} = [V_{j-1}, v_{j}];  
+c     2) v_{j} = r(j-1)/betaj;  V_{j} = [V_{j-1}, v_{j}];
 c        p_{j} = p_{j}/betaj
 c     3) r_{j} = OP*v_{j} where OP is defined as in dnaupd
 c        For shift-invert mode p_{j} = B*v_{j} is already available.
@@ -189,7 +189,7 @@ c        If (rnorm > 0.717*wnorm) accept step and go back to 1)
 c     5) Re-orthogonalization step:
 c        s = V_{j}'*B*r_{j}
 c        r_{j} = r_{j} - V_{j}*s;  rnorm1 = || r_{j} ||
-c        alphaj = alphaj + s_{j};   
+c        alphaj = alphaj + s_{j};
 c     6) Iterative refinement step:
 c        If (rnorm1 > 0.717*rnorm) then
 c           rnorm = rnorm1
@@ -199,7 +199,7 @@ c           rnorm = rnorm1
 c           If this is the first time in step 6), go to 5)
 c           Else r_{j} lies in the span of V_{j} numerically.
 c              Set r_{j} = 0 and rnorm = 0; go to 1)
-c        EndIf 
+c        EndIf
 c  End Do
 c
 c\EndLib
@@ -207,7 +207,7 @@ c
 c-----------------------------------------------------------------------
 c
       subroutine dnaitr
-     &   (ido, bmat, n, k, np, nb, resid, rnorm, v, ldv, h, ldh, 
+     &   (ido, bmat, n, k, np, nb, resid, rnorm, v, ldv, h, ldh,
      &    ipntr, workd, info)
 c
 c     %----------------------------------------------------%
@@ -250,14 +250,14 @@ c
       integer    ierr, i, infol, ipj, irj, ivj, iter, itry, j, msglvl,
      &           jj
       Double precision
-     &           betaj, ovfl, temp1, rnorm1, smlnum, tst1, ulp, unfl, 
+     &           betaj, ovfl, temp1, rnorm1, smlnum, tst1, ulp, unfl,
      &           wnorm
       save       first, orth1, orth2, rstart, step3, step4,
      &           ierr, ipj, irj, ivj, iter, itry, j, msglvl, ovfl,
      &           betaj, rnorm1, smlnum, ulp, unfl, wnorm
 c
 c     %-----------------------%
-c     | Local Array Arguments | 
+c     | Local Array Arguments |
 c     %-----------------------%
 c
       Double precision
@@ -267,7 +267,7 @@ c     %----------------------%
 c     | External Subroutines |
 c     %----------------------%
 c
-      external   daxpy, dcopy, dscal, dgemv, dgetv0, dlabad, 
+      external   daxpy, dcopy, dscal, dgemv, dgetv0, dlabad,
      &           dvout, dmout, ivout, second
 c
 c     %--------------------%
@@ -313,7 +313,7 @@ c
       end if
 c
       if (ido .eq. 0) then
-c 
+c
 c        %-------------------------------%
 c        | Initialize timing statistics  |
 c        | & message level for debugging |
@@ -321,7 +321,7 @@ c        %-------------------------------%
 c
          call second (t0)
          msglvl = mnaitr
-c 
+c
 c        %------------------------------%
 c        | Initial call to this routine |
 c        %------------------------------%
@@ -337,7 +337,7 @@ c
          irj    = ipj   + n
          ivj    = irj   + n
       end if
-c 
+c
 c     %-------------------------------------------------%
 c     | When in reverse communication mode one of:      |
 c     | STEP3, STEP4, ORTH1, ORTH2, RSTART              |
@@ -367,16 +367,16 @@ c     |        A R N O L D I     I T E R A T I O N     L O O P       |
 c     |                                                              |
 c     | Note:  B*r_{j-1} is already in WORKD(1:N)=WORKD(IPJ:IPJ+N-1) |
 c     %--------------------------------------------------------------%
- 
+
  1000 continue
 c
          if (msglvl .gt. 1) then
-            call ivout (logfil, 1, [j], ndigit, 
+            call ivout (logfil, 1, [j], ndigit,
      &                  '_naitr: generating Arnoldi vector number')
-            call dvout (logfil, 1, [rnorm], ndigit, 
+            call dvout (logfil, 1, [rnorm], ndigit,
      &                  '_naitr: B-norm of the current residual is')
          end if
-c 
+c
 c        %---------------------------------------------------%
 c        | STEP 1: Check if the B norm of j-th residual      |
 c        | vector is zero. Equivalent to determing whether   |
@@ -396,13 +396,13 @@ c
                call ivout (logfil, 1, [j], ndigit,
      &                     '_naitr: ****** RESTART AT STEP ******')
             end if
-c 
+c
 c           %---------------------------------------------%
 c           | ITRY is the loop variable that controls the |
 c           | maximum amount of times that a restart is   |
 c           | attempted. NRSTRT is used by stat.h         |
 c           %---------------------------------------------%
-c 
+c
             betaj  = zero
             nrstrt = nrstrt + 1
             itry   = 1
@@ -416,7 +416,7 @@ c           | If in reverse communication mode and |
 c           | RSTART = .true. flow returns here.   |
 c           %--------------------------------------%
 c
-            call dgetv0 (ido, bmat, itry, .false., n, j, v, ldv, 
+            call dgetv0 (ido, bmat, itry, .false., n, j, v, ldv,
      &                   resid, rnorm, ipntr, workd, ierr)
             if (ido .ne. 99) go to 9000
             if (ierr .lt. 0) then
@@ -435,7 +435,7 @@ c
                ido = 99
                go to 9000
             end if
-c 
+c
    40    continue
 c
 c        %---------------------------------------------------------%
@@ -457,9 +457,9 @@ c            | To scale both v_{j} and p_{j} carefully |
 c            | use LAPACK routine SLASCL               |
 c            %-----------------------------------------%
 c
-             call dlascl ('General', i, i, rnorm, one, n, 1, 
+             call dlascl ('General', i, i, rnorm, one, n, 1,
      &                    v(1,j), n, infol)
-             call dlascl ('General', i, i, rnorm, one, n, 1, 
+             call dlascl ('General', i, i, rnorm, one, n, 1,
      &                    workd(ipj), n, infol)
          end if
 c
@@ -476,14 +476,14 @@ c
          ipntr(2) = irj
          ipntr(3) = ipj
          ido = 1
-c 
+c
 c        %-----------------------------------%
 c        | Exit in order to compute OP*v_{j} |
 c        %-----------------------------------%
-c 
-         go to 9000 
+c
+         go to 9000
    50    continue
-c 
+c
 c        %----------------------------------%
 c        | Back from reverse communication; |
 c        | WORKD(IRJ:IRJ+N-1) := OP*v_{j}   |
@@ -492,7 +492,7 @@ c        %----------------------------------%
 c
          call second (t3)
          tmvopx = tmvopx + (t3 - t2)
- 
+
          step3 = .false.
 c
 c        %------------------------------------------%
@@ -500,7 +500,7 @@ c        | Put another copy of OP*v_{j} into RESID. |
 c        %------------------------------------------%
 c
          call dcopy (n, workd(irj), 1, resid, 1)
-c 
+c
 c        %---------------------------------------%
 c        | STEP 4:  Finish extending the Arnoldi |
 c        |          factorization to length j.   |
@@ -513,17 +513,17 @@ c
             ipntr(1) = irj
             ipntr(2) = ipj
             ido = 2
-c 
+c
 c           %-------------------------------------%
 c           | Exit in order to compute B*OP*v_{j} |
 c           %-------------------------------------%
-c 
+c
             go to 9000
          else if (bmat .eq. 'I') then
             call dcopy (n, resid, 1, workd(ipj), 1)
          end if
    60    continue
-c 
+c
 c        %----------------------------------%
 c        | Back from reverse communication; |
 c        | WORKD(IPJ:IPJ+N-1) := B*OP*v_{j} |
@@ -534,7 +534,7 @@ c
             call second (t3)
             tmvbx = tmvbx + (t3 - t2)
          end if
-c 
+c
          step4 = .false.
 c
 c        %-------------------------------------%
@@ -542,7 +542,7 @@ c        | The following is needed for STEP 5. |
 c        | Compute the B-norm of OP*v_{j}.     |
 c        %-------------------------------------%
 c
-         if (bmat .eq. 'G') then  
+         if (bmat .eq. 'G') then
              wnorm = ddot (n, resid, 1, workd(ipj), 1)
              wnorm = sqrt(abs(wnorm))
          else if (bmat .eq. 'I') then
@@ -562,13 +562,13 @@ c        %------------------------------------------%
 c        | Compute the j Fourier coefficients w_{j} |
 c        | WORKD(IPJ:IPJ+N-1) contains B*OP*v_{j}.  |
 c        %------------------------------------------%
-c 
+c
          call dgemv ('T', n, j, one, v, ldv, workd(ipj), 1,
      &               zero, h(1,j), 1)
 c
 c        %--------------------------------------%
 c        | Orthogonalize r_{j} against V_{j}.   |
-c        | RESID contains OP*v_{j}. See STEP 3. | 
+c        | RESID contains OP*v_{j}. See STEP 3. |
 c        %--------------------------------------%
 c
          call dgemv ('N', n, j, -one, v, ldv, h(1,j), 1,
@@ -577,7 +577,7 @@ c
          if (j .gt. 1) h(j,j-1) = betaj
 c
          call second (t4)
-c 
+c
          orth1 = .true.
 c
          call second (t2)
@@ -587,17 +587,17 @@ c
             ipntr(1) = irj
             ipntr(2) = ipj
             ido = 2
-c 
+c
 c           %----------------------------------%
 c           | Exit in order to compute B*r_{j} |
 c           %----------------------------------%
-c 
+c
             go to 9000
          else if (bmat .eq. 'I') then
             call dcopy (n, resid, 1, workd(ipj), 1)
-         end if 
+         end if
    70    continue
-c 
+c
 c        %---------------------------------------------------%
 c        | Back from reverse communication if ORTH1 = .true. |
 c        | WORKD(IPJ:IPJ+N-1) := B*r_{j}.                    |
@@ -607,20 +607,20 @@ c
             call second (t3)
             tmvbx = tmvbx + (t3 - t2)
          end if
-c 
+c
          orth1 = .false.
 c
 c        %------------------------------%
 c        | Compute the B-norm of r_{j}. |
 c        %------------------------------%
 c
-         if (bmat .eq. 'G') then         
+         if (bmat .eq. 'G') then
             rnorm = ddot (n, resid, 1, workd(ipj), 1)
             rnorm = sqrt(abs(rnorm))
          else if (bmat .eq. 'I') then
             rnorm = dnrm2(n, resid, 1)
          end if
-c 
+c
 c        %-----------------------------------------------------------%
 c        | STEP 5: Re-orthogonalization / Iterative refinement phase |
 c        | Maximum NITER_ITREF tries.                                |
@@ -642,20 +642,20 @@ c
          if (rnorm .gt. 0.717*wnorm) go to 100
          iter  = 0
          nrorth = nrorth + 1
-c 
+c
 c        %---------------------------------------------------%
 c        | Enter the Iterative refinement phase. If further  |
 c        | refinement is necessary, loop back here. The loop |
 c        | variable is ITER. Perform a step of Classical     |
 c        | Gram-Schmidt using all the Arnoldi vectors V_{j}  |
 c        %---------------------------------------------------%
-c 
+c
    80    continue
 c
          if (msglvl .gt. 2) then
             xtemp(1) = wnorm
             xtemp(2) = rnorm
-            call dvout (logfil, 2, xtemp, ndigit, 
+            call dvout (logfil, 2, xtemp, ndigit,
      &           '_naitr: re-orthonalization; wnorm and rnorm are')
             call dvout (logfil, j, h(1,j), ndigit,
      &                  '_naitr: j-th column of H')
@@ -666,7 +666,7 @@ c        | Compute V_{j}^T * B * r_{j}.                       |
 c        | WORKD(IRJ:IRJ+J-1) = v(:,1:J)'*WORKD(IPJ:IPJ+N-1). |
 c        %----------------------------------------------------%
 c
-         call dgemv ('T', n, j, one, v, ldv, workd(ipj), 1, 
+         call dgemv ('T', n, j, one, v, ldv, workd(ipj), 1,
      &               zero, workd(irj), 1)
 c
 c        %---------------------------------------------%
@@ -676,10 +676,10 @@ c        | The correction to H is v(:,1:J)*H(1:J,1:J)  |
 c        | + v(:,1:J)*WORKD(IRJ:IRJ+J-1)*e'_j.         |
 c        %---------------------------------------------%
 c
-         call dgemv ('N', n, j, -one, v, ldv, workd(irj), 1, 
+         call dgemv ('N', n, j, -one, v, ldv, workd(irj), 1,
      &               one, resid, 1)
          call daxpy (j, one, workd(irj), 1, h(1,j), 1)
-c 
+c
          orth2 = .true.
          call second (t2)
          if (bmat .eq. 'G') then
@@ -688,16 +688,16 @@ c
             ipntr(1) = irj
             ipntr(2) = ipj
             ido = 2
-c 
+c
 c           %-----------------------------------%
 c           | Exit in order to compute B*r_{j}. |
 c           | r_{j} is the corrected residual.  |
 c           %-----------------------------------%
-c 
+c
             go to 9000
          else if (bmat .eq. 'I') then
             call dcopy (n, resid, 1, workd(ipj), 1)
-         end if 
+         end if
    90    continue
 c
 c        %---------------------------------------------------%
@@ -712,8 +712,8 @@ c
 c        %-----------------------------------------------------%
 c        | Compute the B-norm of the corrected residual r_{j}. |
 c        %-----------------------------------------------------%
-c 
-         if (bmat .eq. 'G') then         
+c
+         if (bmat .eq. 'G') then
              rnorm1 = ddot (n, resid, 1, workd(ipj), 1)
              rnorm1 = sqrt(abs(rnorm1))
          else if (bmat .eq. 'I') then
@@ -749,7 +749,7 @@ c           | angle of less than arcCOS(0.717)      |
 c           %---------------------------------------%
 c
             rnorm = rnorm1
-c 
+c
          else
 c
 c           %-------------------------------------------%
@@ -771,21 +771,21 @@ c
   95        continue
             rnorm = zero
          end if
-c 
+c
 c        %----------------------------------------------%
 c        | Branch here directly if iterative refinement |
 c        | wasn't necessary or after at most NITER_REF  |
 c        | steps of iterative refinement.               |
 c        %----------------------------------------------%
-c 
+c
   100    continue
-c 
+c
          rstart = .false.
          orth2  = .false.
-c 
+c
          call second (t5)
          titref = titref + (t5 - t4)
-c 
+c
 c        %------------------------------------%
 c        | STEP 6: Update  j = j+1;  Continue |
 c        %------------------------------------%
@@ -796,25 +796,25 @@ c
             tnaitr = tnaitr + (t1 - t0)
             ido = 99
             do 110 i = max(1,k), k+np-1
-c     
+c
 c              %--------------------------------------------%
 c              | Check for splitting and deflation.         |
 c              | Use a standard test as in the QR algorithm |
 c              | REFERENCE: LAPACK subroutine dlahqr        |
 c              %--------------------------------------------%
-c     
+c
                tst1 = abs( h( i, i ) ) + abs( h( i+1, i+1 ) )
                if( tst1.eq.zero )
      &              tst1 = dlanhs( '1', k+np, h, ldh, workd(n+1) )
-               if( abs( h( i+1,i ) ).le.max( ulp*tst1, smlnum ) ) 
+               if( abs( h( i+1,i ) ).le.max( ulp*tst1, smlnum ) )
      &              h(i+1,i) = zero
  110        continue
-c     
+c
             if (msglvl .gt. 2) then
-               call dmout (logfil, k+np, k+np, h, ldh, ndigit, 
+               call dmout (logfil, k+np, k+np, h, ldh, ndigit,
      &          '_naitr: Final upper Hessenberg matrix H of order K+NP')
             end if
-c     
+c
             go to 9000
          end if
 c
@@ -823,7 +823,7 @@ c        | Loop back to extend the factorization by another step. |
 c        %--------------------------------------------------------%
 c
       go to 1000
-c 
+c
 c     %---------------------------------------------------------------%
 c     |                                                               |
 c     |  E N D     O F     M A I N     I T E R A T I O N     L O O P  |

--- a/mathlibs/src/arpack/dnapps.f
+++ b/mathlibs/src/arpack/dnapps.f
@@ -266,11 +266,11 @@ c
          sigmai = shifti(jj)
 c
          if (msglvl .gt. 2 ) then
-            call ivout (logfil, 1, jj, ndigit, 
+            call ivout (logfil, 1, [jj], ndigit, 
      &               '_napps: shift number.')
-            call dvout (logfil, 1, sigmar, ndigit, 
+            call dvout (logfil, 1, [sigmar], ndigit, 
      &               '_napps: The real part of the shift ')
-            call dvout (logfil, 1, sigmai, ndigit, 
+            call dvout (logfil, 1, [sigmai], ndigit, 
      &               '_napps: The imaginary part of the shift ')
          end if
 c
@@ -335,9 +335,9 @@ c
      &         tst1 = dlanhs( '1', kplusp-jj+1, h, ldh, workl )
             if( abs( h( i+1,i ) ).le.max( ulp*tst1, smlnum ) ) then
                if (msglvl .gt. 0) then
-                  call ivout (logfil, 1, i, ndigit, 
+                  call ivout (logfil, 1, [i], ndigit, 
      &                 '_napps: matrix splitting at row/column no.')
-                  call ivout (logfil, 1, jj, ndigit, 
+                  call ivout (logfil, 1, [jj], ndigit, 
      &                 '_napps: matrix splitting with shift number.')
                   call dvout (logfil, 1, h(i+1,i), ndigit, 
      &                 '_napps: off diagonal element.')
@@ -351,9 +351,9 @@ c
    40    continue
 c
          if (msglvl .gt. 2) then
-             call ivout (logfil, 1, istart, ndigit, 
+             call ivout (logfil, 1, [istart], ndigit, 
      &                   '_napps: Start of current block ')
-             call ivout (logfil, 1, iend, ndigit, 
+             call ivout (logfil, 1, [iend], ndigit, 
      &                   '_napps: End of current block ')
          end if
 c
@@ -625,7 +625,7 @@ c
      &        '_napps: sigmak = (e_{kev+p}^T*Q)*e_{kev}')
          call dvout (logfil, 1, h(kev+1,kev), ndigit,
      &        '_napps: betak = e_{kev+1}^T*H*e_{kev}')
-         call ivout (logfil, 1, kev, ndigit, 
+         call ivout (logfil, 1, [kev], ndigit, 
      &               '_napps: Order of the final Hessenberg matrix ')
          if (msglvl .gt. 2) then
             call dmout (logfil, kev, kev, h, ldh, ndigit,

--- a/mathlibs/src/arpack/dnapps.f
+++ b/mathlibs/src/arpack/dnapps.f
@@ -20,7 +20,7 @@ c     A*VNEW_{k} - VNEW_{k}*HNEW_{k} = rnew_{k}*e_{k}^T.
 c
 c\Usage:
 c  call dnapps
-c     ( N, KEV, NP, SHIFTR, SHIFTI, V, LDV, H, LDH, RESID, Q, LDQ, 
+c     ( N, KEV, NP, SHIFTR, SHIFTI, V, LDV, H, LDH, RESID, Q, LDQ,
 c       WORKL, WORKD )
 c
 c\Arguments
@@ -29,7 +29,7 @@ c          Problem size, i.e. size of matrix A.
 c
 c  KEV     Integer.  (INPUT/OUTPUT)
 c          KEV+NP is the size of the input matrix H.
-c          KEV is the size of the updated matrix HNEW.  KEV is only 
+c          KEV is the size of the updated matrix HNEW.  KEV is only
 c          updated on ouput when fewer than NP shifts are applied in
 c          order to keep the conjugate pair together.
 c
@@ -38,7 +38,7 @@ c          Number of implicit shifts to be applied.
 c
 c  SHIFTR, Double precision array of length NP.  (INPUT)
 c  SHIFTI  Real and imaginary part of the shifts to be applied.
-c          Upon, entry to dnapps, the shifts must be sorted so that the 
+c          Upon, entry to dnapps, the shifts must be sorted so that the
 c          conjugate pairs are in consecutive locations.
 c
 c  V       Double precision N by (KEV+NP) array.  (INPUT/OUTPUT)
@@ -51,7 +51,7 @@ c          Leading dimension of V exactly as declared in the calling
 c          program.
 c
 c  H       Double precision (KEV+NP) by (KEV+NP) array.  (INPUT/OUTPUT)
-c          On INPUT, H contains the current KEV+NP by KEV+NP upper 
+c          On INPUT, H contains the current KEV+NP by KEV+NP upper
 c          Hessenber matrix of the Arnoldi factorization.
 c          On OUTPUT, H contains the updated KEV by KEV upper Hessenberg
 c          matrix in the KEV leading submatrix.
@@ -62,7 +62,7 @@ c          program.
 c
 c  RESID   Double precision array of length N.  (INPUT/OUTPUT)
 c          On INPUT, RESID contains the the residual vector r_{k+p}.
-c          On OUTPUT, RESID is the update residual vector rnew_{k} 
+c          On OUTPUT, RESID is the update residual vector rnew_{k}
 c          in the first KEV locations.
 c
 c  Q       Double precision KEV+NP by KEV+NP work array.  (WORKSPACE)
@@ -102,7 +102,7 @@ c     dmout   ARPACK utility routine that prints matrices.
 c     dvout   ARPACK utility routine that prints vectors.
 c     dlabad  LAPACK routine that computes machine constants.
 c     dlacpy  LAPACK matrix copy routine.
-c     dlamch  LAPACK routine that determines machine constants. 
+c     dlamch  LAPACK routine that determines machine constants.
 c     dlanhs  LAPACK routine that computes various norms of a matrix.
 c     dlapy2  LAPACK routine to compute sqrt(x**2+y**2) carefully.
 c     dlarf   LAPACK routine that applies Householder reflection to
@@ -120,13 +120,13 @@ c     Danny Sorensen               Phuong Vu
 c     Richard Lehoucq              CRPC / Rice University
 c     Dept. of Computational &     Houston, Texas
 c     Applied Mathematics
-c     Rice University           
-c     Houston, Texas    
+c     Rice University
+c     Houston, Texas
 c
 c\Revision history:
 c     xx/xx/92: Version ' 2.1'
 c
-c\SCCS Information: @(#) 
+c\SCCS Information: @(#)
 c FILE: napps.F   SID: 2.3   DATE OF SID: 4/20/96   RELEASE: 2
 c
 c\Remarks
@@ -141,7 +141,7 @@ c
 c-----------------------------------------------------------------------
 c
       subroutine dnapps
-     &   ( n, kev, np, shiftr, shifti, v, ldv, h, ldh, resid, q, ldq, 
+     &   ( n, kev, np, shiftr, shifti, v, ldv, h, ldh, resid, q, ldq,
      &     workl, workd )
 c
 c     %----------------------------------------------------%
@@ -162,7 +162,7 @@ c     | Array Arguments |
 c     %-----------------%
 c
       Double precision
-     &           h(ldh,kev+np), resid(n), shifti(np), shiftr(np), 
+     &           h(ldh,kev+np), resid(n), shifti(np), shiftr(np),
      &           v(ldv,kev+np), q(ldq,kev+np), workd(2*n), workl(kev+np)
 c
 c     %------------%
@@ -180,9 +180,9 @@ c
       integer    i, iend, ir, istart, j, jj, kplusp, msglvl, nr
       logical    cconj, first
       Double precision
-     &           c, f, g, h11, h12, h21, h22, h32, ovfl, r, s, sigmai, 
+     &           c, f, g, h11, h12, h21, h22, h32, ovfl, r, s, sigmai,
      &           sigmar, smlnum, ulp, unfl, u(3), t, tau, tst1
-      save       first, ovfl, smlnum, ulp, unfl 
+      save       first, ovfl, smlnum, ulp, unfl
 c
 c     %----------------------%
 c     | External Subroutines |
@@ -239,8 +239,8 @@ c     %-------------------------------%
 c
       call second (t0)
       msglvl = mnapps
-      kplusp = kev + np 
-c 
+      kplusp = kev + np
+c
 c     %--------------------------------------------%
 c     | Initialize Q to the identity to accumulate |
 c     | the rotations and reflections              |
@@ -266,11 +266,11 @@ c
          sigmai = shifti(jj)
 c
          if (msglvl .gt. 2 ) then
-            call ivout (logfil, 1, [jj], ndigit, 
+            call ivout (logfil, 1, [jj], ndigit,
      &               '_napps: shift number.')
-            call dvout (logfil, 1, [sigmar], ndigit, 
+            call dvout (logfil, 1, [sigmar], ndigit,
      &               '_napps: The real part of the shift ')
-            call dvout (logfil, 1, [sigmai], ndigit, 
+            call dvout (logfil, 1, [sigmai], ndigit,
      &               '_napps: The imaginary part of the shift ')
          end if
 c
@@ -335,11 +335,11 @@ c
      &         tst1 = dlanhs( '1', kplusp-jj+1, h, ldh, workl )
             if( abs( h( i+1,i ) ).le.max( ulp*tst1, smlnum ) ) then
                if (msglvl .gt. 0) then
-                  call ivout (logfil, 1, [i], ndigit, 
+                  call ivout (logfil, 1, [i], ndigit,
      &                 '_napps: matrix splitting at row/column no.')
-                  call ivout (logfil, 1, [jj], ndigit, 
+                  call ivout (logfil, 1, [jj], ndigit,
      &                 '_napps: matrix splitting with shift number.')
-                  call dvout (logfil, 1, h(i+1,i), ndigit, 
+                  call dvout (logfil, 1, h(i+1,i), ndigit,
      &                 '_napps: off diagonal element.')
                end if
                iend = i
@@ -351,9 +351,9 @@ c
    40    continue
 c
          if (msglvl .gt. 2) then
-             call ivout (logfil, 1, [istart], ndigit, 
+             call ivout (logfil, 1, [istart], ndigit,
      &                   '_napps: Start of current block ')
-             call ivout (logfil, 1, [iend], ndigit, 
+             call ivout (logfil, 1, [iend], ndigit,
      &                   '_napps: End of current block ')
          end if
 c
@@ -368,7 +368,7 @@ c        | If istart + 1 = iend then no reason to apply a       |
 c        | complex conjugate pair of shifts on a 2 by 2 matrix. |
 c        %------------------------------------------------------%
 c
-         if ( istart + 1 .eq. iend .and. abs( sigmai ) .gt. zero ) 
+         if ( istart + 1 .eq. iend .and. abs( sigmai ) .gt. zero )
      &      go to 100
 c
          h11 = h(istart,istart)
@@ -381,7 +381,7 @@ c           %---------------------------------------------%
 c
             f = h11 - sigmar
             g = h21
-c 
+c
             do 80 i = istart, iend-1
 c
 c              %-----------------------------------------------------%
@@ -413,7 +413,7 @@ c
                do 50 j = i, kplusp
                   t        =  c*h(i,j) + s*h(i+1,j)
                   h(i+1,j) = -s*h(i,j) + c*h(i+1,j)
-                  h(i,j)   = t   
+                  h(i,j)   = t
    50          continue
 c
 c              %---------------------------------------------%
@@ -423,17 +423,17 @@ c
                do 60 j = 1, min(i+2,iend)
                   t        =  c*h(j,i) + s*h(j,i+1)
                   h(j,i+1) = -s*h(j,i) + c*h(j,i+1)
-                  h(j,i)   = t   
+                  h(j,i)   = t
    60          continue
 c
 c              %----------------------------------------------------%
 c              | Accumulate the rotation in the matrix Q;  Q <- Q*G |
 c              %----------------------------------------------------%
 c
-               do 70 j = 1, min( j+jj, kplusp ) 
+               do 70 j = 1, min( j+jj, kplusp )
                   t        =   c*q(j,i) + s*q(j,i+1)
                   q(j,i+1) = - s*q(j,i) + c*q(j,i+1)
-                  q(j,i)   = t   
+                  q(j,i)   = t
    70          continue
 c
 c              %---------------------------%
@@ -449,7 +449,7 @@ c
 c           %-----------------------------------%
 c           | Finished applying the real shift. |
 c           %-----------------------------------%
-c 
+c
          else
 c
 c           %----------------------------------------------------%
@@ -465,9 +465,9 @@ c           | Compute 1st column of (H - shift*I)*(H - conj(shift)*I) |
 c           %---------------------------------------------------------%
 c
             s    = 2.0*sigmar
-            t = dlapy2 ( sigmar, sigmai ) 
+            t = dlapy2 ( sigmar, sigmai )
             u(1) = ( h11 * (h11 - s) + t * t ) / h21 + h12
-            u(2) = h11 + h22 - s 
+            u(2) = h11 + h22 - s
             u(3) = h32
 c
             do 90 i = istart, iend-1
@@ -507,7 +507,7 @@ c              %-----------------------------------------------------%
 c              | Accumulate the reflector in the matrix Q;  Q <- Q*G |
 c              %-----------------------------------------------------%
 c
-               call dlarf ('Right', kplusp, nr, u, 1, tau, 
+               call dlarf ('Right', kplusp, nr, u, 1, tau,
      &                     q(1,i), ldq, workl)
 c
 c              %----------------------------%
@@ -526,7 +526,7 @@ c           %--------------------------------------------%
 c           | Finished applying a complex pair of shifts |
 c           | to the current block                       |
 c           %--------------------------------------------%
-c 
+c
          end if
 c
   100    continue
@@ -568,7 +568,7 @@ c
          tst1 = abs( h( i, i ) ) + abs( h( i+1, i+1 ) )
          if( tst1.eq.zero )
      &       tst1 = dlanhs( '1', kev, h, ldh, workl )
-         if( h( i+1,i ) .le. max( ulp*tst1, smlnum ) ) 
+         if( h( i+1,i ) .le. max( ulp*tst1, smlnum ) )
      &       h(i+1,i) = zero
  130  continue
 c
@@ -581,9 +581,9 @@ c     | of H would be zero as in exact arithmetic.      |
 c     %-------------------------------------------------%
 c
       if (h(kev+1,kev) .gt. zero)
-     &    call dgemv ('N', n, kplusp, one, v, ldv, q(1,kev+1), 1, zero, 
+     &    call dgemv ('N', n, kplusp, one, v, ldv, q(1,kev+1), 1, zero,
      &                workd(n+1), 1)
-c 
+c
 c     %----------------------------------------------------------%
 c     | Compute column 1 to kev of (V*Q) in backward order       |
 c     | taking advantage of the upper Hessenberg structure of Q. |
@@ -600,14 +600,14 @@ c     |  Move v(:,kplusp-kev+1:kplusp) into v(:,1:kev). |
 c     %-------------------------------------------------%
 c
       call dlacpy ('A', n, kev, v(1,kplusp-kev+1), ldv, v, ldv)
-c 
+c
 c     %--------------------------------------------------------------%
 c     | Copy the (kev+1)-st column of (V*Q) in the appropriate place |
 c     %--------------------------------------------------------------%
 c
       if (h(kev+1,kev) .gt. zero)
      &   call dcopy (n, workd(n+1), 1, v(1,kev+1), 1)
-c 
+c
 c     %-------------------------------------%
 c     | Update the residual vector:         |
 c     |    r <- sigmak*r + betak*v(:,kev+1) |
@@ -625,7 +625,7 @@ c
      &        '_napps: sigmak = (e_{kev+p}^T*Q)*e_{kev}')
          call dvout (logfil, 1, h(kev+1,kev), ndigit,
      &        '_napps: betak = e_{kev+1}^T*H*e_{kev}')
-         call ivout (logfil, 1, [kev], ndigit, 
+         call ivout (logfil, 1, [kev], ndigit,
      &               '_napps: Order of the final Hessenberg matrix ')
          if (msglvl .gt. 2) then
             call dmout (logfil, kev, kev, h, ldh, ndigit,
@@ -633,11 +633,11 @@ c
          end if
 c
       end if
-c 
+c
  9000 continue
       call second (t1)
       tnapps = tnapps + (t1 - t0)
-c 
+c
       return
 c
 c     %---------------%

--- a/mathlibs/src/arpack/dnaup2.f
+++ b/mathlibs/src/arpack/dnaup2.f
@@ -422,7 +422,7 @@ c
          iter = iter + 1
 c
          if (msglvl .gt. 0) then
-            call ivout (logfil, 1, iter, ndigit, 
+            call ivout (logfil, 1, [iter], ndigit, 
      &           '_naup2: **** Start of major iteration number ****')
          end if
 c 
@@ -435,9 +435,9 @@ c
          np  = kplusp - nev
 c
          if (msglvl .gt. 1) then
-            call ivout (logfil, 1, nev, ndigit, 
+            call ivout (logfil, 1, [nev], ndigit, 
      &     '_naup2: The length of the current Arnoldi factorization')
-            call ivout (logfil, 1, np, ndigit, 
+            call ivout (logfil, 1, [np], ndigit, 
      &           '_naup2: Extend the Arnoldi factorization by')
          end if
 c
@@ -468,7 +468,7 @@ c
          update = .false.
 c
          if (msglvl .gt. 1) then
-            call dvout (logfil, 1, rnorm, ndigit, 
+            call dvout (logfil, 1, [rnorm], ndigit, 
      &           '_naup2: Corresponding B-norm of the residual')
          end if
 c 
@@ -711,7 +711,7 @@ c
          end if              
 c     
          if (msglvl .gt. 0) then
-            call ivout (logfil, 1, nconv, ndigit, 
+            call ivout (logfil, 1, [nconv], ndigit, 
      &           '_naup2: no. of "converged" Ritz values at this iter.')
             if (msglvl .gt. 1) then
                kp(1) = nev
@@ -763,7 +763,7 @@ c
          end if
 c
          if (msglvl .gt. 2) then 
-            call ivout (logfil, 1, np, ndigit, 
+            call ivout (logfil, 1, [np], ndigit, 
      &                  '_naup2: The number of shifts to apply ')
             call dvout (logfil, np, ritzr, ndigit,
      &                  '_naup2: Real part of the shifts')
@@ -829,7 +829,7 @@ c
          cnorm = .false.
 c
          if (msglvl .gt. 2) then
-            call dvout (logfil, 1, rnorm, ndigit, 
+            call dvout (logfil, 1, [rnorm], ndigit, 
      &      '_naup2: B-norm of residual for compressed factorization')
             call dmout (logfil, nev, nev, h, ldh, ndigit,
      &        '_naup2: Compressed upper Hessenberg matrix H')

--- a/mathlibs/src/arpack/dnaup2.f
+++ b/mathlibs/src/arpack/dnaup2.f
@@ -2,13 +2,13 @@ c\BeginDoc
 c
 c\Name: dnaup2
 c
-c\Description: 
+c\Description:
 c  Intermediate level interface called by dnaupd.
 c
 c\Usage:
 c  call dnaup2
 c     ( IDO, BMAT, N, WHICH, NEV, NP, TOL, RESID, MODE, IUPD,
-c       ISHIFT, MXITER, V, LDV, H, LDH, RITZR, RITZI, BOUNDS, 
+c       ISHIFT, MXITER, V, LDV, H, LDH, RITZR, RITZI, BOUNDS,
 c       Q, LDQ, WORKL, IPNTR, WORKD, INFO )
 c
 c\Arguments
@@ -17,22 +17,22 @@ c  IDO, BMAT, N, WHICH, NEV, TOL, RESID: same as defined in dnaupd.
 c  MODE, ISHIFT, MXITER: see the definition of IPARAM in dnaupd.
 c
 c  NP      Integer.  (INPUT/OUTPUT)
-c          Contains the number of implicit shifts to apply during 
-c          each Arnoldi iteration.  
-c          If ISHIFT=1, NP is adjusted dynamically at each iteration 
+c          Contains the number of implicit shifts to apply during
+c          each Arnoldi iteration.
+c          If ISHIFT=1, NP is adjusted dynamically at each iteration
 c          to accelerate convergence and prevent stagnation.
-c          This is also roughly equal to the number of matrix-vector 
+c          This is also roughly equal to the number of matrix-vector
 c          products (involving the operator OP) per Arnoldi iteration.
 c          The logic for adjusting is contained within the current
 c          subroutine.
 c          If ISHIFT=0, NP is the number of shifts the user needs
 c          to provide via reverse comunication. 0 < NP < NCV-NEV.
 c          NP may be less than NCV-NEV for two reasons. The first, is
-c          to keep complex conjugate pairs of "wanted" Ritz values 
+c          to keep complex conjugate pairs of "wanted" Ritz values
 c          together. The second, is that a leading block of the current
 c          upper Hessenberg matrix has split off and contains "unwanted"
 c          Ritz values.
-c          Upon termination of the IRA iteration, NP contains the number 
+c          Upon termination of the IRA iteration, NP contains the number
 c          of "converged" wanted Ritz values.
 c
 c  IUPD    Integer.  (INPUT)
@@ -40,18 +40,18 @@ c          IUPD .EQ. 0: use explicit restart instead implicit update.
 c          IUPD .NE. 0: use implicit update.
 c
 c  V       Double precision N by (NEV+NP) array.  (INPUT/OUTPUT)
-c          The Arnoldi basis vectors are returned in the first NEV 
+c          The Arnoldi basis vectors are returned in the first NEV
 c          columns of V.
 c
 c  LDV     Integer.  (INPUT)
-c          Leading dimension of V exactly as declared in the calling 
+c          Leading dimension of V exactly as declared in the calling
 c          program.
 c
 c  H       Double precision (NEV+NP) by (NEV+NP) array.  (OUTPUT)
 c          H is used to store the generated upper Hessenberg matrix
 c
 c  LDH     Integer.  (INPUT)
-c          Leading dimension of H exactly as declared in the calling 
+c          Leading dimension of H exactly as declared in the calling
 c          program.
 c
 c  RITZR,  Double precision arrays of length NEV+NP.  (OUTPUT)
@@ -59,9 +59,9 @@ c  RITZI   RITZR(1:NEV) (resp. RITZI(1:NEV)) contains the real (resp.
 c          imaginary) part of the computed Ritz values of OP.
 c
 c  BOUNDS  Double precision array of length NEV+NP.  (OUTPUT)
-c          BOUNDS(1:NEV) contain the error bounds corresponding to 
+c          BOUNDS(1:NEV) contain the error bounds corresponding to
 c          the computed Ritz values.
-c          
+c
 c  Q       Double precision (NEV+NP) by (NEV+NP) array.  (WORKSPACE)
 c          Private (replicated) work array used to accumulate the
 c          rotation in the shift application step.
@@ -70,7 +70,7 @@ c  LDQ     Integer.  (INPUT)
 c          Leading dimension of Q exactly as declared in the calling
 c          program.
 c
-c  WORKL   Double precision work array of length at least 
+c  WORKL   Double precision work array of length at least
 c          (NEV+NP)**2 + 3*(NEV+NP).  (INPUT/WORKSPACE)
 c          Private (replicated) array on each PE or array allocated on
 c          the front end.  It is used in shifts calculation, shifts
@@ -82,19 +82,19 @@ c          estimates of the current Hessenberg matrix.  They are
 c          listed in the same order as returned from dneigh.
 c
 c          If ISHIFT .EQ. O and IDO .EQ. 3, the first 2*NP locations
-c          of WORKL are used in reverse communication to hold the user 
+c          of WORKL are used in reverse communication to hold the user
 c          supplied shifts.
 c
 c  IPNTR   Integer array of length 3.  (OUTPUT)
-c          Pointer to mark the starting locations in the WORKD for 
+c          Pointer to mark the starting locations in the WORKD for
 c          vectors used by the Arnoldi iteration.
 c          -------------------------------------------------------------
 c          IPNTR(1): pointer to the current operand vector X.
 c          IPNTR(2): pointer to the current result vector Y.
-c          IPNTR(3): pointer to the vector B * X when used in the 
+c          IPNTR(3): pointer to the vector B * X when used in the
 c                    shift-and-invert mode.  X is the current operand.
 c          -------------------------------------------------------------
-c          
+c
 c  WORKD   Double precision work array of length 3*N.  (WORKSPACE)
 c          Distributed array to be used in the basic Arnoldi iteration
 c          for reverse communication.  The user should not use WORKD
@@ -108,7 +108,7 @@ c                          possibly from a previous run.
 c          Error flag on output.
 c          =     0: Normal return.
 c          =     1: Maximum number of iterations taken.
-c                   All possible eigenvalues of OP has been found.  
+c                   All possible eigenvalues of OP has been found.
 c                   NP returns the number of converged Ritz values.
 c          =     2: No shifts could be applied.
 c          =    -8: Error return from LAPACK eigenvalue calculation;
@@ -130,12 +130,12 @@ c\References:
 c  1. D.C. Sorensen, "Implicit Application of Polynomial Filters in
 c     a k-Step Arnoldi Method", SIAM J. Matr. Anal. Apps., 13 (1992),
 c     pp 357-385.
-c  2. R.B. Lehoucq, "Analysis and Implementation of an Implicitly 
+c  2. R.B. Lehoucq, "Analysis and Implementation of an Implicitly
 c     Restarted Arnoldi Iteration", Rice University Technical Report
 c     TR95-13, Department of Computational and Applied Mathematics.
 c
 c\Routines called:
-c     dgetv0  ARPACK initial vector generation routine. 
+c     dgetv0  ARPACK initial vector generation routine.
 c     dnaitr  ARPACK Arnoldi factorization routine.
 c     dnapps  ARPACK application of implicit shifts routine.
 c     dnconv  ARPACK convergence of Ritz values routine.
@@ -149,19 +149,19 @@ c     dvout   ARPACK utility routine that prints vectors.
 c     dlamch  LAPACK routine that determines machine constants.
 c     dlapy2  LAPACK routine to compute sqrt(x**2+y**2) carefully.
 c     dcopy   Level 1 BLAS that copies one vector to another .
-c     ddot    Level 1 BLAS that computes the scalar product of two vectors. 
+c     ddot    Level 1 BLAS that computes the scalar product of two vectors.
 c     dnrm2   Level 1 BLAS that computes the norm of a vector.
 c     dswap   Level 1 BLAS that swaps two vectors.
 c
 c\Author
 c     Danny Sorensen               Phuong Vu
-c     Richard Lehoucq              CRPC / Rice University 
-c     Dept. of Computational &     Houston, Texas 
+c     Richard Lehoucq              CRPC / Rice University
+c     Dept. of Computational &     Houston, Texas
 c     Applied Mathematics
-c     Rice University           
-c     Houston, Texas    
-c 
-c\SCCS Information: @(#) 
+c     Rice University
+c     Houston, Texas
+c
+c\SCCS Information: @(#)
 c FILE: naup2.F   SID: 2.4   DATE OF SID: 7/30/96   RELEASE: 2
 c
 c\Remarks
@@ -172,8 +172,8 @@ c
 c-----------------------------------------------------------------------
 c
       subroutine dnaup2
-     &   ( ido, bmat, n, which, nev, np, tol, resid, mode, iupd, 
-     &     ishift, mxiter, v, ldv, h, ldh, ritzr, ritzi, bounds, 
+     &   ( ido, bmat, n, which, nev, np, tol, resid, mode, iupd,
+     &     ishift, mxiter, v, ldv, h, ldh, ritzr, ritzi, bounds,
      &     q, ldq, workl, ipntr, workd, info )
 c
 c     %----------------------------------------------------%
@@ -182,8 +182,8 @@ c     %----------------------------------------------------%
 c
 c
 c
-c\SCCS Information: @(#) 
-c FILE: debug.h   SID: 2.3   DATE OF SID: 11/16/95   RELEASE: 2 
+c\SCCS Information: @(#)
+c FILE: debug.h   SID: 2.3   DATE OF SID: 11/16/95   RELEASE: 2
 c
 c     %---------------------------------%
 c     | See debug.doc for documentation |
@@ -192,7 +192,7 @@ c     %---------------------------------%
      &         msaupd, msaup2, msaitr, mseigt, msapps, msgets, mseupd,
      &         mnaupd, mnaup2, mnaitr, mneigh, mnapps, mngets, mneupd,
      &         mcaupd, mcaup2, mcaitr, mceigh, mcapps, mcgets, mceupd
-      common /debug/ 
+      common /debug/
      &         logfil, ndigit, mgetv0,
      &         msaupd, msaup2, msaitr, mseigt, msapps, msgets, mseupd,
      &         mnaupd, mnaup2, mnaitr, mneigh, mnapps, mngets, mneupd,
@@ -201,8 +201,8 @@ c     %--------------------------------%
 c     | See stat.doc for documentation |
 c     %--------------------------------%
 c
-c\SCCS Information: @(#) 
-c FILE: stat.h   SID: 2.2   DATE OF SID: 11/16/95   RELEASE: 2 
+c\SCCS Information: @(#)
+c FILE: stat.h   SID: 2.2   DATE OF SID: 11/16/95   RELEASE: 2
 c
       real       t0, t1, t2, t3, t4, t5
 c     save       t0, t1, t2, t3, t4, t5
@@ -212,7 +212,7 @@ c
      &           tnaupd, tnaup2, tnaitr, tneigh, tngets, tnapps, tnconv,
      &           tcaupd, tcaup2, tcaitr, tceigh, tcgets, tcapps, tcconv,
      &           tmvopx, tmvbx, tgetv0, titref, trvec
-      common /timing/ 
+      common /timing/
      &           nopx, nbx, nrorth, nitref, nrstrt,
      &           tsaupd, tsaup2, tsaitr, tseigt, tsgets, tsapps, tsconv,
      &           tnaupd, tnaup2, tnaitr, tneigh, tngets, tnapps, tnconv,
@@ -235,7 +235,7 @@ c
       integer    ipntr(13)
       Double precision
      &           bounds(nev+np), h(ldh,nev+np), q(ldq,nev+np), resid(n),
-     &           ritzi(nev+np), ritzr(nev+np), v(ldv,nev+np), 
+     &           ritzi(nev+np), ritzr(nev+np), v(ldv,nev+np),
      &           workd(3*n), workl( (nev+np)*(nev+np+3) )
 c
 c     %------------%
@@ -252,7 +252,7 @@ c     %---------------%
 c
       character  wprime*2
       logical    cnorm, getv0, initv, update, ushift
-      integer    ierr, iter, j, kplusp, msglvl, nconv, nevbef, nev0, 
+      integer    ierr, iter, j, kplusp, msglvl, nconv, nevbef, nev0,
      &           np0, nptemp, numcnv
       Double precision
      &           rnorm, temp, eps23
@@ -291,11 +291,11 @@ c     | Executable Statements |
 c     %-----------------------%
 c
       if (ido .eq. 0) then
-c 
+c
          call second (t0)
-c 
+c
          msglvl = mnaup2
-c 
+c
 c        %-------------------------------------%
 c        | Get the machine dependent constant. |
 c        %-------------------------------------%
@@ -318,7 +318,7 @@ c
          kplusp = nev + np
          nconv  = 0
          iter   = 0
-c 
+c
 c        %---------------------------------------%
 c        | Set flags for computing the first NEV |
 c        | steps of the Arnoldi factorization.   |
@@ -341,7 +341,7 @@ c
             initv = .false.
          end if
       end if
-c 
+c
 c     %---------------------------------------------%
 c     | Get a possibly random starting vector and   |
 c     | force it into the range of the operator OP. |
@@ -358,7 +358,7 @@ c
          if (rnorm .eq. zero) then
 c
 c           %-----------------------------------------%
-c           | The initial vector is zero. Error exit. | 
+c           | The initial vector is zero. Error exit. |
 c           %-----------------------------------------%
 c
             info = -9
@@ -367,7 +367,7 @@ c
          getv0 = .false.
          ido  = 0
       end if
-c 
+c
 c     %-----------------------------------%
 c     | Back from reverse communication : |
 c     | continue with update step         |
@@ -387,14 +387,14 @@ c     | at the end of the current iteration |
 c     %-------------------------------------%
 c
       if (cnorm)  go to 100
-c 
+c
 c     %----------------------------------------------------------%
 c     | Compute the first NEV steps of the Arnoldi factorization |
 c     %----------------------------------------------------------%
 c
-      call dnaitr (ido, bmat, n, 0, nev, mode, resid, rnorm, v, ldv, 
+      call dnaitr (ido, bmat, n, 0, nev, mode, resid, rnorm, v, ldv,
      &             h, ldh, ipntr, workd, info)
-c 
+c
 c     %---------------------------------------------------%
 c     | ido .ne. 99 implies use of reverse communication  |
 c     | to compute operations involving OP and possibly B |
@@ -408,7 +408,7 @@ c
          info = -9999
          go to 1200
       end if
-c 
+c
 c     %--------------------------------------------------------------%
 c     |                                                              |
 c     |           M A I N  ARNOLDI  I T E R A T I O N  L O O P       |
@@ -416,16 +416,16 @@ c     |           Each iteration implicitly restarts the Arnoldi     |
 c     |           factorization in place.                            |
 c     |                                                              |
 c     %--------------------------------------------------------------%
-c 
+c
  1000 continue
 c
          iter = iter + 1
 c
          if (msglvl .gt. 0) then
-            call ivout (logfil, 1, [iter], ndigit, 
+            call ivout (logfil, 1, [iter], ndigit,
      &           '_naup2: **** Start of major iteration number ****')
          end if
-c 
+c
 c        %-----------------------------------------------------------%
 c        | Compute NP additional steps of the Arnoldi factorization. |
 c        | Adjust NP since NEV might have been updated by last call  |
@@ -435,9 +435,9 @@ c
          np  = kplusp - nev
 c
          if (msglvl .gt. 1) then
-            call ivout (logfil, 1, [nev], ndigit, 
+            call ivout (logfil, 1, [nev], ndigit,
      &     '_naup2: The length of the current Arnoldi factorization')
-            call ivout (logfil, 1, [np], ndigit, 
+            call ivout (logfil, 1, [np], ndigit,
      &           '_naup2: Extend the Arnoldi factorization by')
          end if
 c
@@ -451,7 +451,7 @@ c
 c
          call dnaitr (ido, bmat, n, nev, np, mode, resid, rnorm, v, ldv,
      &                h, ldh, ipntr, workd, info)
-c 
+c
 c        %---------------------------------------------------%
 c        | ido .ne. 99 implies use of reverse communication  |
 c        | to compute operations involving OP and possibly B |
@@ -468,10 +468,10 @@ c
          update = .false.
 c
          if (msglvl .gt. 1) then
-            call dvout (logfil, 1, [rnorm], ndigit, 
+            call dvout (logfil, 1, [rnorm], ndigit,
      &           '_naup2: Corresponding B-norm of the residual')
          end if
-c 
+c
 c        %--------------------------------------------------------%
 c        | Compute the eigenvalues and corresponding error bounds |
 c        | of the current upper Hessenberg matrix.                |
@@ -510,30 +510,30 @@ c
          nev = nev0
          np = np0
          numcnv = nev
-         call dngets (ishift, which, nev, np, ritzr, ritzi, 
+         call dngets (ishift, which, nev, np, ritzr, ritzi,
      &                bounds, workl, workl(np+1))
          if (nev .eq. nev0+1) numcnv = nev0+1
-c 
+c
 c        %-------------------%
-c        | Convergence test. | 
+c        | Convergence test. |
 c        %-------------------%
 c
          call dcopy (nev, bounds(np+1), 1, workl(2*np+1), 1)
-         call dnconv (nev, ritzr(np+1), ritzi(np+1), workl(2*np+1), 
+         call dnconv (nev, ritzr(np+1), ritzi(np+1), workl(2*np+1),
      &        tol, nconv)
-c 
+c
          if (msglvl .gt. 2) then
             kp(1) = nev
             kp(2) = np
             kp(3) = numcnv
             kp(4) = nconv
-            call ivout (logfil, 4, kp, ndigit, 
+            call ivout (logfil, 4, kp, ndigit,
      &                  '_naup2: NEV, NP, NUMCNV, NCONV are')
             call dvout (logfil, kplusp, ritzr, ndigit,
      &           '_naup2: Real part of the eigenvalues of H')
             call dvout (logfil, kplusp, ritzi, ndigit,
      &           '_naup2: Imaginary part of the eigenvalues of H')
-            call dvout (logfil, kplusp, bounds, ndigit, 
+            call dvout (logfil, kplusp, bounds, ndigit,
      &          '_naup2: Ritz estimates of the current NCV Ritz values')
          end if
 c
@@ -554,8 +554,8 @@ c
                nev = nev + 1
             end if
  30      continue
-c     
-         if ( (nconv .ge. numcnv) .or. 
+c
+         if ( (nconv .ge. numcnv) .or.
      &        (iter .gt. mxiter) .or.
      &        (np .eq. 0) ) then
 c
@@ -569,7 +569,7 @@ c
      &                     ndigit,
      &             '_naup2: Ritz eistmates computed by _neigh:')
             end if
-c     
+c
 c           %------------------------------------------------%
 c           | Prepare to exit. Put the converged Ritz values |
 c           | and corresponding bounds in RITZ(1:NCONV) and  |
@@ -668,13 +668,13 @@ c
             end if
 c
 c           %------------------------------------%
-c           | Max iterations have been exceeded. | 
+c           | Max iterations have been exceeded. |
 c           %------------------------------------%
 c
             if (iter .gt. mxiter .and. nconv .lt. numcnv) info = 1
 c
 c           %---------------------%
-c           | No shifts to apply. | 
+c           | No shifts to apply. |
 c           %---------------------%
 c
             if (np .eq. 0 .and. nconv .lt. numcnv) info = 2
@@ -683,7 +683,7 @@ c
             go to 1100
 c
          else if ( (nconv .lt. numcnv) .and. (ishift .eq. 1) ) then
-c     
+c
 c           %-------------------------------------------------%
 c           | Do not have all the requested eigenvalues yet.  |
 c           | To prevent possible stagnation, adjust the size |
@@ -698,25 +698,25 @@ c
                nev = 2
             end if
             np = kplusp - nev
-c     
+c
 c           %---------------------------------------%
 c           | If the size of NEV was just increased |
 c           | resort the eigenvalues.               |
 c           %---------------------------------------%
-c     
-            if (nevbef .lt. nev) 
-     &         call dngets (ishift, which, nev, np, ritzr, ritzi, 
+c
+            if (nevbef .lt. nev)
+     &         call dngets (ishift, which, nev, np, ritzr, ritzi,
      &              bounds, workl, workl(np+1))
 c
-         end if              
-c     
+         end if
+c
          if (msglvl .gt. 0) then
-            call ivout (logfil, 1, [nconv], ndigit, 
+            call ivout (logfil, 1, [nconv], ndigit,
      &           '_naup2: no. of "converged" Ritz values at this iter.')
             if (msglvl .gt. 1) then
                kp(1) = nev
                kp(2) = np
-               call ivout (logfil, 2, kp, ndigit, 
+               call ivout (logfil, 2, kp, ndigit,
      &              '_naup2: NEV and NP are')
                call dvout (logfil, nev, ritzr(np+1), ndigit,
      &              '_naup2: "wanted" Ritz values -- real part')
@@ -739,7 +739,7 @@ c
             ido = 3
             go to 9000
          end if
-c 
+c
    50    continue
 c
 c        %------------------------------------%
@@ -751,7 +751,7 @@ c
          ushift = .false.
 c
          if ( ishift .eq. 0 ) then
-c 
+c
 c            %----------------------------------%
 c            | Move the NP shifts from WORKL to |
 c            | RITZR, RITZI to free up WORKL    |
@@ -762,14 +762,14 @@ c
              call dcopy (np, workl(np+1), 1, ritzi, 1)
          end if
 c
-         if (msglvl .gt. 2) then 
-            call ivout (logfil, 1, [np], ndigit, 
+         if (msglvl .gt. 2) then
+            call ivout (logfil, 1, [np], ndigit,
      &                  '_naup2: The number of shifts to apply ')
             call dvout (logfil, np, ritzr, ndigit,
      &                  '_naup2: Real part of the shifts')
             call dvout (logfil, np, ritzi, ndigit,
      &                  '_naup2: Imaginary part of the shifts')
-            if ( ishift .eq. 1 ) 
+            if ( ishift .eq. 1 )
      &          call dvout (logfil, np, bounds, ndigit,
      &                  '_naup2: Ritz estimates of the shifts')
          end if
@@ -781,7 +781,7 @@ c        | matrix H.                                               |
 c        | The first 2*N locations of WORKD are used as workspace. |
 c        %---------------------------------------------------------%
 c
-         call dnapps (n, nev, np, ritzr, ritzi, v, ldv, 
+         call dnapps (n, nev, np, ritzr, ritzi, v, ldv,
      &                h, ldh, resid, q, ldq, workl, workd)
 c
 c        %---------------------------------------------%
@@ -798,18 +798,18 @@ c
             ipntr(1) = n + 1
             ipntr(2) = 1
             ido = 2
-c 
+c
 c           %----------------------------------%
 c           | Exit in order to compute B*RESID |
 c           %----------------------------------%
-c 
+c
             go to 9000
          else if (bmat .eq. 'I') then
             call dcopy (n, resid, 1, workd, 1)
          end if
-c 
+c
   100    continue
-c 
+c
 c        %----------------------------------%
 c        | Back from reverse communication; |
 c        | WORKD(1:N) := B*RESID            |
@@ -819,8 +819,8 @@ c
             call second (t3)
             tmvbx = tmvbx + (t3 - t2)
          end if
-c 
-         if (bmat .eq. 'G') then         
+c
+         if (bmat .eq. 'G') then
             rnorm = ddot (n, resid, 1, workd, 1)
             rnorm = sqrt(abs(rnorm))
          else if (bmat .eq. 'I') then
@@ -829,12 +829,12 @@ c
          cnorm = .false.
 c
          if (msglvl .gt. 2) then
-            call dvout (logfil, 1, [rnorm], ndigit, 
+            call dvout (logfil, 1, [rnorm], ndigit,
      &      '_naup2: B-norm of residual for compressed factorization')
             call dmout (logfil, nev, nev, h, ldh, ndigit,
      &        '_naup2: Compressed upper Hessenberg matrix H')
          end if
-c 
+c
       go to 1000
 c
 c     %---------------------------------------------------------------%
@@ -847,7 +847,7 @@ c
 c
       mxiter = iter
       nev = numcnv
-c     
+c
  1200 continue
       ido = 99
 c
@@ -857,7 +857,7 @@ c     %------------%
 c
       call second (t1)
       tnaup2 = t1 - t0
-c     
+c
  9000 continue
 c
 c     %---------------%

--- a/mathlibs/src/arpack/dnaupd.f
+++ b/mathlibs/src/arpack/dnaupd.f
@@ -2,19 +2,19 @@ c\BeginDoc
 c
 c\Name: dnaupd
 c
-c\Description: 
+c\Description:
 c  Reverse communication interface for the Implicitly Restarted Arnoldi
-c  iteration. This subroutine computes approximations to a few eigenpairs 
-c  of a linear operator "OP" with respect to a semi-inner product defined by 
-c  a symmetric positive semi-definite real matrix B. B may be the identity 
-c  matrix. NOTE: If the linear operator "OP" is real and symmetric 
-c  with respect to the real positive semi-definite symmetric matrix B, 
+c  iteration. This subroutine computes approximations to a few eigenpairs
+c  of a linear operator "OP" with respect to a semi-inner product defined by
+c  a symmetric positive semi-definite real matrix B. B may be the identity
+c  matrix. NOTE: If the linear operator "OP" is real and symmetric
+c  with respect to the real positive semi-definite symmetric matrix B,
 c  i.e. B*OP = (OP')*B, then subroutine ssaupd should be used instead.
 c
 c  The computed approximate eigenvalues are called Ritz values and
 c  the corresponding approximate eigenvectors are called Ritz vectors.
 c
-c  dnaupd is usually called iteratively to solve one of the 
+c  dnaupd is usually called iteratively to solve one of the
 c  following problems:
 c
 c  Mode 1:  A*x = lambda*x.
@@ -25,18 +25,18 @@ c           ===> OP = inv[M]*A  and  B = M.
 c           ===> (If M can be factored see remark 3 below)
 c
 c  Mode 3:  A*x = lambda*M*x, M symmetric semi-definite
-c           ===> OP = Real_Part{ inv[A - sigma*M]*M }  and  B = M. 
+c           ===> OP = Real_Part{ inv[A - sigma*M]*M }  and  B = M.
 c           ===> shift-and-invert mode (in real arithmetic)
-c           If OP*x = amu*x, then 
+c           If OP*x = amu*x, then
 c           amu = 1/2 * [ 1/(lambda-sigma) + 1/(lambda-conjg(sigma)) ].
 c           Note: If sigma is real, i.e. imaginary part of sigma is zero;
-c                 Real_Part{ inv[A - sigma*M]*M } == inv[A - sigma*M]*M 
-c                 amu == 1/(lambda-sigma). 
-c  
+c                 Real_Part{ inv[A - sigma*M]*M } == inv[A - sigma*M]*M
+c                 amu == 1/(lambda-sigma).
+c
 c  Mode 4:  A*x = lambda*M*x, M symmetric semi-definite
-c           ===> OP = Imaginary_Part{ inv[A - sigma*M]*M }  and  B = M. 
+c           ===> OP = Imaginary_Part{ inv[A - sigma*M]*M }  and  B = M.
 c           ===> shift-and-invert mode (in real arithmetic)
-c           If OP*x = amu*x, then 
+c           If OP*x = amu*x, then
 c           amu = 1/2i * [ 1/(lambda-sigma) - 1/(lambda-conjg(sigma)) ].
 c
 c  Both mode 3 and 4 give the same enhancement to eigenvalues close to
@@ -63,7 +63,7 @@ c       IPNTR, WORKD, WORKL, LWORKL, INFO )
 c
 c\Arguments
 c  IDO     Integer.  (INPUT/OUTPUT)
-c          Reverse communication flag.  IDO must be zero on the first 
+c          Reverse communication flag.  IDO must be zero on the first
 c          call to dnaupd.  IDO will be set internally to
 c          indicate the type of operation to be performed.  Control is
 c          then given back to the calling routine which has the
@@ -86,13 +86,13 @@ c                    need to be recomputed in forming OP * X.
 c          IDO =  2: compute  Y = B * X  where
 c                    IPNTR(1) is the pointer into WORKD for X,
 c                    IPNTR(2) is the pointer into WORKD for Y.
-c          IDO =  3: compute the IPARAM(8) real and imaginary parts 
+c          IDO =  3: compute the IPARAM(8) real and imaginary parts
 c                    of the shifts where INPTR(14) is the pointer
 c                    into WORKL for placing the shifts. See Remark
 c                    5 below.
 c          IDO = 99: done
 c          -------------------------------------------------------------
-c             
+c
 c  BMAT    Character*1.  (INPUT)
 c          BMAT specifies the type of the matrix B that defines the
 c          semi-inner product for the operator OP.
@@ -114,14 +114,14 @@ c  NEV     Integer.  (INPUT)
 c          Number of eigenvalues of OP to be computed. 0 < NEV < N-1.
 c
 c  TOL     Double precision scalar.  (INPUT)
-c          Stopping criterion: the relative accuracy of the Ritz value 
+c          Stopping criterion: the relative accuracy of the Ritz value
 c          is considered acceptable if BOUNDS(I) .LE. TOL*ABS(RITZ(I))
 c          where ABS(RITZ(I)) is the magnitude when RITZ(I) is complex.
 c          DEFAULT = DLAMCH('EPS')  (machine precision as computed
 c                    by the LAPACK auxiliary subroutine DLAMCH).
 c
 c  RESID   Double precision array of length N.  (INPUT/OUTPUT)
-c          On INPUT: 
+c          On INPUT:
 c          If INFO .EQ. 0, a random initial residual vector is used.
 c          If INFO .NE. 0, RESID contains the initial residual vector,
 c                          possibly from a previous run.
@@ -131,17 +131,17 @@ c
 c  NCV     Integer.  (INPUT)
 c          Number of columns of the matrix V. NCV must satisfy the two
 c          inequalities 2 <= NCV-NEV and NCV <= N.
-c          This will indicate how many Arnoldi vectors are generated 
-c          at each iteration.  After the startup phase in which NEV 
-c          Arnoldi vectors are generated, the algorithm generates 
-c          approximately NCV-NEV Arnoldi vectors at each subsequent update 
-c          iteration. Most of the cost in generating each Arnoldi vector is 
-c          in the matrix-vector operation OP*x. 
-c          NOTE: 2 <= NCV-NEV in order that complex conjugate pairs of Ritz 
+c          This will indicate how many Arnoldi vectors are generated
+c          at each iteration.  After the startup phase in which NEV
+c          Arnoldi vectors are generated, the algorithm generates
+c          approximately NCV-NEV Arnoldi vectors at each subsequent update
+c          iteration. Most of the cost in generating each Arnoldi vector is
+c          in the matrix-vector operation OP*x.
+c          NOTE: 2 <= NCV-NEV in order that complex conjugate pairs of Ritz
 c          values are kept together. (See remark 4 below)
 c
 c  V       Double precision array N by NCV.  (OUTPUT)
-c          Contains the final set of Arnoldi basis vectors. 
+c          Contains the final set of Arnoldi basis vectors.
 c
 c  LDV     Integer.  (INPUT)
 c          Leading dimension of V exactly as declared in the calling program.
@@ -154,11 +154,11 @@ c          -------------------------------------------------------------
 c          ISHIFT = 0: the shifts are provided by the user via
 c                      reverse communication.  The real and imaginary
 c                      parts of the NCV eigenvalues of the Hessenberg
-c                      matrix H are returned in the part of the WORKL 
-c                      array corresponding to RITZR and RITZI. See remark 
+c                      matrix H are returned in the part of the WORKL
+c                      array corresponding to RITZR and RITZI. See remark
 c                      5 below.
 c          ISHIFT = 1: exact shifts with respect to the current
-c                      Hessenberg matrix H.  This is equivalent to 
+c                      Hessenberg matrix H.  This is equivalent to
 c                      restarting the iteration with a starting vector
 c                      that is a linear combination of approximate Schur
 c                      vectors associated with the "wanted" Ritz values.
@@ -167,8 +167,8 @@ c
 c          IPARAM(2) = No longer referenced.
 c
 c          IPARAM(3) = MXITER
-c          On INPUT:  maximum number of Arnoldi update iterations allowed. 
-c          On OUTPUT: actual number of Arnoldi update iterations taken. 
+c          On INPUT:  maximum number of Arnoldi update iterations allowed.
+c          On OUTPUT: actual number of Arnoldi update iterations taken.
 c
 c          IPARAM(4) = NB: blocksize to be used in the recurrence.
 c          The code currently works only for NB = 1.
@@ -178,11 +178,11 @@ c          This represents the number of Ritz values that satisfy
 c          the convergence criterion.
 c
 c          IPARAM(6) = IUPD
-c          No longer referenced. Implicit restarting is ALWAYS used.  
+c          No longer referenced. Implicit restarting is ALWAYS used.
 c
 c          IPARAM(7) = MODE
 c          On INPUT determines what type of eigenproblem is being solved.
-c          Must be 1,2,3,4; See under \Description of dnaupd for the 
+c          Must be 1,2,3,4; See under \Description of dnaupd for the
 c          four modes available.
 c
 c          IPARAM(8) = NP
@@ -194,7 +194,7 @@ c
 c          IPARAM(9) = NUMOP, IPARAM(10) = NUMOPB, IPARAM(11) = NUMREO,
 c          OUTPUT: NUMOP  = total number of OP*x operations,
 c                  NUMOPB = total number of B*x operations if BMAT='G',
-c                  NUMREO = total number of steps of re-orthogonalization.        
+c                  NUMREO = total number of steps of re-orthogonalization.
 c
 c  IPNTR   Integer array of length 14.  (OUTPUT)
 c          Pointer to mark the starting locations in the WORKD and WORKL
@@ -202,13 +202,13 @@ c          arrays for matrices/vectors used by the Arnoldi iteration.
 c          -------------------------------------------------------------
 c          IPNTR(1): pointer to the current operand vector X in WORKD.
 c          IPNTR(2): pointer to the current result vector Y in WORKD.
-c          IPNTR(3): pointer to the vector B * X in WORKD when used in 
+c          IPNTR(3): pointer to the vector B * X in WORKD when used in
 c                    the shift-and-invert mode.
 c          IPNTR(4): pointer to the next available location in WORKL
 c                    that is untouched by the program.
 c          IPNTR(5): pointer to the NCV by NCV upper Hessenberg matrix
 c                    H in WORKL.
-c          IPNTR(6): pointer to the real part of the ritz value array 
+c          IPNTR(6): pointer to the real part of the ritz value array
 c                    RITZR in WORKL.
 c          IPNTR(7): pointer to the imaginary part of the ritz value array
 c                    RITZI in WORKL.
@@ -219,9 +219,9 @@ c          IPNTR(14): pointer to the NP shifts in WORKL. See Remark 5 below.
 c
 c          Note: IPNTR(9:13) is only referenced by dneupd. See Remark 2 below.
 c
-c          IPNTR(9):  pointer to the real part of the NCV RITZ values of the 
+c          IPNTR(9):  pointer to the real part of the NCV RITZ values of the
 c                     original system.
-c          IPNTR(10): pointer to the imaginary part of the NCV RITZ values of 
+c          IPNTR(10): pointer to the imaginary part of the NCV RITZ values of
 c                     the original system.
 c          IPNTR(11): pointer to the NCV corresponding error bounds.
 c          IPNTR(12): pointer to the NCV by NCV upper quasi-triangular
@@ -230,15 +230,15 @@ c          IPNTR(13): pointer to the NCV by NCV matrix of eigenvectors
 c                     of the upper Hessenberg matrix H. Only referenced by
 c                     dneupd if RVEC = .TRUE. See Remark 2 below.
 c          -------------------------------------------------------------
-c          
+c
 c  WORKD   Double precision work array of length 3*N.  (REVERSE COMMUNICATION)
 c          Distributed array to be used in the basic Arnoldi iteration
-c          for reverse communication.  The user should not use WORKD 
+c          for reverse communication.  The user should not use WORKD
 c          as temporary workspace during the iteration. Upon termination
 c          WORKD(1:N) contains B*RESID(1:N). If an invariant subspace
 c          associated with the converged Ritz values is desired, see remark
 c          2 below, subroutine dneupd uses this output.
-c          See Data Distribution Note below.  
+c          See Data Distribution Note below.
 c
 c  WORKL   Double precision work array of length LWORKL.  (OUTPUT/WORKSPACE)
 c          Private (replicated) array on each PE or array allocated on
@@ -254,18 +254,18 @@ c                          possibly from a previous run.
 c          Error flag on output.
 c          =  0: Normal exit.
 c          =  1: Maximum number of iterations taken.
-c                All possible eigenvalues of OP has been found. IPARAM(5)  
+c                All possible eigenvalues of OP has been found. IPARAM(5)
 c                returns the number of wanted converged Ritz values.
 c          =  2: No longer an informational error. Deprecated starting
 c                with release 2 of ARPACK.
-c          =  3: No shifts could be applied during a cycle of the 
-c                Implicitly restarted Arnoldi iteration. One possibility 
-c                is to increase the size of NCV relative to NEV. 
+c          =  3: No shifts could be applied during a cycle of the
+c                Implicitly restarted Arnoldi iteration. One possibility
+c                is to increase the size of NCV relative to NEV.
 c                See remark 4 below.
 c          = -1: N must be positive.
 c          = -2: NEV must be positive.
 c          = -3: NCV-NEV >= 2 and less than or equal to N.
-c          = -4: The maximum number of Arnoldi update iteration 
+c          = -4: The maximum number of Arnoldi update iteration
 c                must be greater than zero.
 c          = -5: WHICH must be one of 'LM', 'SM', 'LR', 'SR', 'LI', 'SI'
 c          = -6: BMAT must be one of 'I' or 'G'.
@@ -285,13 +285,13 @@ c     selection of WHICH should be made with this in mind when
 c     Mode = 3 and 4.  After convergence, approximate eigenvalues of the
 c     original problem may be obtained with the ARPACK subroutine dneupd.
 c
-c  2. If a basis for the invariant subspace corresponding to the converged Ritz 
-c     values is needed, the user must call dneupd immediately following 
+c  2. If a basis for the invariant subspace corresponding to the converged Ritz
+c     values is needed, the user must call dneupd immediately following
 c     completion of dnaupd. This is new starting with release 2 of ARPACK.
 c
 c  3. If M can be factored into a Cholesky factorization M = LL'
 c     then Mode = 2 should not be selected.  Instead one should use
-c     Mode = 1 with  OP = inv(L)*A*inv(L').  Appropriate triangular 
+c     Mode = 1 with  OP = inv(L)*A*inv(L').  Appropriate triangular
 c     linear systems should be solved with L and L' rather
 c     than computing inverses.  After convergence, an approximate
 c     eigenvector z of the original problem is recovered by solving
@@ -301,15 +301,15 @@ c  4. At present there is no a-priori analysis to guide the selection
 c     of NCV relative to NEV.  The only formal requrement is that NCV > NEV + 2.
 c     However, it is recommended that NCV .ge. 2*NEV+1.  If many problems of
 c     the same type are to be solved, one should experiment with increasing
-c     NCV while keeping NEV fixed for a given test problem.  This will 
+c     NCV while keeping NEV fixed for a given test problem.  This will
 c     usually decrease the required number of OP*x operations but it
 c     also increases the work and storage required to maintain the orthogonal
 c     basis vectors.  The optimal "cross-over" with respect to CPU time
-c     is problem dependent and must be determined empirically. 
+c     is problem dependent and must be determined empirically.
 c     See Chapter 8 of Reference 2 for further information.
 c
-c  5. When IPARAM(1) = 0, and IDO = 3, the user needs to provide the 
-c     NP = IPARAM(8) real and imaginary parts of the shifts in locations 
+c  5. When IPARAM(1) = 0, and IDO = 3, the user needs to provide the
+c     NP = IPARAM(8) real and imaginary parts of the shifts in locations
 c         real part                  imaginary part
 c         -----------------------    --------------
 c     1   WORKL(IPNTR(14))           WORKL(IPNTR(14)+NP)
@@ -319,10 +319,10 @@ c                        .                          .
 c                        .                          .
 c     NP  WORKL(IPNTR(14)+NP-1)      WORKL(IPNTR(14)+2*NP-1).
 c
-c     Only complex conjugate pairs of shifts may be applied and the pairs 
-c     must be placed in consecutive locations. The real part of the 
-c     eigenvalues of the current upper Hessenberg matrix are located in 
-c     WORKL(IPNTR(6)) through WORKL(IPNTR(6)+NCV-1) and the imaginary part 
+c     Only complex conjugate pairs of shifts may be applied and the pairs
+c     must be placed in consecutive locations. The real part of the
+c     eigenvalues of the current upper Hessenberg matrix are located in
+c     WORKL(IPNTR(6)) through WORKL(IPNTR(6)+NCV-1) and the imaginary part
 c     in WORKL(IPNTR(7)) through WORKL(IPNTR(7)+NCV-1). They are ordered
 c     according to the order defined by WHICH. The complex conjugate
 c     pairs are kept together and the associated Ritz estimates are located in
@@ -330,7 +330,7 @@ c     WORKL(IPNTR(8)), WORKL(IPNTR(8)+1), ... , WORKL(IPNTR(8)+NCV-1).
 c
 c-----------------------------------------------------------------------
 c
-c\Data Distribution Note: 
+c\Data Distribution Note:
 c
 c  Fortran-D syntax:
 c  ================
@@ -349,10 +349,10 @@ c  ===============
 c  Double precision  resid(n), v(ldv,ncv), workd(n,3), workl(lworkl)
 c  shared     resid(block), v(block,:), workd(block,:)
 c  replicated workl(lworkl)
-c  
+c
 c  CM2/CM5 syntax:
 c  ==============
-c  
+c
 c-----------------------------------------------------------------------
 c
 c     include   'ex-nonsym.doc'
@@ -368,7 +368,7 @@ c\References:
 c  1. D.C. Sorensen, "Implicit Application of Polynomial Filters in
 c     a k-Step Arnoldi Method", SIAM J. Matr. Anal. Apps., 13 (1992),
 c     pp 357-385.
-c  2. R.B. Lehoucq, "Analysis and Implementation of an Implicitly 
+c  2. R.B. Lehoucq, "Analysis and Implementation of an Implicitly
 c     Restarted Arnoldi Iteration", Rice University Technical Report
 c     TR95-13, Department of Computational and Applied Mathematics.
 c  3. B.N. Parlett & Y. Saad, "Complex Shift and Invert Strategies for
@@ -388,13 +388,13 @@ c     Danny Sorensen               Phuong Vu
 c     Richard Lehoucq              CRPC / Rice University
 c     Dept. of Computational &     Houston, Texas
 c     Applied Mathematics
-c     Rice University           
-c     Houston, Texas            
-c 
+c     Rice University
+c     Houston, Texas
+c
 c\Revision history:
 c     12/16/93: Version '1.1'
 c
-c\SCCS Information: @(#) 
+c\SCCS Information: @(#)
 c FILE: naupd.F   SID: 2.5   DATE OF SID: 8/27/96   RELEASE: 2
 c
 c\Remarks
@@ -404,7 +404,7 @@ c
 c-----------------------------------------------------------------------
 c
       subroutine dnaupd
-     &   ( ido, bmat, n, which, nev, tol, resid, ncv, v, ldv, iparam, 
+     &   ( ido, bmat, n, which, nev, tol, resid, ncv, v, ldv, iparam,
      &     ipntr, workd, workl, lworkl, info )
 c
 c     %----------------------------------------------------%
@@ -443,7 +443,7 @@ c     %---------------%
 c     | Local Scalars |
 c     %---------------%
 c
-      integer    bounds, ierr, ih, iq, ishift, iupd, iw, 
+      integer    bounds, ierr, ih, iq, ishift, iupd, iw,
      &           ldh, ldq, levec, mode, msglvl, mxiter, nb,
      &           nev0, next, np, ritzi, ritzr, j
       save       bounds, ih, iq, ishift, iupd, iw, ldh, ldq,
@@ -467,9 +467,9 @@ c
 c     %-----------------------%
 c     | Executable Statements |
 c     %-----------------------%
-c 
+c
       if (ido .eq. 0) then
-c 
+c
 c        %-------------------------------%
 c        | Initialize timing statistics  |
 c        | & message level for debugging |
@@ -522,7 +522,7 @@ c
          else if (ishift .lt. 0 .or. ishift .gt. 1) then
                                                 ierr = -12
          end if
-c 
+c
 c        %------------%
 c        | Error Exit |
 c        %------------%
@@ -532,7 +532,7 @@ c
             ido  = 99
             go to 9000
          end if
-c 
+c
 c        %------------------------%
 c        | Set default parameters |
 c        %------------------------%
@@ -548,8 +548,8 @@ c        | size of the invariant subspace desired.      |
 c        %----------------------------------------------%
 c
          np     = ncv - nev
-         nev0   = nev 
-c 
+         nev0   = nev
+c
 c        %-----------------------------%
 c        | Zero out internal workspace |
 c        %-----------------------------%
@@ -557,7 +557,7 @@ c
          do 10 j = 1, 3*ncv**2 + 6*ncv
             workl(j) = zero
   10     continue
-c 
+c
 c        %-------------------------------------------------------------%
 c        | Pointer into WORKL for address of H, RITZ, BOUNDS, Q        |
 c        | etc... and the remaining workspace.                         |
@@ -590,7 +590,7 @@ c
          ipntr(6) = ritzr
          ipntr(7) = ritzi
          ipntr(8) = bounds
-         ipntr(14) = iw 
+         ipntr(14) = iw
 c
       end if
 c
@@ -598,12 +598,12 @@ c     %-------------------------------------------------------%
 c     | Carry out the Implicitly restarted Arnoldi Iteration. |
 c     %-------------------------------------------------------%
 c
-      call dnaup2 
+      call dnaup2
      &   ( ido, bmat, n, which, nev0, np, tol, resid, mode, iupd,
-     &     ishift, mxiter, v, ldv, workl(ih), ldh, workl(ritzr), 
-     &     workl(ritzi), workl(bounds), workl(iq), ldq, workl(iw), 
+     &     ishift, mxiter, v, ldv, workl(ih), ldh, workl(ritzr),
+     &     workl(ritzi), workl(bounds), workl(iq), ldq, workl(iw),
      &     ipntr, workd, info )
-c 
+c
 c     %--------------------------------------------------%
 c     | ido .ne. 99 implies use of reverse communication |
 c     | to compute operations involving OP or shifts.    |
@@ -611,7 +611,7 @@ c     %--------------------------------------------------%
 c
       if (ido .eq. 3) iparam(8) = np
       if (ido .ne. 99) go to 9000
-c 
+c
       iparam(3) = mxiter
       iparam(5) = np
       iparam(9) = nopx
@@ -631,11 +631,11 @@ c
      &               '_naupd: Number of update iterations taken')
          call ivout (logfil, 1, [np], ndigit,
      &               '_naupd: Number of wanted "converged" Ritz values')
-         call dvout (logfil, np, workl(ritzr), ndigit, 
+         call dvout (logfil, np, workl(ritzr), ndigit,
      &               '_naupd: Real part of the final Ritz values')
-         call dvout (logfil, np, workl(ritzi), ndigit, 
+         call dvout (logfil, np, workl(ritzi), ndigit,
      &               '_naupd: Imaginary part of the final Ritz values')
-         call dvout (logfil, np, workl(bounds), ndigit, 
+         call dvout (logfil, np, workl(bounds), ndigit,
      &               '_naupd: Associated Ritz estimates')
       end if
 c

--- a/mathlibs/src/arpack/dnaupd.f
+++ b/mathlibs/src/arpack/dnaupd.f
@@ -627,9 +627,9 @@ c
       if (info .eq. 2) info = 3
 c
       if (msglvl .gt. 0) then
-         call ivout (logfil, 1, mxiter, ndigit,
+         call ivout (logfil, 1, [mxiter], ndigit,
      &               '_naupd: Number of update iterations taken')
-         call ivout (logfil, 1, np, ndigit,
+         call ivout (logfil, 1, [np], ndigit,
      &               '_naupd: Number of wanted "converged" Ritz values')
          call dvout (logfil, np, workl(ritzr), ndigit, 
      &               '_naupd: Real part of the final Ritz values')

--- a/mathlibs/src/arpack/dneupd.f
+++ b/mathlibs/src/arpack/dneupd.f
@@ -2,7 +2,7 @@ c\BeginDoc
 c
 c\Name: dneupd
 c
-c\Description: 
+c\Description:
 c
 c  This subroutine returns the converged approximations to eigenvalues
 c  of A*z = lambda*B*z and (optionally):
@@ -28,34 +28,34 @@ c  in the comments that follow.  The computed orthonormal basis for the
 c  invariant subspace corresponding to these Ritz values is referred to as a
 c  Schur basis.
 c
-c  See documentation in the header of the subroutine DNAUPD for 
+c  See documentation in the header of the subroutine DNAUPD for
 c  definition of OP as well as other terms and the relation of computed
 c  Ritz values and Ritz vectors of OP with respect to the given problem
-c  A*z = lambda*B*z.  For a brief description, see definitions of 
+c  A*z = lambda*B*z.  For a brief description, see definitions of
 c  IPARAM(7), MODE and WHICH in the documentation of DNAUPD.
 c
 c\Usage:
-c  call dneupd 
-c     ( RVEC, HOWMNY, SELECT, DR, DI, Z, LDZ, SIGMAR, SIGMAI, WORKEV, BMAT, 
-c       N, WHICH, NEV, TOL, RESID, NCV, V, LDV, IPARAM, IPNTR, WORKD, WORKL, 
+c  call dneupd
+c     ( RVEC, HOWMNY, SELECT, DR, DI, Z, LDZ, SIGMAR, SIGMAI, WORKEV, BMAT,
+c       N, WHICH, NEV, TOL, RESID, NCV, V, LDV, IPARAM, IPNTR, WORKD, WORKL,
 c       LWORKL, INFO )
 c
 c\Arguments:
-c  RVEC    LOGICAL  (INPUT) 
-c          Specifies whether a basis for the invariant subspace corresponding 
-c          to the converged Ritz value approximations for the eigenproblem 
+c  RVEC    LOGICAL  (INPUT)
+c          Specifies whether a basis for the invariant subspace corresponding
+c          to the converged Ritz value approximations for the eigenproblem
 c          A*z = lambda*B*z is computed.
 c
 c             RVEC = .FALSE.     Compute Ritz values only.
 c
 c             RVEC = .TRUE.      Compute the Ritz vectors or Schur vectors.
-c                                See Remarks below. 
-c 
-c  HOWMNY  Character*1  (INPUT) 
-c          Specifies the form of the basis for the invariant subspace 
+c                                See Remarks below.
+c
+c  HOWMNY  Character*1  (INPUT)
+c          Specifies the form of the basis for the invariant subspace
 c          corresponding to the converged Ritz values that is to be computed.
 c
-c          = 'A': Compute NEV Ritz vectors; 
+c          = 'A': Compute NEV Ritz vectors;
 c          = 'P': Compute NEV Schur vectors;
 c          = 'S': compute some of the Ritz vectors, specified
 c                 by the logical array SELECT.
@@ -63,43 +63,43 @@ c
 c  SELECT  Logical array of dimension NCV.  (INPUT)
 c          If HOWMNY = 'S', SELECT specifies the Ritz vectors to be
 c          computed. To select the Ritz vector corresponding to a
-c          Ritz value (DR(j), DI(j)), SELECT(j) must be set to .TRUE.. 
+c          Ritz value (DR(j), DI(j)), SELECT(j) must be set to .TRUE..
 c          If HOWMNY = 'A' or 'P', SELECT is used as internal workspace.
 c
 c  DR      Double precision array of dimension NEV+1.  (OUTPUT)
-c          If IPARAM(7) = 1,2 or 3 and SIGMAI=0.0  then on exit: DR contains 
-c          the real part of the Ritz  approximations to the eigenvalues of 
-c          A*z = lambda*B*z. 
+c          If IPARAM(7) = 1,2 or 3 and SIGMAI=0.0  then on exit: DR contains
+c          the real part of the Ritz  approximations to the eigenvalues of
+c          A*z = lambda*B*z.
 c          If IPARAM(7) = 3, 4 and SIGMAI is not equal to zero, then on exit:
-c          DR contains the real part of the Ritz values of OP computed by 
+c          DR contains the real part of the Ritz values of OP computed by
 c          DNAUPD. A further computation must be performed by the user
 c          to transform the Ritz values computed for OP by DNAUPD to those
 c          of the original system A*z = lambda*B*z. See remark 3 below.
 c
 c  DI      Double precision array of dimension NEV+1.  (OUTPUT)
-c          On exit, DI contains the imaginary part of the Ritz value 
+c          On exit, DI contains the imaginary part of the Ritz value
 c          approximations to the eigenvalues of A*z = lambda*B*z associated
 c          with DR.
 c
-c          NOTE: When Ritz values are complex, they will come in complex 
-c                conjugate pairs.  If eigenvectors are requested, the 
-c                corresponding Ritz vectors will also come in conjugate 
-c                pairs and the real and imaginary parts of these are 
-c                represented in two consecutive columns of the array Z 
+c          NOTE: When Ritz values are complex, they will come in complex
+c                conjugate pairs.  If eigenvectors are requested, the
+c                corresponding Ritz vectors will also come in conjugate
+c                pairs and the real and imaginary parts of these are
+c                represented in two consecutive columns of the array Z
 c                (see below).
 c
 c  Z       Double precision N by NEV+1 array if RVEC = .TRUE. and HOWMNY = 'A'. (OUTPUT)
-c          On exit, if RVEC = .TRUE. and HOWMNY = 'A', then the columns of 
-c          Z represent approximate eigenvectors (Ritz vectors) corresponding 
-c          to the NCONV=IPARAM(5) Ritz values for eigensystem 
-c          A*z = lambda*B*z. 
-c 
-c          The complex Ritz vector associated with the Ritz value 
-c          with positive imaginary part is stored in two consecutive 
-c          columns.  The first column holds the real part of the Ritz 
-c          vector and the second column holds the imaginary part.  The 
-c          Ritz vector associated with the Ritz value with negative 
-c          imaginary part is simply the complex conjugate of the Ritz vector 
+c          On exit, if RVEC = .TRUE. and HOWMNY = 'A', then the columns of
+c          Z represent approximate eigenvectors (Ritz vectors) corresponding
+c          to the NCONV=IPARAM(5) Ritz values for eigensystem
+c          A*z = lambda*B*z.
+c
+c          The complex Ritz vector associated with the Ritz value
+c          with positive imaginary part is stored in two consecutive
+c          columns.  The first column holds the real part of the Ritz
+c          vector and the second column holds the imaginary part.  The
+c          Ritz vector associated with the Ritz value with negative
+c          imaginary part is simply the complex conjugate of the Ritz vector
 c          associated with the positive imaginary part.
 c
 c          If  RVEC = .FALSE. or HOWMNY = 'P', then Z is not referenced.
@@ -114,11 +114,11 @@ c          The leading dimension of the array Z.  If Ritz vectors are
 c          desired, then  LDZ >= max( 1, N ).  In any case,  LDZ >= 1.
 c
 c  SIGMAR  Double precision  (INPUT)
-c          If IPARAM(7) = 3 or 4, represents the real part of the shift. 
+c          If IPARAM(7) = 3 or 4, represents the real part of the shift.
 c          Not referenced if IPARAM(7) = 1 or 2.
 c
 c  SIGMAI  Double precision  (INPUT)
-c          If IPARAM(7) = 3 or 4, represents the imaginary part of the shift. 
+c          If IPARAM(7) = 3 or 4, represents the imaginary part of the shift.
 c          Not referenced if IPARAM(7) = 1 or 2. See remark 3 below.
 c
 c  WORKEV  Double precision work array of dimension 3*NCV.  (WORKSPACE)
@@ -183,10 +183,10 @@ c          =  0: Normal exit.
 c
 c          =  1: The Schur form computed by LAPACK routine dlahqr
 c                could not be reordered by LAPACK routine dtrsen.
-c                Re-enter subroutine dneupd with IPARAM(5)=NCV and 
-c                increase the size of the arrays DR and DI to have 
-c                dimension at least dimension NCV and allocate at least NCV 
-c                columns for Z. NOTE: Not necessary if Z and V share 
+c                Re-enter subroutine dneupd with IPARAM(5)=NCV and
+c                increase the size of the arrays DR and DI to have
+c                dimension at least dimension NCV and allocate at least NCV
+c                columns for Z. NOTE: Not necessary if Z and V share
 c                the same space. Please notify the authors if this error
 c                occurs.
 c
@@ -213,7 +213,7 @@ c\References:
 c  1. D.C. Sorensen, "Implicit Application of Polynomial Filters in
 c     a k-Step Arnoldi Method", SIAM J. Matr. Anal. Apps., 13 (1992),
 c     pp 357-385.
-c  2. R.B. Lehoucq, "Analysis and Implementation of an Implicitly 
+c  2. R.B. Lehoucq, "Analysis and Implementation of an Implicitly
 c     Restarted Arnoldi Iteration", Rice University Technical Report
 c     TR95-13, Department of Computational and Applied Mathematics.
 c  3. B.N. Parlett & Y. Saad, "Complex Shift and Invert Strategies for
@@ -224,7 +224,7 @@ c\Routines called:
 c     ivout   ARPACK utility routine that prints integers.
 c     dmout   ARPACK utility routine that prints matrices
 c     dvout   ARPACK utility routine that prints vectors.
-c     dgeqr2  LAPACK routine that computes the QR factorization of 
+c     dgeqr2  LAPACK routine that computes the QR factorization of
 c             a matrix.
 c     dlacpy  LAPACK matrix copy routine.
 c     dlahqr  LAPACK routine to compute the real Schur form of an
@@ -232,7 +232,7 @@ c             upper Hessenberg matrix.
 c     dlamch  LAPACK routine that determines machine constants.
 c     dlapy2  LAPACK routine to compute sqrt(x**2+y**2) carefully.
 c     dlaset  LAPACK matrix initialization routine.
-c     dorm2r  LAPACK routine that applies an orthogonal matrix in 
+c     dorm2r  LAPACK routine that applies an orthogonal matrix in
 c             factored form.
 c     dtrevc  LAPACK routine to compute the eigenvectors of a matrix
 c             in upper quasi-triangular form.
@@ -255,9 +255,9 @@ c     Ritz vectors. Thus, their numerical properties are often superior.
 c     If RVEC = .TRUE. then the relationship
 c             A * V(:,1:IPARAM(5)) = V(:,1:IPARAM(5)) * T, and
 c     V(:,1:IPARAM(5))' * V(:,1:IPARAM(5)) = I are approximately satisfied.
-c     Here T is the leading submatrix of order IPARAM(5) of the real 
+c     Here T is the leading submatrix of order IPARAM(5) of the real
 c     upper quasi-triangular matrix stored workl(ipntr(12)). That is,
-c     T is block upper triangular with 1-by-1 and 2-by-2 diagonal blocks; 
+c     T is block upper triangular with 1-by-1 and 2-by-2 diagonal blocks;
 c     each 2-by-2 diagonal block has its diagonal elements equal and its
 c     off-diagonal elements of opposite sign.  Corresponding to each 2-by-2
 c     diagonal block is a complex conjugate pair of Ritz values. The real
@@ -265,11 +265,11 @@ c     Ritz values are stored on the diagonal of T.
 c
 c  3. If IPARAM(7) = 3 or 4 and SIGMAI is not equal zero, then the user must
 c     form the IPARAM(5) Rayleigh quotients in order to transform the Ritz
-c     values computed by DNAUPD for OP to those of A*z = lambda*B*z. 
+c     values computed by DNAUPD for OP to those of A*z = lambda*B*z.
 c     Set RVEC = .true. and HOWMNY = 'A', and
-c     compute 
+c     compute
 c           Z(:,I)' * A * Z(:,I) if DI(I) = 0.
-c     If DI(I) is not equal to zero and DI(I+1) = - D(I), 
+c     If DI(I) is not equal to zero and DI(I+1) = - D(I),
 c     then the desired real and imaginary parts of the Ritz value are
 c           Z(:,I)' * A * Z(:,I) +  Z(:,I+1)' * A * Z(:,I+1),
 c           Z(:,I)' * A * Z(:,I+1) -  Z(:,I+1)' * A * Z(:,I), respectively.
@@ -280,22 +280,22 @@ c     2 above.
 c
 c\Authors
 c     Danny Sorensen               Phuong Vu
-c     Richard Lehoucq              CRPC / Rice University 
+c     Richard Lehoucq              CRPC / Rice University
 c     Chao Yang                    Houston, Texas
 c     Dept. of Computational &
-c     Applied Mathematics          
-c     Rice University           
-c     Houston, Texas            
-c 
-c\SCCS Information: @(#) 
-c FILE: neupd.F   SID: 2.5   DATE OF SID: 7/31/96   RELEASE: 2 
+c     Applied Mathematics
+c     Rice University
+c     Houston, Texas
+c
+c\SCCS Information: @(#)
+c FILE: neupd.F   SID: 2.5   DATE OF SID: 7/31/96   RELEASE: 2
 c
 c\EndLib
 c
 c-----------------------------------------------------------------------
-      subroutine dneupd (rvec, howmny, select, dr, di, z, ldz, sigmar, 
-     &                   sigmai, workev, bmat, n, which, nev, tol, 
-     &                   resid, ncv, v, ldv, iparam, ipntr, workd, 
+      subroutine dneupd (rvec, howmny, select, dr, di, z, ldz, sigmar,
+     &                   sigmai, workev, bmat, n, which, nev, tol,
+     &                   resid, ncv, v, ldv, iparam, ipntr, workd,
      &                   workl, lworkl, info)
 c
 c     %----------------------------------------------------%
@@ -312,7 +312,7 @@ c
       character  bmat, howmny, which*2
       logical    rvec
       integer    info, ldz, ldv, lworkl, n, ncv, nev
-      Double precision     
+      Double precision
      &           sigmar, sigmai, tol
 c
 c     %-----------------%
@@ -322,7 +322,7 @@ c
       integer    iparam(11), ipntr(14)
       logical    select(ncv)
       Double precision
-     &           dr(nev+1), di(nev+1), resid(n), v(ldv,ncv), z(ldz,*), 
+     &           dr(nev+1), di(nev+1), resid(n), v(ldv,ncv), z(ldz,*),
      &           workd(3*n), workl(lworkl), workev(3*ncv)
 c
 c     %------------%
@@ -338,8 +338,8 @@ c     | Local Scalars |
 c     %---------------%
 c
       character  type*6
-      integer    bounds, ierr, ih, ihbds, iheigr, iheigi, iconj, nconv, 
-     &           invsub, iuptri, iwev, iwork(1), j, k, ktrord, 
+      integer    bounds, ierr, ih, ihbds, iheigr, iheigi, iconj, nconv,
+     &           invsub, iuptri, iwev, iwork(1), j, k, ktrord,
      &           ldh, ldq, mode, msglvl, outncv, ritzr, ritzi, wri, wrr,
      &           irr, iri, ibd
       logical    reord
@@ -350,7 +350,7 @@ c     %----------------------%
 c     | External Subroutines |
 c     %----------------------%
 c
-      external   dcopy, dger, dgeqr2, dlacpy, dlahqr, dlaset, dmout, 
+      external   dcopy, dger, dgeqr2, dlacpy, dlahqr, dlaset, dmout,
      &           dorm2r, dtrevc, dtrmm, dtrsen, dscal, dvout, ivout
 c
 c     %--------------------%
@@ -370,7 +370,7 @@ c
 c     %-----------------------%
 c     | Executable Statements |
 c     %-----------------------%
-c 
+c
 c     %------------------------%
 c     | Set default parameters |
 c     %------------------------%
@@ -419,7 +419,7 @@ c
       else if (howmny .eq. 'S' ) then
          ierr = -12
       end if
-c     
+c
       if (mode .eq. 1 .or. mode .eq. 2) then
          type = 'REGULR'
       else if (mode .eq. 3 .and. sigmai .eq. zero) then
@@ -428,7 +428,7 @@ c
          type = 'REALPT'
       else if (mode .eq. 4 ) then
          type = 'IMAGPT'
-      else 
+      else
                                               ierr = -10
       end if
       if (mode .eq. 1 .and. bmat .eq. 'G')    ierr = -11
@@ -441,7 +441,7 @@ c
          info = ierr
          go to 9000
       end if
-c 
+c
 c     %--------------------------------------------------------%
 c     | Pointer into WORKL for address of H, RITZ, BOUNDS, Q   |
 c     | etc... and the remaining workspace.                    |
@@ -468,7 +468,7 @@ c     |       associated matrix representation of the invariant   |
 c     |       subspace for H.                                     |
 c     | GRAND total of NCV * ( 3 * NCV + 6 ) locations.           |
 c     %-----------------------------------------------------------%
-c     
+c
       ih     = ipntr(5)
       ritzr  = ipntr(6)
       ritzi  = ipntr(7)
@@ -511,9 +511,9 @@ c     %------------------------------------%
 c
       rnorm = workl(ih+2)
       workl(ih+2) = zero
-c     
+c
       if (rvec) then
-c     
+c
 c        %-------------------------------------------%
 c        | Get converged Ritz value on the boundary. |
 c        | Note: converged Ritz values have been     |
@@ -544,7 +544,7 @@ c        |                                                          |
 c        | 1) For each Ritz value obtained from _neigh, compare it  |
 c        |    with the threshold Ritz value computed above to       |
 c        |    determine whether it is a wanted one.                 |
-c        |                                                          | 
+c        |                                                          |
 c        | 2) If it is wanted, then check the corresponding Ritz    |
 c        |    estimate to see if it has converged.  If it has, set  |
 c        |    correponding entry in the logical array SELECT to     |
@@ -563,7 +563,7 @@ c
             if (which .eq. 'LM') then
                if (dlapy2(workl(irr+j), workl(iri+j))
      &            .ge. thres) then
-                  temp1 = max( eps23, 
+                  temp1 = max( eps23,
      &                         dlapy2( workl(irr+j), workl(iri+j) ) )
                   if (workl(ibd+j) .le. tol*temp1)
      &               select(j+1) = .true.
@@ -607,7 +607,7 @@ c
             end if
             if (j+1 .gt. nconv ) reord = ( select(j+1) .or. reord )
             if (select(j+1)) ktrord = ktrord + 1
- 10      continue 
+ 10      continue
 c
          if (msglvl .gt. 2) then
              call ivout(logfil, 1, [ktrord], ndigit,
@@ -622,19 +622,19 @@ c        | of the upper Hessenberg matrix returned by DNAUPD.        |
 c        | Make a copy of the upper Hessenberg matrix.               |
 c        | Initialize the Schur vector matrix Q to the identity.     |
 c        %-----------------------------------------------------------%
-c     
+c
          call dcopy (ldh*ncv, workl(ih), 1, workl(iuptri), 1)
          call dlaset ('All', ncv, ncv, zero, one, workl(invsub), ldq)
          call dlahqr (.true., .true., ncv, 1, ncv, workl(iuptri), ldh,
-     &        workl(iheigr), workl(iheigi), 1, ncv, 
+     &        workl(iheigr), workl(iheigi), 1, ncv,
      &        workl(invsub), ldq, ierr)
          call dcopy (ncv, workl(invsub+ncv-1), ldq, workl(ihbds), 1)
-c     
+c
          if (ierr .ne. 0) then
             info = -8
             go to 9000
          end if
-c     
+c
          if (msglvl .gt. 1) then
             call dvout (logfil, ncv, workl(iheigr), ndigit,
      &           '_neupd: Real part of the eigenvalues of H')
@@ -646,16 +646,16 @@ c
                call dmout (logfil, ncv, ncv, workl(iuptri), ldh, ndigit,
      &              '_neupd: The upper quasi-triangular matrix ')
             end if
-         end if 
+         end if
 c
          if (reord) then
-c     
+c
 c           %-----------------------------------------------------%
-c           | Reorder the computed upper quasi-triangular matrix. | 
+c           | Reorder the computed upper quasi-triangular matrix. |
 c           %-----------------------------------------------------%
-c     
-            call dtrsen ('None', 'V', select, ncv, workl(iuptri), ldh, 
-     &           workl(invsub), ldq, workl(iheigr), workl(iheigi), 
+c
+            call dtrsen ('None', 'V', select, ncv, workl(iuptri), ldh,
+     &           workl(invsub), ldq, workl(iheigr), workl(iheigi),
      &           nconv, conds, sep, workl(ihbds), ncv, iwork, 1, ierr)
 c
             if (ierr .eq. 1) then
@@ -669,12 +669,12 @@ c
                 call dvout (logfil, ncv, workl(iheigi), ndigit,
      &           '_neupd: Imag part of the eigenvalues of H--reordered')
                 if (msglvl .gt. 3) then
-                   call dmout (logfil, ncv, ncv, workl(iuptri), ldq, 
+                   call dmout (logfil, ncv, ncv, workl(iuptri), ldq,
      &                  ndigit,
      &              '_neupd: Quasi-triangular matrix after re-ordering')
                 end if
             end if
-c     
+c
          end if
 c
 c        %---------------------------------------%
@@ -691,22 +691,22 @@ c        | Place the computed eigenvalues of H into DR and DI |
 c        | if a spectral transformation was not used.         |
 c        %----------------------------------------------------%
 c
-         if (type .eq. 'REGULR') then 
+         if (type .eq. 'REGULR') then
             call dcopy (nconv, workl(iheigr), 1, dr, 1)
             call dcopy (nconv, workl(iheigi), 1, di, 1)
          end if
-c     
+c
 c        %----------------------------------------------------------%
 c        | Compute the QR factorization of the matrix representing  |
 c        | the wanted invariant subspace located in the first NCONV |
 c        | columns of workl(invsub,ldq).                            |
 c        %----------------------------------------------------------%
-c     
-         call dgeqr2 (ncv, nconv, workl(invsub), ldq, workev, 
+c
+         call dgeqr2 (ncv, nconv, workl(invsub), ldq, workev,
      &        workev(ncv+1), ierr)
 c
 c        %---------------------------------------------------------%
-c        | * Postmultiply V by Q using dorm2r.                     |   
+c        | * Postmultiply V by Q using dorm2r.                     |
 c        | * Copy the first NCONV columns of VQ into Z.            |
 c        | * Postmultiply Z by R.                                  |
 c        | The N by NCONV matrix Z is now a matrix representation  |
@@ -716,13 +716,13 @@ c        | The first NCONV columns of V are now approximate Schur  |
 c        | vectors associated with the real upper quasi-triangular |
 c        | matrix of order NCONV in workl(iuptri)                  |
 c        %---------------------------------------------------------%
-c     
+c
          call dorm2r ('Right', 'Notranspose', n, ncv, nconv,
      &        workl(invsub), ldq, workev, v, ldv, workd(n+1), ierr)
          call dlacpy ('All', n, nconv, v, ldv, z, ldz)
 c
          do 20 j=1, nconv
-c     
+c
 c           %---------------------------------------------------%
 c           | Perform both a column and row scaling if the      |
 c           | diagonal element of workl(invsub,ldq) is negative |
@@ -731,21 +731,21 @@ c           | quasi-triangular form of workl(iuptri,ldq)        |
 c           | Note that since Q is orthogonal, R is a diagonal  |
 c           | matrix consisting of plus or minus ones           |
 c           %---------------------------------------------------%
-c     
+c
             if (workl(invsub+(j-1)*ldq+j-1) .lt. zero) then
                call dscal (nconv, -one, workl(iuptri+j-1), ldq)
                call dscal (nconv, -one, workl(iuptri+(j-1)*ldq), 1)
             end if
-c     
+c
  20      continue
-c     
+c
          if (howmny .eq. 'A') then
-c     
+c
 c           %--------------------------------------------%
-c           | Compute the NCONV wanted eigenvectors of T | 
+c           | Compute the NCONV wanted eigenvectors of T |
 c           | located in workl(iuptri,ldq).              |
 c           %--------------------------------------------%
-c     
+c
             do 30 j=1, ncv
                if (j .le. nconv) then
                   select(j) = .true.
@@ -754,7 +754,7 @@ c
                end if
  30         continue
 c
-            call dtrevc ('Right', 'Select', select, ncv, workl(iuptri), 
+            call dtrevc ('Right', 'Select', select, ncv, workl(iuptri),
      &           ldq, vl, 1, workl(invsub), ldq, ncv, outncv, workev,
      &           ierr)
 c
@@ -762,7 +762,7 @@ c
                 info = -9
                 go to 9000
             end if
-c     
+c
 c           %------------------------------------------------%
 c           | Scale the returning eigenvectors so that their |
 c           | Euclidean norms are all one. LAPACK subroutine |
@@ -770,22 +770,22 @@ c           | dtrevc returns each eigenvector normalized so  |
 c           | that the element of largest magnitude has      |
 c           | magnitude 1;                                   |
 c           %------------------------------------------------%
-c     
+c
             iconj = 0
             do 40 j=1, nconv
 c
                if ( workl(iheigi+j-1) .eq. zero ) then
-c     
+c
 c                 %----------------------%
 c                 | real eigenvalue case |
 c                 %----------------------%
-c     
+c
                   temp = dnrm2( ncv, workl(invsub+(j-1)*ldq), 1 )
-                  call dscal ( ncv, one / temp, 
+                  call dscal ( ncv, one / temp,
      &                 workl(invsub+(j-1)*ldq), 1 )
 c
                else
-c     
+c
 c                 %-------------------------------------------%
 c                 | Complex conjugate pair case. Note that    |
 c                 | since the real and imaginary part of      |
@@ -795,11 +795,11 @@ c                 | square root of two.                       |
 c                 %-------------------------------------------%
 c
                   if (iconj .eq. 0) then
-                     temp = dlapy2( dnrm2( ncv, workl(invsub+(j-1)*ldq), 
-     &                      1 ), dnrm2( ncv, workl(invsub+j*ldq),  1) )  
-                     call dscal ( ncv, one / temp, 
+                     temp = dlapy2( dnrm2( ncv, workl(invsub+(j-1)*ldq),
+     &                      1 ), dnrm2( ncv, workl(invsub+j*ldq),  1) )
+                     call dscal ( ncv, one / temp,
      &                      workl(invsub+(j-1)*ldq), 1 )
-                     call dscal ( ncv, one / temp, 
+                     call dscal ( ncv, one / temp,
      &                      workl(invsub+j*ldq), 1 )
                      iconj = 1
                   else
@@ -839,7 +839,7 @@ c
                call dvout (logfil, ncv, workl(ihbds), ndigit,
      &              '_neupd: Last row of the eigenvector matrix for T')
                if (msglvl .gt. 3) then
-                  call dmout (logfil, ncv, ncv, workl(invsub), ldq, 
+                  call dmout (logfil, ncv, ncv, workl(invsub), ldq,
      &                 ndigit, '_neupd: The eigenvector matrix for T')
                end if
             end if
@@ -855,27 +855,27 @@ c           | Compute the QR factorization of the eigenvector matrix  |
 c           | associated with leading portion of T in the first NCONV |
 c           | columns of workl(invsub,ldq).                           |
 c           %---------------------------------------------------------%
-c     
-            call dgeqr2 (ncv, nconv, workl(invsub), ldq, workev, 
+c
+            call dgeqr2 (ncv, nconv, workl(invsub), ldq, workev,
      &                   workev(ncv+1), ierr)
-c     
+c
 c           %----------------------------------------------%
-c           | * Postmultiply Z by Q.                       |   
+c           | * Postmultiply Z by Q.                       |
 c           | * Postmultiply Z by R.                       |
-c           | The N by NCONV matrix Z is now contains the  | 
+c           | The N by NCONV matrix Z is now contains the  |
 c           | Ritz vectors associated with the Ritz values |
 c           | in workl(iheigr) and workl(iheigi).          |
 c           %----------------------------------------------%
-c     
+c
             call dorm2r ('Right', 'Notranspose', n, ncv, nconv,
      &           workl(invsub), ldq, workev, z, ldz, workd(n+1), ierr)
-c     
+c
             call dtrmm ('Right', 'Upper', 'No transpose', 'Non-unit',
      &                  n, nconv, one, workl(invsub), ldq, z, ldz)
-c     
+c
          end if
-c     
-      else 
+c
+      else
 c
 c        %------------------------------------------------------%
 c        | An approximate invariant subspace is not needed.     |
@@ -888,7 +888,7 @@ c
          call dcopy (nconv, workl(ritzi), 1, workl(iheigi), 1)
          call dcopy (nconv, workl(bounds), 1, workl(ihbds), 1)
       end if
-c 
+c
 c     %------------------------------------------------%
 c     | Transform the Ritz values and possibly vectors |
 c     | and corresponding error bounds of OP to those  |
@@ -897,26 +897,26 @@ c     %------------------------------------------------%
 c
       if (type .eq. 'REGULR') then
 c
-         if (rvec) 
-     &      call dscal (ncv, rnorm, workl(ihbds), 1)     
-c     
-      else 
-c     
+         if (rvec)
+     &      call dscal (ncv, rnorm, workl(ihbds), 1)
+c
+      else
+c
 c        %---------------------------------------%
 c        |   A spectral transformation was used. |
 c        | * Determine the Ritz estimates of the |
 c        |   Ritz values in the original system. |
 c        %---------------------------------------%
-c     
+c
          if (type .eq. 'SHIFTI') then
 c
-            if (rvec) 
+            if (rvec)
      &         call dscal (ncv, rnorm, workl(ihbds), 1)
 c
             do 50 k=1, ncv
-               temp = dlapy2( workl(iheigr+k-1), 
+               temp = dlapy2( workl(iheigr+k-1),
      &                        workl(iheigi+k-1) )
-               workl(ihbds+k-1) = abs( workl(ihbds+k-1) ) 
+               workl(ihbds+k-1) = abs( workl(ihbds+k-1) )
      &                          / temp / temp
  50         continue
 c
@@ -931,26 +931,26 @@ c
  70         continue
 c
          end if
-c     
+c
 c        %-----------------------------------------------------------%
 c        | *  Transform the Ritz values back to the original system. |
 c        |    For TYPE = 'SHIFTI' the transformation is              |
 c        |             lambda = 1/theta + sigma                      |
 c        |    For TYPE = 'REALPT' or 'IMAGPT' the user must from     |
-c        |    Rayleigh quotients or a projection. See remark 3 above.| 
+c        |    Rayleigh quotients or a projection. See remark 3 above.|
 c        | NOTES:                                                    |
 c        | *The Ritz vectors are not affected by the transformation. |
 c        %-----------------------------------------------------------%
-c     
-         if (type .eq. 'SHIFTI') then 
+c
+         if (type .eq. 'SHIFTI') then
 c
             do 80 k=1, ncv
-               temp = dlapy2( workl(iheigr+k-1), 
+               temp = dlapy2( workl(iheigr+k-1),
      &                        workl(iheigi+k-1) )
-               workl(iheigr+k-1) = workl(iheigr+k-1) / temp / temp 
-     &                           + sigmar   
+               workl(iheigr+k-1) = workl(iheigr+k-1) / temp / temp
+     &                           + sigmar
                workl(iheigi+k-1) = -workl(iheigi+k-1) / temp / temp
-     &                           + sigmai   
+     &                           + sigmai
  80         continue
 c
             call dcopy (nconv, workl(iheigr), 1, dr, 1)
@@ -980,7 +980,7 @@ c
          call dvout (logfil, nconv, workl(ihbds), ndigit,
      &   '_neupd: Associated Ritz estimates.')
       end if
-c 
+c
 c     %-------------------------------------------------%
 c     | Eigenvector Purification step. Formally perform |
 c     | one of inverse subspace iteration. Only used    |
@@ -1007,13 +1007,13 @@ c
      &                      workl(iheigr+j-1)
             else if (iconj .eq. 0) then
                temp = dlapy2( workl(iheigr+j-1), workl(iheigi+j-1) )
-               workev(j) = ( workl(invsub+(j-1)*ldq+ncv-1) * 
+               workev(j) = ( workl(invsub+(j-1)*ldq+ncv-1) *
      &                       workl(iheigr+j-1) +
-     &                       workl(invsub+j*ldq+ncv-1) * 
+     &                       workl(invsub+j*ldq+ncv-1) *
      &                       workl(iheigi+j-1) ) / temp / temp
-               workev(j+1) = ( workl(invsub+j*ldq+ncv-1) * 
+               workev(j+1) = ( workl(invsub+j*ldq+ncv-1) *
      &                         workl(iheigr+j-1) -
-     &                         workl(invsub+(j-1)*ldq+ncv-1) * 
+     &                         workl(invsub+(j-1)*ldq+ncv-1) *
      &                         workl(iheigi+j-1) ) / temp / temp
                iconj = 1
             else
@@ -1033,7 +1033,7 @@ c
  9000 continue
 c
       return
-c     
+c
 c     %---------------%
 c     | End of DNEUPD |
 c     %---------------%

--- a/mathlibs/src/arpack/dneupd.f
+++ b/mathlibs/src/arpack/dneupd.f
@@ -532,7 +532,7 @@ c
          end if
 c
          if (msglvl .gt. 2) then
-            call dvout(logfil, 1, thres, ndigit,
+            call dvout(logfil, 1, [thres], ndigit,
      &           '_neupd: Threshold eigenvalue used for re-ordering')
          end if
 c
@@ -610,9 +610,9 @@ c
  10      continue 
 c
          if (msglvl .gt. 2) then
-             call ivout(logfil, 1, ktrord, ndigit,
+             call ivout(logfil, 1, [ktrord], ndigit,
      &            '_neupd: Number of specified eigenvalues')
-             call ivout(logfil, 1, nconv, ndigit,
+             call ivout(logfil, 1, [nconv], ndigit,
      &            '_neupd: Number of "converged" eigenvalues')
          end if
 c

--- a/mathlibs/src/arpack/dngets.f
+++ b/mathlibs/src/arpack/dngets.f
@@ -212,8 +212,8 @@ c
       tngets = tngets + (t1 - t0)
 c
       if (msglvl .gt. 0) then
-         call ivout (logfil, 1, kev, ndigit, '_ngets: KEV is')
-         call ivout (logfil, 1, np, ndigit, '_ngets: NP is')
+         call ivout (logfil, 1, [kev], ndigit, '_ngets: KEV is')
+         call ivout (logfil, 1, [np], ndigit, '_ngets: NP is')
          call dvout (logfil, kev+np, ritzr, ndigit,
      &        '_ngets: Eigenvalues of current H matrix -- real part')
          call dvout (logfil, kev+np, ritzi, ndigit,

--- a/mathlibs/src/arpack/dngets.f
+++ b/mathlibs/src/arpack/dngets.f
@@ -3,9 +3,9 @@ c\BeginDoc
 c
 c\Name: dngets
 c
-c\Description: 
+c\Description:
 c  Given the eigenvalues of the upper Hessenberg matrix H,
-c  computes the NP shifts AMU that are zeros of the polynomial of 
+c  computes the NP shifts AMU that are zeros of the polynomial of
 c  degree NP which filters out components of the unwanted eigenvectors
 c  corresponding to the AMU's based on some given criteria.
 c
@@ -42,12 +42,12 @@ c           OUTPUT: Possibly decreases NP by one to keep complex conjugate
 c           pairs together.
 c
 c  RITZR,  Double precision array of length KEV+NP.  (INPUT/OUTPUT)
-c  RITZI   On INPUT, RITZR and RITZI contain the real and imaginary 
+c  RITZI   On INPUT, RITZR and RITZI contain the real and imaginary
 c          parts of the eigenvalues of H.
 c          On OUTPUT, RITZR and RITZI are sorted so that the unwanted
 c          eigenvalues are in the first NP locations and the wanted
-c          portion is in the last KEV locations.  When exact shifts are 
-c          selected, the unwanted part corresponds to the shifts to 
+c          portion is in the last KEV locations.  When exact shifts are
+c          selected, the unwanted part corresponds to the shifts to
 c          be applied. Also, if ISHIFT .eq. 1, the unwanted eigenvalues
 c          are further sorted so that the ones with largest Ritz values
 c          are first.
@@ -56,7 +56,7 @@ c  BOUNDS  Double precision array of length KEV+NP.  (INPUT/OUTPUT)
 c          Error bounds corresponding to the ordering in RITZ.
 c
 c  SHIFTR, SHIFTI  *** USE deprecated as of version 2.1. ***
-c  
+c
 c
 c\EndDoc
 c
@@ -76,13 +76,13 @@ c     Danny Sorensen               Phuong Vu
 c     Richard Lehoucq              CRPC / Rice University
 c     Dept. of Computational &     Houston, Texas
 c     Applied Mathematics
-c     Rice University           
-c     Houston, Texas    
+c     Rice University
+c     Houston, Texas
 c
 c\Revision history:
 c     xx/xx/92: Version ' 2.1'
 c
-c\SCCS Information: @(#) 
+c\SCCS Information: @(#)
 c FILE: ngets.F   SID: 2.3   DATE OF SID: 4/20/96   RELEASE: 2
 c
 c\Remarks
@@ -114,7 +114,7 @@ c     | Array Arguments |
 c     %-----------------%
 c
       Double precision
-     &           bounds(kev+np), ritzr(kev+np), ritzi(kev+np), 
+     &           bounds(kev+np), ritzr(kev+np), ritzi(kev+np),
      &           shiftr(1), shifti(1)
 c
 c     %------------%
@@ -151,10 +151,10 @@ c     %-------------------------------%
 c     | Initialize timing statistics  |
 c     | & message level for debugging |
 c     %-------------------------------%
-c 
+c
       call second (t0)
       msglvl = mngets
-c 
+c
 c     %----------------------------------------------------%
 c     | LM, SM, LR, SR, LI, SI case.                       |
 c     | Sort the eigenvalues of H into the desired order   |
@@ -178,16 +178,16 @@ c
       else if (which .eq. 'SI') then
          call dsortc ('SM', .true., kev+np, ritzr, ritzi, bounds)
       end if
-c      
+c
       call dsortc (which, .true., kev+np, ritzr, ritzi, bounds)
-c     
+c
 c     %-------------------------------------------------------%
 c     | Increase KEV by one if the ( ritzr(np),ritzi(np) )    |
 c     | = ( ritzr(np+1),-ritzi(np+1) ) and ritz(np) .ne. zero |
 c     | Accordingly decrease NP by one. In other words keep   |
 c     | complex conjugate pairs together.                     |
 c     %-------------------------------------------------------%
-c     
+c
       if (       ( ritzr(np+1) - ritzr(np) ) .eq. zero
      &     .and. ( ritzi(np+1) + ritzi(np) ) .eq. zero ) then
          np = np - 1
@@ -195,7 +195,7 @@ c
       end if
 c
       if ( ishift .eq. 1 ) then
-c     
+c
 c        %-------------------------------------------------------%
 c        | Sort the unwanted Ritz values used as shifts so that  |
 c        | the ones with largest Ritz estimates are first        |
@@ -204,10 +204,10 @@ c        | forward instability of the iteration when they shifts |
 c        | are applied in subroutine dnapps.                     |
 c        | Be careful and use 'SR' since we want to sort BOUNDS! |
 c        %-------------------------------------------------------%
-c     
+c
          call dsortc ( 'SR', .true., np, bounds, ritzr, ritzi )
       end if
-c     
+c
       call second (t1)
       tngets = tngets + (t1 - t0)
 c
@@ -218,14 +218,14 @@ c
      &        '_ngets: Eigenvalues of current H matrix -- real part')
          call dvout (logfil, kev+np, ritzi, ndigit,
      &        '_ngets: Eigenvalues of current H matrix -- imag part')
-         call dvout (logfil, kev+np, bounds, ndigit, 
+         call dvout (logfil, kev+np, bounds, ndigit,
      &      '_ngets: Ritz estimates of the current KEV+NP Ritz values')
       end if
-c     
+c
       return
-c     
+c
 c     %---------------%
 c     | End of dngets |
 c     %---------------%
-c     
+c
       end

--- a/mathlibs/src/arpack/dsaitr.f
+++ b/mathlibs/src/arpack/dsaitr.f
@@ -364,9 +364,9 @@ c
  1000 continue
 c
          if (msglvl .gt. 2) then
-            call ivout (logfil, 1, j, ndigit, 
+            call ivout (logfil, 1, [j], ndigit, 
      &                  '_saitr: generating Arnoldi vector no.')
-            call dvout (logfil, 1, rnorm, ndigit, 
+            call dvout (logfil, 1, [rnorm], ndigit, 
      &                  '_saitr: B-norm of the current residual =')
          end if
 c 
@@ -384,7 +384,7 @@ c           | basis and continue the iteration.                 |
 c           %---------------------------------------------------%
 c
             if (msglvl .gt. 0) then
-               call ivout (logfil, 1, j, ndigit,
+               call ivout (logfil, 1, [j], ndigit,
      &                     '_saitr: ****** restart at step ******')
             end if
 c 
@@ -735,7 +735,7 @@ c
          end if
 c
          if (msglvl .gt. 0 .and. iter .gt. 0) then
-            call ivout (logfil, 1, j, ndigit,
+            call ivout (logfil, 1, [j], ndigit,
      &           '_saitr: Iterative refinement for Arnoldi residual')
             if (msglvl .gt. 2) then
                 xtemp(1) = rnorm

--- a/mathlibs/src/arpack/dsaitr.f
+++ b/mathlibs/src/arpack/dsaitr.f
@@ -3,8 +3,8 @@ c\BeginDoc
 c
 c\Name: dsaitr
 c
-c\Description: 
-c  Reverse communication interface for applying NP additional steps to 
+c\Description:
+c  Reverse communication interface for applying NP additional steps to
 c  a K step symmetric Arnoldi factorization.
 c
 c  Input:  OP*V_{k}  -  V_{k}*H = r_{k}*e_{k}^T
@@ -20,7 +20,7 @@ c  computed and returned.
 c
 c\Usage:
 c  call dsaitr
-c     ( IDO, BMAT, N, K, NP, MODE, RESID, RNORM, V, LDV, H, LDH, 
+c     ( IDO, BMAT, N, K, NP, MODE, RESID, RNORM, V, LDV, H, LDH,
 c       IPNTR, WORKD, INFO )
 c
 c\Arguments
@@ -76,13 +76,13 @@ c          On INPUT the B-norm of r_{k}.
 c          On OUTPUT the B-norm of the updated residual r_{k+p}.
 c
 c  V       Double precision N by K+NP array.  (INPUT/OUTPUT)
-c          On INPUT:  V contains the Arnoldi vectors in the first K 
+c          On INPUT:  V contains the Arnoldi vectors in the first K
 c          columns.
 c          On OUTPUT: V contains the new NP Arnoldi vectors in the next
 c          NP columns.  The first K columns are unchanged.
 c
 c  LDV     Integer.  (INPUT)
-c          Leading dimension of V exactly as declared in the calling 
+c          Leading dimension of V exactly as declared in the calling
 c          program.
 c
 c  H       Double precision (K+NP) by 2 array.  (INPUT/OUTPUT)
@@ -91,26 +91,26 @@ c          with the subdiagonal in the first column starting at H(2,1)
 c          and the main diagonal in the second column.
 c
 c  LDH     Integer.  (INPUT)
-c          Leading dimension of H exactly as declared in the calling 
+c          Leading dimension of H exactly as declared in the calling
 c          program.
 c
 c  IPNTR   Integer array of length 3.  (OUTPUT)
-c          Pointer to mark the starting locations in the WORK for 
+c          Pointer to mark the starting locations in the WORK for
 c          vectors used by the Arnoldi iteration.
 c          -------------------------------------------------------------
 c          IPNTR(1): pointer to the current operand vector X.
 c          IPNTR(2): pointer to the current result vector Y.
-c          IPNTR(3): pointer to the vector B * X when used in the 
+c          IPNTR(3): pointer to the vector B * X when used in the
 c                    shift-and-invert mode.  X is the current operand.
 c          -------------------------------------------------------------
-c          
+c
 c  WORKD   Double precision work array of length 3*N.  (REVERSE COMMUNICATION)
 c          Distributed array to be used in the basic Arnoldi iteration
-c          for reverse communication.  The calling program should not 
+c          for reverse communication.  The calling program should not
 c          use WORKD as temporary workspace during the iteration !!!!!!
 c          On INPUT, WORKD(1:N) = B*RESID where RESID is associated
-c          with the K step Arnoldi factorization. Used to save some 
-c          computation at the first step. 
+c          with the K step Arnoldi factorization. Used to save some
+c          computation at the first step.
 c          On OUTPUT, WORKD(1:N) = B*RESID where RESID is associated
 c          with the K+NP step Arnoldi factorization.
 c
@@ -139,7 +139,7 @@ c     dgemv   Level 2 BLAS routine for matrix vector multiplication.
 c     daxpy   Level 1 BLAS that computes a vector triad.
 c     dscal   Level 1 BLAS that scales a vector.
 c     dcopy   Level 1 BLAS that copies one vector to another .
-c     ddot    Level 1 BLAS that computes the scalar product of two vectors. 
+c     ddot    Level 1 BLAS that computes the scalar product of two vectors.
 c     dnrm2   Level 1 BLAS that computes the norm of a vector.
 c
 c\Author
@@ -147,29 +147,29 @@ c     Danny Sorensen               Phuong Vu
 c     Richard Lehoucq              CRPC / Rice University
 c     Dept. of Computational &     Houston, Texas
 c     Applied Mathematics
-c     Rice University           
-c     Houston, Texas            
-c 
+c     Rice University
+c     Houston, Texas
+c
 c\Revision history:
 c     xx/xx/93: Version ' 2.4'
 c
-c\SCCS Information: @(#) 
+c\SCCS Information: @(#)
 c FILE: saitr.F   SID: 2.6   DATE OF SID: 8/28/96   RELEASE: 2
 c
 c\Remarks
 c  The algorithm implemented is:
-c  
+c
 c  restart = .false.
-c  Given V_{k} = [v_{1}, ..., v_{k}], r_{k}; 
+c  Given V_{k} = [v_{1}, ..., v_{k}], r_{k};
 c  r_{k} contains the initial residual vector even for k = 0;
-c  Also assume that rnorm = || B*r_{k} || and B*r_{k} are already 
+c  Also assume that rnorm = || B*r_{k} || and B*r_{k} are already
 c  computed by the calling program.
 c
 c  betaj = rnorm ; p_{k+1} = B*r_{k} ;
 c  For  j = k+1, ..., k+np  Do
 c     1) if ( betaj < tol ) stop or restart depending on j.
 c        if ( restart ) generate a new starting vector.
-c     2) v_{j} = r(j-1)/betaj;  V_{j} = [V_{j-1}, v_{j}];  
+c     2) v_{j} = r(j-1)/betaj;  V_{j} = [V_{j-1}, v_{j}];
 c        p_{j} = p_{j}/betaj
 c     3) r_{j} = OP*v_{j} where OP is defined as in dsaupd
 c        For shift-invert mode p_{j} = B*v_{j} is already available.
@@ -184,7 +184,7 @@ c        If (rnorm > 0.717*wnorm) accept step and go back to 1)
 c     5) Re-orthogonalization step:
 c        s = V_{j}'*B*r_{j}
 c        r_{j} = r_{j} - V_{j}*s;  rnorm1 = || r_{j} ||
-c        alphaj = alphaj + s_{j};   
+c        alphaj = alphaj + s_{j};
 c     6) Iterative refinement step:
 c        If (rnorm1 > 0.717*rnorm) then
 c           rnorm = rnorm1
@@ -194,7 +194,7 @@ c           rnorm = rnorm1
 c           If this is the first time in step 6), go to 5)
 c           Else r_{j} lies in the span of V_{j} numerically.
 c              Set r_{j} = 0 and rnorm = 0; go to 1)
-c        EndIf 
+c        EndIf
 c  End Do
 c
 c\EndLib
@@ -202,7 +202,7 @@ c
 c-----------------------------------------------------------------------
 c
       subroutine dsaitr
-     &   (ido, bmat, n, k, np, mode, resid, rnorm, v, ldv, h, ldh, 
+     &   (ido, bmat, n, k, np, mode, resid, rnorm, v, ldv, h, ldh,
      &    ipntr, workd, info)
 c
 c     %----------------------------------------------------%
@@ -242,7 +242,7 @@ c     | Local Scalars |
 c     %---------------%
 c
       logical    first, orth1, orth2, rstart, step3, step4
-      integer    i, ierr, ipj, irj, ivj, iter, itry, j, msglvl, 
+      integer    i, ierr, ipj, irj, ivj, iter, itry, j, msglvl,
      &           infol, jj
       Double precision
      &           rnorm1, wnorm, safmin, temp1
@@ -251,7 +251,7 @@ c
      &           rnorm1, safmin, wnorm
 c
 c     %-----------------------%
-c     | Local Array Arguments | 
+c     | Local Array Arguments |
 c     %-----------------------%
 c
       Double precision
@@ -294,7 +294,7 @@ c
       end if
 c
       if (ido .eq. 0) then
-c 
+c
 c        %-------------------------------%
 c        | Initialize timing statistics  |
 c        | & message level for debugging |
@@ -302,7 +302,7 @@ c        %-------------------------------%
 c
          call second (t0)
          msglvl = msaitr
-c 
+c
 c        %------------------------------%
 c        | Initial call to this routine |
 c        %------------------------------%
@@ -313,14 +313,14 @@ c
          rstart = .false.
          orth1  = .false.
          orth2  = .false.
-c 
+c
 c        %--------------------------------%
 c        | Pointer to the current step of |
 c        | the factorization to build     |
 c        %--------------------------------%
 c
          j      = k + 1
-c 
+c
 c        %------------------------------------------%
 c        | Pointers used for reverse communication  |
 c        | when using WORKD.                        |
@@ -330,7 +330,7 @@ c
          irj    = ipj   + n
          ivj    = irj   + n
       end if
-c 
+c
 c     %-------------------------------------------------%
 c     | When in reverse communication mode one of:      |
 c     | STEP3, STEP4, ORTH1, ORTH2, RSTART              |
@@ -353,7 +353,7 @@ c
 c     %------------------------------%
 c     | Else this is the first step. |
 c     %------------------------------%
-c 
+c
 c     %--------------------------------------------------------------%
 c     |                                                              |
 c     |        A R N O L D I     I T E R A T I O N     L O O P       |
@@ -364,12 +364,12 @@ c
  1000 continue
 c
          if (msglvl .gt. 2) then
-            call ivout (logfil, 1, [j], ndigit, 
+            call ivout (logfil, 1, [j], ndigit,
      &                  '_saitr: generating Arnoldi vector no.')
-            call dvout (logfil, 1, [rnorm], ndigit, 
+            call dvout (logfil, 1, [rnorm], ndigit,
      &                  '_saitr: B-norm of the current residual =')
          end if
-c 
+c
 c        %---------------------------------------------------------%
 c        | Check for exact zero. Equivalent to determing whether a |
 c        | j-step Arnoldi factorization is present.                |
@@ -387,7 +387,7 @@ c
                call ivout (logfil, 1, [j], ndigit,
      &                     '_saitr: ****** restart at step ******')
             end if
-c 
+c
 c           %---------------------------------------------%
 c           | ITRY is the loop variable that controls the |
 c           | maximum amount of times that a restart is   |
@@ -406,7 +406,7 @@ c           | If in reverse communication mode and |
 c           | RSTART = .true. flow returns here.   |
 c           %--------------------------------------%
 c
-            call dgetv0 (ido, bmat, itry, .false., n, j, v, ldv, 
+            call dgetv0 (ido, bmat, itry, .false., n, j, v, ldv,
      &                   resid, rnorm, ipntr, workd, ierr)
             if (ido .ne. 99) go to 9000
             if (ierr .lt. 0) then
@@ -425,7 +425,7 @@ c
                ido = 99
                go to 9000
             end if
-c 
+c
    40    continue
 c
 c        %---------------------------------------------------------%
@@ -447,12 +447,12 @@ c            | To scale both v_{j} and p_{j} carefully |
 c            | use LAPACK routine SLASCL               |
 c            %-----------------------------------------%
 c
-             call dlascl ('General', i, i, rnorm, one, n, 1, 
+             call dlascl ('General', i, i, rnorm, one, n, 1,
      &                    v(1,j), n, infol)
-             call dlascl ('General', i, i, rnorm, one, n, 1, 
+             call dlascl ('General', i, i, rnorm, one, n, 1,
      &                    workd(ipj), n, infol)
          end if
-c 
+c
 c        %------------------------------------------------------%
 c        | STEP 3:  r_{j} = OP*v_{j}; Note that p_{j} = B*v_{j} |
 c        | Note that this is not quite yet r_{j}. See STEP 4    |
@@ -466,14 +466,14 @@ c
          ipntr(2) = irj
          ipntr(3) = ipj
          ido = 1
-c 
+c
 c        %-----------------------------------%
 c        | Exit in order to compute OP*v_{j} |
 c        %-----------------------------------%
-c 
+c
          go to 9000
    50    continue
-c 
+c
 c        %-----------------------------------%
 c        | Back from reverse communication;  |
 c        | WORKD(IRJ:IRJ+N-1) := OP*v_{j}.   |
@@ -481,7 +481,7 @@ c        %-----------------------------------%
 c
          call second (t3)
          tmvopx = tmvopx + (t3 - t2)
-c 
+c
          step3 = .false.
 c
 c        %------------------------------------------%
@@ -489,7 +489,7 @@ c        | Put another copy of OP*v_{j} into RESID. |
 c        %------------------------------------------%
 c
          call dcopy (n, workd(irj), 1, resid, 1)
-c 
+c
 c        %-------------------------------------------%
 c        | STEP 4:  Finish extending the symmetric   |
 c        |          Arnoldi to length j. If MODE = 2 |
@@ -507,17 +507,17 @@ c
             ipntr(1) = irj
             ipntr(2) = ipj
             ido = 2
-c 
+c
 c           %-------------------------------------%
 c           | Exit in order to compute B*OP*v_{j} |
 c           %-------------------------------------%
-c 
+c
             go to 9000
          else if (bmat .eq. 'I') then
               call dcopy(n, resid, 1 , workd(ipj), 1)
          end if
    60    continue
-c 
+c
 c        %-----------------------------------%
 c        | Back from reverse communication;  |
 c        | WORKD(IPJ:IPJ+N-1) := B*OP*v_{j}. |
@@ -526,7 +526,7 @@ c
          if (bmat .eq. 'G') then
             call second (t3)
             tmvbx = tmvbx + (t3 - t2)
-         end if 
+         end if
 c
          step4 = .false.
 c
@@ -545,7 +545,7 @@ c           %----------------------------------%
 c
             wnorm = ddot (n, resid, 1, workd(ivj), 1)
             wnorm = sqrt(abs(wnorm))
-         else if (bmat .eq. 'G') then         
+         else if (bmat .eq. 'G') then
             wnorm = ddot (n, resid, 1, workd(ipj), 1)
             wnorm = sqrt(abs(wnorm))
          else if (bmat .eq. 'I') then
@@ -567,19 +567,19 @@ c        | WORKD(IPJ:IPJ+N-1) contains B*OP*v_{j}.  |
 c        %------------------------------------------%
 c
          if (mode .ne. 2 ) then
-            call dgemv('T', n, j, one, v, ldv, workd(ipj), 1, zero, 
+            call dgemv('T', n, j, one, v, ldv, workd(ipj), 1, zero,
      &                  workd(irj), 1)
          else if (mode .eq. 2) then
-            call dgemv('T', n, j, one, v, ldv, workd(ivj), 1, zero, 
+            call dgemv('T', n, j, one, v, ldv, workd(ivj), 1, zero,
      &                  workd(irj), 1)
          end if
 c
 c        %--------------------------------------%
 c        | Orthgonalize r_{j} against V_{j}.    |
-c        | RESID contains OP*v_{j}. See STEP 3. | 
+c        | RESID contains OP*v_{j}. See STEP 3. |
 c        %--------------------------------------%
 c
-         call dgemv('N', n, j, -one, v, ldv, workd(irj), 1, one, 
+         call dgemv('N', n, j, -one, v, ldv, workd(irj), 1, one,
      &               resid, 1)
 c
 c        %--------------------------------------%
@@ -593,10 +593,10 @@ c
             h(j,1) = rnorm
          end if
          call second (t4)
-c 
+c
          orth1 = .true.
          iter  = 0
-c 
+c
          call second (t2)
          if (bmat .eq. 'G') then
             nbx = nbx + 1
@@ -604,17 +604,17 @@ c
             ipntr(1) = irj
             ipntr(2) = ipj
             ido = 2
-c 
+c
 c           %----------------------------------%
 c           | Exit in order to compute B*r_{j} |
 c           %----------------------------------%
-c 
+c
             go to 9000
          else if (bmat .eq. 'I') then
             call dcopy (n, resid, 1, workd(ipj), 1)
          end if
    70    continue
-c 
+c
 c        %---------------------------------------------------%
 c        | Back from reverse communication if ORTH1 = .true. |
 c        | WORKD(IPJ:IPJ+N-1) := B*r_{j}.                    |
@@ -624,14 +624,14 @@ c
             call second (t3)
             tmvbx = tmvbx + (t3 - t2)
          end if
-c 
+c
          orth1 = .false.
 c
 c        %------------------------------%
 c        | Compute the B-norm of r_{j}. |
 c        %------------------------------%
 c
-         if (bmat .eq. 'G') then         
+         if (bmat .eq. 'G') then
             rnorm = ddot (n, resid, 1, workd(ipj), 1)
             rnorm = sqrt(abs(rnorm))
          else if (bmat .eq. 'I') then
@@ -655,7 +655,7 @@ c        %-----------------------------------------------------------%
 c
          if (rnorm .gt. 0.717*wnorm) go to 100
          nrorth = nrorth + 1
-c 
+c
 c        %---------------------------------------------------%
 c        | Enter the Iterative refinement phase. If further  |
 c        | refinement is necessary, loop back here. The loop |
@@ -668,7 +668,7 @@ c
          if (msglvl .gt. 2) then
             xtemp(1) = wnorm
             xtemp(2) = rnorm
-            call dvout (logfil, 2, xtemp, ndigit, 
+            call dvout (logfil, 2, xtemp, ndigit,
      &           '_saitr: re-orthonalization ; wnorm and rnorm are')
          end if
 c
@@ -677,7 +677,7 @@ c        | Compute V_{j}^T * B * r_{j}.                       |
 c        | WORKD(IRJ:IRJ+J-1) = v(:,1:J)'*WORKD(IPJ:IPJ+N-1). |
 c        %----------------------------------------------------%
 c
-         call dgemv ('T', n, j, one, v, ldv, workd(ipj), 1, 
+         call dgemv ('T', n, j, one, v, ldv, workd(ipj), 1,
      &               zero, workd(irj), 1)
 c
 c        %----------------------------------------------%
@@ -688,12 +688,12 @@ c        | v(:,1:J)*WORKD(IRJ:IRJ+J-1)*e'_j, but only   |
 c        | H(j,j) is updated.                           |
 c        %----------------------------------------------%
 c
-         call dgemv ('N', n, j, -one, v, ldv, workd(irj), 1, 
+         call dgemv ('N', n, j, -one, v, ldv, workd(irj), 1,
      &               one, resid, 1)
 c
          if (j .eq. 1  .or.  rstart) h(j,1) = zero
          h(j,2) = h(j,2) + workd(irj + j - 1)
-c 
+c
          orth2 = .true.
          call second (t2)
          if (bmat .eq. 'G') then
@@ -702,12 +702,12 @@ c
             ipntr(1) = irj
             ipntr(2) = ipj
             ido = 2
-c 
+c
 c           %-----------------------------------%
 c           | Exit in order to compute B*r_{j}. |
 c           | r_{j} is the corrected residual.  |
 c           %-----------------------------------%
-c 
+c
             go to 9000
          else if (bmat .eq. 'I') then
             call dcopy (n, resid, 1, workd(ipj), 1)
@@ -726,8 +726,8 @@ c
 c        %-----------------------------------------------------%
 c        | Compute the B-norm of the corrected residual r_{j}. |
 c        %-----------------------------------------------------%
-c 
-         if (bmat .eq. 'G') then         
+c
+         if (bmat .eq. 'G') then
              rnorm1 = ddot (n, resid, 1, workd(ipj), 1)
              rnorm1 = sqrt(abs(rnorm1))
          else if (bmat .eq. 'I') then
@@ -744,7 +744,7 @@ c
      &           '_saitr: iterative refinement ; rnorm and rnorm1 are')
             end if
          end if
-c 
+c
 c        %-----------------------------------------%
 c        | Determine if we need to perform another |
 c        | step of re-orthogonalization.           |
@@ -757,7 +757,7 @@ c           | No need for further refinement |
 c           %--------------------------------%
 c
             rnorm = rnorm1
-c 
+c
          else
 c
 c           %-------------------------------------------%
@@ -779,7 +779,7 @@ c
   95        continue
             rnorm = zero
          end if
-c 
+c
 c        %----------------------------------------------%
 c        | Branch here directly if iterative refinement |
 c        | wasn't necessary or after at most NITER_REF  |
@@ -787,13 +787,13 @@ c        | steps of iterative refinement.               |
 c        %----------------------------------------------%
 c
   100    continue
-c 
+c
          rstart = .false.
          orth2  = .false.
-c 
+c
          call second (t5)
          titref = titref + (t5 - t4)
-c 
+c
 c        %----------------------------------------------------------%
 c        | Make sure the last off-diagonal element is non negative  |
 c        | If not perform a similarity transformation on H(1:j,1:j) |
@@ -802,13 +802,13 @@ c        %----------------------------------------------------------%
 c
          if (h(j,1) .lt. zero) then
             h(j,1) = -h(j,1)
-            if ( j .lt. k+np) then 
+            if ( j .lt. k+np) then
                call dscal(n, -one, v(1,j+1), 1)
             else
                call dscal(n, -one, resid, 1)
             end if
          end if
-c 
+c
 c        %------------------------------------%
 c        | STEP 6: Update  j = j+1;  Continue |
 c        %------------------------------------%
@@ -820,10 +820,10 @@ c
             ido = 99
 c
             if (msglvl .gt. 1) then
-               call dvout (logfil, k+np, h(1,2), ndigit, 
+               call dvout (logfil, k+np, h(1,2), ndigit,
      &         '_saitr: main diagonal of matrix H of step K+NP.')
                if (k+np .gt. 1) then
-               call dvout (logfil, k+np-1, h(2,1), ndigit, 
+               call dvout (logfil, k+np-1, h(2,1), ndigit,
      &         '_saitr: sub diagonal of matrix H of step K+NP.')
                end if
             end if
@@ -836,7 +836,7 @@ c        | Loop back to extend the factorization by another step. |
 c        %--------------------------------------------------------%
 c
       go to 1000
-c 
+c
 c     %---------------------------------------------------------------%
 c     |                                                               |
 c     |  E N D     O F     M A I N     I T E R A T I O N     L O O P  |

--- a/mathlibs/src/arpack/dsapps.f
+++ b/mathlibs/src/arpack/dsapps.f
@@ -261,9 +261,9 @@ c
             big   = abs(h(i,2)) + abs(h(i+1,2))
             if (h(i+1,1) .le. epsmch*big) then
                if (msglvl .gt. 0) then
-                  call ivout (logfil, 1, i, ndigit, 
+                  call ivout (logfil, 1, [i], ndigit, 
      &                 '_sapps: deflation at row/column no.')
-                  call ivout (logfil, 1, jj, ndigit, 
+                  call ivout (logfil, 1, [jj], ndigit, 
      &                 '_sapps: occured before shift number.')
                   call dvout (logfil, 1, h(i+1,1), ndigit, 
      &                 '_sapps: the corresponding off diagonal element')
@@ -432,7 +432,7 @@ c
          big   = abs(h(i,2)) + abs(h(i+1,2))
          if (h(i+1,1) .le. epsmch*big) then
             if (msglvl .gt. 0) then
-               call ivout (logfil, 1, i, ndigit, 
+               call ivout (logfil, 1, [i], ndigit, 
      &              '_sapps: deflation at row/column no.')
                call dvout (logfil, 1, h(i+1,1), ndigit, 
      &              '_sapps: the corresponding off diagonal element')

--- a/mathlibs/src/arpack/dsapps.f
+++ b/mathlibs/src/arpack/dsapps.f
@@ -12,8 +12,8 @@ c  apply NP shifts implicitly resulting in
 c
 c     A*(V_{k}*Q) - (V_{k}*Q)*(Q^T* H_{k}*Q) = r_{k+p}*e_{k+p}^T * Q
 c
-c  where Q is an orthogonal matrix of order KEV+NP. Q is the product of 
-c  rotations resulting from the NP bulge chasing sweeps.  The updated Arnoldi 
+c  where Q is an orthogonal matrix of order KEV+NP. Q is the product of
+c  rotations resulting from the NP bulge chasing sweeps.  The updated Arnoldi
 c  factorization becomes:
 c
 c     A*VNEW_{k} - VNEW_{k}*HNEW_{k} = rnew_{k}*e_{k}^T.
@@ -49,7 +49,7 @@ c  H       Double precision (KEV+NP) by 2 array.  (INPUT/OUTPUT)
 c          INPUT: H contains the symmetric tridiagonal matrix of the
 c          Arnoldi factorization with the subdiagonal in the 1st column
 c          starting at H(2,1) and the main diagonal in the 2nd column.
-c          OUTPUT: H contains the updated tridiagonal matrix in the 
+c          OUTPUT: H contains the updated tridiagonal matrix in the
 c          KEV leading submatrix.
 c
 c  LDH     Integer.  (INPUT)
@@ -85,12 +85,12 @@ c\References:
 c  1. D.C. Sorensen, "Implicit Application of Polynomial Filters in
 c     a k-Step Arnoldi Method", SIAM J. Matr. Anal. Apps., 13 (1992),
 c     pp 357-385.
-c  2. R.B. Lehoucq, "Analysis and Implementation of an Implicitly 
+c  2. R.B. Lehoucq, "Analysis and Implementation of an Implicitly
 c     Restarted Arnoldi Iteration", Rice University Technical Report
 c     TR95-13, Department of Computational and Applied Mathematics.
 c
 c\Routines called:
-c     ivout   ARPACK utility routine that prints integers. 
+c     ivout   ARPACK utility routine that prints integers.
 c     second  ARPACK utility routine for timing.
 c     dvout   ARPACK utility routine that prints vectors.
 c     dlamch  LAPACK routine that determines machine constants.
@@ -107,19 +107,19 @@ c     Danny Sorensen               Phuong Vu
 c     Richard Lehoucq              CRPC / Rice University
 c     Dept. of Computational &     Houston, Texas
 c     Applied Mathematics
-c     Rice University           
-c     Houston, Texas            
+c     Rice University
+c     Houston, Texas
 c
 c\Revision history:
 c     12/16/93: Version ' 2.1'
 c
-c\SCCS Information: @(#) 
+c\SCCS Information: @(#)
 c FILE: sapps.F   SID: 2.5   DATE OF SID: 4/19/96   RELEASE: 2
 c
 c\Remarks
 c  1. In this version, each shift is applied to all the subblocks of
-c     the tridiagonal matrix H and not just to the submatrix that it 
-c     comes from. This routine assumes that the subdiagonal elements 
+c     the tridiagonal matrix H and not just to the submatrix that it
+c     comes from. This routine assumes that the subdiagonal elements
 c     of H that are stored in h(1:kev+np,1) are nonegative upon input
 c     and enforce this condition upon output. This version incorporates
 c     deflation. See code for documentation.
@@ -149,7 +149,7 @@ c     | Array Arguments |
 c     %-----------------%
 c
       Double precision
-     &           h(ldh,2), q(ldq,kev+np), resid(n), shift(np), 
+     &           h(ldh,2), q(ldq,kev+np), resid(n), shift(np),
      &           v(ldv,kev+np), workd(2*n)
 c
 c     %------------%
@@ -175,7 +175,7 @@ c     %----------------------%
 c     | External Subroutines |
 c     %----------------------%
 c
-      external   daxpy, dcopy, dscal, dlacpy, dlartg, dlaset, dvout, 
+      external   daxpy, dcopy, dscal, dlacpy, dlartg, dlaset, dvout,
      &           ivout, second, dgemv
 c
 c     %--------------------%
@@ -215,9 +215,9 @@ c     %-------------------------------%
 c
       call second (t0)
       msglvl = msapps
-c 
-      kplusp = kev + np 
-c 
+c
+      kplusp = kev + np
+c
 c     %----------------------------------------------%
 c     | Initialize Q to the identity matrix of order |
 c     | kplusp used to accumulate the rotations.     |
@@ -230,7 +230,7 @@ c     | Quick return if there are no shifts to apply |
 c     %----------------------------------------------%
 c
       if (np .eq. 0) go to 9000
-c 
+c
 c     %----------------------------------------------------------%
 c     | Apply the np shifts implicitly. Apply each shift to the  |
 c     | whole matrix and not just to the submatrix from which it |
@@ -238,7 +238,7 @@ c     | comes.                                                   |
 c     %----------------------------------------------------------%
 c
       do 90 jj = 1, np
-c 
+c
          istart = itop
 c
 c        %----------------------------------------------------------%
@@ -261,11 +261,11 @@ c
             big   = abs(h(i,2)) + abs(h(i+1,2))
             if (h(i+1,1) .le. epsmch*big) then
                if (msglvl .gt. 0) then
-                  call ivout (logfil, 1, [i], ndigit, 
+                  call ivout (logfil, 1, [i], ndigit,
      &                 '_sapps: deflation at row/column no.')
-                  call ivout (logfil, 1, [jj], ndigit, 
+                  call ivout (logfil, 1, [jj], ndigit,
      &                 '_sapps: occured before shift number.')
-                  call dvout (logfil, 1, h(i+1,1), ndigit, 
+                  call dvout (logfil, 1, h(i+1,1), ndigit,
      &                 '_sapps: the corresponding off diagonal element')
                end if
                h(i+1,1) = zero
@@ -277,7 +277,7 @@ c
    40    continue
 c
          if (istart .lt. iend) then
-c 
+c
 c           %--------------------------------------------------------%
 c           | Construct the plane rotation G'(istart,istart+1,theta) |
 c           | that attempts to drive h(istart+1,1) to zero.          |
@@ -286,7 +286,7 @@ c
              f = h(istart,2) - shift(jj)
              g = h(istart+1,1)
              call dlartg (f, g, c, s, r)
-c 
+c
 c            %-------------------------------------------------------%
 c            | Apply rotation to the left and right of H;            |
 c            | H <- G' * H * G,  where G = G(istart,istart+1,theta). |
@@ -296,11 +296,11 @@ c
              a1 = c*h(istart,2)   + s*h(istart+1,1)
              a2 = c*h(istart+1,1) + s*h(istart+1,2)
              a4 = c*h(istart+1,2) - s*h(istart+1,1)
-             a3 = c*h(istart+1,1) - s*h(istart,2) 
+             a3 = c*h(istart+1,1) - s*h(istart,2)
              h(istart,2)   = c*a1 + s*a2
              h(istart+1,2) = c*a4 - s*a3
              h(istart+1,1) = c*a3 + s*a4
-c 
+c
 c            %----------------------------------------------------%
 c            | Accumulate the rotation in the matrix Q;  Q <- Q*G |
 c            %----------------------------------------------------%
@@ -323,7 +323,7 @@ c            | zero.                                        |
 c            %----------------------------------------------%
 c
              do 70 i = istart+1, iend-1
-c 
+c
 c               %----------------------------------------------%
 c               | Construct the plane rotation G'(i,i+1,theta) |
 c               | that zeros the i-th bulge that was created   |
@@ -351,23 +351,23 @@ c
                    c = -c
                    s = -s
                 end if
-c 
+c
 c               %--------------------------------------------%
 c               | Apply rotation to the left and right of H; |
 c               | H <- G * H * G',  where G = G(i,i+1,theta) |
 c               %--------------------------------------------%
 c
                 h(i,1) = r
-c 
+c
                 a1 = c*h(i,2)   + s*h(i+1,1)
                 a2 = c*h(i+1,1) + s*h(i+1,2)
                 a3 = c*h(i+1,1) - s*h(i,2)
                 a4 = c*h(i+1,2) - s*h(i+1,1)
-c 
+c
                 h(i,2)   = c*a1 + s*a2
                 h(i+1,2) = c*a4 - s*a3
                 h(i+1,1) = c*a3 + s*a4
-c 
+c
 c               %----------------------------------------------------%
 c               | Accumulate the rotation in the matrix Q;  Q <- Q*G |
 c               %----------------------------------------------------%
@@ -425,16 +425,16 @@ c
 c     %------------------------------------------%
 c     | All shifts have been applied. Check for  |
 c     | more possible deflation that might occur |
-c     | after the last shift is applied.         |                               
+c     | after the last shift is applied.         |
 c     %------------------------------------------%
 c
       do 100 i = itop, kplusp-1
          big   = abs(h(i,2)) + abs(h(i+1,2))
          if (h(i+1,1) .le. epsmch*big) then
             if (msglvl .gt. 0) then
-               call ivout (logfil, 1, [i], ndigit, 
+               call ivout (logfil, 1, [i], ndigit,
      &              '_sapps: deflation at row/column no.')
-               call dvout (logfil, 1, h(i+1,1), ndigit, 
+               call dvout (logfil, 1, h(i+1,1), ndigit,
      &              '_sapps: the corresponding off diagonal element')
             end if
             h(i+1,1) = zero
@@ -447,13 +447,13 @@ c     | temporarily store the result in WORKD(N+1:2*N). |
 c     | This is not necessary if h(kev+1,1) = 0.         |
 c     %-------------------------------------------------%
 c
-      if ( h(kev+1,1) .gt. zero ) 
+      if ( h(kev+1,1) .gt. zero )
      &   call dgemv ('N', n, kplusp, one, v, ldv,
      &                q(1,kev+1), 1, zero, workd(n+1), 1)
-c 
+c
 c     %-------------------------------------------------------%
 c     | Compute column 1 to kev of (V*Q) in backward order    |
-c     | taking advantage that Q is an upper triangular matrix |    
+c     | taking advantage that Q is an upper triangular matrix |
 c     | with lower bandwidth np.                              |
 c     | Place results in v(:,kplusp-kev:kplusp) temporarily.  |
 c     %-------------------------------------------------------%
@@ -469,15 +469,15 @@ c     |  Move v(:,kplusp-kev+1:kplusp) into v(:,1:kev). |
 c     %-------------------------------------------------%
 c
       call dlacpy ('All', n, kev, v(1,np+1), ldv, v, ldv)
-c 
+c
 c     %--------------------------------------------%
 c     | Copy the (kev+1)-st column of (V*Q) in the |
 c     | appropriate place if h(kev+1,1) .ne. zero. |
 c     %--------------------------------------------%
 c
-      if ( h(kev+1,1) .gt. zero ) 
+      if ( h(kev+1,1) .gt. zero )
      &     call dcopy (n, workd(n+1), 1, v(1,kev+1), 1)
-c 
+c
 c     %-------------------------------------%
 c     | Update the residual vector:         |
 c     |    r <- sigmak*r + betak*v(:,kev+1) |
@@ -487,26 +487,26 @@ c     |    betak = e_{kev+1}'*H*e_{kev}     |
 c     %-------------------------------------%
 c
       call dscal (n, q(kplusp,kev), resid, 1)
-      if (h(kev+1,1) .gt. zero) 
+      if (h(kev+1,1) .gt. zero)
      &   call daxpy (n, h(kev+1,1), v(1,kev+1), 1, resid, 1)
 c
       if (msglvl .gt. 1) then
-         call dvout (logfil, 1, q(kplusp,kev), ndigit, 
+         call dvout (logfil, 1, q(kplusp,kev), ndigit,
      &      '_sapps: sigmak of the updated residual vector')
-         call dvout (logfil, 1, h(kev+1,1), ndigit, 
+         call dvout (logfil, 1, h(kev+1,1), ndigit,
      &      '_sapps: betak of the updated residual vector')
-         call dvout (logfil, kev, h(1,2), ndigit, 
+         call dvout (logfil, kev, h(1,2), ndigit,
      &      '_sapps: updated main diagonal of H for next iteration')
          if (kev .gt. 1) then
-         call dvout (logfil, kev-1, h(2,1), ndigit, 
+         call dvout (logfil, kev-1, h(2,1), ndigit,
      &      '_sapps: updated sub diagonal of H for next iteration')
          end if
       end if
 c
       call second (t1)
       tsapps = tsapps + (t1 - t0)
-c 
- 9000 continue 
+c
+ 9000 continue
       return
 c
 c     %---------------%

--- a/mathlibs/src/arpack/dsaup2.f
+++ b/mathlibs/src/arpack/dsaup2.f
@@ -402,13 +402,13 @@ c
          iter = iter + 1
 c
          if (msglvl .gt. 0) then
-            call ivout (logfil, 1, iter, ndigit, 
+            call ivout (logfil, 1, [iter], ndigit, 
      &           '_saup2: **** Start of major iteration number ****')
          end if
          if (msglvl .gt. 1) then
-            call ivout (logfil, 1, nev, ndigit, 
+            call ivout (logfil, 1, [nev], ndigit, 
      &     '_saup2: The length of the current Lanczos factorization')
-            call ivout (logfil, 1, np, ndigit, 
+            call ivout (logfil, 1, [np], ndigit, 
      &           '_saup2: Extend the Lanczos factorization by')
          end if
 c 
@@ -446,7 +446,7 @@ c
          update = .false.
 c
          if (msglvl .gt. 1) then
-            call dvout (logfil, 1, rnorm, ndigit, 
+            call dvout (logfil, 1, [rnorm], ndigit, 
      &           '_saup2: Current B-norm of residual for factorization')
          end if
 c 
@@ -694,7 +694,7 @@ c
          end if
 c
          if (msglvl .gt. 0) then
-            call ivout (logfil, 1, nconv, ndigit,
+            call ivout (logfil, 1, [nconv], ndigit,
      &           '_saup2: no. of "converged" Ritz values at this iter.')
             if (msglvl .gt. 1) then
                kp(1) = nev
@@ -742,7 +742,7 @@ c
          if (ishift .eq. 0) call dcopy (np, workl, 1, ritz, 1)
 c
          if (msglvl .gt. 2) then
-            call ivout (logfil, 1, np, ndigit,
+            call ivout (logfil, 1, [np], ndigit,
      &                  '_saup2: The number of shifts to apply ')
             call dvout (logfil, np, workl, ndigit,
      &                  '_saup2: shifts selected')
@@ -809,7 +809,7 @@ c
   130    continue
 c
          if (msglvl .gt. 2) then
-            call dvout (logfil, 1, rnorm, ndigit, 
+            call dvout (logfil, 1, [rnorm], ndigit, 
      &      '_saup2: B-norm of residual for NEV factorization')
             call dvout (logfil, nev, h(1,2), ndigit,
      &           '_saup2: main diagonal of compressed H matrix')

--- a/mathlibs/src/arpack/dsaup2.f
+++ b/mathlibs/src/arpack/dsaup2.f
@@ -3,26 +3,26 @@ c\BeginDoc
 c
 c\Name: dsaup2
 c
-c\Description: 
+c\Description:
 c  Intermediate level interface called by dsaupd.
 c
 c\Usage:
-c  call dsaup2 
+c  call dsaup2
 c     ( IDO, BMAT, N, WHICH, NEV, NP, TOL, RESID, MODE, IUPD,
-c       ISHIFT, MXITER, V, LDV, H, LDH, RITZ, BOUNDS, Q, LDQ, WORKL, 
+c       ISHIFT, MXITER, V, LDV, H, LDH, RITZ, BOUNDS, Q, LDQ, WORKL,
 c       IPNTR, WORKD, INFO )
 c
 c\Arguments
 c
 c  IDO, BMAT, N, WHICH, NEV, TOL, RESID: same as defined in dsaupd.
 c  MODE, ISHIFT, MXITER: see the definition of IPARAM in dsaupd.
-c  
+c
 c  NP      Integer.  (INPUT/OUTPUT)
-c          Contains the number of implicit shifts to apply during 
-c          each Arnoldi/Lanczos iteration.  
-c          If ISHIFT=1, NP is adjusted dynamically at each iteration 
+c          Contains the number of implicit shifts to apply during
+c          each Arnoldi/Lanczos iteration.
+c          If ISHIFT=1, NP is adjusted dynamically at each iteration
 c          to accelerate convergence and prevent stagnation.
-c          This is also roughly equal to the number of matrix-vector 
+c          This is also roughly equal to the number of matrix-vector
 c          products (involving the operator OP) per Arnoldi iteration.
 c          The logic for adjusting is contained within the current
 c          subroutine.
@@ -31,7 +31,7 @@ c          to provide via reverse comunication. 0 < NP < NCV-NEV.
 c          NP may be less than NCV-NEV since a leading block of the current
 c          upper Tridiagonal matrix has split off and contains "unwanted"
 c          Ritz values.
-c          Upon termination of the IRA iteration, NP contains the number 
+c          Upon termination of the IRA iteration, NP contains the number
 c          of "converged" wanted Ritz values.
 c
 c  IUPD    Integer.  (INPUT)
@@ -42,18 +42,18 @@ c  V       Double precision N by (NEV+NP) array.  (INPUT/OUTPUT)
 c          The Lanczos basis vectors.
 c
 c  LDV     Integer.  (INPUT)
-c          Leading dimension of V exactly as declared in the calling 
+c          Leading dimension of V exactly as declared in the calling
 c          program.
 c
 c  H       Double precision (NEV+NP) by 2 array.  (OUTPUT)
 c          H is used to store the generated symmetric tridiagonal matrix
-c          The subdiagonal is stored in the first column of H starting 
+c          The subdiagonal is stored in the first column of H starting
 c          at H(2,1).  The main diagonal is stored in the second column
-c          of H starting at H(1,2). If dsaup2 converges store the 
+c          of H starting at H(1,2). If dsaup2 converges store the
 c          B-norm of the final residual vector in H(1,1).
 c
 c  LDH     Integer.  (INPUT)
-c          Leading dimension of H exactly as declared in the calling 
+c          Leading dimension of H exactly as declared in the calling
 c          program.
 c
 c  RITZ    Double precision array of length NEV+NP.  (OUTPUT)
@@ -63,33 +63,33 @@ c  BOUNDS  Double precision array of length NEV+NP.  (OUTPUT)
 c          BOUNDS(1:NEV) contain the error bounds corresponding to RITZ.
 c
 c  Q       Double precision (NEV+NP) by (NEV+NP) array.  (WORKSPACE)
-c          Private (replicated) work array used to accumulate the 
+c          Private (replicated) work array used to accumulate the
 c          rotation in the shift application step.
 c
 c  LDQ     Integer.  (INPUT)
 c          Leading dimension of Q exactly as declared in the calling
 c          program.
-c          
+c
 c  WORKL   Double precision array of length at least 3*(NEV+NP).  (INPUT/WORKSPACE)
 c          Private (replicated) array on each PE or array allocated on
-c          the front end.  It is used in the computation of the 
+c          the front end.  It is used in the computation of the
 c          tridiagonal eigenvalue problem, the calculation and
 c          application of the shifts and convergence checking.
 c          If ISHIFT .EQ. O and IDO .EQ. 3, the first NP locations
-c          of WORKL are used in reverse communication to hold the user 
+c          of WORKL are used in reverse communication to hold the user
 c          supplied shifts.
 c
 c  IPNTR   Integer array of length 3.  (OUTPUT)
-c          Pointer to mark the starting locations in the WORKD for 
+c          Pointer to mark the starting locations in the WORKD for
 c          vectors used by the Lanczos iteration.
 c          -------------------------------------------------------------
 c          IPNTR(1): pointer to the current operand vector X.
 c          IPNTR(2): pointer to the current result vector Y.
-c          IPNTR(3): pointer to the vector B * X when used in one of  
+c          IPNTR(3): pointer to the vector B * X when used in one of
 c                    the spectral transformation modes.  X is the current
 c                    operand.
 c          -------------------------------------------------------------
-c          
+c
 c  WORKD   Double precision work array of length 3*N.  (REVERSE COMMUNICATION)
 c          Distributed array to be used in the basic Lanczos iteration
 c          for reverse communication.  The user should not use WORKD
@@ -102,9 +102,9 @@ c          If INFO .NE. 0, RESID contains the initial residual vector,
 c                          possibly from a previous run.
 c          Error flag on output.
 c          =     0: Normal return.
-c          =     1: All possible eigenvalues of OP has been found.  
+c          =     1: All possible eigenvalues of OP has been found.
 c                   NP returns the size of the invariant subspace
-c                   spanning the operator OP. 
+c                   spanning the operator OP.
 c          =     2: No shifts could be applied.
 c          =    -8: Error return from trid. eigenvalue calculation;
 c                   This should never happen.
@@ -122,7 +122,7 @@ c\References:
 c  1. D.C. Sorensen, "Implicit Application of Polynomial Filters in
 c     a k-Step Arnoldi Method", SIAM J. Matr. Anal. Apps., 13 (1992),
 c     pp 357-385.
-c  2. R.B. Lehoucq, "Analysis and Implementation of an Implicitly 
+c  2. R.B. Lehoucq, "Analysis and Implementation of an Implicitly
 c     Restarted Arnoldi Iteration", Rice University Technical Report
 c     TR95-13, Department of Computational and Applied Mathematics.
 c  3. B.N. Parlett, "The Symmetric Eigenvalue Problem". Prentice-Hall,
@@ -132,15 +132,15 @@ c     Computer Physics Communications, 53 (1989), pp 169-179.
 c  5. B. Nour-Omid, B.N. Parlett, T. Ericson, P.S. Jensen, "How to
 c     Implement the Spectral Transformation", Math. Comp., 48 (1987),
 c     pp 663-673.
-c  6. R.G. Grimes, J.G. Lewis and H.D. Simon, "A Shifted Block Lanczos 
-c     Algorithm for Solving Sparse Symmetric Generalized Eigenproblems", 
+c  6. R.G. Grimes, J.G. Lewis and H.D. Simon, "A Shifted Block Lanczos
+c     Algorithm for Solving Sparse Symmetric Generalized Eigenproblems",
 c     SIAM J. Matr. Anal. Apps.,  January (1993).
 c  7. L. Reichel, W.B. Gragg, "Algorithm 686: FORTRAN Subroutines
 c     for Updating the QR decomposition", ACM TOMS, December 1990,
 c     Volume 16 Number 4, pp 369-377.
 c
 c\Routines called:
-c     dgetv0  ARPACK initial vector generation routine. 
+c     dgetv0  ARPACK initial vector generation routine.
 c     dsaitr  ARPACK Lanczos factorization routine.
 c     dsapps  ARPACK application of implicit shifts routine.
 c     dsconv  ARPACK convergence of Ritz values routine.
@@ -152,7 +152,7 @@ c     second  ARPACK utility routine for timing.
 c     dvout   ARPACK utility routine that prints vectors.
 c     dlamch  LAPACK routine that determines machine constants.
 c     dcopy   Level 1 BLAS that copies one vector to another.
-c     ddot    Level 1 BLAS that computes the scalar product of two vectors. 
+c     ddot    Level 1 BLAS that computes the scalar product of two vectors.
 c     dnrm2   Level 1 BLAS that computes the norm of a vector.
 c     dscal   Level 1 BLAS that scales a vector.
 c     dswap   Level 1 BLAS that swaps two vectors.
@@ -162,14 +162,14 @@ c     Danny Sorensen               Phuong Vu
 c     Richard Lehoucq              CRPC / Rice University
 c     Dept. of Computational &     Houston, Texas
 c     Applied Mathematics
-c     Rice University           
-c     Houston, Texas            
-c 
+c     Rice University
+c     Houston, Texas
+c
 c\Revision history:
 c     12/15/93: Version ' 2.4'
 c     xx/xx/95: Version ' 2.4'.  (R.B. Lehoucq)
 c
-c\SCCS Information: @(#) 
+c\SCCS Information: @(#)
 c FILE: saup2.F   SID: 2.6   DATE OF SID: 8/16/96   RELEASE: 2
 c
 c\EndLib
@@ -177,8 +177,8 @@ c
 c-----------------------------------------------------------------------
 c
       subroutine dsaup2
-     &   ( ido, bmat, n, which, nev, np, tol, resid, mode, iupd, 
-     &     ishift, mxiter, v, ldv, h, ldh, ritz, bounds, 
+     &   ( ido, bmat, n, which, nev, np, tol, resid, mode, iupd,
+     &     ishift, mxiter, v, ldv, h, ldh, ritz, bounds,
      &     q, ldq, workl, ipntr, workd, info )
 c
 c     %----------------------------------------------------%
@@ -204,8 +204,8 @@ c     %-----------------%
 c
       integer    ipntr(3)
       Double precision
-     &           bounds(nev+np), h(ldh,2), q(ldq,nev+np), resid(n), 
-     &           ritz(nev+np), v(ldv,nev+np), workd(3*n), 
+     &           bounds(nev+np), h(ldh,2), q(ldq,nev+np), resid(n),
+     &           ritz(nev+np), v(ldv,nev+np), workd(3*n),
      &           workl(3*(nev+np))
 c
 c     %------------%
@@ -222,8 +222,8 @@ c     %---------------%
 c
       character  wprime*2
       logical    cnorm, getv0, initv, update, ushift
-      integer    ierr, iter, j, kplusp, msglvl, nconv, nevbef, nev0, 
-     &           np0, nptemp, nevd2, nevm2, kp(3) 
+      integer    ierr, iter, j, kplusp, msglvl, nconv, nevbef, nev0,
+     &           np0, nptemp, nevd2, nevm2, kp(3)
       Double precision
      &           rnorm, temp, eps23
       save       cnorm, getv0, initv, update, ushift,
@@ -234,7 +234,7 @@ c     %----------------------%
 c     | External Subroutines |
 c     %----------------------%
 c
-      external   dcopy, dgetv0, dsaitr, dscal, dsconv, dseigt, dsgets, 
+      external   dcopy, dgetv0, dsaitr, dscal, dsconv, dseigt, dsgets,
      &           dsapps, dsortr, dvout, ivout, second, dswap
 c
 c     %--------------------%
@@ -256,7 +256,7 @@ c     | Executable Statements |
 c     %-----------------------%
 c
       if (ido .eq. 0) then
-c 
+c
 c        %-------------------------------%
 c        | Initialize timing statistics  |
 c        | & message level for debugging |
@@ -292,7 +292,7 @@ c
          kplusp = nev0 + np0
          nconv  = 0
          iter   = 0
-c 
+c
 c        %--------------------------------------------%
 c        | Set flags for computing the first NEV steps |
 c        | of the Lanczos factorization.              |
@@ -315,7 +315,7 @@ c
             initv = .false.
          end if
       end if
-c 
+c
 c     %---------------------------------------------%
 c     | Get a possibly random starting vector and   |
 c     | force it into the range of the operator OP. |
@@ -332,7 +332,7 @@ c
          if (rnorm .eq. zero) then
 c
 c           %-----------------------------------------%
-c           | The initial vector is zero. Error exit. | 
+c           | The initial vector is zero. Error exit. |
 c           %-----------------------------------------%
 c
             info = -9
@@ -341,7 +341,7 @@ c
          getv0 = .false.
          ido  = 0
       end if
-c 
+c
 c     %------------------------------------------------------------%
 c     | Back from reverse communication: continue with update step |
 c     %------------------------------------------------------------%
@@ -360,14 +360,14 @@ c     | at the end of the current iteration |
 c     %-------------------------------------%
 c
       if (cnorm)  go to 100
-c 
+c
 c     %----------------------------------------------------------%
 c     | Compute the first NEV steps of the Lanczos factorization |
 c     %----------------------------------------------------------%
 c
-      call dsaitr (ido, bmat, n, 0, nev0, mode, resid, rnorm, v, ldv, 
+      call dsaitr (ido, bmat, n, 0, nev0, mode, resid, rnorm, v, ldv,
      &             h, ldh, ipntr, workd, info)
-c 
+c
 c     %---------------------------------------------------%
 c     | ido .ne. 99 implies use of reverse communication  |
 c     | to compute operations involving OP and possibly B |
@@ -388,7 +388,7 @@ c
          info = -9999
          go to 1200
       end if
-c 
+c
 c     %--------------------------------------------------------------%
 c     |                                                              |
 c     |           M A I N  LANCZOS  I T E R A T I O N  L O O P       |
@@ -396,22 +396,22 @@ c     |           Each iteration implicitly restarts the Lanczos     |
 c     |           factorization in place.                            |
 c     |                                                              |
 c     %--------------------------------------------------------------%
-c 
+c
  1000 continue
 c
          iter = iter + 1
 c
          if (msglvl .gt. 0) then
-            call ivout (logfil, 1, [iter], ndigit, 
+            call ivout (logfil, 1, [iter], ndigit,
      &           '_saup2: **** Start of major iteration number ****')
          end if
          if (msglvl .gt. 1) then
-            call ivout (logfil, 1, [nev], ndigit, 
+            call ivout (logfil, 1, [nev], ndigit,
      &     '_saup2: The length of the current Lanczos factorization')
-            call ivout (logfil, 1, [np], ndigit, 
+            call ivout (logfil, 1, [np], ndigit,
      &           '_saup2: Extend the Lanczos factorization by')
          end if
-c 
+c
 c        %------------------------------------------------------------%
 c        | Compute NP additional steps of the Lanczos factorization. |
 c        %------------------------------------------------------------%
@@ -420,9 +420,9 @@ c
    20    continue
          update = .true.
 c
-         call dsaitr (ido, bmat, n, nev, np, mode, resid, rnorm, v, 
+         call dsaitr (ido, bmat, n, nev, np, mode, resid, rnorm, v,
      &                ldv, h, ldh, ipntr, workd, info)
-c 
+c
 c        %---------------------------------------------------%
 c        | ido .ne. 99 implies use of reverse communication  |
 c        | to compute operations involving OP and possibly B |
@@ -434,7 +434,7 @@ c
 c
 c           %-----------------------------------------------------%
 c           | dsaitr was unable to build an Lanczos factorization |
-c           | of length NEV0+NP0. INFO is returned with the size  |  
+c           | of length NEV0+NP0. INFO is returned with the size  |
 c           | of the factorization built. Exit main loop.         |
 c           %-----------------------------------------------------%
 c
@@ -446,10 +446,10 @@ c
          update = .false.
 c
          if (msglvl .gt. 1) then
-            call dvout (logfil, 1, [rnorm], ndigit, 
+            call dvout (logfil, 1, [rnorm], ndigit,
      &           '_saup2: Current B-norm of residual for factorization')
          end if
-c 
+c
 c        %--------------------------------------------------------%
 c        | Compute the eigenvalues and corresponding error bounds |
 c        | of the current symmetric tridiagonal matrix.           |
@@ -483,7 +483,7 @@ c
          nev = nev0
          np = np0
          call dsgets (ishift, which, nev, np, ritz, bounds, workl)
-c 
+c
 c        %-------------------%
 c        | Convergence test. |
 c        %-------------------%
@@ -520,11 +520,11 @@ c
                nev = nev + 1
             end if
  30      continue
-c 
-         if ( (nconv .ge. nev0) .or. 
+c
+         if ( (nconv .ge. nev0) .or.
      &        (iter .gt. mxiter) .or.
      &        (np .eq. 0) ) then
-c     
+c
 c           %------------------------------------------------%
 c           | Prepare to exit. Put the converged Ritz values |
 c           | and corresponding bounds in RITZ(1:NCONV) and  |
@@ -547,7 +547,7 @@ c
                wprime = 'SA'
                call dsortr (wprime, .true., kplusp, ritz, bounds)
                nevd2 = nev / 2
-               nevm2 = nev - nevd2 
+               nevm2 = nev - nevd2
                if ( nev .gt. 1 ) then
                   call dswap ( min(nevd2,np), ritz(nevm2+1), 1,
      &                 ritz( max(kplusp-nevd2+1,kplusp-np+1) ), 1)
@@ -651,13 +651,13 @@ c
             end if
 c
 c           %------------------------------------%
-c           | Max iterations have been exceeded. | 
+c           | Max iterations have been exceeded. |
 c           %------------------------------------%
 c
             if (iter .gt. mxiter .and. nconv .lt. nev) info = 1
 c
 c           %---------------------%
-c           | No shifts to apply. | 
+c           | No shifts to apply. |
 c           %---------------------%
 c
             if (np .eq. 0 .and. nconv .lt. nev0) info = 2
@@ -681,13 +681,13 @@ c
                nev = 2
             end if
             np  = kplusp - nev
-c     
+c
 c           %---------------------------------------%
 c           | If the size of NEV was just increased |
 c           | resort the eigenvalues.               |
 c           %---------------------------------------%
-c     
-            if (nevbef .lt. nev) 
+c
+            if (nevbef .lt. nev)
      &         call dsgets (ishift, which, nev, np, ritz, bounds,
      &              workl)
 c
@@ -708,7 +708,7 @@ c
             end if
          end if
 
-c 
+c
          if (ishift .eq. 0) then
 c
 c           %-----------------------------------------------------%
@@ -731,8 +731,8 @@ c        | in WORKL(1:*NP)                   |
 c        %------------------------------------%
 c
          ushift = .false.
-c 
-c 
+c
+c
 c        %---------------------------------------------------------%
 c        | Move the NP shifts to the first NP locations of RITZ to |
 c        | free up WORKL.  This is for the non-exact shift case;   |
@@ -751,7 +751,7 @@ c
      &                  '_saup2: corresponding Ritz estimates')
              end if
          end if
-c 
+c
 c        %---------------------------------------------------------%
 c        | Apply the NP0 implicit shifts by QR bulge chasing.      |
 c        | Each shift is applied to the entire tridiagonal matrix. |
@@ -777,18 +777,18 @@ c
             ipntr(1) = n + 1
             ipntr(2) = 1
             ido = 2
-c 
+c
 c           %----------------------------------%
 c           | Exit in order to compute B*RESID |
 c           %----------------------------------%
-c 
+c
             go to 9000
          else if (bmat .eq. 'I') then
             call dcopy (n, resid, 1, workd, 1)
          end if
-c 
+c
   100    continue
-c 
+c
 c        %----------------------------------%
 c        | Back from reverse communication; |
 c        | WORKD(1:N) := B*RESID            |
@@ -798,8 +798,8 @@ c
             call second (t3)
             tmvbx = tmvbx + (t3 - t2)
          end if
-c 
-         if (bmat .eq. 'G') then         
+c
+         if (bmat .eq. 'G') then
             rnorm = ddot (n, resid, 1, workd, 1)
             rnorm = sqrt(abs(rnorm))
          else if (bmat .eq. 'I') then
@@ -809,14 +809,14 @@ c
   130    continue
 c
          if (msglvl .gt. 2) then
-            call dvout (logfil, 1, [rnorm], ndigit, 
+            call dvout (logfil, 1, [rnorm], ndigit,
      &      '_saup2: B-norm of residual for NEV factorization')
             call dvout (logfil, nev, h(1,2), ndigit,
      &           '_saup2: main diagonal of compressed H matrix')
             call dvout (logfil, nev-1, h(2,1), ndigit,
      &           '_saup2: subdiagonal of compressed H matrix')
          end if
-c 
+c
       go to 1000
 c
 c     %---------------------------------------------------------------%
@@ -824,12 +824,12 @@ c     |                                                               |
 c     |  E N D     O F     M A I N     I T E R A T I O N     L O O P  |
 c     |                                                               |
 c     %---------------------------------------------------------------%
-c 
+c
  1100 continue
 c
       mxiter = iter
       nev = nconv
-c 
+c
  1200 continue
       ido = 99
 c
@@ -839,7 +839,7 @@ c     %------------%
 c
       call second (t1)
       tsaup2 = t1 - t0
-c 
+c
  9000 continue
       return
 c

--- a/mathlibs/src/arpack/dsaupd.f
+++ b/mathlibs/src/arpack/dsaupd.f
@@ -627,9 +627,9 @@ c
       if (info .eq. 2) info = 3
 c
       if (msglvl .gt. 0) then
-         call ivout (logfil, 1, mxiter, ndigit,
+         call ivout (logfil, 1, [mxiter], ndigit,
      &               '_saupd: number of update iterations taken')
-         call ivout (logfil, 1, np, ndigit,
+         call ivout (logfil, 1, [np], ndigit,
      &               '_saupd: number of "converged" Ritz values')
          call dvout (logfil, np, workl(Ritz), ndigit, 
      &               '_saupd: final Ritz values')

--- a/mathlibs/src/arpack/dsaupd.f
+++ b/mathlibs/src/arpack/dsaupd.f
@@ -3,31 +3,31 @@ c\BeginDoc
 c
 c\Name: dsaupd
 c
-c\Description: 
+c\Description:
 c
-c  Reverse communication interface for the Implicitly Restarted Arnoldi 
-c  Iteration.  For symmetric problems this reduces to a variant of the Lanczos 
-c  method.  This method has been designed to compute approximations to a 
-c  few eigenpairs of a linear operator OP that is real and symmetric 
-c  with respect to a real positive semi-definite symmetric matrix B, 
+c  Reverse communication interface for the Implicitly Restarted Arnoldi
+c  Iteration.  For symmetric problems this reduces to a variant of the Lanczos
+c  method.  This method has been designed to compute approximations to a
+c  few eigenpairs of a linear operator OP that is real and symmetric
+c  with respect to a real positive semi-definite symmetric matrix B,
 c  i.e.
-c                   
-c       B*OP = (OP')*B.  
 c
-c  Another way to express this condition is 
+c       B*OP = (OP')*B.
+c
+c  Another way to express this condition is
 c
 c       < x,OPy > = < OPx,y >  where < z,w > = z'Bw  .
-c  
-c  In the standard eigenproblem B is the identity matrix.  
+c
+c  In the standard eigenproblem B is the identity matrix.
 c  ( A' denotes transpose of A)
 c
 c  The computed approximate eigenvalues are called Ritz values and
 c  the corresponding approximate eigenvectors are called Ritz vectors.
 c
-c  dsaupd is usually called iteratively to solve one of the 
+c  dsaupd is usually called iteratively to solve one of the
 c  following problems:
 c
-c  Mode 1:  A*x = lambda*x, A symmetric 
+c  Mode 1:  A*x = lambda*x, A symmetric
 c           ===> OP = A  and  B = I.
 c
 c  Mode 2:  A*x = lambda*M*x, A symmetric, M symmetric positive definite
@@ -35,10 +35,10 @@ c           ===> OP = inv[M]*A  and  B = M.
 c           ===> (If M can be factored see remark 3 below)
 c
 c  Mode 3:  K*x = lambda*M*x, K symmetric, M symmetric positive semi-definite
-c           ===> OP = (inv[K - sigma*M])*M  and  B = M. 
+c           ===> OP = (inv[K - sigma*M])*M  and  B = M.
 c           ===> Shift-and-Invert mode
 c
-c  Mode 4:  K*x = lambda*KG*x, K symmetric positive semi-definite, 
+c  Mode 4:  K*x = lambda*KG*x, K symmetric positive semi-definite,
 c           KG symmetric indefinite
 c           ===> OP = (inv[K - sigma*KG])*K  and  B = K.
 c           ===> Buckling mode
@@ -60,13 +60,13 @@ c        the accuracy requirements for the eigenvalue
 c        approximations.
 c
 c\Usage:
-c  call dsaupd 
+c  call dsaupd
 c     ( IDO, BMAT, N, WHICH, NEV, TOL, RESID, NCV, V, LDV, IPARAM,
 c       IPNTR, WORKD, WORKL, LWORKL, INFO )
 c
 c\Arguments
 c  IDO     Integer.  (INPUT/OUTPUT)
-c          Reverse communication flag.  IDO must be zero on the first 
+c          Reverse communication flag.  IDO must be zero on the first
 c          call to dsaupd.  IDO will be set internally to
 c          indicate the type of operation to be performed.  Control is
 c          then given back to the calling routine which has the
@@ -95,7 +95,7 @@ c                    IPNTR(11) is the pointer into WORKL for
 c                    placing the shifts. See remark 6 below.
 c          IDO = 99: done
 c          -------------------------------------------------------------
-c             
+c
 c  BMAT    Character*1.  (INPUT)
 c          BMAT specifies the type of the matrix B that defines the
 c          semi-inner product for the operator OP.
@@ -111,7 +111,7 @@ c
 c          'LA' - compute the NEV largest (algebraic) eigenvalues.
 c          'SA' - compute the NEV smallest (algebraic) eigenvalues.
 c          'LM' - compute the NEV largest (in magnitude) eigenvalues.
-c          'SM' - compute the NEV smallest (in magnitude) eigenvalues. 
+c          'SM' - compute the NEV smallest (in magnitude) eigenvalues.
 c          'BE' - compute NEV eigenvalues, half from each end of the
 c                 spectrum.  When NEV is odd, compute one more from the
 c                 high end than from the low end.
@@ -121,27 +121,27 @@ c  NEV     Integer.  (INPUT)
 c          Number of eigenvalues of OP to be computed. 0 < NEV < N.
 c
 c  TOL     Double precision scalar.  (INPUT)
-c          Stopping criterion: the relative accuracy of the Ritz value 
+c          Stopping criterion: the relative accuracy of the Ritz value
 c          is considered acceptable if BOUNDS(I) .LE. TOL*ABS(RITZ(I)).
 c          If TOL .LE. 0. is passed a default is set:
 c          DEFAULT = DLAMCH('EPS')  (machine precision as computed
 c                    by the LAPACK auxiliary subroutine DLAMCH).
 c
 c  RESID   Double precision array of length N.  (INPUT/OUTPUT)
-c          On INPUT: 
+c          On INPUT:
 c          If INFO .EQ. 0, a random initial residual vector is used.
 c          If INFO .NE. 0, RESID contains the initial residual vector,
 c                          possibly from a previous run.
 c          On OUTPUT:
-c          RESID contains the final residual vector. 
+c          RESID contains the final residual vector.
 c
 c  NCV     Integer.  (INPUT)
 c          Number of columns of the matrix V (less than or equal to N).
-c          This will indicate how many Lanczos vectors are generated 
-c          at each iteration.  After the startup phase in which NEV 
-c          Lanczos vectors are generated, the algorithm generates 
+c          This will indicate how many Lanczos vectors are generated
+c          at each iteration.  After the startup phase in which NEV
+c          Lanczos vectors are generated, the algorithm generates
 c          NCV-NEV Lanczos vectors at each subsequent update iteration.
-c          Most of the cost in generating each Lanczos vector is in the 
+c          Most of the cost in generating each Lanczos vector is in the
 c          matrix-vector product OP*x. (See remark 4 below).
 c
 c  V       Double precision N by NCV array.  (OUTPUT)
@@ -161,10 +161,10 @@ c                      reverse communication.  The NCV eigenvalues of
 c                      the current tridiagonal matrix T are returned in
 c                      the part of WORKL array corresponding to RITZ.
 c                      See remark 6 below.
-c          ISHIFT = 1: exact shifts with respect to the reduced 
-c                      tridiagonal matrix T.  This is equivalent to 
-c                      restarting the iteration with a starting vector 
-c                      that is a linear combination of Ritz vectors 
+c          ISHIFT = 1: exact shifts with respect to the reduced
+c                      tridiagonal matrix T.  This is equivalent to
+c                      restarting the iteration with a starting vector
+c                      that is a linear combination of Ritz vectors
 c                      associated with the "wanted" Ritz values.
 c          -------------------------------------------------------------
 c
@@ -172,8 +172,8 @@ c          IPARAM(2) = LEVEC
 c          No longer referenced. See remark 2 below.
 c
 c          IPARAM(3) = MXITER
-c          On INPUT:  maximum number of Arnoldi update iterations allowed. 
-c          On OUTPUT: actual number of Arnoldi update iterations taken. 
+c          On INPUT:  maximum number of Arnoldi update iterations allowed.
+c          On OUTPUT: actual number of Arnoldi update iterations taken.
 c
 c          IPARAM(4) = NB: blocksize to be used in the recurrence.
 c          The code currently works only for NB = 1.
@@ -183,11 +183,11 @@ c          This represents the number of Ritz values that satisfy
 c          the convergence criterion.
 c
 c          IPARAM(6) = IUPD
-c          No longer referenced. Implicit restarting is ALWAYS used. 
+c          No longer referenced. Implicit restarting is ALWAYS used.
 c
 c          IPARAM(7) = MODE
 c          On INPUT determines what type of eigenproblem is being solved.
-c          Must be 1,2,3,4,5; See under \Description of dsaupd for the 
+c          Must be 1,2,3,4,5; See under \Description of dsaupd for the
 c          five modes available.
 c
 c          IPARAM(8) = NP
@@ -199,7 +199,7 @@ c
 c          IPARAM(9) = NUMOP, IPARAM(10) = NUMOPB, IPARAM(11) = NUMREO,
 c          OUTPUT: NUMOP  = total number of OP*x operations,
 c                  NUMOPB = total number of B*x operations if BMAT='G',
-c                  NUMREO = total number of steps of re-orthogonalization.        
+c                  NUMREO = total number of steps of re-orthogonalization.
 c
 c  IPNTR   Integer array of length 11.  (OUTPUT)
 c          Pointer to mark the starting locations in the WORKD and WORKL
@@ -207,7 +207,7 @@ c          arrays for matrices/vectors used by the Lanczos iteration.
 c          -------------------------------------------------------------
 c          IPNTR(1): pointer to the current operand vector X in WORKD.
 c          IPNTR(2): pointer to the current result vector Y in WORKD.
-c          IPNTR(3): pointer to the vector B * X in WORKD when used in 
+c          IPNTR(3): pointer to the vector B * X in WORKD when used in
 c                    the shift-and-invert mode.
 c          IPNTR(4): pointer to the next available location in WORKL
 c                    that is untouched by the program.
@@ -224,14 +224,14 @@ c          IPNTR(10): pointer to the NCV by NCV matrix of eigenvectors
 c                     of the tridiagonal matrix T. Only referenced by
 c                     dseupd if RVEC = .TRUE. See Remarks.
 c          -------------------------------------------------------------
-c          
+c
 c  WORKD   Double precision work array of length 3*N.  (REVERSE COMMUNICATION)
 c          Distributed array to be used in the basic Arnoldi iteration
-c          for reverse communication.  The user should not use WORKD 
+c          for reverse communication.  The user should not use WORKD
 c          as temporary workspace during the iteration. Upon termination
 c          WORKD(1:N) contains B*RESID(1:N). If the Ritz vectors are desired
 c          subroutine dseupd uses this output.
-c          See Data Distribution Note below.  
+c          See Data Distribution Note below.
 c
 c  WORKL   Double precision work array of length LWORKL.  (OUTPUT/WORKSPACE)
 c          Private (replicated) array on each PE or array allocated on
@@ -247,13 +247,13 @@ c                          possibly from a previous run.
 c          Error flag on output.
 c          =  0: Normal exit.
 c          =  1: Maximum number of iterations taken.
-c                All possible eigenvalues of OP has been found. IPARAM(5)  
+c                All possible eigenvalues of OP has been found. IPARAM(5)
 c                returns the number of wanted converged Ritz values.
 c          =  2: No longer an informational error. Deprecated starting
 c                with release 2 of ARPACK.
-c          =  3: No shifts could be applied during a cycle of the 
-c                Implicitly restarted Arnoldi iteration. One possibility 
-c                is to increase the size of NCV relative to NEV. 
+c          =  3: No shifts could be applied during a cycle of the
+c                Implicitly restarted Arnoldi iteration. One possibility
+c                is to increase the size of NCV relative to NEV.
 c                See remark 4 below.
 c          = -1: N must be positive.
 c          = -2: NEV must be positive.
@@ -277,12 +277,12 @@ c                   enough workspace and array storage has been allocated.
 c
 c
 c\Remarks
-c  1. The converged Ritz values are always returned in ascending 
+c  1. The converged Ritz values are always returned in ascending
 c     algebraic order.  The computed Ritz values are approximate
 c     eigenvalues of OP.  The selection of WHICH should be made
-c     with this in mind when Mode = 3,4,5.  After convergence, 
-c     approximate eigenvalues of the original problem may be obtained 
-c     with the ARPACK subroutine dseupd. 
+c     with this in mind when Mode = 3,4,5.  After convergence,
+c     approximate eigenvalues of the original problem may be obtained
+c     with the ARPACK subroutine dseupd.
 c
 c  2. If the Ritz vectors corresponding to the converged Ritz values
 c     are needed, the user must call dseupd immediately following completion
@@ -290,7 +290,7 @@ c     of dsaupd. This is new starting with version 2.1 of ARPACK.
 c
 c  3. If M can be factored into a Cholesky factorization M = LL'
 c     then Mode = 2 should not be selected.  Instead one should use
-c     Mode = 1 with  OP = inv(L)*A*inv(L').  Appropriate triangular 
+c     Mode = 1 with  OP = inv(L)*A*inv(L').  Appropriate triangular
 c     linear systems should be solved with L and L' rather
 c     than computing inverses.  After convergence, an approximate
 c     eigenvector z of the original problem is recovered by solving
@@ -300,7 +300,7 @@ c  4. At present there is no a-priori analysis to guide the selection
 c     of NCV relative to NEV.  The only formal requrement is that NCV > NEV.
 c     However, it is recommended that NCV .ge. 2*NEV.  If many problems of
 c     the same type are to be solved, one should experiment with increasing
-c     NCV while keeping NEV fixed for a given test problem.  This will 
+c     NCV while keeping NEV fixed for a given test problem.  This will
 c     usually decrease the required number of OP*x operations but it
 c     also increases the work and storage required to maintain the orthogonal
 c     basis vectors.   The optimal "cross-over" with respect to CPU time
@@ -312,16 +312,16 @@ c     When IPARAM(7) = 2 OP = inv(B)*A. After computing A*X the user
 c     must overwrite X with A*X. Y is then the solution to the linear set
 c     of equations B*Y = A*X.
 c
-c  6. When IPARAM(1) = 0, and IDO = 3, the user needs to provide the 
-c     NP = IPARAM(8) shifts in locations: 
-c     1   WORKL(IPNTR(11))           
-c     2   WORKL(IPNTR(11)+1)         
-c                        .           
-c                        .           
-c                        .      
-c     NP  WORKL(IPNTR(11)+NP-1). 
+c  6. When IPARAM(1) = 0, and IDO = 3, the user needs to provide the
+c     NP = IPARAM(8) shifts in locations:
+c     1   WORKL(IPNTR(11))
+c     2   WORKL(IPNTR(11)+1)
+c                        .
+c                        .
+c                        .
+c     NP  WORKL(IPNTR(11)+NP-1).
 c
-c     The eigenvalues of the current tridiagonal matrix are located in 
+c     The eigenvalues of the current tridiagonal matrix are located in
 c     WORKL(IPNTR(6)) through WORKL(IPNTR(6)+NCV-1). They are in the
 c     order defined by WHICH. The associated Ritz estimates are located in
 c     WORKL(IPNTR(8)), WORKL(IPNTR(8)+1), ... , WORKL(IPNTR(8)+NCV-1).
@@ -347,7 +347,7 @@ c  ===============
 c  REAL       RESID(N), V(LDV,NCV), WORKD(N,3), WORKL(LWORKL)
 c  SHARED     RESID(BLOCK), V(BLOCK,:), WORKD(BLOCK,:)
 c  REPLICATED WORKL(LWORKL)
-c  
+c
 c
 c\BeginLib
 c
@@ -355,7 +355,7 @@ c\References:
 c  1. D.C. Sorensen, "Implicit Application of Polynomial Filters in
 c     a k-Step Arnoldi Method", SIAM J. Matr. Anal. Apps., 13 (1992),
 c     pp 357-385.
-c  2. R.B. Lehoucq, "Analysis and Implementation of an Implicitly 
+c  2. R.B. Lehoucq, "Analysis and Implementation of an Implicitly
 c     Restarted Arnoldi Iteration", Rice University Technical Report
 c     TR95-13, Department of Computational and Applied Mathematics.
 c  3. B.N. Parlett, "The Symmetric Eigenvalue Problem". Prentice-Hall,
@@ -365,8 +365,8 @@ c     Computer Physics Communications, 53 (1989), pp 169-179.
 c  5. B. Nour-Omid, B.N. Parlett, T. Ericson, P.S. Jensen, "How to
 c     Implement the Spectral Transformation", Math. Comp., 48 (1987),
 c     pp 663-673.
-c  6. R.G. Grimes, J.G. Lewis and H.D. Simon, "A Shifted Block Lanczos 
-c     Algorithm for Solving Sparse Symmetric Generalized Eigenproblems", 
+c  6. R.G. Grimes, J.G. Lewis and H.D. Simon, "A Shifted Block Lanczos
+c     Algorithm for Solving Sparse Symmetric Generalized Eigenproblems",
 c     SIAM J. Matr. Anal. Apps.,  January (1993).
 c  7. L. Reichel, W.B. Gragg, "Algorithm 686: FORTRAN Subroutines
 c     for Updating the QR decomposition", ACM TOMS, December 1990,
@@ -389,14 +389,14 @@ c     Danny Sorensen               Phuong Vu
 c     Richard Lehoucq              CRPC / Rice University
 c     Dept. of Computational &     Houston, Texas
 c     Applied Mathematics
-c     Rice University           
-c     Houston, Texas            
-c 
+c     Rice University
+c     Houston, Texas
+c
 c\Revision history:
 c     12/15/93: Version ' 2.4'
 c
-c\SCCS Information: @(#) 
-c FILE: saupd.F   SID: 2.7   DATE OF SID: 8/27/96   RELEASE: 2 
+c\SCCS Information: @(#)
+c FILE: saupd.F   SID: 2.7   DATE OF SID: 8/27/96   RELEASE: 2
 c
 c\Remarks
 c     1. None
@@ -406,7 +406,7 @@ c
 c-----------------------------------------------------------------------
 c
       subroutine dsaupd
-     &   ( ido, bmat, n, which, nev, tol, resid, ncv, v, ldv, iparam, 
+     &   ( ido, bmat, n, which, nev, tol, resid, ncv, v, ldv, iparam,
      &     ipntr, workd, workl, lworkl, info )
 c
 c     %----------------------------------------------------%
@@ -445,7 +445,7 @@ c     %---------------%
 c     | Local Scalars |
 c     %---------------%
 c
-      integer    bounds, ierr, ih, iq, ishift, iupd, iw, 
+      integer    bounds, ierr, ih, iq, ishift, iupd, iw,
      &           ldh, ldq, msglvl, mxiter, mode, nb,
      &           nev0, next, np, ritz, j
       save       bounds, ierr, ih, iq, ishift, iupd, iw,
@@ -469,7 +469,7 @@ c
 c     %-----------------------%
 c     | Executable Statements |
 c     %-----------------------%
-c 
+c
       if (ido .eq. 0) then
 c
 c        %-------------------------------%
@@ -511,7 +511,7 @@ c        | extend the length NEV Lanczos factorization. |
 c        %----------------------------------------------%
 c
          np     = ncv - nev
-c 
+c
          if (mxiter .le. 0)                     ierr = -4
          if (which .ne. 'LM' .and.
      &       which .ne. 'SM' .and.
@@ -530,7 +530,7 @@ c
          else if (nev .eq. 1 .and. which .eq. 'BE') then
                                                 ierr = -13
          end if
-c 
+c
 c        %------------%
 c        | Error Exit |
 c        %------------%
@@ -540,7 +540,7 @@ c
             ido  = 99
             go to 9000
          end if
-c 
+c
 c        %------------------------%
 c        | Set default parameters |
 c        %------------------------%
@@ -556,8 +556,8 @@ c        | size of the invariant subspace desired.      |
 c        %----------------------------------------------%
 c
          np     = ncv - nev
-         nev0   = nev 
-c 
+         nev0   = nev
+c
 c        %-----------------------------%
 c        | Zero out internal workspace |
 c        %-----------------------------%
@@ -565,7 +565,7 @@ c
          do 10 j = 1, ncv**2 + 8*ncv
             workl(j) = zero
  10      continue
-c 
+c
 c        %-------------------------------------------------------%
 c        | Pointer into WORKL for address of H, RITZ, BOUNDS, Q  |
 c        | etc... and the remaining workspace.                   |
@@ -598,7 +598,7 @@ c     %-------------------------------------------------------%
 c     | Carry out the Implicitly restarted Lanczos Iteration. |
 c     %-------------------------------------------------------%
 c
-      call dsaup2 
+      call dsaup2
      &   ( ido, bmat, n, which, nev0, np, tol, resid, mode, iupd,
      &     ishift, mxiter, v, ldv, workl(ih), ldh, workl(ritz),
      &     workl(bounds), workl(iq), ldq, workl(iw), ipntr, workd,
@@ -611,7 +611,7 @@ c     %--------------------------------------------------%
 c
       if (ido .eq. 3) iparam(8) = np
       if (ido .ne. 99) go to 9000
-c 
+c
       iparam(3) = mxiter
       iparam(5) = np
       iparam(9) = nopx
@@ -631,15 +631,15 @@ c
      &               '_saupd: number of update iterations taken')
          call ivout (logfil, 1, [np], ndigit,
      &               '_saupd: number of "converged" Ritz values')
-         call dvout (logfil, np, workl(Ritz), ndigit, 
+         call dvout (logfil, np, workl(Ritz), ndigit,
      &               '_saupd: final Ritz values')
-         call dvout (logfil, np, workl(Bounds), ndigit, 
+         call dvout (logfil, np, workl(Bounds), ndigit,
      &               '_saupd: corresponding error bounds')
-      end if 
+      end if
 c
       call second (t1)
       tsaupd = t1 - t0
-c 
+c
       if (msglvl .gt. 0) then
 c
 c        %--------------------------------------------------------%
@@ -677,9 +677,9 @@ c
      &      5x, 'Total time in applying the shifts          = ', f12.6,/
      &      5x, 'Total time in convergence testing          = ', f12.6)
       end if
-c 
+c
  9000 continue
-c 
+c
       return
 c
 c     %---------------%

--- a/mathlibs/src/arpack/dseigt.f
+++ b/mathlibs/src/arpack/dseigt.f
@@ -3,7 +3,7 @@ c\BeginDoc
 c
 c\Name: dseigt
 c
-c\Description: 
+c\Description:
 c  Compute the eigenvalues of the current symmetric tridiagonal matrix
 c  and the corresponding error bounds given the current residual norm.
 c
@@ -20,16 +20,16 @@ c  N       Integer.  (INPUT)
 c          Size of the symmetric tridiagonal matrix H.
 c
 c  H       Double precision N by 2 array.  (INPUT)
-c          H contains the symmetric tridiagonal matrix with the 
-c          subdiagonal in the first column starting at H(2,1) and the 
+c          H contains the symmetric tridiagonal matrix with the
+c          subdiagonal in the first column starting at H(2,1) and the
 c          main diagonal in second column.
 c
 c  LDH     Integer.  (INPUT)
-c          Leading dimension of H exactly as declared in the calling 
+c          Leading dimension of H exactly as declared in the calling
 c          program.
 c
 c  EIG     Double precision array of length N.  (OUTPUT)
-c          On output, EIG contains the N eigenvalues of H possibly 
+c          On output, EIG contains the N eigenvalues of H possibly
 c          unsorted.  The BOUNDS arrays are returned in the
 c          same sorted order as EIG.
 c
@@ -65,16 +65,16 @@ c     dcopy   Level 1 BLAS that copies one vector to another.
 c
 c\Author
 c     Danny Sorensen               Phuong Vu
-c     Richard Lehoucq              CRPC / Rice University 
-c     Dept. of Computational &     Houston, Texas 
+c     Richard Lehoucq              CRPC / Rice University
+c     Dept. of Computational &     Houston, Texas
 c     Applied Mathematics
-c     Rice University           
-c     Houston, Texas            
+c     Rice University
+c     Houston, Texas
 c
 c\Revision history:
 c     xx/xx/92: Version ' 2.4'
 c
-c\SCCS Information: @(#) 
+c\SCCS Information: @(#)
 c FILE: seigt.F   SID: 2.4   DATE OF SID: 8/27/96   RELEASE: 2
 c
 c\Remarks
@@ -84,7 +84,7 @@ c\EndLib
 c
 c-----------------------------------------------------------------------
 c
-      subroutine dseigt 
+      subroutine dseigt
      &   ( rnorm, n, h, ldh, eig, bounds, workl, ierr )
 c
 c     %----------------------------------------------------%
@@ -136,7 +136,7 @@ c
 c     %-------------------------------%
 c     | Initialize timing statistics  |
 c     | & message level for debugging |
-c     %-------------------------------% 
+c     %-------------------------------%
 c
       call second (t0)
       msglvl = mseigt
@@ -167,7 +167,7 @@ c
       do 30 k = 1, n
          bounds(k) = rnorm*abs(bounds(k))
    30 continue
-c 
+c
       call second (t1)
       tseigt = tseigt + (t1 - t0)
 c

--- a/mathlibs/src/arpack/dseupd.f
+++ b/mathlibs/src/arpack/dseupd.f
@@ -2,7 +2,7 @@ c\BeginDoc
 c
 c\Name: dseupd
 c
-c\Description: 
+c\Description:
 c
 c  This subroutine returns the converged approximations to eigenvalues
 c  of A*z = lambda*B*z and (optionally):
@@ -15,22 +15,22 @@ c
 c      (3) Both.
 c
 c  There is negligible additional cost to obtain eigenvectors.  An orthonormal
-c  (Lanczos) basis is always computed.  There is an additional storage cost 
-c  of n*nev if both are requested (in this case a separate array Z must be 
+c  (Lanczos) basis is always computed.  There is an additional storage cost
+c  of n*nev if both are requested (in this case a separate array Z must be
 c  supplied).
 c
 c  These quantities are obtained from the Lanczos factorization computed
 c  by DSAUPD for the linear operator OP prescribed by the MODE selection
 c  (see IPARAM(7) in DSAUPD documentation.)  DSAUPD must be called before
-c  this routine is called. These approximate eigenvalues and vectors are 
-c  commonly called Ritz values and Ritz vectors respectively.  They are 
-c  referred to as such in the comments that follow.   The computed orthonormal 
-c  basis for the invariant subspace corresponding to these Ritz values is 
+c  this routine is called. These approximate eigenvalues and vectors are
+c  commonly called Ritz values and Ritz vectors respectively.  They are
+c  referred to as such in the comments that follow.   The computed orthonormal
+c  basis for the invariant subspace corresponding to these Ritz values is
 c  referred to as a Lanczos basis.
 c
-c  See documentation in the header of the subroutine DSAUPD for a definition 
-c  of OP as well as other terms and the relation of computed Ritz values 
-c  and vectors of OP with respect to the given problem  A*z = lambda*B*z.  
+c  See documentation in the header of the subroutine DSAUPD for a definition
+c  of OP as well as other terms and the relation of computed Ritz values
+c  and vectors of OP with respect to the given problem  A*z = lambda*B*z.
 c
 c  The approximate eigenvalues of the original problem are returned in
 c  ascending algebraic order.  The user may elect to call this routine
@@ -39,19 +39,19 @@ c  There is also the option of computing a selected set of these vectors
 c  with a single call.
 c
 c\Usage:
-c  call dseupd 
+c  call dseupd
 c     ( RVEC, HOWMNY, SELECT, D, Z, LDZ, SIGMA, BMAT, N, WHICH, NEV, TOL,
 c       RESID, NCV, V, LDV, IPARAM, IPNTR, WORKD, WORKL, LWORKL, INFO )
 c
-c  RVEC    LOGICAL  (INPUT) 
-c          Specifies whether Ritz vectors corresponding to the Ritz value 
+c  RVEC    LOGICAL  (INPUT)
+c          Specifies whether Ritz vectors corresponding to the Ritz value
 c          approximations to the eigenproblem A*z = lambda*B*z are computed.
 c
 c             RVEC = .FALSE.     Compute Ritz values only.
 c
 c             RVEC = .TRUE.      Compute Ritz vectors.
 c
-c  HOWMNY  Character*1  (INPUT) 
+c  HOWMNY  Character*1  (INPUT)
 c          Specifies how many Ritz vectors are wanted and the form of Z
 c          the matrix of Ritz vectors. See remark 1 below.
 c          = 'A': compute NEV Ritz vectors;
@@ -61,7 +61,7 @@ c
 c  SELECT  Logical array of dimension NEV.  (INPUT)
 c          If HOWMNY = 'S', SELECT specifies the Ritz vectors to be
 c          computed. To select the Ritz vector corresponding to a
-c          Ritz value D(j), SELECT(j) must be set to .TRUE.. 
+c          Ritz value D(j), SELECT(j) must be set to .TRUE..
 c          If HOWMNY = 'A' , SELECT is not referenced.
 c
 c  D       Double precision array of dimension NEV.  (OUTPUT)
@@ -69,8 +69,8 @@ c          On exit, D contains the Ritz value approximations to the
 c          eigenvalues of A*z = lambda*B*z. The values are returned
 c          in ascending order. If IPARAM(7) = 3,4,5 then D represents
 c          the Ritz values of OP computed by dsaupd transformed to
-c          those of the original eigensystem A*z = lambda*B*z. If 
-c          IPARAM(7) = 1,2 then the Ritz values of OP are the same 
+c          those of the original eigensystem A*z = lambda*B*z. If
+c          IPARAM(7) = 1,2 then the Ritz values of OP are the same
 c          as the those of A*z = lambda*B*z.
 c
 c  Z       Double precision N by NEV array if HOWMNY = 'A'.  (OUTPUT)
@@ -78,7 +78,7 @@ c          On exit, Z contains the B-orthonormal Ritz vectors of the
 c          eigensystem A*z = lambda*B*z corresponding to the Ritz
 c          value approximations.
 c          If  RVEC = .FALSE. then Z is not referenced.
-c          NOTE: The array Z may be set equal to first NEV columns of the 
+c          NOTE: The array Z may be set equal to first NEV columns of the
 c          Arnoldi/Lanczos basis array V computed by DSAUPD.
 c
 c  LDZ     Integer.  (INPUT)
@@ -147,7 +147,7 @@ c\References:
 c  1. D.C. Sorensen, "Implicit Application of Polynomial Filters in
 c     a k-Step Arnoldi Method", SIAM J. Matr. Anal. Apps., 13 (1992),
 c     pp 357-385.
-c  2. R.B. Lehoucq, "Analysis and Implementation of an Implicitly 
+c  2. R.B. Lehoucq, "Analysis and Implementation of an Implicitly
 c     Restarted Arnoldi Iteration", Rice University Technical Report
 c     TR95-13, Department of Computational and Applied Mathematics.
 c  3. B.N. Parlett, "The Symmetric Eigenvalue Problem". Prentice-Hall,
@@ -157,19 +157,19 @@ c     Computer Physics Communications, 53 (1989), pp 169-179.
 c  5. B. Nour-Omid, B.N. Parlett, T. Ericson, P.S. Jensen, "How to
 c     Implement the Spectral Transformation", Math. Comp., 48 (1987),
 c     pp 663-673.
-c  6. R.G. Grimes, J.G. Lewis and H.D. Simon, "A Shifted Block Lanczos 
-c     Algorithm for Solving Sparse Symmetric Generalized Eigenproblems", 
+c  6. R.G. Grimes, J.G. Lewis and H.D. Simon, "A Shifted Block Lanczos
+c     Algorithm for Solving Sparse Symmetric Generalized Eigenproblems",
 c     SIAM J. Matr. Anal. Apps.,  January (1993).
 c  7. L. Reichel, W.B. Gragg, "Algorithm 686: FORTRAN Subroutines
 c     for Updating the QR decomposition", ACM TOMS, December 1990,
 c     Volume 16 Number 4, pp 369-377.
 c
 c\Remarks
-c  1. The converged Ritz values are always returned in increasing 
+c  1. The converged Ritz values are always returned in increasing
 c     (algebraic) order.
 c
 c  2. Currently only HOWMNY = 'A' is implemented. It is included at this
-c     stage for the user who wants to incorporate it. 
+c     stage for the user who wants to incorporate it.
 c
 c\Routines called:
 c     dsesrt  ARPACK routine that sorts an array X, and applies the
@@ -195,22 +195,22 @@ c\Authors
 c     Danny Sorensen               Phuong Vu
 c     Richard Lehoucq              CRPC / Rice University
 c     Chao Yang                    Houston, Texas
-c     Dept. of Computational & 
+c     Dept. of Computational &
 c     Applied Mathematics
-c     Rice University           
-c     Houston, Texas            
-c 
+c     Rice University
+c     Houston, Texas
+c
 c\Revision history:
 c     12/15/93: Version ' 2.1'
 c
-c\SCCS Information: @(#) 
+c\SCCS Information: @(#)
 c FILE: seupd.F   SID: 2.7   DATE OF SID: 8/27/96   RELEASE: 2
 c
 c\EndLib
 c
 c-----------------------------------------------------------------------
       subroutine dseupd (rvec, howmny, select, d, z, ldz, sigma, bmat,
-     &                   n, which, nev, tol, resid, ncv, v, ldv, iparam, 
+     &                   n, which, nev, tol, resid, ncv, v, ldv, iparam,
      &                   ipntr, workd, workl, lworkl, info )
 c
 c     %----------------------------------------------------%
@@ -227,7 +227,7 @@ c
       character  bmat, howmny, which*2
       logical    rvec, select(ncv)
       integer    info, ldz, ldv, lworkl, n, ncv, nev
-      Double precision     
+      Double precision
      &           sigma, tol
 c
 c     %-----------------%
@@ -236,7 +236,7 @@ c     %-----------------%
 c
       integer    iparam(7), ipntr(11)
       Double precision
-     &           d(nev), resid(n), v(ldv,ncv), z(ldz, nev), 
+     &           d(nev), resid(n), v(ldv,ncv), z(ldz, nev),
      &           workd(2*n), workl(lworkl)
 c
 c     %------------%
@@ -252,7 +252,7 @@ c     | Local Scalars |
 c     %---------------%
 c
       character  type*6
-      integer    bounds, ierr, ih, ihb, ihd, iq, iw, j, k, 
+      integer    bounds, ierr, ih, ihb, ihd, iq, iw, j, k,
      &           ldh, ldq, mode, msglvl, nconv, next, ritz,
      &           irz, ibd, ktrord, leftptr, rghtptr, ism, ilg
       Double precision
@@ -263,14 +263,14 @@ c     %--------------%
 c     | Local Arrays |
 c     %--------------%
 c
-      Double precision 
+      Double precision
      &           kv(2)
 c
 c     %----------------------%
 c     | External Subroutines |
 c     %----------------------%
 c
-      external   dcopy, dger, dgeqr2, dlacpy, dorm2r, dscal, 
+      external   dcopy, dger, dgeqr2, dlacpy, dorm2r, dscal,
      &           dsesrt, dsteqr, dswap, dvout, ivout, dsortr
 c
 c     %--------------------%
@@ -290,7 +290,7 @@ c
 c     %-----------------------%
 c     | Executable Statements |
 c     %-----------------------%
-c 
+c
 c     %------------------------%
 c     | Set default parameters |
 c     %------------------------%
@@ -307,7 +307,7 @@ c
       if (nconv .eq. 0) go to 9000
       ierr = 0
 c
-      if (nconv .le. 0)                        ierr = -14 
+      if (nconv .le. 0)                        ierr = -14
       if (n .le. 0)                            ierr = -1
       if (nev .le. 0)                          ierr = -2
       if (ncv .le. nev .or.  ncv .gt. n)       ierr = -3
@@ -319,12 +319,12 @@ c
       if (bmat .ne. 'I' .and. bmat .ne. 'G')   ierr = -6
       if ( (howmny .ne. 'A' .and.
      &           howmny .ne. 'P' .and.
-     &           howmny .ne. 'S') .and. rvec ) 
+     &           howmny .ne. 'S') .and. rvec )
      &                                         ierr = -15
       if (rvec .and. howmny .eq. 'S')           ierr = -16
 c
       if (rvec .and. lworkl .lt. ncv**2+8*ncv) ierr = -7
-c     
+c
       if (mode .eq. 1 .or. mode .eq. 2) then
          type = 'REGULR'
       else if (mode .eq. 3 ) then
@@ -333,7 +333,7 @@ c
          type = 'BUCKLE'
       else if (mode .eq. 5 ) then
          type = 'CAYLEY'
-      else 
+      else
                                                ierr = -10
       end if
       if (mode .eq. 1 .and. bmat .eq. 'G')     ierr = -11
@@ -347,7 +347,7 @@ c
          info = ierr
          go to 9000
       end if
-c     
+c
 c     %-------------------------------------------------------%
 c     | Pointer into WORKL for address of H, RITZ, BOUNDS, Q  |
 c     | etc... and the remaining workspace.                   |
@@ -422,7 +422,7 @@ c     %---------------------------------%
 c     | Set machine dependent constant. |
 c     %---------------------------------%
 c
-      eps23 = dlamch('Epsilon-Machine') 
+      eps23 = dlamch('Epsilon-Machine')
       eps23 = eps23**(2.0D+0 / 3.0D+0)
 c
 c     %---------------------------------------%
@@ -489,7 +489,7 @@ c
              ism = max(nev,nconv) / 2
              ilg = ism + 1
              thres1 = workl(ism)
-             thres2 = workl(ilg) 
+             thres2 = workl(ilg)
 c
              if (msglvl .gt. 2) then
                 kv(1) = thres1
@@ -704,8 +704,8 @@ c
             call dcopy (ncv, workl(bounds), 1, workl(ihb), 1)
          end if
 c
-      else 
-c 
+      else
+c
 c        %-------------------------------------------------------------%
 c        | *  Make a copy of all the Ritz values.                      |
 c        | *  Transform the Ritz values back to the original system.   |
@@ -722,13 +722,13 @@ c        |  They are only reordered.                                   |
 c        %-------------------------------------------------------------%
 c
          call dcopy (ncv, workl(ihd), 1, workl(iw), 1)
-         if (type .eq. 'SHIFTI') then 
+         if (type .eq. 'SHIFTI') then
             do 40 k=1, ncv
                workl(ihd+k-1) = one / workl(ihd+k-1) + sigma
   40        continue
          else if (type .eq. 'BUCKLE') then
             do 50 k=1, ncv
-               workl(ihd+k-1) = sigma * workl(ihd+k-1) / 
+               workl(ihd+k-1) = sigma * workl(ihd+k-1) /
      &                          (workl(ihd+k-1) - one)
   50        continue
          else if (type .eq. 'CAYLEY') then
@@ -737,7 +737,7 @@ c
      &                          (workl(ihd+k-1) - one)
   60        continue
          end if
-c 
+c
 c        %-------------------------------------------------------------%
 c        | *  Store the wanted NCONV lambda values into D.             |
 c        | *  Sort the NCONV wanted lambda in WORKL(IHD:IHD+NCONV-1)   |
@@ -763,8 +763,8 @@ c
             call dsortr ('LA', .true., nconv, d, workl(ihb))
          end if
 c
-      end if 
-c 
+      end if
+c
 c     %------------------------------------------------%
 c     | Compute the Ritz vectors. Transform the wanted |
 c     | eigenvectors of the symmetric tridiagonal H by |
@@ -772,25 +772,25 @@ c     | the Lanczos basis matrix V.                    |
 c     %------------------------------------------------%
 c
       if (rvec .and. howmny .eq. 'A') then
-c    
+c
 c        %----------------------------------------------------------%
 c        | Compute the QR factorization of the matrix representing  |
 c        | the wanted invariant subspace located in the first NCONV |
 c        | columns of workl(iq,ldq).                                |
 c        %----------------------------------------------------------%
-c     
-         call dgeqr2 (ncv, nconv, workl(iq), ldq, workl(iw+ncv), 
+c
+         call dgeqr2 (ncv, nconv, workl(iq), ldq, workl(iw+ncv),
      &        workl(ihb), ierr)
 c
-c     
+c
 c        %--------------------------------------------------------%
-c        | * Postmultiply V by Q.                                 |   
+c        | * Postmultiply V by Q.                                 |
 c        | * Copy the first NCONV columns of VQ into Z.           |
 c        | The N by NCONV matrix Z is now a matrix representation |
 c        | of the approximate invariant subspace associated with  |
 c        | the Ritz values in workl(ihd).                         |
 c        %--------------------------------------------------------%
-c     
+c
          call dorm2r ('Right', 'Notranspose', n, ncv, nconv, workl(iq),
      &        ldq, workl(iw+ncv), v, ldv, workd(n+1), ierr)
          call dlacpy ('All', n, nconv, v, ldv, z, ldz)
@@ -802,7 +802,7 @@ c        | eigenvector matrix. Remember, it's in factored form |
 c        %-----------------------------------------------------%
 c
          do 65 j = 1, ncv-1
-            workl(ihb+j-1) = zero 
+            workl(ihb+j-1) = zero
   65     continue
          workl(ihb+ncv-1) = one
          call dorm2r ('Left', 'Transpose', ncv, 1, nconv, workl(iq),
@@ -832,7 +832,7 @@ c        | *  Determine Ritz estimates of the lambda.      |
 c        %-------------------------------------------------%
 c
          call dscal (ncv, bnorm2, workl(ihb), 1)
-         if (type .eq. 'SHIFTI') then 
+         if (type .eq. 'SHIFTI') then
 c
             do 80 k=1, ncv
                workl(ihb+k-1) = abs( workl(ihb+k-1) ) / workl(iw+k-1)**2
@@ -841,14 +841,14 @@ c
          else if (type .eq. 'BUCKLE') then
 c
             do 90 k=1, ncv
-               workl(ihb+k-1) = sigma * abs( workl(ihb+k-1) ) / 
+               workl(ihb+k-1) = sigma * abs( workl(ihb+k-1) ) /
      &                          ( workl(iw+k-1)-one )**2
  90         continue
 c
          else if (type .eq. 'CAYLEY') then
 c
             do 100 k=1, ncv
-               workl(ihb+k-1) = abs( workl(ihb+k-1) / 
+               workl(ihb+k-1) = abs( workl(ihb+k-1) /
      &                          workl(iw+k-1)*(workl(iw+k-1)-one) )
  100        continue
 c
@@ -859,15 +859,15 @@ c
       if (type .ne. 'REGULR' .and. msglvl .gt. 1) then
          call dvout (logfil, nconv, d, ndigit,
      &          '_seupd: Untransformed converged Ritz values')
-         call dvout (logfil, nconv, workl(ihb), ndigit, 
+         call dvout (logfil, nconv, workl(ihb), ndigit,
      &     '_seupd: Ritz estimates of the untransformed Ritz values')
       else if (msglvl .gt. 1) then
          call dvout (logfil, nconv, d, ndigit,
      &          '_seupd: Converged Ritz values')
-         call dvout (logfil, nconv, workl(ihb), ndigit, 
+         call dvout (logfil, nconv, workl(ihb), ndigit,
      &     '_seupd: Associated Ritz estimates')
       end if
-c 
+c
 c     %-------------------------------------------------%
 c     | Ritz vector purification step. Formally perform |
 c     | one of inverse subspace iteration. Only used    |
@@ -886,7 +886,7 @@ c
             workl(iw+k) = workl(iq+k*ldq+ncv-1) / (workl(iw+k)-one)
  120     continue
 c
-      end if 
+      end if
 c
       if (type .ne. 'REGULR')
      &   call dger (n, nconv, one, resid, 1, workl(iw), 1, z, ldz)

--- a/mathlibs/src/arpack/dseupd.f
+++ b/mathlibs/src/arpack/dseupd.f
@@ -473,7 +473,7 @@ c
              thres1 = workl(ritz)
 c
              if (msglvl .gt. 2) then
-                call dvout(logfil, 1, thres1, ndigit,
+                call dvout(logfil, 1, [thres1], ndigit,
      &          '_seupd: Threshold eigenvalue used for re-ordering')
              end if
 c
@@ -570,9 +570,9 @@ c        | If KTRORD .ne. NCONV, something is wrong. |
 c        %-------------------------------------------%
 c
          if (msglvl .gt. 2) then
-             call ivout(logfil, 1, ktrord, ndigit,
+             call ivout(logfil, 1, [ktrord], ndigit,
      &            '_seupd: Number of specified eigenvalues')
-             call ivout(logfil, 1, nconv, ndigit,
+             call ivout(logfil, 1, [nconv], ndigit,
      &            '_seupd: Number of "converged" eigenvalues')
          end if
 c

--- a/mathlibs/src/arpack/dsgets.f
+++ b/mathlibs/src/arpack/dsgets.f
@@ -202,8 +202,8 @@ c
       tsgets = tsgets + (t1 - t0)
 c
       if (msglvl .gt. 0) then
-         call ivout (logfil, 1, kev, ndigit, '_sgets: KEV is')
-         call ivout (logfil, 1, np, ndigit, '_sgets: NP is')
+         call ivout (logfil, 1, [kev], ndigit, '_sgets: KEV is')
+         call ivout (logfil, 1, [np], ndigit, '_sgets: NP is')
          call dvout (logfil, kev+np, ritz, ndigit,
      &        '_sgets: Eigenvalues of current H matrix')
          call dvout (logfil, kev+np, bounds, ndigit, 

--- a/mathlibs/src/arpack/dsgets.f
+++ b/mathlibs/src/arpack/dsgets.f
@@ -3,13 +3,13 @@ c\BeginDoc
 c
 c\Name: dsgets
 c
-c\Description: 
+c\Description:
 c  Given the eigenvalues of the symmetric tridiagonal matrix H,
-c  computes the NP shifts AMU that are zeros of the polynomial of 
-c  degree NP which filters out components of the unwanted eigenvectors 
+c  computes the NP shifts AMU that are zeros of the polynomial of
+c  degree NP which filters out components of the unwanted eigenvectors
 c  corresponding to the AMU's based on some given criteria.
 c
-c  NOTE: This is called even in the case of user specified shifts in 
+c  NOTE: This is called even in the case of user specified shifts in
 c  order to sort the eigenvalues, and error bounds of H for later use.
 c
 c\Usage:
@@ -39,8 +39,8 @@ c          Number of implicit shifts to be computed.
 c
 c  RITZ    Double precision array of length KEV+NP.  (INPUT/OUTPUT)
 c          On INPUT, RITZ contains the eigenvalues of H.
-c          On OUTPUT, RITZ are sorted so that the unwanted eigenvalues 
-c          are in the first NP locations and the wanted part is in 
+c          On OUTPUT, RITZ are sorted so that the unwanted eigenvalues
+c          are in the first NP locations and the wanted part is in
 c          the last KEV locations.  When exact shifts are selected, the
 c          unwanted part corresponds to the shifts to be applied.
 c
@@ -49,7 +49,7 @@ c          Error bounds corresponding to the ordering in RITZ.
 c
 c  SHIFTS  Double precision array of length NP.  (INPUT/OUTPUT)
 c          On INPUT:  contains the user specified shifts if ISHIFT = 0.
-c          On OUTPUT: contains the shifts sorted into decreasing order 
+c          On OUTPUT: contains the shifts sorted into decreasing order
 c          of magnitude with respect to the Ritz estimates contained in
 c          BOUNDS. If ISHIFT = 0, SHIFTS is not modified on exit.
 c
@@ -75,13 +75,13 @@ c     Danny Sorensen               Phuong Vu
 c     Richard Lehoucq              CRPC / Rice University
 c     Dept. of Computational &     Houston, Texas
 c     Applied Mathematics
-c     Rice University           
-c     Houston, Texas            
+c     Rice University
+c     Houston, Texas
 c
 c\Revision history:
 c     xx/xx/93: Version ' 2.1'
 c
-c\SCCS Information: @(#) 
+c\SCCS Information: @(#)
 c FILE: sgets.F   SID: 2.4   DATE OF SID: 4/19/96   RELEASE: 2
 c
 c\Remarks
@@ -142,7 +142,7 @@ c
 c     %-----------------------%
 c     | Executable Statements |
 c     %-----------------------%
-c 
+c
 c     %-------------------------------%
 c     | Initialize timing statistics  |
 c     | & message level for debugging |
@@ -150,7 +150,7 @@ c     %-------------------------------%
 c
       call second (t0)
       msglvl = msgets
-c 
+c
       if (which .eq. 'BE') then
 c
 c        %-----------------------------------------------------%
@@ -163,11 +163,11 @@ c        | overlapping locations.                              |
 c        %-----------------------------------------------------%
 c
          call dsortr ('LA', .true., kev+np, ritz, bounds)
-         kevd2 = kev / 2 
+         kevd2 = kev / 2
          if ( kev .gt. 1 ) then
-            call dswap ( min(kevd2,np), ritz, 1, 
+            call dswap ( min(kevd2,np), ritz, 1,
      &                   ritz( max(kevd2,np)+1 ), 1)
-            call dswap ( min(kevd2,np), bounds, 1, 
+            call dswap ( min(kevd2,np), bounds, 1,
      &                   bounds( max(kevd2,np)+1 ), 1)
          end if
 c
@@ -185,7 +185,7 @@ c
       end if
 c
       if (ishift .eq. 1 .and. np .gt. 0) then
-c     
+c
 c        %-------------------------------------------------------%
 c        | Sort the unwanted Ritz values used as shifts so that  |
 c        | the ones with largest Ritz estimates are first.       |
@@ -193,11 +193,11 @@ c        | This will tend to minimize the effects of the         |
 c        | forward instability of the iteration when the shifts  |
 c        | are applied in subroutine dsapps.                     |
 c        %-------------------------------------------------------%
-c     
+c
          call dsortr ('SM', .true., np, bounds, ritz)
          call dcopy (np, ritz, 1, shifts, 1)
       end if
-c 
+c
       call second (t1)
       tsgets = tsgets + (t1 - t0)
 c
@@ -206,10 +206,10 @@ c
          call ivout (logfil, 1, [np], ndigit, '_sgets: NP is')
          call dvout (logfil, kev+np, ritz, ndigit,
      &        '_sgets: Eigenvalues of current H matrix')
-         call dvout (logfil, kev+np, bounds, ndigit, 
+         call dvout (logfil, kev+np, bounds, ndigit,
      &        '_sgets: Associated Ritz estimates')
       end if
-c 
+c
       return
 c
 c     %---------------%

--- a/mathlibs/src/arpack/sgetv0.f
+++ b/mathlibs/src/arpack/sgetv0.f
@@ -3,13 +3,13 @@ c\BeginDoc
 c
 c\Name: sgetv0
 c
-c\Description: 
+c\Description:
 c  Generate a random initial residual vector for the Arnoldi process.
-c  Force the residual vector to be in the range of the operator OP.  
+c  Force the residual vector to be in the range of the operator OP.
 c
 c\Usage:
 c  call sgetv0
-c     ( IDO, BMAT, ITRY, INITV, N, J, V, LDV, RESID, RNORM, 
+c     ( IDO, BMAT, ITRY, INITV, N, J, V, LDV, RESID, RNORM,
 c       IPNTR, WORKD, IERR )
 c
 c\Arguments
@@ -36,7 +36,7 @@ c          B = 'I' -> standard eigenvalue problem A*x = lambda*x
 c          B = 'G' -> generalized eigenvalue problem A*x = lambda*B*x
 c
 c  ITRY    Integer.  (INPUT)
-c          ITRY counts the number of times that sgetv0 is called.  
+c          ITRY counts the number of times that sgetv0 is called.
 c          It should be set to 1 on the initial call to sgetv0.
 c
 c  INITV   Logical variable.  (INPUT)
@@ -55,11 +55,11 @@ c          The first J-1 columns of V contain the current Arnoldi basis
 c          if this is a "restart".
 c
 c  LDV     Integer.  (INPUT)
-c          Leading dimension of V exactly as declared in the calling 
+c          Leading dimension of V exactly as declared in the calling
 c          program.
 c
 c  RESID   Real array of length N.  (INPUT/OUTPUT)
-c          Initial residual vector to be generated.  If RESID is 
+c          Initial residual vector to be generated.  If RESID is
 c          provided, force RESID into the range of the operator OP.
 c
 c  RNORM   Real scalar.  (OUTPUT)
@@ -88,7 +88,7 @@ c\References:
 c  1. D.C. Sorensen, "Implicit Application of Polynomial Filters in
 c     a k-Step Arnoldi Method", SIAM J. Matr. Anal. Apps., 13 (1992),
 c     pp 357-385.
-c  2. R.B. Lehoucq, "Analysis and Implementation of an Implicitly 
+c  2. R.B. Lehoucq, "Analysis and Implementation of an Implicitly
 c     Restarted Arnoldi Iteration", Rice University Technical Report
 c     TR95-13, Department of Computational and Applied Mathematics.
 c
@@ -98,7 +98,7 @@ c     svout   ARPACK utility routine for vector output.
 c     slarnv  LAPACK routine for generating a random vector.
 c     sgemv   Level 2 BLAS routine for matrix vector multiplication.
 c     scopy   Level 1 BLAS that copies one vector to another.
-c     sdot    Level 1 BLAS that computes the scalar product of two vectors. 
+c     sdot    Level 1 BLAS that computes the scalar product of two vectors.
 c     snrm2   Level 1 BLAS that computes the norm of a vector.
 c
 c\Author
@@ -106,20 +106,20 @@ c     Danny Sorensen               Phuong Vu
 c     Richard Lehoucq              CRPC / Rice University
 c     Dept. of Computational &     Houston, Texas
 c     Applied Mathematics
-c     Rice University           
-c     Houston, Texas            
+c     Rice University
+c     Houston, Texas
 c
-c\SCCS Information: @(#) 
+c\SCCS Information: @(#)
 c FILE: getv0.F   SID: 2.6   DATE OF SID: 8/27/96   RELEASE: 2
 c
 c\EndLib
 c
 c-----------------------------------------------------------------------
 c
-      subroutine sgetv0 
-     &   ( ido, bmat, itry, initv, n, j, v, ldv, resid, rnorm, 
+      subroutine sgetv0
+     &   ( ido, bmat, itry, initv, n, j, v, ldv, resid, rnorm,
      &     ipntr, workd, ierr )
-c 
+c
 c     %----------------------------------------------------%
 c     | Include files for debugging and timing information |
 c     %----------------------------------------------------%
@@ -208,7 +208,7 @@ c
       end if
 c
       if (ido .eq.  0) then
-c 
+c
 c        %-------------------------------%
 c        | Initialize timing statistics  |
 c        | & message level for debugging |
@@ -216,7 +216,7 @@ c        %-------------------------------%
 c
          call second (t0)
          msglvl = mgetv0
-c 
+c
          ierr   = 0
          iter   = 0
          first  = .FALSE.
@@ -235,7 +235,7 @@ c
             idist = 2
             call slarnv (idist, iseed, n, resid)
          end if
-c 
+c
 c        %----------------------------------------------------------%
 c        | Force the starting vector into the range of OP to handle |
 c        | the generalized problem when B is possibly (singular).   |
@@ -251,7 +251,7 @@ c
             go to 9000
          end if
       end if
-c 
+c
 c     %-----------------------------------------%
 c     | Back from computing OP*(initial-vector) |
 c     %-----------------------------------------%
@@ -263,12 +263,12 @@ c     | Back from computing B*(orthogonalized-vector) |
 c     %-----------------------------------------------%
 c
       if (orth)  go to 40
-c 
+c
       if (bmat .eq. 'G') then
          call second (t3)
          tmvopx = tmvopx + (t3 - t2)
       end if
-c 
+c
 c     %------------------------------------------------------%
 c     | Starting vector is now in the range of OP; r = OP*r; |
 c     | Compute B-norm of starting vector.                   |
@@ -286,14 +286,14 @@ c
       else if (bmat .eq. 'I') then
          call scopy (n, resid, 1, workd, 1)
       end if
-c 
+c
    20 continue
 c
       if (bmat .eq. 'G') then
          call second (t3)
          tmvbx = tmvbx + (t3 - t2)
       end if
-c 
+c
       first = .FALSE.
       if (bmat .eq. 'G') then
           rnorm0 = sdot (n, resid, 1, workd, 1)
@@ -308,7 +308,7 @@ c     | Exit if this is the very first Arnoldi step |
 c     %---------------------------------------------%
 c
       if (j .eq. 1) go to 50
-c 
+c
 c     %----------------------------------------------------------------
 c     | Otherwise need to B-orthogonalize the starting vector against |
 c     | the current Arnoldi basis using Gram-Schmidt with iter. ref.  |
@@ -324,11 +324,11 @@ c
       orth = .TRUE.
    30 continue
 c
-      call sgemv ('T', n, j-1, one, v, ldv, workd, 1, 
+      call sgemv ('T', n, j-1, one, v, ldv, workd, 1,
      &            zero, workd(n+1), 1)
-      call sgemv ('N', n, j-1, -one, v, ldv, workd(n+1), 1, 
+      call sgemv ('N', n, j-1, -one, v, ldv, workd(n+1), 1,
      &            one, resid, 1)
-c 
+c
 c     %----------------------------------------------------------%
 c     | Compute the B-norm of the orthogonalized starting vector |
 c     %----------------------------------------------------------%
@@ -344,14 +344,14 @@ c
       else if (bmat .eq. 'I') then
          call scopy (n, resid, 1, workd, 1)
       end if
-c 
+c
    40 continue
 c
       if (bmat .eq. 'G') then
          call second (t3)
          tmvbx = tmvbx + (t3 - t2)
       end if
-c 
+c
       if (bmat .eq. 'G') then
          rnorm = sdot (n, resid, 1, workd, 1)
          rnorm = sqrt(abs(rnorm))
@@ -364,14 +364,14 @@ c     | Check for further orthogonalization. |
 c     %--------------------------------------%
 c
       if (msglvl .gt. 2) then
-          call svout (logfil, 1, [rnorm0], ndigit, 
+          call svout (logfil, 1, [rnorm0], ndigit,
      &                '_getv0: re-orthonalization ; rnorm0 is')
-          call svout (logfil, 1, [rnorm], ndigit, 
+          call svout (logfil, 1, [rnorm], ndigit,
      &                '_getv0: re-orthonalization ; rnorm is')
       end if
 c
       if (rnorm .gt. 0.717*rnorm0) go to 50
-c 
+c
       iter = iter + 1
       if (iter .le. 1) then
 c
@@ -393,7 +393,7 @@ c
          rnorm = zero
          ierr = -1
       end if
-c 
+c
    50 continue
 c
       if (msglvl .gt. 0) then
@@ -405,10 +405,10 @@ c
      &        '_getv0: initial / restarted starting vector')
       end if
       ido = 99
-c 
+c
       call second (t1)
       tgetv0 = tgetv0 + (t1 - t0)
-c 
+c
  9000 continue
       return
 c

--- a/mathlibs/src/arpack/sgetv0.f
+++ b/mathlibs/src/arpack/sgetv0.f
@@ -364,9 +364,9 @@ c     | Check for further orthogonalization. |
 c     %--------------------------------------%
 c
       if (msglvl .gt. 2) then
-          call svout (logfil, 1, rnorm0, ndigit, 
+          call svout (logfil, 1, [rnorm0], ndigit, 
      &                '_getv0: re-orthonalization ; rnorm0 is')
-          call svout (logfil, 1, rnorm, ndigit, 
+          call svout (logfil, 1, [rnorm], ndigit, 
      &                '_getv0: re-orthonalization ; rnorm is')
       end if
 c
@@ -397,7 +397,7 @@ c
    50 continue
 c
       if (msglvl .gt. 0) then
-         call svout (logfil, 1, rnorm, ndigit,
+         call svout (logfil, 1, [rnorm], ndigit,
      &        '_getv0: B-norm of initial / restarted starting vector')
       end if
       if (msglvl .gt. 2) then

--- a/mathlibs/src/arpack/snaitr.f
+++ b/mathlibs/src/arpack/snaitr.f
@@ -371,9 +371,9 @@ c     %--------------------------------------------------------------%
  1000 continue
 c
          if (msglvl .gt. 1) then
-            call ivout (logfil, 1, j, ndigit, 
+            call ivout (logfil, 1, [j], ndigit, 
      &                  '_naitr: generating Arnoldi vector number')
-            call svout (logfil, 1, rnorm, ndigit, 
+            call svout (logfil, 1, [rnorm], ndigit, 
      &                  '_naitr: B-norm of the current residual is')
          end if
 c 
@@ -393,7 +393,7 @@ c           | basis and continue the iteration.                 |
 c           %---------------------------------------------------%
 c
             if (msglvl .gt. 0) then
-               call ivout (logfil, 1, j, ndigit,
+               call ivout (logfil, 1, [j], ndigit,
      &                     '_naitr: ****** RESTART AT STEP ******')
             end if
 c 
@@ -721,7 +721,7 @@ c
          end if
 c
          if (msglvl .gt. 0 .and. iter .gt. 0) then
-            call ivout (logfil, 1, j, ndigit,
+            call ivout (logfil, 1, [j], ndigit,
      &           '_naitr: Iterative refinement for Arnoldi residual')
             if (msglvl .gt. 2) then
                 xtemp(1) = rnorm

--- a/mathlibs/src/arpack/snaitr.f
+++ b/mathlibs/src/arpack/snaitr.f
@@ -3,8 +3,8 @@ c\BeginDoc
 c
 c\Name: snaitr
 c
-c\Description: 
-c  Reverse communication interface for applying NP additional steps to 
+c\Description:
+c  Reverse communication interface for applying NP additional steps to
 c  a K step nonsymmetric Arnoldi factorization.
 c
 c  Input:  OP*V_{k}  -  V_{k}*H = r_{k}*e_{k}^T
@@ -20,7 +20,7 @@ c  computed and returned.
 c
 c\Usage:
 c  call snaitr
-c     ( IDO, BMAT, N, K, NP, NB, RESID, RNORM, V, LDV, H, LDH, 
+c     ( IDO, BMAT, N, K, NP, NB, RESID, RNORM, V, LDV, H, LDH,
 c       IPNTR, WORKD, INFO )
 c
 c\Arguments
@@ -62,8 +62,8 @@ c  NP      Integer.  (INPUT)
 c          Number of additional Arnoldi steps to take.
 c
 c  NB      Integer.  (INPUT)
-c          Blocksize to be used in the recurrence.          
-c          Only work for NB = 1 right now.  The goal is to have a 
+c          Blocksize to be used in the recurrence.
+c          Only work for NB = 1 right now.  The goal is to have a
 c          program that implement both the block and non-block method.
 c
 c  RESID   Real array of length N.  (INPUT/OUTPUT)
@@ -75,37 +75,37 @@ c          B-norm of the starting residual on input.
 c          B-norm of the updated residual r_{k+p} on output.
 c
 c  V       Real N by K+NP array.  (INPUT/OUTPUT)
-c          On INPUT:  V contains the Arnoldi vectors in the first K 
+c          On INPUT:  V contains the Arnoldi vectors in the first K
 c          columns.
 c          On OUTPUT: V contains the new NP Arnoldi vectors in the next
 c          NP columns.  The first K columns are unchanged.
 c
 c  LDV     Integer.  (INPUT)
-c          Leading dimension of V exactly as declared in the calling 
+c          Leading dimension of V exactly as declared in the calling
 c          program.
 c
 c  H       Real (K+NP) by (K+NP) array.  (INPUT/OUTPUT)
 c          H is used to store the generated upper Hessenberg matrix.
 c
 c  LDH     Integer.  (INPUT)
-c          Leading dimension of H exactly as declared in the calling 
+c          Leading dimension of H exactly as declared in the calling
 c          program.
 c
 c  IPNTR   Integer array of length 3.  (OUTPUT)
-c          Pointer to mark the starting locations in the WORK for 
+c          Pointer to mark the starting locations in the WORK for
 c          vectors used by the Arnoldi iteration.
 c          -------------------------------------------------------------
 c          IPNTR(1): pointer to the current operand vector X.
 c          IPNTR(2): pointer to the current result vector Y.
-c          IPNTR(3): pointer to the vector B * X when used in the 
+c          IPNTR(3): pointer to the vector B * X when used in the
 c                    shift-and-invert mode.  X is the current operand.
 c          -------------------------------------------------------------
-c          
+c
 c  WORKD   Real work array of length 3*N.  (REVERSE COMMUNICATION)
 c          Distributed array to be used in the basic Arnoldi iteration
-c          for reverse communication.  The calling program should not 
+c          for reverse communication.  The calling program should not
 c          use WORKD as temporary workspace during the iteration !!!!!!
-c          On input, WORKD(1:N) = B*RESID and is used to save some 
+c          On input, WORKD(1:N) = B*RESID and is used to save some
 c          computation at the first step.
 c
 c  INFO    Integer.  (OUTPUT)
@@ -125,7 +125,7 @@ c\References:
 c  1. D.C. Sorensen, "Implicit Application of Polynomial Filters in
 c     a k-Step Arnoldi Method", SIAM J. Matr. Anal. Apps., 13 (1992),
 c     pp 357-385.
-c  2. R.B. Lehoucq, "Analysis and Implementation of an Implicitly 
+c  2. R.B. Lehoucq, "Analysis and Implementation of an Implicitly
 c     Restarted Arnoldi Iteration", Rice University Technical Report
 c     TR95-13, Department of Computational and Applied Mathematics.
 c
@@ -143,7 +143,7 @@ c     sgemv   Level 2 BLAS routine for matrix vector multiplication.
 c     saxpy   Level 1 BLAS that computes a vector triad.
 c     sscal   Level 1 BLAS that scales a vector.
 c     scopy   Level 1 BLAS that copies one vector to another .
-c     sdot    Level 1 BLAS that computes the scalar product of two vectors. 
+c     sdot    Level 1 BLAS that computes the scalar product of two vectors.
 c     snrm2   Level 1 BLAS that computes the norm of a vector.
 c
 c\Author
@@ -151,22 +151,22 @@ c     Danny Sorensen               Phuong Vu
 c     Richard Lehoucq              CRPC / Rice University
 c     Dept. of Computational &     Houston, Texas
 c     Applied Mathematics
-c     Rice University           
-c     Houston, Texas    
-c 
+c     Rice University
+c     Houston, Texas
+c
 c\Revision history:
 c     xx/xx/92: Version ' 2.4'
 c
-c\SCCS Information: @(#) 
+c\SCCS Information: @(#)
 c FILE: naitr.F   SID: 2.4   DATE OF SID: 8/27/96   RELEASE: 2
 c
 c\Remarks
 c  The algorithm implemented is:
-c  
+c
 c  restart = .false.
-c  Given V_{k} = [v_{1}, ..., v_{k}], r_{k}; 
+c  Given V_{k} = [v_{1}, ..., v_{k}], r_{k};
 c  r_{k} contains the initial residual vector even for k = 0;
-c  Also assume that rnorm = || B*r_{k} || and B*r_{k} are already 
+c  Also assume that rnorm = || B*r_{k} || and B*r_{k} are already
 c  computed by the calling program.
 c
 c  betaj = rnorm ; p_{k+1} = B*r_{k} ;
@@ -174,7 +174,7 @@ c  For  j = k+1, ..., k+np  Do
 c     1) if ( betaj < tol ) stop or restart depending on j.
 c        ( At present tol is zero )
 c        if ( restart ) generate a new starting vector.
-c     2) v_{j} = r(j-1)/betaj;  V_{j} = [V_{j-1}, v_{j}];  
+c     2) v_{j} = r(j-1)/betaj;  V_{j} = [V_{j-1}, v_{j}];
 c        p_{j} = p_{j}/betaj
 c     3) r_{j} = OP*v_{j} where OP is defined as in snaupd
 c        For shift-invert mode p_{j} = B*v_{j} is already available.
@@ -189,7 +189,7 @@ c        If (rnorm > 0.717*wnorm) accept step and go back to 1)
 c     5) Re-orthogonalization step:
 c        s = V_{j}'*B*r_{j}
 c        r_{j} = r_{j} - V_{j}*s;  rnorm1 = || r_{j} ||
-c        alphaj = alphaj + s_{j};   
+c        alphaj = alphaj + s_{j};
 c     6) Iterative refinement step:
 c        If (rnorm1 > 0.717*rnorm) then
 c           rnorm = rnorm1
@@ -199,7 +199,7 @@ c           rnorm = rnorm1
 c           If this is the first time in step 6), go to 5)
 c           Else r_{j} lies in the span of V_{j} numerically.
 c              Set r_{j} = 0 and rnorm = 0; go to 1)
-c        EndIf 
+c        EndIf
 c  End Do
 c
 c\EndLib
@@ -207,7 +207,7 @@ c
 c-----------------------------------------------------------------------
 c
       subroutine snaitr
-     &   (ido, bmat, n, k, np, nb, resid, rnorm, v, ldv, h, ldh, 
+     &   (ido, bmat, n, k, np, nb, resid, rnorm, v, ldv, h, ldh,
      &    ipntr, workd, info)
 c
 c     %----------------------------------------------------%
@@ -250,14 +250,14 @@ c
       integer    ierr, i, infol, ipj, irj, ivj, iter, itry, j, msglvl,
      &           jj
       Real
-     &           betaj, ovfl, temp1, rnorm1, smlnum, tst1, ulp, unfl, 
+     &           betaj, ovfl, temp1, rnorm1, smlnum, tst1, ulp, unfl,
      &           wnorm
       save       first, orth1, orth2, rstart, step3, step4,
      &           ierr, ipj, irj, ivj, iter, itry, j, msglvl, ovfl,
      &           betaj, rnorm1, smlnum, ulp, unfl, wnorm
 c
 c     %-----------------------%
-c     | Local Array Arguments | 
+c     | Local Array Arguments |
 c     %-----------------------%
 c
       Real
@@ -267,7 +267,7 @@ c     %----------------------%
 c     | External Subroutines |
 c     %----------------------%
 c
-      external   saxpy, scopy, sscal, sgemv, sgetv0, slabad, 
+      external   saxpy, scopy, sscal, sgemv, sgetv0, slabad,
      &           svout, smout, ivout, second
 c
 c     %--------------------%
@@ -313,7 +313,7 @@ c
       end if
 c
       if (ido .eq. 0) then
-c 
+c
 c        %-------------------------------%
 c        | Initialize timing statistics  |
 c        | & message level for debugging |
@@ -321,7 +321,7 @@ c        %-------------------------------%
 c
          call second (t0)
          msglvl = mnaitr
-c 
+c
 c        %------------------------------%
 c        | Initial call to this routine |
 c        %------------------------------%
@@ -337,7 +337,7 @@ c
          irj    = ipj   + n
          ivj    = irj   + n
       end if
-c 
+c
 c     %-------------------------------------------------%
 c     | When in reverse communication mode one of:      |
 c     | STEP3, STEP4, ORTH1, ORTH2, RSTART              |
@@ -367,16 +367,16 @@ c     |        A R N O L D I     I T E R A T I O N     L O O P       |
 c     |                                                              |
 c     | Note:  B*r_{j-1} is already in WORKD(1:N)=WORKD(IPJ:IPJ+N-1) |
 c     %--------------------------------------------------------------%
- 
+
  1000 continue
 c
          if (msglvl .gt. 1) then
-            call ivout (logfil, 1, [j], ndigit, 
+            call ivout (logfil, 1, [j], ndigit,
      &                  '_naitr: generating Arnoldi vector number')
-            call svout (logfil, 1, [rnorm], ndigit, 
+            call svout (logfil, 1, [rnorm], ndigit,
      &                  '_naitr: B-norm of the current residual is')
          end if
-c 
+c
 c        %---------------------------------------------------%
 c        | STEP 1: Check if the B norm of j-th residual      |
 c        | vector is zero. Equivalent to determing whether   |
@@ -396,13 +396,13 @@ c
                call ivout (logfil, 1, [j], ndigit,
      &                     '_naitr: ****** RESTART AT STEP ******')
             end if
-c 
+c
 c           %---------------------------------------------%
 c           | ITRY is the loop variable that controls the |
 c           | maximum amount of times that a restart is   |
 c           | attempted. NRSTRT is used by stat.h         |
 c           %---------------------------------------------%
-c 
+c
             betaj  = zero
             nrstrt = nrstrt + 1
             itry   = 1
@@ -416,7 +416,7 @@ c           | If in reverse communication mode and |
 c           | RSTART = .true. flow returns here.   |
 c           %--------------------------------------%
 c
-            call sgetv0 (ido, bmat, itry, .false., n, j, v, ldv, 
+            call sgetv0 (ido, bmat, itry, .false., n, j, v, ldv,
      &                   resid, rnorm, ipntr, workd, ierr)
             if (ido .ne. 99) go to 9000
             if (ierr .lt. 0) then
@@ -435,7 +435,7 @@ c
                ido = 99
                go to 9000
             end if
-c 
+c
    40    continue
 c
 c        %---------------------------------------------------------%
@@ -457,9 +457,9 @@ c            | To scale both v_{j} and p_{j} carefully |
 c            | use LAPACK routine SLASCL               |
 c            %-----------------------------------------%
 c
-             call slascl ('General', i, i, rnorm, one, n, 1, 
+             call slascl ('General', i, i, rnorm, one, n, 1,
      &                    v(1,j), n, infol)
-             call slascl ('General', i, i, rnorm, one, n, 1, 
+             call slascl ('General', i, i, rnorm, one, n, 1,
      &                    workd(ipj), n, infol)
          end if
 c
@@ -476,14 +476,14 @@ c
          ipntr(2) = irj
          ipntr(3) = ipj
          ido = 1
-c 
+c
 c        %-----------------------------------%
 c        | Exit in order to compute OP*v_{j} |
 c        %-----------------------------------%
-c 
-         go to 9000 
+c
+         go to 9000
    50    continue
-c 
+c
 c        %----------------------------------%
 c        | Back from reverse communication; |
 c        | WORKD(IRJ:IRJ+N-1) := OP*v_{j}   |
@@ -492,7 +492,7 @@ c        %----------------------------------%
 c
          call second (t3)
          tmvopx = tmvopx + (t3 - t2)
- 
+
          step3 = .false.
 c
 c        %------------------------------------------%
@@ -500,7 +500,7 @@ c        | Put another copy of OP*v_{j} into RESID. |
 c        %------------------------------------------%
 c
          call scopy (n, workd(irj), 1, resid, 1)
-c 
+c
 c        %---------------------------------------%
 c        | STEP 4:  Finish extending the Arnoldi |
 c        |          factorization to length j.   |
@@ -513,17 +513,17 @@ c
             ipntr(1) = irj
             ipntr(2) = ipj
             ido = 2
-c 
+c
 c           %-------------------------------------%
 c           | Exit in order to compute B*OP*v_{j} |
 c           %-------------------------------------%
-c 
+c
             go to 9000
          else if (bmat .eq. 'I') then
             call scopy (n, resid, 1, workd(ipj), 1)
          end if
    60    continue
-c 
+c
 c        %----------------------------------%
 c        | Back from reverse communication; |
 c        | WORKD(IPJ:IPJ+N-1) := B*OP*v_{j} |
@@ -534,7 +534,7 @@ c
             call second (t3)
             tmvbx = tmvbx + (t3 - t2)
          end if
-c 
+c
          step4 = .false.
 c
 c        %-------------------------------------%
@@ -542,7 +542,7 @@ c        | The following is needed for STEP 5. |
 c        | Compute the B-norm of OP*v_{j}.     |
 c        %-------------------------------------%
 c
-         if (bmat .eq. 'G') then  
+         if (bmat .eq. 'G') then
              wnorm = sdot (n, resid, 1, workd(ipj), 1)
              wnorm = sqrt(abs(wnorm))
          else if (bmat .eq. 'I') then
@@ -562,13 +562,13 @@ c        %------------------------------------------%
 c        | Compute the j Fourier coefficients w_{j} |
 c        | WORKD(IPJ:IPJ+N-1) contains B*OP*v_{j}.  |
 c        %------------------------------------------%
-c 
+c
          call sgemv ('T', n, j, one, v, ldv, workd(ipj), 1,
      &               zero, h(1,j), 1)
 c
 c        %--------------------------------------%
 c        | Orthogonalize r_{j} against V_{j}.   |
-c        | RESID contains OP*v_{j}. See STEP 3. | 
+c        | RESID contains OP*v_{j}. See STEP 3. |
 c        %--------------------------------------%
 c
          call sgemv ('N', n, j, -one, v, ldv, h(1,j), 1,
@@ -577,7 +577,7 @@ c
          if (j .gt. 1) h(j,j-1) = betaj
 c
          call second (t4)
-c 
+c
          orth1 = .true.
 c
          call second (t2)
@@ -587,17 +587,17 @@ c
             ipntr(1) = irj
             ipntr(2) = ipj
             ido = 2
-c 
+c
 c           %----------------------------------%
 c           | Exit in order to compute B*r_{j} |
 c           %----------------------------------%
-c 
+c
             go to 9000
          else if (bmat .eq. 'I') then
             call scopy (n, resid, 1, workd(ipj), 1)
-         end if 
+         end if
    70    continue
-c 
+c
 c        %---------------------------------------------------%
 c        | Back from reverse communication if ORTH1 = .true. |
 c        | WORKD(IPJ:IPJ+N-1) := B*r_{j}.                    |
@@ -607,20 +607,20 @@ c
             call second (t3)
             tmvbx = tmvbx + (t3 - t2)
          end if
-c 
+c
          orth1 = .false.
 c
 c        %------------------------------%
 c        | Compute the B-norm of r_{j}. |
 c        %------------------------------%
 c
-         if (bmat .eq. 'G') then         
+         if (bmat .eq. 'G') then
             rnorm = sdot (n, resid, 1, workd(ipj), 1)
             rnorm = sqrt(abs(rnorm))
          else if (bmat .eq. 'I') then
             rnorm = snrm2(n, resid, 1)
          end if
-c 
+c
 c        %-----------------------------------------------------------%
 c        | STEP 5: Re-orthogonalization / Iterative refinement phase |
 c        | Maximum NITER_ITREF tries.                                |
@@ -642,20 +642,20 @@ c
          if (rnorm .gt. 0.717*wnorm) go to 100
          iter  = 0
          nrorth = nrorth + 1
-c 
+c
 c        %---------------------------------------------------%
 c        | Enter the Iterative refinement phase. If further  |
 c        | refinement is necessary, loop back here. The loop |
 c        | variable is ITER. Perform a step of Classical     |
 c        | Gram-Schmidt using all the Arnoldi vectors V_{j}  |
 c        %---------------------------------------------------%
-c 
+c
    80    continue
 c
          if (msglvl .gt. 2) then
             xtemp(1) = wnorm
             xtemp(2) = rnorm
-            call svout (logfil, 2, xtemp, ndigit, 
+            call svout (logfil, 2, xtemp, ndigit,
      &           '_naitr: re-orthonalization; wnorm and rnorm are')
             call svout (logfil, j, h(1,j), ndigit,
      &                  '_naitr: j-th column of H')
@@ -666,7 +666,7 @@ c        | Compute V_{j}^T * B * r_{j}.                       |
 c        | WORKD(IRJ:IRJ+J-1) = v(:,1:J)'*WORKD(IPJ:IPJ+N-1). |
 c        %----------------------------------------------------%
 c
-         call sgemv ('T', n, j, one, v, ldv, workd(ipj), 1, 
+         call sgemv ('T', n, j, one, v, ldv, workd(ipj), 1,
      &               zero, workd(irj), 1)
 c
 c        %---------------------------------------------%
@@ -676,10 +676,10 @@ c        | The correction to H is v(:,1:J)*H(1:J,1:J)  |
 c        | + v(:,1:J)*WORKD(IRJ:IRJ+J-1)*e'_j.         |
 c        %---------------------------------------------%
 c
-         call sgemv ('N', n, j, -one, v, ldv, workd(irj), 1, 
+         call sgemv ('N', n, j, -one, v, ldv, workd(irj), 1,
      &               one, resid, 1)
          call saxpy (j, one, workd(irj), 1, h(1,j), 1)
-c 
+c
          orth2 = .true.
          call second (t2)
          if (bmat .eq. 'G') then
@@ -688,16 +688,16 @@ c
             ipntr(1) = irj
             ipntr(2) = ipj
             ido = 2
-c 
+c
 c           %-----------------------------------%
 c           | Exit in order to compute B*r_{j}. |
 c           | r_{j} is the corrected residual.  |
 c           %-----------------------------------%
-c 
+c
             go to 9000
          else if (bmat .eq. 'I') then
             call scopy (n, resid, 1, workd(ipj), 1)
-         end if 
+         end if
    90    continue
 c
 c        %---------------------------------------------------%
@@ -712,8 +712,8 @@ c
 c        %-----------------------------------------------------%
 c        | Compute the B-norm of the corrected residual r_{j}. |
 c        %-----------------------------------------------------%
-c 
-         if (bmat .eq. 'G') then         
+c
+         if (bmat .eq. 'G') then
              rnorm1 = sdot (n, resid, 1, workd(ipj), 1)
              rnorm1 = sqrt(abs(rnorm1))
          else if (bmat .eq. 'I') then
@@ -749,7 +749,7 @@ c           | angle of less than arcCOS(0.717)      |
 c           %---------------------------------------%
 c
             rnorm = rnorm1
-c 
+c
          else
 c
 c           %-------------------------------------------%
@@ -771,21 +771,21 @@ c
   95        continue
             rnorm = zero
          end if
-c 
+c
 c        %----------------------------------------------%
 c        | Branch here directly if iterative refinement |
 c        | wasn't necessary or after at most NITER_REF  |
 c        | steps of iterative refinement.               |
 c        %----------------------------------------------%
-c 
+c
   100    continue
-c 
+c
          rstart = .false.
          orth2  = .false.
-c 
+c
          call second (t5)
          titref = titref + (t5 - t4)
-c 
+c
 c        %------------------------------------%
 c        | STEP 6: Update  j = j+1;  Continue |
 c        %------------------------------------%
@@ -796,25 +796,25 @@ c
             tnaitr = tnaitr + (t1 - t0)
             ido = 99
             do 110 i = max(1,k), k+np-1
-c     
+c
 c              %--------------------------------------------%
 c              | Check for splitting and deflation.         |
 c              | Use a standard test as in the QR algorithm |
 c              | REFERENCE: LAPACK subroutine slahqr        |
 c              %--------------------------------------------%
-c     
+c
                tst1 = abs( h( i, i ) ) + abs( h( i+1, i+1 ) )
                if( tst1.eq.zero )
      &              tst1 = slanhs( '1', k+np, h, ldh, workd(n+1) )
-               if( abs( h( i+1,i ) ).le.max( ulp*tst1, smlnum ) ) 
+               if( abs( h( i+1,i ) ).le.max( ulp*tst1, smlnum ) )
      &              h(i+1,i) = zero
  110        continue
-c     
+c
             if (msglvl .gt. 2) then
-               call smout (logfil, k+np, k+np, h, ldh, ndigit, 
+               call smout (logfil, k+np, k+np, h, ldh, ndigit,
      &          '_naitr: Final upper Hessenberg matrix H of order K+NP')
             end if
-c     
+c
             go to 9000
          end if
 c
@@ -823,7 +823,7 @@ c        | Loop back to extend the factorization by another step. |
 c        %--------------------------------------------------------%
 c
       go to 1000
-c 
+c
 c     %---------------------------------------------------------------%
 c     |                                                               |
 c     |  E N D     O F     M A I N     I T E R A T I O N     L O O P  |

--- a/mathlibs/src/arpack/snapps.f
+++ b/mathlibs/src/arpack/snapps.f
@@ -266,11 +266,11 @@ c
          sigmai = shifti(jj)
 c
          if (msglvl .gt. 2 ) then
-            call ivout (logfil, 1, jj, ndigit, 
+            call ivout (logfil, 1, [jj], ndigit, 
      &               '_napps: shift number.')
-            call svout (logfil, 1, sigmar, ndigit, 
+            call svout (logfil, 1, [sigmar], ndigit, 
      &               '_napps: The real part of the shift ')
-            call svout (logfil, 1, sigmai, ndigit, 
+            call svout (logfil, 1, [sigmai], ndigit, 
      &               '_napps: The imaginary part of the shift ')
          end if
 c
@@ -335,9 +335,9 @@ c
      &         tst1 = slanhs( '1', kplusp-jj+1, h, ldh, workl )
             if( abs( h( i+1,i ) ).le.max( ulp*tst1, smlnum ) ) then
                if (msglvl .gt. 0) then
-                  call ivout (logfil, 1, i, ndigit, 
+                  call ivout (logfil, 1, [i], ndigit, 
      &                 '_napps: matrix splitting at row/column no.')
-                  call ivout (logfil, 1, jj, ndigit, 
+                  call ivout (logfil, 1, [jj], ndigit, 
      &                 '_napps: matrix splitting with shift number.')
                   call svout (logfil, 1, h(i+1,i), ndigit, 
      &                 '_napps: off diagonal element.')
@@ -351,9 +351,9 @@ c
    40    continue
 c
          if (msglvl .gt. 2) then
-             call ivout (logfil, 1, istart, ndigit, 
+             call ivout (logfil, 1, [istart], ndigit, 
      &                   '_napps: Start of current block ')
-             call ivout (logfil, 1, iend, ndigit, 
+             call ivout (logfil, 1, [iend], ndigit, 
      &                   '_napps: End of current block ')
          end if
 c
@@ -625,7 +625,7 @@ c
      &        '_napps: sigmak = (e_{kev+p}^T*Q)*e_{kev}')
          call svout (logfil, 1, h(kev+1,kev), ndigit,
      &        '_napps: betak = e_{kev+1}^T*H*e_{kev}')
-         call ivout (logfil, 1, kev, ndigit, 
+         call ivout (logfil, 1, [kev], ndigit, 
      &               '_napps: Order of the final Hessenberg matrix ')
          if (msglvl .gt. 2) then
             call smout (logfil, kev, kev, h, ldh, ndigit,

--- a/mathlibs/src/arpack/snapps.f
+++ b/mathlibs/src/arpack/snapps.f
@@ -20,7 +20,7 @@ c     A*VNEW_{k} - VNEW_{k}*HNEW_{k} = rnew_{k}*e_{k}^T.
 c
 c\Usage:
 c  call snapps
-c     ( N, KEV, NP, SHIFTR, SHIFTI, V, LDV, H, LDH, RESID, Q, LDQ, 
+c     ( N, KEV, NP, SHIFTR, SHIFTI, V, LDV, H, LDH, RESID, Q, LDQ,
 c       WORKL, WORKD )
 c
 c\Arguments
@@ -29,7 +29,7 @@ c          Problem size, i.e. size of matrix A.
 c
 c  KEV     Integer.  (INPUT/OUTPUT)
 c          KEV+NP is the size of the input matrix H.
-c          KEV is the size of the updated matrix HNEW.  KEV is only 
+c          KEV is the size of the updated matrix HNEW.  KEV is only
 c          updated on ouput when fewer than NP shifts are applied in
 c          order to keep the conjugate pair together.
 c
@@ -38,7 +38,7 @@ c          Number of implicit shifts to be applied.
 c
 c  SHIFTR, Real array of length NP.  (INPUT)
 c  SHIFTI  Real and imaginary part of the shifts to be applied.
-c          Upon, entry to snapps, the shifts must be sorted so that the 
+c          Upon, entry to snapps, the shifts must be sorted so that the
 c          conjugate pairs are in consecutive locations.
 c
 c  V       Real N by (KEV+NP) array.  (INPUT/OUTPUT)
@@ -51,7 +51,7 @@ c          Leading dimension of V exactly as declared in the calling
 c          program.
 c
 c  H       Real (KEV+NP) by (KEV+NP) array.  (INPUT/OUTPUT)
-c          On INPUT, H contains the current KEV+NP by KEV+NP upper 
+c          On INPUT, H contains the current KEV+NP by KEV+NP upper
 c          Hessenber matrix of the Arnoldi factorization.
 c          On OUTPUT, H contains the updated KEV by KEV upper Hessenberg
 c          matrix in the KEV leading submatrix.
@@ -62,7 +62,7 @@ c          program.
 c
 c  RESID   Real array of length N.  (INPUT/OUTPUT)
 c          On INPUT, RESID contains the the residual vector r_{k+p}.
-c          On OUTPUT, RESID is the update residual vector rnew_{k} 
+c          On OUTPUT, RESID is the update residual vector rnew_{k}
 c          in the first KEV locations.
 c
 c  Q       Real KEV+NP by KEV+NP work array.  (WORKSPACE)
@@ -102,7 +102,7 @@ c     smout   ARPACK utility routine that prints matrices.
 c     svout   ARPACK utility routine that prints vectors.
 c     slabad  LAPACK routine that computes machine constants.
 c     slacpy  LAPACK matrix copy routine.
-c     slamch  LAPACK routine that determines machine constants. 
+c     slamch  LAPACK routine that determines machine constants.
 c     slanhs  LAPACK routine that computes various norms of a matrix.
 c     slapy2  LAPACK routine to compute sqrt(x**2+y**2) carefully.
 c     slarf   LAPACK routine that applies Householder reflection to
@@ -120,13 +120,13 @@ c     Danny Sorensen               Phuong Vu
 c     Richard Lehoucq              CRPC / Rice University
 c     Dept. of Computational &     Houston, Texas
 c     Applied Mathematics
-c     Rice University           
-c     Houston, Texas    
+c     Rice University
+c     Houston, Texas
 c
 c\Revision history:
 c     xx/xx/92: Version ' 2.1'
 c
-c\SCCS Information: @(#) 
+c\SCCS Information: @(#)
 c FILE: napps.F   SID: 2.3   DATE OF SID: 4/20/96   RELEASE: 2
 c
 c\Remarks
@@ -141,7 +141,7 @@ c
 c-----------------------------------------------------------------------
 c
       subroutine snapps
-     &   ( n, kev, np, shiftr, shifti, v, ldv, h, ldh, resid, q, ldq, 
+     &   ( n, kev, np, shiftr, shifti, v, ldv, h, ldh, resid, q, ldq,
      &     workl, workd )
 c
 c     %----------------------------------------------------%
@@ -162,7 +162,7 @@ c     | Array Arguments |
 c     %-----------------%
 c
       Real
-     &           h(ldh,kev+np), resid(n), shifti(np), shiftr(np), 
+     &           h(ldh,kev+np), resid(n), shifti(np), shiftr(np),
      &           v(ldv,kev+np), q(ldq,kev+np), workd(2*n), workl(kev+np)
 c
 c     %------------%
@@ -180,9 +180,9 @@ c
       integer    i, iend, ir, istart, j, jj, kplusp, msglvl, nr
       logical    cconj, first
       Real
-     &           c, f, g, h11, h12, h21, h22, h32, ovfl, r, s, sigmai, 
+     &           c, f, g, h11, h12, h21, h22, h32, ovfl, r, s, sigmai,
      &           sigmar, smlnum, ulp, unfl, u(3), t, tau, tst1
-      save       first, ovfl, smlnum, ulp, unfl 
+      save       first, ovfl, smlnum, ulp, unfl
 c
 c     %----------------------%
 c     | External Subroutines |
@@ -239,8 +239,8 @@ c     %-------------------------------%
 c
       call second (t0)
       msglvl = mnapps
-      kplusp = kev + np 
-c 
+      kplusp = kev + np
+c
 c     %--------------------------------------------%
 c     | Initialize Q to the identity to accumulate |
 c     | the rotations and reflections              |
@@ -266,11 +266,11 @@ c
          sigmai = shifti(jj)
 c
          if (msglvl .gt. 2 ) then
-            call ivout (logfil, 1, [jj], ndigit, 
+            call ivout (logfil, 1, [jj], ndigit,
      &               '_napps: shift number.')
-            call svout (logfil, 1, [sigmar], ndigit, 
+            call svout (logfil, 1, [sigmar], ndigit,
      &               '_napps: The real part of the shift ')
-            call svout (logfil, 1, [sigmai], ndigit, 
+            call svout (logfil, 1, [sigmai], ndigit,
      &               '_napps: The imaginary part of the shift ')
          end if
 c
@@ -335,11 +335,11 @@ c
      &         tst1 = slanhs( '1', kplusp-jj+1, h, ldh, workl )
             if( abs( h( i+1,i ) ).le.max( ulp*tst1, smlnum ) ) then
                if (msglvl .gt. 0) then
-                  call ivout (logfil, 1, [i], ndigit, 
+                  call ivout (logfil, 1, [i], ndigit,
      &                 '_napps: matrix splitting at row/column no.')
-                  call ivout (logfil, 1, [jj], ndigit, 
+                  call ivout (logfil, 1, [jj], ndigit,
      &                 '_napps: matrix splitting with shift number.')
-                  call svout (logfil, 1, h(i+1,i), ndigit, 
+                  call svout (logfil, 1, h(i+1,i), ndigit,
      &                 '_napps: off diagonal element.')
                end if
                iend = i
@@ -351,9 +351,9 @@ c
    40    continue
 c
          if (msglvl .gt. 2) then
-             call ivout (logfil, 1, [istart], ndigit, 
+             call ivout (logfil, 1, [istart], ndigit,
      &                   '_napps: Start of current block ')
-             call ivout (logfil, 1, [iend], ndigit, 
+             call ivout (logfil, 1, [iend], ndigit,
      &                   '_napps: End of current block ')
          end if
 c
@@ -368,7 +368,7 @@ c        | If istart + 1 = iend then no reason to apply a       |
 c        | complex conjugate pair of shifts on a 2 by 2 matrix. |
 c        %------------------------------------------------------%
 c
-         if ( istart + 1 .eq. iend .and. abs( sigmai ) .gt. zero ) 
+         if ( istart + 1 .eq. iend .and. abs( sigmai ) .gt. zero )
      &      go to 100
 c
          h11 = h(istart,istart)
@@ -381,7 +381,7 @@ c           %---------------------------------------------%
 c
             f = h11 - sigmar
             g = h21
-c 
+c
             do 80 i = istart, iend-1
 c
 c              %-----------------------------------------------------%
@@ -413,7 +413,7 @@ c
                do 50 j = i, kplusp
                   t        =  c*h(i,j) + s*h(i+1,j)
                   h(i+1,j) = -s*h(i,j) + c*h(i+1,j)
-                  h(i,j)   = t   
+                  h(i,j)   = t
    50          continue
 c
 c              %---------------------------------------------%
@@ -423,17 +423,17 @@ c
                do 60 j = 1, min(i+2,iend)
                   t        =  c*h(j,i) + s*h(j,i+1)
                   h(j,i+1) = -s*h(j,i) + c*h(j,i+1)
-                  h(j,i)   = t   
+                  h(j,i)   = t
    60          continue
 c
 c              %----------------------------------------------------%
 c              | Accumulate the rotation in the matrix Q;  Q <- Q*G |
 c              %----------------------------------------------------%
 c
-               do 70 j = 1, min( j+jj, kplusp ) 
+               do 70 j = 1, min( j+jj, kplusp )
                   t        =   c*q(j,i) + s*q(j,i+1)
                   q(j,i+1) = - s*q(j,i) + c*q(j,i+1)
-                  q(j,i)   = t   
+                  q(j,i)   = t
    70          continue
 c
 c              %---------------------------%
@@ -449,7 +449,7 @@ c
 c           %-----------------------------------%
 c           | Finished applying the real shift. |
 c           %-----------------------------------%
-c 
+c
          else
 c
 c           %----------------------------------------------------%
@@ -465,9 +465,9 @@ c           | Compute 1st column of (H - shift*I)*(H - conj(shift)*I) |
 c           %---------------------------------------------------------%
 c
             s    = 2.0*sigmar
-            t = slapy2 ( sigmar, sigmai ) 
+            t = slapy2 ( sigmar, sigmai )
             u(1) = ( h11 * (h11 - s) + t * t ) / h21 + h12
-            u(2) = h11 + h22 - s 
+            u(2) = h11 + h22 - s
             u(3) = h32
 c
             do 90 i = istart, iend-1
@@ -507,7 +507,7 @@ c              %-----------------------------------------------------%
 c              | Accumulate the reflector in the matrix Q;  Q <- Q*G |
 c              %-----------------------------------------------------%
 c
-               call slarf ('Right', kplusp, nr, u, 1, tau, 
+               call slarf ('Right', kplusp, nr, u, 1, tau,
      &                     q(1,i), ldq, workl)
 c
 c              %----------------------------%
@@ -526,7 +526,7 @@ c           %--------------------------------------------%
 c           | Finished applying a complex pair of shifts |
 c           | to the current block                       |
 c           %--------------------------------------------%
-c 
+c
          end if
 c
   100    continue
@@ -568,7 +568,7 @@ c
          tst1 = abs( h( i, i ) ) + abs( h( i+1, i+1 ) )
          if( tst1.eq.zero )
      &       tst1 = slanhs( '1', kev, h, ldh, workl )
-         if( h( i+1,i ) .le. max( ulp*tst1, smlnum ) ) 
+         if( h( i+1,i ) .le. max( ulp*tst1, smlnum ) )
      &       h(i+1,i) = zero
  130  continue
 c
@@ -581,9 +581,9 @@ c     | of H would be zero as in exact arithmetic.      |
 c     %-------------------------------------------------%
 c
       if (h(kev+1,kev) .gt. zero)
-     &    call sgemv ('N', n, kplusp, one, v, ldv, q(1,kev+1), 1, zero, 
+     &    call sgemv ('N', n, kplusp, one, v, ldv, q(1,kev+1), 1, zero,
      &                workd(n+1), 1)
-c 
+c
 c     %----------------------------------------------------------%
 c     | Compute column 1 to kev of (V*Q) in backward order       |
 c     | taking advantage of the upper Hessenberg structure of Q. |
@@ -600,14 +600,14 @@ c     |  Move v(:,kplusp-kev+1:kplusp) into v(:,1:kev). |
 c     %-------------------------------------------------%
 c
       call slacpy ('A', n, kev, v(1,kplusp-kev+1), ldv, v, ldv)
-c 
+c
 c     %--------------------------------------------------------------%
 c     | Copy the (kev+1)-st column of (V*Q) in the appropriate place |
 c     %--------------------------------------------------------------%
 c
       if (h(kev+1,kev) .gt. zero)
      &   call scopy (n, workd(n+1), 1, v(1,kev+1), 1)
-c 
+c
 c     %-------------------------------------%
 c     | Update the residual vector:         |
 c     |    r <- sigmak*r + betak*v(:,kev+1) |
@@ -625,7 +625,7 @@ c
      &        '_napps: sigmak = (e_{kev+p}^T*Q)*e_{kev}')
          call svout (logfil, 1, h(kev+1,kev), ndigit,
      &        '_napps: betak = e_{kev+1}^T*H*e_{kev}')
-         call ivout (logfil, 1, [kev], ndigit, 
+         call ivout (logfil, 1, [kev], ndigit,
      &               '_napps: Order of the final Hessenberg matrix ')
          if (msglvl .gt. 2) then
             call smout (logfil, kev, kev, h, ldh, ndigit,
@@ -633,11 +633,11 @@ c
          end if
 c
       end if
-c 
+c
  9000 continue
       call second (t1)
       tnapps = tnapps + (t1 - t0)
-c 
+c
       return
 c
 c     %---------------%

--- a/mathlibs/src/arpack/snaup2.f
+++ b/mathlibs/src/arpack/snaup2.f
@@ -2,13 +2,13 @@ c\BeginDoc
 c
 c\Name: snaup2
 c
-c\Description: 
+c\Description:
 c  Intermediate level interface called by snaupd.
 c
 c\Usage:
 c  call snaup2
 c     ( IDO, BMAT, N, WHICH, NEV, NP, TOL, RESID, MODE, IUPD,
-c       ISHIFT, MXITER, V, LDV, H, LDH, RITZR, RITZI, BOUNDS, 
+c       ISHIFT, MXITER, V, LDV, H, LDH, RITZR, RITZI, BOUNDS,
 c       Q, LDQ, WORKL, IPNTR, WORKD, INFO )
 c
 c\Arguments
@@ -17,22 +17,22 @@ c  IDO, BMAT, N, WHICH, NEV, TOL, RESID: same as defined in snaupd.
 c  MODE, ISHIFT, MXITER: see the definition of IPARAM in snaupd.
 c
 c  NP      Integer.  (INPUT/OUTPUT)
-c          Contains the number of implicit shifts to apply during 
-c          each Arnoldi iteration.  
-c          If ISHIFT=1, NP is adjusted dynamically at each iteration 
+c          Contains the number of implicit shifts to apply during
+c          each Arnoldi iteration.
+c          If ISHIFT=1, NP is adjusted dynamically at each iteration
 c          to accelerate convergence and prevent stagnation.
-c          This is also roughly equal to the number of matrix-vector 
+c          This is also roughly equal to the number of matrix-vector
 c          products (involving the operator OP) per Arnoldi iteration.
 c          The logic for adjusting is contained within the current
 c          subroutine.
 c          If ISHIFT=0, NP is the number of shifts the user needs
 c          to provide via reverse comunication. 0 < NP < NCV-NEV.
 c          NP may be less than NCV-NEV for two reasons. The first, is
-c          to keep complex conjugate pairs of "wanted" Ritz values 
+c          to keep complex conjugate pairs of "wanted" Ritz values
 c          together. The second, is that a leading block of the current
 c          upper Hessenberg matrix has split off and contains "unwanted"
 c          Ritz values.
-c          Upon termination of the IRA iteration, NP contains the number 
+c          Upon termination of the IRA iteration, NP contains the number
 c          of "converged" wanted Ritz values.
 c
 c  IUPD    Integer.  (INPUT)
@@ -40,18 +40,18 @@ c          IUPD .EQ. 0: use explicit restart instead implicit update.
 c          IUPD .NE. 0: use implicit update.
 c
 c  V       Real N by (NEV+NP) array.  (INPUT/OUTPUT)
-c          The Arnoldi basis vectors are returned in the first NEV 
+c          The Arnoldi basis vectors are returned in the first NEV
 c          columns of V.
 c
 c  LDV     Integer.  (INPUT)
-c          Leading dimension of V exactly as declared in the calling 
+c          Leading dimension of V exactly as declared in the calling
 c          program.
 c
 c  H       Real (NEV+NP) by (NEV+NP) array.  (OUTPUT)
 c          H is used to store the generated upper Hessenberg matrix
 c
 c  LDH     Integer.  (INPUT)
-c          Leading dimension of H exactly as declared in the calling 
+c          Leading dimension of H exactly as declared in the calling
 c          program.
 c
 c  RITZR,  Real arrays of length NEV+NP.  (OUTPUT)
@@ -59,9 +59,9 @@ c  RITZI   RITZR(1:NEV) (resp. RITZI(1:NEV)) contains the real (resp.
 c          imaginary) part of the computed Ritz values of OP.
 c
 c  BOUNDS  Real array of length NEV+NP.  (OUTPUT)
-c          BOUNDS(1:NEV) contain the error bounds corresponding to 
+c          BOUNDS(1:NEV) contain the error bounds corresponding to
 c          the computed Ritz values.
-c          
+c
 c  Q       Real (NEV+NP) by (NEV+NP) array.  (WORKSPACE)
 c          Private (replicated) work array used to accumulate the
 c          rotation in the shift application step.
@@ -70,7 +70,7 @@ c  LDQ     Integer.  (INPUT)
 c          Leading dimension of Q exactly as declared in the calling
 c          program.
 c
-c  WORKL   Real work array of length at least 
+c  WORKL   Real work array of length at least
 c          (NEV+NP)**2 + 3*(NEV+NP).  (INPUT/WORKSPACE)
 c          Private (replicated) array on each PE or array allocated on
 c          the front end.  It is used in shifts calculation, shifts
@@ -82,19 +82,19 @@ c          estimates of the current Hessenberg matrix.  They are
 c          listed in the same order as returned from sneigh.
 c
 c          If ISHIFT .EQ. O and IDO .EQ. 3, the first 2*NP locations
-c          of WORKL are used in reverse communication to hold the user 
+c          of WORKL are used in reverse communication to hold the user
 c          supplied shifts.
 c
 c  IPNTR   Integer array of length 3.  (OUTPUT)
-c          Pointer to mark the starting locations in the WORKD for 
+c          Pointer to mark the starting locations in the WORKD for
 c          vectors used by the Arnoldi iteration.
 c          -------------------------------------------------------------
 c          IPNTR(1): pointer to the current operand vector X.
 c          IPNTR(2): pointer to the current result vector Y.
-c          IPNTR(3): pointer to the vector B * X when used in the 
+c          IPNTR(3): pointer to the vector B * X when used in the
 c                    shift-and-invert mode.  X is the current operand.
 c          -------------------------------------------------------------
-c          
+c
 c  WORKD   Real work array of length 3*N.  (WORKSPACE)
 c          Distributed array to be used in the basic Arnoldi iteration
 c          for reverse communication.  The user should not use WORKD
@@ -108,7 +108,7 @@ c                          possibly from a previous run.
 c          Error flag on output.
 c          =     0: Normal return.
 c          =     1: Maximum number of iterations taken.
-c                   All possible eigenvalues of OP has been found.  
+c                   All possible eigenvalues of OP has been found.
 c                   NP returns the number of converged Ritz values.
 c          =     2: No shifts could be applied.
 c          =    -8: Error return from LAPACK eigenvalue calculation;
@@ -130,12 +130,12 @@ c\References:
 c  1. D.C. Sorensen, "Implicit Application of Polynomial Filters in
 c     a k-Step Arnoldi Method", SIAM J. Matr. Anal. Apps., 13 (1992),
 c     pp 357-385.
-c  2. R.B. Lehoucq, "Analysis and Implementation of an Implicitly 
+c  2. R.B. Lehoucq, "Analysis and Implementation of an Implicitly
 c     Restarted Arnoldi Iteration", Rice University Technical Report
 c     TR95-13, Department of Computational and Applied Mathematics.
 c
 c\Routines called:
-c     sgetv0  ARPACK initial vector generation routine. 
+c     sgetv0  ARPACK initial vector generation routine.
 c     snaitr  ARPACK Arnoldi factorization routine.
 c     snapps  ARPACK application of implicit shifts routine.
 c     snconv  ARPACK convergence of Ritz values routine.
@@ -149,19 +149,19 @@ c     svout   ARPACK utility routine that prints vectors.
 c     slamch  LAPACK routine that determines machine constants.
 c     slapy2  LAPACK routine to compute sqrt(x**2+y**2) carefully.
 c     scopy   Level 1 BLAS that copies one vector to another .
-c     sdot    Level 1 BLAS that computes the scalar product of two vectors. 
+c     sdot    Level 1 BLAS that computes the scalar product of two vectors.
 c     snrm2   Level 1 BLAS that computes the norm of a vector.
 c     sswap   Level 1 BLAS that swaps two vectors.
 c
 c\Author
 c     Danny Sorensen               Phuong Vu
-c     Richard Lehoucq              CRPC / Rice University 
-c     Dept. of Computational &     Houston, Texas 
+c     Richard Lehoucq              CRPC / Rice University
+c     Dept. of Computational &     Houston, Texas
 c     Applied Mathematics
-c     Rice University           
-c     Houston, Texas    
-c 
-c\SCCS Information: @(#) 
+c     Rice University
+c     Houston, Texas
+c
+c\SCCS Information: @(#)
 c FILE: naup2.F   SID: 2.4   DATE OF SID: 7/30/96   RELEASE: 2
 c
 c\Remarks
@@ -172,8 +172,8 @@ c
 c-----------------------------------------------------------------------
 c
       subroutine snaup2
-     &   ( ido, bmat, n, which, nev, np, tol, resid, mode, iupd, 
-     &     ishift, mxiter, v, ldv, h, ldh, ritzr, ritzi, bounds, 
+     &   ( ido, bmat, n, which, nev, np, tol, resid, mode, iupd,
+     &     ishift, mxiter, v, ldv, h, ldh, ritzr, ritzi, bounds,
      &     q, ldq, workl, ipntr, workd, info )
 c
 c     %----------------------------------------------------%
@@ -182,8 +182,8 @@ c     %----------------------------------------------------%
 c
 
 c
-c\SCCS Information: @(#) 
-c FILE: debug.h   SID: 2.3   DATE OF SID: 11/16/95   RELEASE: 2 
+c\SCCS Information: @(#)
+c FILE: debug.h   SID: 2.3   DATE OF SID: 11/16/95   RELEASE: 2
 c
 c     %---------------------------------%
 c     | See debug.doc for documentation |
@@ -192,7 +192,7 @@ c     %---------------------------------%
      &         msaupd, msaup2, msaitr, mseigt, msapps, msgets, mseupd,
      &         mnaupd, mnaup2, mnaitr, mneigh, mnapps, mngets, mneupd,
      &         mcaupd, mcaup2, mcaitr, mceigh, mcapps, mcgets, mceupd
-      common /debug/ 
+      common /debug/
      &         logfil, ndigit, mgetv0,
      &         msaupd, msaup2, msaitr, mseigt, msapps, msgets, mseupd,
      &         mnaupd, mnaup2, mnaitr, mneigh, mnapps, mngets, mneupd,
@@ -202,8 +202,8 @@ c     %--------------------------------%
 c     | See stat.doc for documentation |
 c     %--------------------------------%
 c
-c\SCCS Information: @(#) 
-c FILE: stat.h   SID: 2.2   DATE OF SID: 11/16/95   RELEASE: 2 
+c\SCCS Information: @(#)
+c FILE: stat.h   SID: 2.2   DATE OF SID: 11/16/95   RELEASE: 2
 c
       real       t0, t1, t2, t3, t4, t5
 c     save       t0, t1, t2, t3, t4, t5
@@ -213,7 +213,7 @@ c
      &           tnaupd, tnaup2, tnaitr, tneigh, tngets, tnapps, tnconv,
      &           tcaupd, tcaup2, tcaitr, tceigh, tcgets, tcapps, tcconv,
      &           tmvopx, tmvbx, tgetv0, titref, trvec
-      common /timing/ 
+      common /timing/
      &           nopx, nbx, nrorth, nitref, nrstrt,
      &           tsaupd, tsaup2, tsaitr, tseigt, tsgets, tsapps, tsconv,
      &           tnaupd, tnaup2, tnaitr, tneigh, tngets, tnapps, tnconv,
@@ -237,7 +237,7 @@ c
       integer    ipntr(13)
       Real
      &           bounds(nev+np), h(ldh,nev+np), q(ldq,nev+np), resid(n),
-     &           ritzi(nev+np), ritzr(nev+np), v(ldv,nev+np), 
+     &           ritzi(nev+np), ritzr(nev+np), v(ldv,nev+np),
      &           workd(3*n), workl( (nev+np)*(nev+np+3) )
 c
 c     %------------%
@@ -254,7 +254,7 @@ c     %---------------%
 c
       character  wprime*2
       logical    cnorm, getv0, initv, update, ushift
-      integer    ierr, iter, j, kplusp, msglvl, nconv, nevbef, nev0, 
+      integer    ierr, iter, j, kplusp, msglvl, nconv, nevbef, nev0,
      &           np0, nptemp, numcnv
       Real
      &           rnorm, temp, eps23
@@ -292,11 +292,11 @@ c     | Executable Statements |
 c     %-----------------------%
 c
       if (ido .eq. 0) then
-c 
+c
          call second (t0)
-c 
+c
          msglvl = mnaup2
-c 
+c
 c        %-------------------------------------%
 c        | Get the machine dependent constant. |
 c        %-------------------------------------%
@@ -319,7 +319,7 @@ c
          kplusp = nev + np
          nconv  = 0
          iter   = 0
-c 
+c
 c        %---------------------------------------%
 c        | Set flags for computing the first NEV |
 c        | steps of the Arnoldi factorization.   |
@@ -342,7 +342,7 @@ c
             initv = .false.
          end if
       end if
-c 
+c
 c     %---------------------------------------------%
 c     | Get a possibly random starting vector and   |
 c     | force it into the range of the operator OP. |
@@ -359,7 +359,7 @@ c
          if (rnorm .eq. zero) then
 c
 c           %-----------------------------------------%
-c           | The initial vector is zero. Error exit. | 
+c           | The initial vector is zero. Error exit. |
 c           %-----------------------------------------%
 c
             info = -9
@@ -368,7 +368,7 @@ c
          getv0 = .false.
          ido  = 0
       end if
-c 
+c
 c     %-----------------------------------%
 c     | Back from reverse communication : |
 c     | continue with update step         |
@@ -388,14 +388,14 @@ c     | at the end of the current iteration |
 c     %-------------------------------------%
 c
       if (cnorm)  go to 100
-c 
+c
 c     %----------------------------------------------------------%
 c     | Compute the first NEV steps of the Arnoldi factorization |
 c     %----------------------------------------------------------%
 c
-      call snaitr (ido, bmat, n, 0, nev, mode, resid, rnorm, v, ldv, 
+      call snaitr (ido, bmat, n, 0, nev, mode, resid, rnorm, v, ldv,
      &             h, ldh, ipntr, workd, info)
-c 
+c
 c     %---------------------------------------------------%
 c     | ido .ne. 99 implies use of reverse communication  |
 c     | to compute operations involving OP and possibly B |
@@ -409,7 +409,7 @@ c
          info = -9999
          go to 1200
       end if
-c 
+c
 c     %--------------------------------------------------------------%
 c     |                                                              |
 c     |           M A I N  ARNOLDI  I T E R A T I O N  L O O P       |
@@ -417,16 +417,16 @@ c     |           Each iteration implicitly restarts the Arnoldi     |
 c     |           factorization in place.                            |
 c     |                                                              |
 c     %--------------------------------------------------------------%
-c 
+c
  1000 continue
 c
          iter = iter + 1
 c
          if (msglvl .gt. 0) then
-            call ivout (logfil, 1, [iter], ndigit, 
+            call ivout (logfil, 1, [iter], ndigit,
      &           '_naup2: **** Start of major iteration number ****')
          end if
-c 
+c
 c        %-----------------------------------------------------------%
 c        | Compute NP additional steps of the Arnoldi factorization. |
 c        | Adjust NP since NEV might have been updated by last call  |
@@ -436,9 +436,9 @@ c
          np  = kplusp - nev
 c
          if (msglvl .gt. 1) then
-            call ivout (logfil, 1, [nev], ndigit, 
+            call ivout (logfil, 1, [nev], ndigit,
      &     '_naup2: The length of the current Arnoldi factorization')
-            call ivout (logfil, 1, [np], ndigit, 
+            call ivout (logfil, 1, [np], ndigit,
      &           '_naup2: Extend the Arnoldi factorization by')
          end if
 c
@@ -452,7 +452,7 @@ c
 c
          call snaitr (ido, bmat, n, nev, np, mode, resid, rnorm, v, ldv,
      &                h, ldh, ipntr, workd, info)
-c 
+c
 c        %---------------------------------------------------%
 c        | ido .ne. 99 implies use of reverse communication  |
 c        | to compute operations involving OP and possibly B |
@@ -469,10 +469,10 @@ c
          update = .false.
 c
          if (msglvl .gt. 1) then
-            call svout (logfil, 1, [rnorm], ndigit, 
+            call svout (logfil, 1, [rnorm], ndigit,
      &           '_naup2: Corresponding B-norm of the residual')
          end if
-c 
+c
 c        %--------------------------------------------------------%
 c        | Compute the eigenvalues and corresponding error bounds |
 c        | of the current upper Hessenberg matrix.                |
@@ -511,30 +511,30 @@ c
          nev = nev0
          np = np0
          numcnv = nev
-         call sngets (ishift, which, nev, np, ritzr, ritzi, 
+         call sngets (ishift, which, nev, np, ritzr, ritzi,
      &                bounds, workl, workl(np+1))
          if (nev .eq. nev0+1) numcnv = nev0+1
-c 
+c
 c        %-------------------%
-c        | Convergence test. | 
+c        | Convergence test. |
 c        %-------------------%
 c
          call scopy (nev, bounds(np+1), 1, workl(2*np+1), 1)
-         call snconv (nev, ritzr(np+1), ritzi(np+1), workl(2*np+1), 
+         call snconv (nev, ritzr(np+1), ritzi(np+1), workl(2*np+1),
      &        tol, nconv)
-c 
+c
          if (msglvl .gt. 2) then
             kp(1) = nev
             kp(2) = np
             kp(3) = numcnv
             kp(4) = nconv
-            call ivout (logfil, 4, kp, ndigit, 
+            call ivout (logfil, 4, kp, ndigit,
      &                  '_naup2: NEV, NP, NUMCNV, NCONV are')
             call svout (logfil, kplusp, ritzr, ndigit,
      &           '_naup2: Real part of the eigenvalues of H')
             call svout (logfil, kplusp, ritzi, ndigit,
      &           '_naup2: Imaginary part of the eigenvalues of H')
-            call svout (logfil, kplusp, bounds, ndigit, 
+            call svout (logfil, kplusp, bounds, ndigit,
      &          '_naup2: Ritz estimates of the current NCV Ritz values')
          end if
 c
@@ -555,8 +555,8 @@ c
                nev = nev + 1
             end if
  30      continue
-c     
-         if ( (nconv .ge. numcnv) .or. 
+c
+         if ( (nconv .ge. numcnv) .or.
      &        (iter .gt. mxiter) .or.
      &        (np .eq. 0) ) then
 c
@@ -570,7 +570,7 @@ c
      &                     ndigit,
      &             '_naup2: Ritz eistmates computed by _neigh:')
             end if
-c     
+c
 c           %------------------------------------------------%
 c           | Prepare to exit. Put the converged Ritz values |
 c           | and corresponding bounds in RITZ(1:NCONV) and  |
@@ -669,13 +669,13 @@ c
             end if
 c
 c           %------------------------------------%
-c           | Max iterations have been exceeded. | 
+c           | Max iterations have been exceeded. |
 c           %------------------------------------%
 c
             if (iter .gt. mxiter .and. nconv .lt. numcnv) info = 1
 c
 c           %---------------------%
-c           | No shifts to apply. | 
+c           | No shifts to apply. |
 c           %---------------------%
 c
             if (np .eq. 0 .and. nconv .lt. numcnv) info = 2
@@ -684,7 +684,7 @@ c
             go to 1100
 c
          else if ( (nconv .lt. numcnv) .and. (ishift .eq. 1) ) then
-c     
+c
 c           %-------------------------------------------------%
 c           | Do not have all the requested eigenvalues yet.  |
 c           | To prevent possible stagnation, adjust the size |
@@ -699,25 +699,25 @@ c
                nev = 2
             end if
             np = kplusp - nev
-c     
+c
 c           %---------------------------------------%
 c           | If the size of NEV was just increased |
 c           | resort the eigenvalues.               |
 c           %---------------------------------------%
-c     
-            if (nevbef .lt. nev) 
-     &         call sngets (ishift, which, nev, np, ritzr, ritzi, 
+c
+            if (nevbef .lt. nev)
+     &         call sngets (ishift, which, nev, np, ritzr, ritzi,
      &              bounds, workl, workl(np+1))
 c
-         end if              
-c     
+         end if
+c
          if (msglvl .gt. 0) then
-            call ivout (logfil, 1, [nconv], ndigit, 
+            call ivout (logfil, 1, [nconv], ndigit,
      &           '_naup2: no. of "converged" Ritz values at this iter.')
             if (msglvl .gt. 1) then
                kp(1) = nev
                kp(2) = np
-               call ivout (logfil, 2, kp, ndigit, 
+               call ivout (logfil, 2, kp, ndigit,
      &              '_naup2: NEV and NP are')
                call svout (logfil, nev, ritzr(np+1), ndigit,
      &              '_naup2: "wanted" Ritz values -- real part')
@@ -740,7 +740,7 @@ c
             ido = 3
             go to 9000
          end if
-c 
+c
    50    continue
 c
 c        %------------------------------------%
@@ -752,7 +752,7 @@ c
          ushift = .false.
 c
          if ( ishift .eq. 0 ) then
-c 
+c
 c            %----------------------------------%
 c            | Move the NP shifts from WORKL to |
 c            | RITZR, RITZI to free up WORKL    |
@@ -763,14 +763,14 @@ c
              call scopy (np, workl(np+1), 1, ritzi, 1)
          end if
 c
-         if (msglvl .gt. 2) then 
-            call ivout (logfil, 1, [np], ndigit, 
+         if (msglvl .gt. 2) then
+            call ivout (logfil, 1, [np], ndigit,
      &                  '_naup2: The number of shifts to apply ')
             call svout (logfil, np, ritzr, ndigit,
      &                  '_naup2: Real part of the shifts')
             call svout (logfil, np, ritzi, ndigit,
      &                  '_naup2: Imaginary part of the shifts')
-            if ( ishift .eq. 1 ) 
+            if ( ishift .eq. 1 )
      &          call svout (logfil, np, bounds, ndigit,
      &                  '_naup2: Ritz estimates of the shifts')
          end if
@@ -782,7 +782,7 @@ c        | matrix H.                                               |
 c        | The first 2*N locations of WORKD are used as workspace. |
 c        %---------------------------------------------------------%
 c
-         call snapps (n, nev, np, ritzr, ritzi, v, ldv, 
+         call snapps (n, nev, np, ritzr, ritzi, v, ldv,
      &                h, ldh, resid, q, ldq, workl, workd)
 c
 c        %---------------------------------------------%
@@ -799,18 +799,18 @@ c
             ipntr(1) = n + 1
             ipntr(2) = 1
             ido = 2
-c 
+c
 c           %----------------------------------%
 c           | Exit in order to compute B*RESID |
 c           %----------------------------------%
-c 
+c
             go to 9000
          else if (bmat .eq. 'I') then
             call scopy (n, resid, 1, workd, 1)
          end if
-c 
+c
   100    continue
-c 
+c
 c        %----------------------------------%
 c        | Back from reverse communication; |
 c        | WORKD(1:N) := B*RESID            |
@@ -820,8 +820,8 @@ c
             call second (t3)
             tmvbx = tmvbx + (t3 - t2)
          end if
-c 
-         if (bmat .eq. 'G') then         
+c
+         if (bmat .eq. 'G') then
             rnorm = sdot (n, resid, 1, workd, 1)
             rnorm = sqrt(abs(rnorm))
          else if (bmat .eq. 'I') then
@@ -830,12 +830,12 @@ c
          cnorm = .false.
 c
          if (msglvl .gt. 2) then
-            call svout (logfil, 1, [rnorm], ndigit, 
+            call svout (logfil, 1, [rnorm], ndigit,
      &      '_naup2: B-norm of residual for compressed factorization')
             call smout (logfil, nev, nev, h, ldh, ndigit,
      &        '_naup2: Compressed upper Hessenberg matrix H')
          end if
-c 
+c
       go to 1000
 c
 c     %---------------------------------------------------------------%
@@ -848,7 +848,7 @@ c
 c
       mxiter = iter
       nev = numcnv
-c     
+c
  1200 continue
       ido = 99
 c
@@ -858,7 +858,7 @@ c     %------------%
 c
       call second (t1)
       tnaup2 = t1 - t0
-c     
+c
  9000 continue
 c
 c     %---------------%

--- a/mathlibs/src/arpack/snaup2.f
+++ b/mathlibs/src/arpack/snaup2.f
@@ -423,7 +423,7 @@ c
          iter = iter + 1
 c
          if (msglvl .gt. 0) then
-            call ivout (logfil, 1, iter, ndigit, 
+            call ivout (logfil, 1, [iter], ndigit, 
      &           '_naup2: **** Start of major iteration number ****')
          end if
 c 
@@ -436,9 +436,9 @@ c
          np  = kplusp - nev
 c
          if (msglvl .gt. 1) then
-            call ivout (logfil, 1, nev, ndigit, 
+            call ivout (logfil, 1, [nev], ndigit, 
      &     '_naup2: The length of the current Arnoldi factorization')
-            call ivout (logfil, 1, np, ndigit, 
+            call ivout (logfil, 1, [np], ndigit, 
      &           '_naup2: Extend the Arnoldi factorization by')
          end if
 c
@@ -469,7 +469,7 @@ c
          update = .false.
 c
          if (msglvl .gt. 1) then
-            call svout (logfil, 1, rnorm, ndigit, 
+            call svout (logfil, 1, [rnorm], ndigit, 
      &           '_naup2: Corresponding B-norm of the residual')
          end if
 c 
@@ -712,7 +712,7 @@ c
          end if              
 c     
          if (msglvl .gt. 0) then
-            call ivout (logfil, 1, nconv, ndigit, 
+            call ivout (logfil, 1, [nconv], ndigit, 
      &           '_naup2: no. of "converged" Ritz values at this iter.')
             if (msglvl .gt. 1) then
                kp(1) = nev
@@ -764,7 +764,7 @@ c
          end if
 c
          if (msglvl .gt. 2) then 
-            call ivout (logfil, 1, np, ndigit, 
+            call ivout (logfil, 1, [np], ndigit, 
      &                  '_naup2: The number of shifts to apply ')
             call svout (logfil, np, ritzr, ndigit,
      &                  '_naup2: Real part of the shifts')
@@ -830,7 +830,7 @@ c
          cnorm = .false.
 c
          if (msglvl .gt. 2) then
-            call svout (logfil, 1, rnorm, ndigit, 
+            call svout (logfil, 1, [rnorm], ndigit, 
      &      '_naup2: B-norm of residual for compressed factorization')
             call smout (logfil, nev, nev, h, ldh, ndigit,
      &        '_naup2: Compressed upper Hessenberg matrix H')

--- a/mathlibs/src/arpack/snaupd.f
+++ b/mathlibs/src/arpack/snaupd.f
@@ -627,9 +627,9 @@ c
       if (info .eq. 2) info = 3
 c
       if (msglvl .gt. 0) then
-         call ivout (logfil, 1, mxiter, ndigit,
+         call ivout (logfil, 1, [mxiter], ndigit,
      &               '_naupd: Number of update iterations taken')
-         call ivout (logfil, 1, np, ndigit,
+         call ivout (logfil, 1, [np], ndigit,
      &               '_naupd: Number of wanted "converged" Ritz values')
          call svout (logfil, np, workl(ritzr), ndigit, 
      &               '_naupd: Real part of the final Ritz values')

--- a/mathlibs/src/arpack/snaupd.f
+++ b/mathlibs/src/arpack/snaupd.f
@@ -2,19 +2,19 @@ c\BeginDoc
 c
 c\Name: snaupd
 c
-c\Description: 
+c\Description:
 c  Reverse communication interface for the Implicitly Restarted Arnoldi
-c  iteration. This subroutine computes approximations to a few eigenpairs 
-c  of a linear operator "OP" with respect to a semi-inner product defined by 
-c  a symmetric positive semi-definite real matrix B. B may be the identity 
-c  matrix. NOTE: If the linear operator "OP" is real and symmetric 
-c  with respect to the real positive semi-definite symmetric matrix B, 
+c  iteration. This subroutine computes approximations to a few eigenpairs
+c  of a linear operator "OP" with respect to a semi-inner product defined by
+c  a symmetric positive semi-definite real matrix B. B may be the identity
+c  matrix. NOTE: If the linear operator "OP" is real and symmetric
+c  with respect to the real positive semi-definite symmetric matrix B,
 c  i.e. B*OP = (OP')*B, then subroutine ssaupd should be used instead.
 c
 c  The computed approximate eigenvalues are called Ritz values and
 c  the corresponding approximate eigenvectors are called Ritz vectors.
 c
-c  snaupd is usually called iteratively to solve one of the 
+c  snaupd is usually called iteratively to solve one of the
 c  following problems:
 c
 c  Mode 1:  A*x = lambda*x.
@@ -25,18 +25,18 @@ c           ===> OP = inv[M]*A  and  B = M.
 c           ===> (If M can be factored see remark 3 below)
 c
 c  Mode 3:  A*x = lambda*M*x, M symmetric semi-definite
-c           ===> OP = Real_Part{ inv[A - sigma*M]*M }  and  B = M. 
+c           ===> OP = Real_Part{ inv[A - sigma*M]*M }  and  B = M.
 c           ===> shift-and-invert mode (in real arithmetic)
-c           If OP*x = amu*x, then 
+c           If OP*x = amu*x, then
 c           amu = 1/2 * [ 1/(lambda-sigma) + 1/(lambda-conjg(sigma)) ].
 c           Note: If sigma is real, i.e. imaginary part of sigma is zero;
-c                 Real_Part{ inv[A - sigma*M]*M } == inv[A - sigma*M]*M 
-c                 amu == 1/(lambda-sigma). 
-c  
+c                 Real_Part{ inv[A - sigma*M]*M } == inv[A - sigma*M]*M
+c                 amu == 1/(lambda-sigma).
+c
 c  Mode 4:  A*x = lambda*M*x, M symmetric semi-definite
-c           ===> OP = Imaginary_Part{ inv[A - sigma*M]*M }  and  B = M. 
+c           ===> OP = Imaginary_Part{ inv[A - sigma*M]*M }  and  B = M.
 c           ===> shift-and-invert mode (in real arithmetic)
-c           If OP*x = amu*x, then 
+c           If OP*x = amu*x, then
 c           amu = 1/2i * [ 1/(lambda-sigma) - 1/(lambda-conjg(sigma)) ].
 c
 c  Both mode 3 and 4 give the same enhancement to eigenvalues close to
@@ -63,7 +63,7 @@ c       IPNTR, WORKD, WORKL, LWORKL, INFO )
 c
 c\Arguments
 c  IDO     Integer.  (INPUT/OUTPUT)
-c          Reverse communication flag.  IDO must be zero on the first 
+c          Reverse communication flag.  IDO must be zero on the first
 c          call to snaupd.  IDO will be set internally to
 c          indicate the type of operation to be performed.  Control is
 c          then given back to the calling routine which has the
@@ -86,13 +86,13 @@ c                    need to be recomputed in forming OP * X.
 c          IDO =  2: compute  Y = B * X  where
 c                    IPNTR(1) is the pointer into WORKD for X,
 c                    IPNTR(2) is the pointer into WORKD for Y.
-c          IDO =  3: compute the IPARAM(8) real and imaginary parts 
+c          IDO =  3: compute the IPARAM(8) real and imaginary parts
 c                    of the shifts where INPTR(14) is the pointer
 c                    into WORKL for placing the shifts. See Remark
 c                    5 below.
 c          IDO = 99: done
 c          -------------------------------------------------------------
-c             
+c
 c  BMAT    Character*1.  (INPUT)
 c          BMAT specifies the type of the matrix B that defines the
 c          semi-inner product for the operator OP.
@@ -114,14 +114,14 @@ c  NEV     Integer.  (INPUT)
 c          Number of eigenvalues of OP to be computed. 0 < NEV < N-1.
 c
 c  TOL     Real scalar.  (INPUT)
-c          Stopping criterion: the relative accuracy of the Ritz value 
+c          Stopping criterion: the relative accuracy of the Ritz value
 c          is considered acceptable if BOUNDS(I) .LE. TOL*ABS(RITZ(I))
 c          where ABS(RITZ(I)) is the magnitude when RITZ(I) is complex.
 c          DEFAULT = SLAMCH('EPS')  (machine precision as computed
 c                    by the LAPACK auxiliary subroutine SLAMCH).
 c
 c  RESID   Real array of length N.  (INPUT/OUTPUT)
-c          On INPUT: 
+c          On INPUT:
 c          If INFO .EQ. 0, a random initial residual vector is used.
 c          If INFO .NE. 0, RESID contains the initial residual vector,
 c                          possibly from a previous run.
@@ -131,17 +131,17 @@ c
 c  NCV     Integer.  (INPUT)
 c          Number of columns of the matrix V. NCV must satisfy the two
 c          inequalities 2 <= NCV-NEV and NCV <= N.
-c          This will indicate how many Arnoldi vectors are generated 
-c          at each iteration.  After the startup phase in which NEV 
-c          Arnoldi vectors are generated, the algorithm generates 
-c          approximately NCV-NEV Arnoldi vectors at each subsequent update 
-c          iteration. Most of the cost in generating each Arnoldi vector is 
-c          in the matrix-vector operation OP*x. 
-c          NOTE: 2 <= NCV-NEV in order that complex conjugate pairs of Ritz 
+c          This will indicate how many Arnoldi vectors are generated
+c          at each iteration.  After the startup phase in which NEV
+c          Arnoldi vectors are generated, the algorithm generates
+c          approximately NCV-NEV Arnoldi vectors at each subsequent update
+c          iteration. Most of the cost in generating each Arnoldi vector is
+c          in the matrix-vector operation OP*x.
+c          NOTE: 2 <= NCV-NEV in order that complex conjugate pairs of Ritz
 c          values are kept together. (See remark 4 below)
 c
 c  V       Real array N by NCV.  (OUTPUT)
-c          Contains the final set of Arnoldi basis vectors. 
+c          Contains the final set of Arnoldi basis vectors.
 c
 c  LDV     Integer.  (INPUT)
 c          Leading dimension of V exactly as declared in the calling program.
@@ -154,11 +154,11 @@ c          -------------------------------------------------------------
 c          ISHIFT = 0: the shifts are provided by the user via
 c                      reverse communication.  The real and imaginary
 c                      parts of the NCV eigenvalues of the Hessenberg
-c                      matrix H are returned in the part of the WORKL 
-c                      array corresponding to RITZR and RITZI. See remark 
+c                      matrix H are returned in the part of the WORKL
+c                      array corresponding to RITZR and RITZI. See remark
 c                      5 below.
 c          ISHIFT = 1: exact shifts with respect to the current
-c                      Hessenberg matrix H.  This is equivalent to 
+c                      Hessenberg matrix H.  This is equivalent to
 c                      restarting the iteration with a starting vector
 c                      that is a linear combination of approximate Schur
 c                      vectors associated with the "wanted" Ritz values.
@@ -167,8 +167,8 @@ c
 c          IPARAM(2) = No longer referenced.
 c
 c          IPARAM(3) = MXITER
-c          On INPUT:  maximum number of Arnoldi update iterations allowed. 
-c          On OUTPUT: actual number of Arnoldi update iterations taken. 
+c          On INPUT:  maximum number of Arnoldi update iterations allowed.
+c          On OUTPUT: actual number of Arnoldi update iterations taken.
 c
 c          IPARAM(4) = NB: blocksize to be used in the recurrence.
 c          The code currently works only for NB = 1.
@@ -178,11 +178,11 @@ c          This represents the number of Ritz values that satisfy
 c          the convergence criterion.
 c
 c          IPARAM(6) = IUPD
-c          No longer referenced. Implicit restarting is ALWAYS used.  
+c          No longer referenced. Implicit restarting is ALWAYS used.
 c
 c          IPARAM(7) = MODE
 c          On INPUT determines what type of eigenproblem is being solved.
-c          Must be 1,2,3,4; See under \Description of snaupd for the 
+c          Must be 1,2,3,4; See under \Description of snaupd for the
 c          four modes available.
 c
 c          IPARAM(8) = NP
@@ -194,7 +194,7 @@ c
 c          IPARAM(9) = NUMOP, IPARAM(10) = NUMOPB, IPARAM(11) = NUMREO,
 c          OUTPUT: NUMOP  = total number of OP*x operations,
 c                  NUMOPB = total number of B*x operations if BMAT='G',
-c                  NUMREO = total number of steps of re-orthogonalization.        
+c                  NUMREO = total number of steps of re-orthogonalization.
 c
 c  IPNTR   Integer array of length 14.  (OUTPUT)
 c          Pointer to mark the starting locations in the WORKD and WORKL
@@ -202,13 +202,13 @@ c          arrays for matrices/vectors used by the Arnoldi iteration.
 c          -------------------------------------------------------------
 c          IPNTR(1): pointer to the current operand vector X in WORKD.
 c          IPNTR(2): pointer to the current result vector Y in WORKD.
-c          IPNTR(3): pointer to the vector B * X in WORKD when used in 
+c          IPNTR(3): pointer to the vector B * X in WORKD when used in
 c                    the shift-and-invert mode.
 c          IPNTR(4): pointer to the next available location in WORKL
 c                    that is untouched by the program.
 c          IPNTR(5): pointer to the NCV by NCV upper Hessenberg matrix
 c                    H in WORKL.
-c          IPNTR(6): pointer to the real part of the ritz value array 
+c          IPNTR(6): pointer to the real part of the ritz value array
 c                    RITZR in WORKL.
 c          IPNTR(7): pointer to the imaginary part of the ritz value array
 c                    RITZI in WORKL.
@@ -219,9 +219,9 @@ c          IPNTR(14): pointer to the NP shifts in WORKL. See Remark 5 below.
 c
 c          Note: IPNTR(9:13) is only referenced by sneupd. See Remark 2 below.
 c
-c          IPNTR(9):  pointer to the real part of the NCV RITZ values of the 
+c          IPNTR(9):  pointer to the real part of the NCV RITZ values of the
 c                     original system.
-c          IPNTR(10): pointer to the imaginary part of the NCV RITZ values of 
+c          IPNTR(10): pointer to the imaginary part of the NCV RITZ values of
 c                     the original system.
 c          IPNTR(11): pointer to the NCV corresponding error bounds.
 c          IPNTR(12): pointer to the NCV by NCV upper quasi-triangular
@@ -230,15 +230,15 @@ c          IPNTR(13): pointer to the NCV by NCV matrix of eigenvectors
 c                     of the upper Hessenberg matrix H. Only referenced by
 c                     sneupd if RVEC = .TRUE. See Remark 2 below.
 c          -------------------------------------------------------------
-c          
+c
 c  WORKD   Real work array of length 3*N.  (REVERSE COMMUNICATION)
 c          Distributed array to be used in the basic Arnoldi iteration
-c          for reverse communication.  The user should not use WORKD 
+c          for reverse communication.  The user should not use WORKD
 c          as temporary workspace during the iteration. Upon termination
 c          WORKD(1:N) contains B*RESID(1:N). If an invariant subspace
 c          associated with the converged Ritz values is desired, see remark
 c          2 below, subroutine sneupd uses this output.
-c          See Data Distribution Note below.  
+c          See Data Distribution Note below.
 c
 c  WORKL   Real work array of length LWORKL.  (OUTPUT/WORKSPACE)
 c          Private (replicated) array on each PE or array allocated on
@@ -254,18 +254,18 @@ c                          possibly from a previous run.
 c          Error flag on output.
 c          =  0: Normal exit.
 c          =  1: Maximum number of iterations taken.
-c                All possible eigenvalues of OP has been found. IPARAM(5)  
+c                All possible eigenvalues of OP has been found. IPARAM(5)
 c                returns the number of wanted converged Ritz values.
 c          =  2: No longer an informational error. Deprecated starting
 c                with release 2 of ARPACK.
-c          =  3: No shifts could be applied during a cycle of the 
-c                Implicitly restarted Arnoldi iteration. One possibility 
-c                is to increase the size of NCV relative to NEV. 
+c          =  3: No shifts could be applied during a cycle of the
+c                Implicitly restarted Arnoldi iteration. One possibility
+c                is to increase the size of NCV relative to NEV.
 c                See remark 4 below.
 c          = -1: N must be positive.
 c          = -2: NEV must be positive.
 c          = -3: NCV-NEV >= 2 and less than or equal to N.
-c          = -4: The maximum number of Arnoldi update iteration 
+c          = -4: The maximum number of Arnoldi update iteration
 c                must be greater than zero.
 c          = -5: WHICH must be one of 'LM', 'SM', 'LR', 'SR', 'LI', 'SI'
 c          = -6: BMAT must be one of 'I' or 'G'.
@@ -285,13 +285,13 @@ c     selection of WHICH should be made with this in mind when
 c     Mode = 3 and 4.  After convergence, approximate eigenvalues of the
 c     original problem may be obtained with the ARPACK subroutine sneupd.
 c
-c  2. If a basis for the invariant subspace corresponding to the converged Ritz 
-c     values is needed, the user must call sneupd immediately following 
+c  2. If a basis for the invariant subspace corresponding to the converged Ritz
+c     values is needed, the user must call sneupd immediately following
 c     completion of snaupd. This is new starting with release 2 of ARPACK.
 c
 c  3. If M can be factored into a Cholesky factorization M = LL'
 c     then Mode = 2 should not be selected.  Instead one should use
-c     Mode = 1 with  OP = inv(L)*A*inv(L').  Appropriate triangular 
+c     Mode = 1 with  OP = inv(L)*A*inv(L').  Appropriate triangular
 c     linear systems should be solved with L and L' rather
 c     than computing inverses.  After convergence, an approximate
 c     eigenvector z of the original problem is recovered by solving
@@ -301,15 +301,15 @@ c  4. At present there is no a-priori analysis to guide the selection
 c     of NCV relative to NEV.  The only formal requrement is that NCV > NEV + 2.
 c     However, it is recommended that NCV .ge. 2*NEV+1.  If many problems of
 c     the same type are to be solved, one should experiment with increasing
-c     NCV while keeping NEV fixed for a given test problem.  This will 
+c     NCV while keeping NEV fixed for a given test problem.  This will
 c     usually decrease the required number of OP*x operations but it
 c     also increases the work and storage required to maintain the orthogonal
 c     basis vectors.  The optimal "cross-over" with respect to CPU time
-c     is problem dependent and must be determined empirically. 
+c     is problem dependent and must be determined empirically.
 c     See Chapter 8 of Reference 2 for further information.
 c
-c  5. When IPARAM(1) = 0, and IDO = 3, the user needs to provide the 
-c     NP = IPARAM(8) real and imaginary parts of the shifts in locations 
+c  5. When IPARAM(1) = 0, and IDO = 3, the user needs to provide the
+c     NP = IPARAM(8) real and imaginary parts of the shifts in locations
 c         real part                  imaginary part
 c         -----------------------    --------------
 c     1   WORKL(IPNTR(14))           WORKL(IPNTR(14)+NP)
@@ -319,10 +319,10 @@ c                        .                          .
 c                        .                          .
 c     NP  WORKL(IPNTR(14)+NP-1)      WORKL(IPNTR(14)+2*NP-1).
 c
-c     Only complex conjugate pairs of shifts may be applied and the pairs 
-c     must be placed in consecutive locations. The real part of the 
-c     eigenvalues of the current upper Hessenberg matrix are located in 
-c     WORKL(IPNTR(6)) through WORKL(IPNTR(6)+NCV-1) and the imaginary part 
+c     Only complex conjugate pairs of shifts may be applied and the pairs
+c     must be placed in consecutive locations. The real part of the
+c     eigenvalues of the current upper Hessenberg matrix are located in
+c     WORKL(IPNTR(6)) through WORKL(IPNTR(6)+NCV-1) and the imaginary part
 c     in WORKL(IPNTR(7)) through WORKL(IPNTR(7)+NCV-1). They are ordered
 c     according to the order defined by WHICH. The complex conjugate
 c     pairs are kept together and the associated Ritz estimates are located in
@@ -330,7 +330,7 @@ c     WORKL(IPNTR(8)), WORKL(IPNTR(8)+1), ... , WORKL(IPNTR(8)+NCV-1).
 c
 c-----------------------------------------------------------------------
 c
-c\Data Distribution Note: 
+c\Data Distribution Note:
 c
 c  Fortran-D syntax:
 c  ================
@@ -349,10 +349,10 @@ c  ===============
 c  Real  resid(n), v(ldv,ncv), workd(n,3), workl(lworkl)
 c  shared     resid(block), v(block,:), workd(block,:)
 c  replicated workl(lworkl)
-c  
+c
 c  CM2/CM5 syntax:
 c  ==============
-c  
+c
 c-----------------------------------------------------------------------
 c
 c     include   'ex-nonsym.doc'
@@ -368,7 +368,7 @@ c\References:
 c  1. D.C. Sorensen, "Implicit Application of Polynomial Filters in
 c     a k-Step Arnoldi Method", SIAM J. Matr. Anal. Apps., 13 (1992),
 c     pp 357-385.
-c  2. R.B. Lehoucq, "Analysis and Implementation of an Implicitly 
+c  2. R.B. Lehoucq, "Analysis and Implementation of an Implicitly
 c     Restarted Arnoldi Iteration", Rice University Technical Report
 c     TR95-13, Department of Computational and Applied Mathematics.
 c  3. B.N. Parlett & Y. Saad, "Complex Shift and Invert Strategies for
@@ -388,13 +388,13 @@ c     Danny Sorensen               Phuong Vu
 c     Richard Lehoucq              CRPC / Rice University
 c     Dept. of Computational &     Houston, Texas
 c     Applied Mathematics
-c     Rice University           
-c     Houston, Texas            
-c 
+c     Rice University
+c     Houston, Texas
+c
 c\Revision history:
 c     12/16/93: Version '1.1'
 c
-c\SCCS Information: @(#) 
+c\SCCS Information: @(#)
 c FILE: naupd.F   SID: 2.5   DATE OF SID: 8/27/96   RELEASE: 2
 c
 c\Remarks
@@ -404,7 +404,7 @@ c
 c-----------------------------------------------------------------------
 c
       subroutine snaupd
-     &   ( ido, bmat, n, which, nev, tol, resid, ncv, v, ldv, iparam, 
+     &   ( ido, bmat, n, which, nev, tol, resid, ncv, v, ldv, iparam,
      &     ipntr, workd, workl, lworkl, info )
 c
 c     %----------------------------------------------------%
@@ -443,7 +443,7 @@ c     %---------------%
 c     | Local Scalars |
 c     %---------------%
 c
-      integer    bounds, ierr, ih, iq, ishift, iupd, iw, 
+      integer    bounds, ierr, ih, iq, ishift, iupd, iw,
      &           ldh, ldq, levec, mode, msglvl, mxiter, nb,
      &           nev0, next, np, ritzi, ritzr, j
       save       bounds, ih, iq, ishift, iupd, iw, ldh, ldq,
@@ -467,9 +467,9 @@ c
 c     %-----------------------%
 c     | Executable Statements |
 c     %-----------------------%
-c 
+c
       if (ido .eq. 0) then
-c 
+c
 c        %-------------------------------%
 c        | Initialize timing statistics  |
 c        | & message level for debugging |
@@ -522,7 +522,7 @@ c
          else if (ishift .lt. 0 .or. ishift .gt. 1) then
                                                 ierr = -12
          end if
-c 
+c
 c        %------------%
 c        | Error Exit |
 c        %------------%
@@ -532,7 +532,7 @@ c
             ido  = 99
             go to 9000
          end if
-c 
+c
 c        %------------------------%
 c        | Set default parameters |
 c        %------------------------%
@@ -548,8 +548,8 @@ c        | size of the invariant subspace desired.      |
 c        %----------------------------------------------%
 c
          np     = ncv - nev
-         nev0   = nev 
-c 
+         nev0   = nev
+c
 c        %-----------------------------%
 c        | Zero out internal workspace |
 c        %-----------------------------%
@@ -557,7 +557,7 @@ c
          do 10 j = 1, 3*ncv**2 + 6*ncv
             workl(j) = zero
   10     continue
-c 
+c
 c        %-------------------------------------------------------------%
 c        | Pointer into WORKL for address of H, RITZ, BOUNDS, Q        |
 c        | etc... and the remaining workspace.                         |
@@ -590,7 +590,7 @@ c
          ipntr(6) = ritzr
          ipntr(7) = ritzi
          ipntr(8) = bounds
-         ipntr(14) = iw 
+         ipntr(14) = iw
 c
       end if
 c
@@ -598,12 +598,12 @@ c     %-------------------------------------------------------%
 c     | Carry out the Implicitly restarted Arnoldi Iteration. |
 c     %-------------------------------------------------------%
 c
-      call snaup2 
+      call snaup2
      &   ( ido, bmat, n, which, nev0, np, tol, resid, mode, iupd,
-     &     ishift, mxiter, v, ldv, workl(ih), ldh, workl(ritzr), 
-     &     workl(ritzi), workl(bounds), workl(iq), ldq, workl(iw), 
+     &     ishift, mxiter, v, ldv, workl(ih), ldh, workl(ritzr),
+     &     workl(ritzi), workl(bounds), workl(iq), ldq, workl(iw),
      &     ipntr, workd, info )
-c 
+c
 c     %--------------------------------------------------%
 c     | ido .ne. 99 implies use of reverse communication |
 c     | to compute operations involving OP or shifts.    |
@@ -611,7 +611,7 @@ c     %--------------------------------------------------%
 c
       if (ido .eq. 3) iparam(8) = np
       if (ido .ne. 99) go to 9000
-c 
+c
       iparam(3) = mxiter
       iparam(5) = np
       iparam(9) = nopx
@@ -631,11 +631,11 @@ c
      &               '_naupd: Number of update iterations taken')
          call ivout (logfil, 1, [np], ndigit,
      &               '_naupd: Number of wanted "converged" Ritz values')
-         call svout (logfil, np, workl(ritzr), ndigit, 
+         call svout (logfil, np, workl(ritzr), ndigit,
      &               '_naupd: Real part of the final Ritz values')
-         call svout (logfil, np, workl(ritzi), ndigit, 
+         call svout (logfil, np, workl(ritzi), ndigit,
      &               '_naupd: Imaginary part of the final Ritz values')
-         call svout (logfil, np, workl(bounds), ndigit, 
+         call svout (logfil, np, workl(bounds), ndigit,
      &               '_naupd: Associated Ritz estimates')
       end if
 c

--- a/mathlibs/src/arpack/sneupd.f
+++ b/mathlibs/src/arpack/sneupd.f
@@ -2,7 +2,7 @@ c\BeginDoc
 c
 c\Name: sneupd
 c
-c\Description: 
+c\Description:
 c
 c  This subroutine returns the converged approximations to eigenvalues
 c  of A*z = lambda*B*z and (optionally):
@@ -28,34 +28,34 @@ c  in the comments that follow.  The computed orthonormal basis for the
 c  invariant subspace corresponding to these Ritz values is referred to as a
 c  Schur basis.
 c
-c  See documentation in the header of the subroutine SNAUPD for 
+c  See documentation in the header of the subroutine SNAUPD for
 c  definition of OP as well as other terms and the relation of computed
 c  Ritz values and Ritz vectors of OP with respect to the given problem
-c  A*z = lambda*B*z.  For a brief description, see definitions of 
+c  A*z = lambda*B*z.  For a brief description, see definitions of
 c  IPARAM(7), MODE and WHICH in the documentation of SNAUPD.
 c
 c\Usage:
-c  call sneupd 
-c     ( RVEC, HOWMNY, SELECT, DR, DI, Z, LDZ, SIGMAR, SIGMAI, WORKEV, BMAT, 
-c       N, WHICH, NEV, TOL, RESID, NCV, V, LDV, IPARAM, IPNTR, WORKD, WORKL, 
+c  call sneupd
+c     ( RVEC, HOWMNY, SELECT, DR, DI, Z, LDZ, SIGMAR, SIGMAI, WORKEV, BMAT,
+c       N, WHICH, NEV, TOL, RESID, NCV, V, LDV, IPARAM, IPNTR, WORKD, WORKL,
 c       LWORKL, INFO )
 c
 c\Arguments:
-c  RVEC    LOGICAL  (INPUT) 
-c          Specifies whether a basis for the invariant subspace corresponding 
-c          to the converged Ritz value approximations for the eigenproblem 
+c  RVEC    LOGICAL  (INPUT)
+c          Specifies whether a basis for the invariant subspace corresponding
+c          to the converged Ritz value approximations for the eigenproblem
 c          A*z = lambda*B*z is computed.
 c
 c             RVEC = .FALSE.     Compute Ritz values only.
 c
 c             RVEC = .TRUE.      Compute the Ritz vectors or Schur vectors.
-c                                See Remarks below. 
-c 
-c  HOWMNY  Character*1  (INPUT) 
-c          Specifies the form of the basis for the invariant subspace 
+c                                See Remarks below.
+c
+c  HOWMNY  Character*1  (INPUT)
+c          Specifies the form of the basis for the invariant subspace
 c          corresponding to the converged Ritz values that is to be computed.
 c
-c          = 'A': Compute NEV Ritz vectors; 
+c          = 'A': Compute NEV Ritz vectors;
 c          = 'P': Compute NEV Schur vectors;
 c          = 'S': compute some of the Ritz vectors, specified
 c                 by the logical array SELECT.
@@ -63,43 +63,43 @@ c
 c  SELECT  Logical array of dimension NCV.  (INPUT)
 c          If HOWMNY = 'S', SELECT specifies the Ritz vectors to be
 c          computed. To select the Ritz vector corresponding to a
-c          Ritz value (DR(j), DI(j)), SELECT(j) must be set to .TRUE.. 
+c          Ritz value (DR(j), DI(j)), SELECT(j) must be set to .TRUE..
 c          If HOWMNY = 'A' or 'P', SELECT is used as internal workspace.
 c
 c  DR      Real array of dimension NEV+1.  (OUTPUT)
-c          If IPARAM(7) = 1,2 or 3 and SIGMAI=0.0  then on exit: DR contains 
-c          the real part of the Ritz  approximations to the eigenvalues of 
-c          A*z = lambda*B*z. 
+c          If IPARAM(7) = 1,2 or 3 and SIGMAI=0.0  then on exit: DR contains
+c          the real part of the Ritz  approximations to the eigenvalues of
+c          A*z = lambda*B*z.
 c          If IPARAM(7) = 3, 4 and SIGMAI is not equal to zero, then on exit:
-c          DR contains the real part of the Ritz values of OP computed by 
+c          DR contains the real part of the Ritz values of OP computed by
 c          SNAUPD. A further computation must be performed by the user
 c          to transform the Ritz values computed for OP by SNAUPD to those
 c          of the original system A*z = lambda*B*z. See remark 3 below.
 c
 c  DI      Real array of dimension NEV+1.  (OUTPUT)
-c          On exit, DI contains the imaginary part of the Ritz value 
+c          On exit, DI contains the imaginary part of the Ritz value
 c          approximations to the eigenvalues of A*z = lambda*B*z associated
 c          with DR.
 c
-c          NOTE: When Ritz values are complex, they will come in complex 
-c                conjugate pairs.  If eigenvectors are requested, the 
-c                corresponding Ritz vectors will also come in conjugate 
-c                pairs and the real and imaginary parts of these are 
-c                represented in two consecutive columns of the array Z 
+c          NOTE: When Ritz values are complex, they will come in complex
+c                conjugate pairs.  If eigenvectors are requested, the
+c                corresponding Ritz vectors will also come in conjugate
+c                pairs and the real and imaginary parts of these are
+c                represented in two consecutive columns of the array Z
 c                (see below).
 c
 c  Z       Real N by NEV+1 array if RVEC = .TRUE. and HOWMNY = 'A'. (OUTPUT)
-c          On exit, if RVEC = .TRUE. and HOWMNY = 'A', then the columns of 
-c          Z represent approximate eigenvectors (Ritz vectors) corresponding 
-c          to the NCONV=IPARAM(5) Ritz values for eigensystem 
-c          A*z = lambda*B*z. 
-c 
-c          The complex Ritz vector associated with the Ritz value 
-c          with positive imaginary part is stored in two consecutive 
-c          columns.  The first column holds the real part of the Ritz 
-c          vector and the second column holds the imaginary part.  The 
-c          Ritz vector associated with the Ritz value with negative 
-c          imaginary part is simply the complex conjugate of the Ritz vector 
+c          On exit, if RVEC = .TRUE. and HOWMNY = 'A', then the columns of
+c          Z represent approximate eigenvectors (Ritz vectors) corresponding
+c          to the NCONV=IPARAM(5) Ritz values for eigensystem
+c          A*z = lambda*B*z.
+c
+c          The complex Ritz vector associated with the Ritz value
+c          with positive imaginary part is stored in two consecutive
+c          columns.  The first column holds the real part of the Ritz
+c          vector and the second column holds the imaginary part.  The
+c          Ritz vector associated with the Ritz value with negative
+c          imaginary part is simply the complex conjugate of the Ritz vector
 c          associated with the positive imaginary part.
 c
 c          If  RVEC = .FALSE. or HOWMNY = 'P', then Z is not referenced.
@@ -114,11 +114,11 @@ c          The leading dimension of the array Z.  If Ritz vectors are
 c          desired, then  LDZ >= max( 1, N ).  In any case,  LDZ >= 1.
 c
 c  SIGMAR  Real  (INPUT)
-c          If IPARAM(7) = 3 or 4, represents the real part of the shift. 
+c          If IPARAM(7) = 3 or 4, represents the real part of the shift.
 c          Not referenced if IPARAM(7) = 1 or 2.
 c
 c  SIGMAI  Real  (INPUT)
-c          If IPARAM(7) = 3 or 4, represents the imaginary part of the shift. 
+c          If IPARAM(7) = 3 or 4, represents the imaginary part of the shift.
 c          Not referenced if IPARAM(7) = 1 or 2. See remark 3 below.
 c
 c  WORKEV  Real work array of dimension 3*NCV.  (WORKSPACE)
@@ -183,10 +183,10 @@ c          =  0: Normal exit.
 c
 c          =  1: The Schur form computed by LAPACK routine slahqr
 c                could not be reordered by LAPACK routine strsen.
-c                Re-enter subroutine sneupd with IPARAM(5)=NCV and 
-c                increase the size of the arrays DR and DI to have 
-c                dimension at least dimension NCV and allocate at least NCV 
-c                columns for Z. NOTE: Not necessary if Z and V share 
+c                Re-enter subroutine sneupd with IPARAM(5)=NCV and
+c                increase the size of the arrays DR and DI to have
+c                dimension at least dimension NCV and allocate at least NCV
+c                columns for Z. NOTE: Not necessary if Z and V share
 c                the same space. Please notify the authors if this error
 c                occurs.
 c
@@ -213,7 +213,7 @@ c\References:
 c  1. D.C. Sorensen, "Implicit Application of Polynomial Filters in
 c     a k-Step Arnoldi Method", SIAM J. Matr. Anal. Apps., 13 (1992),
 c     pp 357-385.
-c  2. R.B. Lehoucq, "Analysis and Implementation of an Implicitly 
+c  2. R.B. Lehoucq, "Analysis and Implementation of an Implicitly
 c     Restarted Arnoldi Iteration", Rice University Technical Report
 c     TR95-13, Department of Computational and Applied Mathematics.
 c  3. B.N. Parlett & Y. Saad, "Complex Shift and Invert Strategies for
@@ -224,7 +224,7 @@ c\Routines called:
 c     ivout   ARPACK utility routine that prints integers.
 c     smout   ARPACK utility routine that prints matrices
 c     svout   ARPACK utility routine that prints vectors.
-c     sgeqr2  LAPACK routine that computes the QR factorization of 
+c     sgeqr2  LAPACK routine that computes the QR factorization of
 c             a matrix.
 c     slacpy  LAPACK matrix copy routine.
 c     slahqr  LAPACK routine to compute the real Schur form of an
@@ -232,7 +232,7 @@ c             upper Hessenberg matrix.
 c     slamch  LAPACK routine that determines machine constants.
 c     slapy2  LAPACK routine to compute sqrt(x**2+y**2) carefully.
 c     slaset  LAPACK matrix initialization routine.
-c     sorm2r  LAPACK routine that applies an orthogonal matrix in 
+c     sorm2r  LAPACK routine that applies an orthogonal matrix in
 c             factored form.
 c     strevc  LAPACK routine to compute the eigenvectors of a matrix
 c             in upper quasi-triangular form.
@@ -255,9 +255,9 @@ c     Ritz vectors. Thus, their numerical properties are often superior.
 c     If RVEC = .TRUE. then the relationship
 c             A * V(:,1:IPARAM(5)) = V(:,1:IPARAM(5)) * T, and
 c     V(:,1:IPARAM(5))' * V(:,1:IPARAM(5)) = I are approximately satisfied.
-c     Here T is the leading submatrix of order IPARAM(5) of the real 
+c     Here T is the leading submatrix of order IPARAM(5) of the real
 c     upper quasi-triangular matrix stored workl(ipntr(12)). That is,
-c     T is block upper triangular with 1-by-1 and 2-by-2 diagonal blocks; 
+c     T is block upper triangular with 1-by-1 and 2-by-2 diagonal blocks;
 c     each 2-by-2 diagonal block has its diagonal elements equal and its
 c     off-diagonal elements of opposite sign.  Corresponding to each 2-by-2
 c     diagonal block is a complex conjugate pair of Ritz values. The real
@@ -265,11 +265,11 @@ c     Ritz values are stored on the diagonal of T.
 c
 c  3. If IPARAM(7) = 3 or 4 and SIGMAI is not equal zero, then the user must
 c     form the IPARAM(5) Rayleigh quotients in order to transform the Ritz
-c     values computed by SNAUPD for OP to those of A*z = lambda*B*z. 
+c     values computed by SNAUPD for OP to those of A*z = lambda*B*z.
 c     Set RVEC = .true. and HOWMNY = 'A', and
-c     compute 
+c     compute
 c           Z(:,I)' * A * Z(:,I) if DI(I) = 0.
-c     If DI(I) is not equal to zero and DI(I+1) = - D(I), 
+c     If DI(I) is not equal to zero and DI(I+1) = - D(I),
 c     then the desired real and imaginary parts of the Ritz value are
 c           Z(:,I)' * A * Z(:,I) +  Z(:,I+1)' * A * Z(:,I+1),
 c           Z(:,I)' * A * Z(:,I+1) -  Z(:,I+1)' * A * Z(:,I), respectively.
@@ -280,22 +280,22 @@ c     2 above.
 c
 c\Authors
 c     Danny Sorensen               Phuong Vu
-c     Richard Lehoucq              CRPC / Rice University 
+c     Richard Lehoucq              CRPC / Rice University
 c     Chao Yang                    Houston, Texas
 c     Dept. of Computational &
-c     Applied Mathematics          
-c     Rice University           
-c     Houston, Texas            
-c 
-c\SCCS Information: @(#) 
-c FILE: neupd.F   SID: 2.5   DATE OF SID: 7/31/96   RELEASE: 2 
+c     Applied Mathematics
+c     Rice University
+c     Houston, Texas
+c
+c\SCCS Information: @(#)
+c FILE: neupd.F   SID: 2.5   DATE OF SID: 7/31/96   RELEASE: 2
 c
 c\EndLib
 c
 c-----------------------------------------------------------------------
-      subroutine sneupd (rvec, howmny, select, dr, di, z, ldz, sigmar, 
-     &                   sigmai, workev, bmat, n, which, nev, tol, 
-     &                   resid, ncv, v, ldv, iparam, ipntr, workd, 
+      subroutine sneupd (rvec, howmny, select, dr, di, z, ldz, sigmar,
+     &                   sigmai, workev, bmat, n, which, nev, tol,
+     &                   resid, ncv, v, ldv, iparam, ipntr, workd,
      &                   workl, lworkl, info)
 c
 c     %----------------------------------------------------%
@@ -312,7 +312,7 @@ c
       character  bmat, howmny, which*2
       logical    rvec
       integer    info, ldz, ldv, lworkl, n, ncv, nev
-      Real     
+      Real
      &           sigmar, sigmai, tol
 c
 c     %-----------------%
@@ -322,7 +322,7 @@ c
       integer    iparam(11), ipntr(14)
       logical    select(ncv)
       Real
-     &           dr(nev+1), di(nev+1), resid(n), v(ldv,ncv), z(ldz,*), 
+     &           dr(nev+1), di(nev+1), resid(n), v(ldv,ncv), z(ldz,*),
      &           workd(3*n), workl(lworkl), workev(3*ncv)
 c
 c     %------------%
@@ -338,8 +338,8 @@ c     | Local Scalars |
 c     %---------------%
 c
       character  type*6
-      integer    bounds, ierr, ih, ihbds, iheigr, iheigi, iconj, nconv, 
-     &           invsub, iuptri, iwev, iwork(1), j, k, ktrord, 
+      integer    bounds, ierr, ih, ihbds, iheigr, iheigi, iconj, nconv,
+     &           invsub, iuptri, iwev, iwork(1), j, k, ktrord,
      &           ldh, ldq, mode, msglvl, outncv, ritzr, ritzi, wri, wrr,
      &           irr, iri, ibd
       logical    reord
@@ -350,7 +350,7 @@ c     %----------------------%
 c     | External Subroutines |
 c     %----------------------%
 c
-      external   scopy, sger, sgeqr2, slacpy, slahqr, slaset, smout, 
+      external   scopy, sger, sgeqr2, slacpy, slahqr, slaset, smout,
      &           sorm2r, strevc, strmm, strsen, sscal, svout, ivout
 c
 c     %--------------------%
@@ -370,7 +370,7 @@ c
 c     %-----------------------%
 c     | Executable Statements |
 c     %-----------------------%
-c 
+c
 c     %------------------------%
 c     | Set default parameters |
 c     %------------------------%
@@ -419,7 +419,7 @@ c
       else if (howmny .eq. 'S' ) then
          ierr = -12
       end if
-c     
+c
       if (mode .eq. 1 .or. mode .eq. 2) then
          type = 'REGULR'
       else if (mode .eq. 3 .and. sigmai .eq. zero) then
@@ -428,7 +428,7 @@ c
          type = 'REALPT'
       else if (mode .eq. 4 ) then
          type = 'IMAGPT'
-      else 
+      else
                                               ierr = -10
       end if
       if (mode .eq. 1 .and. bmat .eq. 'G')    ierr = -11
@@ -441,7 +441,7 @@ c
          info = ierr
          go to 9000
       end if
-c 
+c
 c     %--------------------------------------------------------%
 c     | Pointer into WORKL for address of H, RITZ, BOUNDS, Q   |
 c     | etc... and the remaining workspace.                    |
@@ -468,7 +468,7 @@ c     |       associated matrix representation of the invariant   |
 c     |       subspace for H.                                     |
 c     | GRAND total of NCV * ( 3 * NCV + 6 ) locations.           |
 c     %-----------------------------------------------------------%
-c     
+c
       ih     = ipntr(5)
       ritzr  = ipntr(6)
       ritzi  = ipntr(7)
@@ -511,9 +511,9 @@ c     %------------------------------------%
 c
       rnorm = workl(ih+2)
       workl(ih+2) = zero
-c     
+c
       if (rvec) then
-c     
+c
 c        %-------------------------------------------%
 c        | Get converged Ritz value on the boundary. |
 c        | Note: converged Ritz values have been     |
@@ -544,7 +544,7 @@ c        |                                                          |
 c        | 1) For each Ritz value obtained from _neigh, compare it  |
 c        |    with the threshold Ritz value computed above to       |
 c        |    determine whether it is a wanted one.                 |
-c        |                                                          | 
+c        |                                                          |
 c        | 2) If it is wanted, then check the corresponding Ritz    |
 c        |    estimate to see if it has converged.  If it has, set  |
 c        |    correponding entry in the logical array SELECT to     |
@@ -563,7 +563,7 @@ c
             if (which .eq. 'LM') then
                if (slapy2(workl(irr+j), workl(iri+j))
      &            .ge. thres) then
-                  temp1 = max( eps23, 
+                  temp1 = max( eps23,
      &                         slapy2( workl(irr+j), workl(iri+j) ) )
                   if (workl(ibd+j) .le. tol*temp1)
      &               select(j+1) = .true.
@@ -607,7 +607,7 @@ c
             end if
             if (j+1 .gt. nconv ) reord = ( select(j+1) .or. reord )
             if (select(j+1)) ktrord = ktrord + 1
- 10      continue 
+ 10      continue
 c
          if (msglvl .gt. 2) then
              call ivout(logfil, 1, [ktrord], ndigit,
@@ -622,19 +622,19 @@ c        | of the upper Hessenberg matrix returned by SNAUPD.        |
 c        | Make a copy of the upper Hessenberg matrix.               |
 c        | Initialize the Schur vector matrix Q to the identity.     |
 c        %-----------------------------------------------------------%
-c     
+c
          call scopy (ldh*ncv, workl(ih), 1, workl(iuptri), 1)
          call slaset ('All', ncv, ncv, zero, one, workl(invsub), ldq)
          call slahqr (.true., .true., ncv, 1, ncv, workl(iuptri), ldh,
-     &        workl(iheigr), workl(iheigi), 1, ncv, 
+     &        workl(iheigr), workl(iheigi), 1, ncv,
      &        workl(invsub), ldq, ierr)
          call scopy (ncv, workl(invsub+ncv-1), ldq, workl(ihbds), 1)
-c     
+c
          if (ierr .ne. 0) then
             info = -8
             go to 9000
          end if
-c     
+c
          if (msglvl .gt. 1) then
             call svout (logfil, ncv, workl(iheigr), ndigit,
      &           '_neupd: Real part of the eigenvalues of H')
@@ -646,16 +646,16 @@ c
                call smout (logfil, ncv, ncv, workl(iuptri), ldh, ndigit,
      &              '_neupd: The upper quasi-triangular matrix ')
             end if
-         end if 
+         end if
 c
          if (reord) then
-c     
+c
 c           %-----------------------------------------------------%
-c           | Reorder the computed upper quasi-triangular matrix. | 
+c           | Reorder the computed upper quasi-triangular matrix. |
 c           %-----------------------------------------------------%
-c     
-            call strsen ('None', 'V', select, ncv, workl(iuptri), ldh, 
-     &           workl(invsub), ldq, workl(iheigr), workl(iheigi), 
+c
+            call strsen ('None', 'V', select, ncv, workl(iuptri), ldh,
+     &           workl(invsub), ldq, workl(iheigr), workl(iheigi),
      &           nconv, conds, sep, workl(ihbds), ncv, iwork, 1, ierr)
 c
             if (ierr .eq. 1) then
@@ -669,12 +669,12 @@ c
                 call svout (logfil, ncv, workl(iheigi), ndigit,
      &           '_neupd: Imag part of the eigenvalues of H--reordered')
                 if (msglvl .gt. 3) then
-                   call smout (logfil, ncv, ncv, workl(iuptri), ldq, 
+                   call smout (logfil, ncv, ncv, workl(iuptri), ldq,
      &                  ndigit,
      &              '_neupd: Quasi-triangular matrix after re-ordering')
                 end if
             end if
-c     
+c
          end if
 c
 c        %---------------------------------------%
@@ -691,22 +691,22 @@ c        | Place the computed eigenvalues of H into DR and DI |
 c        | if a spectral transformation was not used.         |
 c        %----------------------------------------------------%
 c
-         if (type .eq. 'REGULR') then 
+         if (type .eq. 'REGULR') then
             call scopy (nconv, workl(iheigr), 1, dr, 1)
             call scopy (nconv, workl(iheigi), 1, di, 1)
          end if
-c     
+c
 c        %----------------------------------------------------------%
 c        | Compute the QR factorization of the matrix representing  |
 c        | the wanted invariant subspace located in the first NCONV |
 c        | columns of workl(invsub,ldq).                            |
 c        %----------------------------------------------------------%
-c     
-         call sgeqr2 (ncv, nconv, workl(invsub), ldq, workev, 
+c
+         call sgeqr2 (ncv, nconv, workl(invsub), ldq, workev,
      &        workev(ncv+1), ierr)
 c
 c        %---------------------------------------------------------%
-c        | * Postmultiply V by Q using sorm2r.                     |   
+c        | * Postmultiply V by Q using sorm2r.                     |
 c        | * Copy the first NCONV columns of VQ into Z.            |
 c        | * Postmultiply Z by R.                                  |
 c        | The N by NCONV matrix Z is now a matrix representation  |
@@ -716,13 +716,13 @@ c        | The first NCONV columns of V are now approximate Schur  |
 c        | vectors associated with the real upper quasi-triangular |
 c        | matrix of order NCONV in workl(iuptri)                  |
 c        %---------------------------------------------------------%
-c     
+c
          call sorm2r ('Right', 'Notranspose', n, ncv, nconv,
      &        workl(invsub), ldq, workev, v, ldv, workd(n+1), ierr)
          call slacpy ('All', n, nconv, v, ldv, z, ldz)
 c
          do 20 j=1, nconv
-c     
+c
 c           %---------------------------------------------------%
 c           | Perform both a column and row scaling if the      |
 c           | diagonal element of workl(invsub,ldq) is negative |
@@ -731,21 +731,21 @@ c           | quasi-triangular form of workl(iuptri,ldq)        |
 c           | Note that since Q is orthogonal, R is a diagonal  |
 c           | matrix consisting of plus or minus ones           |
 c           %---------------------------------------------------%
-c     
+c
             if (workl(invsub+(j-1)*ldq+j-1) .lt. zero) then
                call sscal (nconv, -one, workl(iuptri+j-1), ldq)
                call sscal (nconv, -one, workl(iuptri+(j-1)*ldq), 1)
             end if
-c     
+c
  20      continue
-c     
+c
          if (howmny .eq. 'A') then
-c     
+c
 c           %--------------------------------------------%
-c           | Compute the NCONV wanted eigenvectors of T | 
+c           | Compute the NCONV wanted eigenvectors of T |
 c           | located in workl(iuptri,ldq).              |
 c           %--------------------------------------------%
-c     
+c
             do 30 j=1, ncv
                if (j .le. nconv) then
                   select(j) = .true.
@@ -754,7 +754,7 @@ c
                end if
  30         continue
 c
-            call strevc ('Right', 'Select', select, ncv, workl(iuptri), 
+            call strevc ('Right', 'Select', select, ncv, workl(iuptri),
      &           ldq, vl, 1, workl(invsub), ldq, ncv, outncv, workev,
      &           ierr)
 c
@@ -762,7 +762,7 @@ c
                 info = -9
                 go to 9000
             end if
-c     
+c
 c           %------------------------------------------------%
 c           | Scale the returning eigenvectors so that their |
 c           | Euclidean norms are all one. LAPACK subroutine |
@@ -770,22 +770,22 @@ c           | strevc returns each eigenvector normalized so  |
 c           | that the element of largest magnitude has      |
 c           | magnitude 1;                                   |
 c           %------------------------------------------------%
-c     
+c
             iconj = 0
             do 40 j=1, nconv
 c
                if ( workl(iheigi+j-1) .eq. zero ) then
-c     
+c
 c                 %----------------------%
 c                 | real eigenvalue case |
 c                 %----------------------%
-c     
+c
                   temp = snrm2( ncv, workl(invsub+(j-1)*ldq), 1 )
-                  call sscal ( ncv, one / temp, 
+                  call sscal ( ncv, one / temp,
      &                 workl(invsub+(j-1)*ldq), 1 )
 c
                else
-c     
+c
 c                 %-------------------------------------------%
 c                 | Complex conjugate pair case. Note that    |
 c                 | since the real and imaginary part of      |
@@ -795,11 +795,11 @@ c                 | square root of two.                       |
 c                 %-------------------------------------------%
 c
                   if (iconj .eq. 0) then
-                     temp = slapy2( snrm2( ncv, workl(invsub+(j-1)*ldq), 
-     &                      1 ), snrm2( ncv, workl(invsub+j*ldq),  1) )  
-                     call sscal ( ncv, one / temp, 
+                     temp = slapy2( snrm2( ncv, workl(invsub+(j-1)*ldq),
+     &                      1 ), snrm2( ncv, workl(invsub+j*ldq),  1) )
+                     call sscal ( ncv, one / temp,
      &                      workl(invsub+(j-1)*ldq), 1 )
-                     call sscal ( ncv, one / temp, 
+                     call sscal ( ncv, one / temp,
      &                      workl(invsub+j*ldq), 1 )
                      iconj = 1
                   else
@@ -839,7 +839,7 @@ c
                call svout (logfil, ncv, workl(ihbds), ndigit,
      &              '_neupd: Last row of the eigenvector matrix for T')
                if (msglvl .gt. 3) then
-                  call smout (logfil, ncv, ncv, workl(invsub), ldq, 
+                  call smout (logfil, ncv, ncv, workl(invsub), ldq,
      &                 ndigit, '_neupd: The eigenvector matrix for T')
                end if
             end if
@@ -855,27 +855,27 @@ c           | Compute the QR factorization of the eigenvector matrix  |
 c           | associated with leading portion of T in the first NCONV |
 c           | columns of workl(invsub,ldq).                           |
 c           %---------------------------------------------------------%
-c     
-            call sgeqr2 (ncv, nconv, workl(invsub), ldq, workev, 
+c
+            call sgeqr2 (ncv, nconv, workl(invsub), ldq, workev,
      &                   workev(ncv+1), ierr)
-c     
+c
 c           %----------------------------------------------%
-c           | * Postmultiply Z by Q.                       |   
+c           | * Postmultiply Z by Q.                       |
 c           | * Postmultiply Z by R.                       |
-c           | The N by NCONV matrix Z is now contains the  | 
+c           | The N by NCONV matrix Z is now contains the  |
 c           | Ritz vectors associated with the Ritz values |
 c           | in workl(iheigr) and workl(iheigi).          |
 c           %----------------------------------------------%
-c     
+c
             call sorm2r ('Right', 'Notranspose', n, ncv, nconv,
      &           workl(invsub), ldq, workev, z, ldz, workd(n+1), ierr)
-c     
+c
             call strmm ('Right', 'Upper', 'No transpose', 'Non-unit',
      &                  n, nconv, one, workl(invsub), ldq, z, ldz)
-c     
+c
          end if
-c     
-      else 
+c
+      else
 c
 c        %------------------------------------------------------%
 c        | An approximate invariant subspace is not needed.     |
@@ -888,7 +888,7 @@ c
          call scopy (nconv, workl(ritzi), 1, workl(iheigi), 1)
          call scopy (nconv, workl(bounds), 1, workl(ihbds), 1)
       end if
-c 
+c
 c     %------------------------------------------------%
 c     | Transform the Ritz values and possibly vectors |
 c     | and corresponding error bounds of OP to those  |
@@ -897,26 +897,26 @@ c     %------------------------------------------------%
 c
       if (type .eq. 'REGULR') then
 c
-         if (rvec) 
-     &      call sscal (ncv, rnorm, workl(ihbds), 1)     
-c     
-      else 
-c     
+         if (rvec)
+     &      call sscal (ncv, rnorm, workl(ihbds), 1)
+c
+      else
+c
 c        %---------------------------------------%
 c        |   A spectral transformation was used. |
 c        | * Determine the Ritz estimates of the |
 c        |   Ritz values in the original system. |
 c        %---------------------------------------%
-c     
+c
          if (type .eq. 'SHIFTI') then
 c
-            if (rvec) 
+            if (rvec)
      &         call sscal (ncv, rnorm, workl(ihbds), 1)
 c
             do 50 k=1, ncv
-               temp = slapy2( workl(iheigr+k-1), 
+               temp = slapy2( workl(iheigr+k-1),
      &                        workl(iheigi+k-1) )
-               workl(ihbds+k-1) = abs( workl(ihbds+k-1) ) 
+               workl(ihbds+k-1) = abs( workl(ihbds+k-1) )
      &                          / temp / temp
  50         continue
 c
@@ -931,26 +931,26 @@ c
  70         continue
 c
          end if
-c     
+c
 c        %-----------------------------------------------------------%
 c        | *  Transform the Ritz values back to the original system. |
 c        |    For TYPE = 'SHIFTI' the transformation is              |
 c        |             lambda = 1/theta + sigma                      |
 c        |    For TYPE = 'REALPT' or 'IMAGPT' the user must from     |
-c        |    Rayleigh quotients or a projection. See remark 3 above.| 
+c        |    Rayleigh quotients or a projection. See remark 3 above.|
 c        | NOTES:                                                    |
 c        | *The Ritz vectors are not affected by the transformation. |
 c        %-----------------------------------------------------------%
-c     
-         if (type .eq. 'SHIFTI') then 
+c
+         if (type .eq. 'SHIFTI') then
 c
             do 80 k=1, ncv
-               temp = slapy2( workl(iheigr+k-1), 
+               temp = slapy2( workl(iheigr+k-1),
      &                        workl(iheigi+k-1) )
-               workl(iheigr+k-1) = workl(iheigr+k-1) / temp / temp 
-     &                           + sigmar   
+               workl(iheigr+k-1) = workl(iheigr+k-1) / temp / temp
+     &                           + sigmar
                workl(iheigi+k-1) = -workl(iheigi+k-1) / temp / temp
-     &                           + sigmai   
+     &                           + sigmai
  80         continue
 c
             call scopy (nconv, workl(iheigr), 1, dr, 1)
@@ -980,7 +980,7 @@ c
          call svout (logfil, nconv, workl(ihbds), ndigit,
      &   '_neupd: Associated Ritz estimates.')
       end if
-c 
+c
 c     %-------------------------------------------------%
 c     | Eigenvector Purification step. Formally perform |
 c     | one of inverse subspace iteration. Only used    |
@@ -1007,13 +1007,13 @@ c
      &                      workl(iheigr+j-1)
             else if (iconj .eq. 0) then
                temp = slapy2( workl(iheigr+j-1), workl(iheigi+j-1) )
-               workev(j) = ( workl(invsub+(j-1)*ldq+ncv-1) * 
+               workev(j) = ( workl(invsub+(j-1)*ldq+ncv-1) *
      &                       workl(iheigr+j-1) +
-     &                       workl(invsub+j*ldq+ncv-1) * 
+     &                       workl(invsub+j*ldq+ncv-1) *
      &                       workl(iheigi+j-1) ) / temp / temp
-               workev(j+1) = ( workl(invsub+j*ldq+ncv-1) * 
+               workev(j+1) = ( workl(invsub+j*ldq+ncv-1) *
      &                         workl(iheigr+j-1) -
-     &                         workl(invsub+(j-1)*ldq+ncv-1) * 
+     &                         workl(invsub+(j-1)*ldq+ncv-1) *
      &                         workl(iheigi+j-1) ) / temp / temp
                iconj = 1
             else
@@ -1033,7 +1033,7 @@ c
  9000 continue
 c
       return
-c     
+c
 c     %---------------%
 c     | End of SNEUPD |
 c     %---------------%

--- a/mathlibs/src/arpack/sneupd.f
+++ b/mathlibs/src/arpack/sneupd.f
@@ -532,7 +532,7 @@ c
          end if
 c
          if (msglvl .gt. 2) then
-            call svout(logfil, 1, thres, ndigit,
+            call svout(logfil, 1, [thres], ndigit,
      &           '_neupd: Threshold eigenvalue used for re-ordering')
          end if
 c
@@ -610,9 +610,9 @@ c
  10      continue 
 c
          if (msglvl .gt. 2) then
-             call ivout(logfil, 1, ktrord, ndigit,
+             call ivout(logfil, 1, [ktrord], ndigit,
      &            '_neupd: Number of specified eigenvalues')
-             call ivout(logfil, 1, nconv, ndigit,
+             call ivout(logfil, 1, [nconv], ndigit,
      &            '_neupd: Number of "converged" eigenvalues')
          end if
 c

--- a/mathlibs/src/arpack/sngets.f
+++ b/mathlibs/src/arpack/sngets.f
@@ -212,8 +212,8 @@ c
       tngets = tngets + (t1 - t0)
 c
       if (msglvl .gt. 0) then
-         call ivout (logfil, 1, kev, ndigit, '_ngets: KEV is')
-         call ivout (logfil, 1, np, ndigit, '_ngets: NP is')
+         call ivout (logfil, 1, [kev], ndigit, '_ngets: KEV is')
+         call ivout (logfil, 1, [np], ndigit, '_ngets: NP is')
          call svout (logfil, kev+np, ritzr, ndigit,
      &        '_ngets: Eigenvalues of current H matrix -- real part')
          call svout (logfil, kev+np, ritzi, ndigit,

--- a/mathlibs/src/arpack/sngets.f
+++ b/mathlibs/src/arpack/sngets.f
@@ -3,9 +3,9 @@ c\BeginDoc
 c
 c\Name: sngets
 c
-c\Description: 
+c\Description:
 c  Given the eigenvalues of the upper Hessenberg matrix H,
-c  computes the NP shifts AMU that are zeros of the polynomial of 
+c  computes the NP shifts AMU that are zeros of the polynomial of
 c  degree NP which filters out components of the unwanted eigenvectors
 c  corresponding to the AMU's based on some given criteria.
 c
@@ -42,12 +42,12 @@ c           OUTPUT: Possibly decreases NP by one to keep complex conjugate
 c           pairs together.
 c
 c  RITZR,  Real array of length KEV+NP.  (INPUT/OUTPUT)
-c  RITZI   On INPUT, RITZR and RITZI contain the real and imaginary 
+c  RITZI   On INPUT, RITZR and RITZI contain the real and imaginary
 c          parts of the eigenvalues of H.
 c          On OUTPUT, RITZR and RITZI are sorted so that the unwanted
 c          eigenvalues are in the first NP locations and the wanted
-c          portion is in the last KEV locations.  When exact shifts are 
-c          selected, the unwanted part corresponds to the shifts to 
+c          portion is in the last KEV locations.  When exact shifts are
+c          selected, the unwanted part corresponds to the shifts to
 c          be applied. Also, if ISHIFT .eq. 1, the unwanted eigenvalues
 c          are further sorted so that the ones with largest Ritz values
 c          are first.
@@ -56,7 +56,7 @@ c  BOUNDS  Real array of length KEV+NP.  (INPUT/OUTPUT)
 c          Error bounds corresponding to the ordering in RITZ.
 c
 c  SHIFTR, SHIFTI  *** USE deprecated as of version 2.1. ***
-c  
+c
 c
 c\EndDoc
 c
@@ -76,13 +76,13 @@ c     Danny Sorensen               Phuong Vu
 c     Richard Lehoucq              CRPC / Rice University
 c     Dept. of Computational &     Houston, Texas
 c     Applied Mathematics
-c     Rice University           
-c     Houston, Texas    
+c     Rice University
+c     Houston, Texas
 c
 c\Revision history:
 c     xx/xx/92: Version ' 2.1'
 c
-c\SCCS Information: @(#) 
+c\SCCS Information: @(#)
 c FILE: ngets.F   SID: 2.3   DATE OF SID: 4/20/96   RELEASE: 2
 c
 c\Remarks
@@ -114,7 +114,7 @@ c     | Array Arguments |
 c     %-----------------%
 c
       Real
-     &           bounds(kev+np), ritzr(kev+np), ritzi(kev+np), 
+     &           bounds(kev+np), ritzr(kev+np), ritzi(kev+np),
      &           shiftr(1), shifti(1)
 c
 c     %------------%
@@ -151,10 +151,10 @@ c     %-------------------------------%
 c     | Initialize timing statistics  |
 c     | & message level for debugging |
 c     %-------------------------------%
-c 
+c
       call second (t0)
       msglvl = mngets
-c 
+c
 c     %----------------------------------------------------%
 c     | LM, SM, LR, SR, LI, SI case.                       |
 c     | Sort the eigenvalues of H into the desired order   |
@@ -178,16 +178,16 @@ c
       else if (which .eq. 'SI') then
          call ssortc ('SM', .true., kev+np, ritzr, ritzi, bounds)
       end if
-c      
+c
       call ssortc (which, .true., kev+np, ritzr, ritzi, bounds)
-c     
+c
 c     %-------------------------------------------------------%
 c     | Increase KEV by one if the ( ritzr(np),ritzi(np) )    |
 c     | = ( ritzr(np+1),-ritzi(np+1) ) and ritz(np) .ne. zero |
 c     | Accordingly decrease NP by one. In other words keep   |
 c     | complex conjugate pairs together.                     |
 c     %-------------------------------------------------------%
-c     
+c
       if (       ( ritzr(np+1) - ritzr(np) ) .eq. zero
      &     .and. ( ritzi(np+1) + ritzi(np) ) .eq. zero ) then
          np = np - 1
@@ -195,7 +195,7 @@ c
       end if
 c
       if ( ishift .eq. 1 ) then
-c     
+c
 c        %-------------------------------------------------------%
 c        | Sort the unwanted Ritz values used as shifts so that  |
 c        | the ones with largest Ritz estimates are first        |
@@ -204,10 +204,10 @@ c        | forward instability of the iteration when they shifts |
 c        | are applied in subroutine snapps.                     |
 c        | Be careful and use 'SR' since we want to sort BOUNDS! |
 c        %-------------------------------------------------------%
-c     
+c
          call ssortc ( 'SR', .true., np, bounds, ritzr, ritzi )
       end if
-c     
+c
       call second (t1)
       tngets = tngets + (t1 - t0)
 c
@@ -218,14 +218,14 @@ c
      &        '_ngets: Eigenvalues of current H matrix -- real part')
          call svout (logfil, kev+np, ritzi, ndigit,
      &        '_ngets: Eigenvalues of current H matrix -- imag part')
-         call svout (logfil, kev+np, bounds, ndigit, 
+         call svout (logfil, kev+np, bounds, ndigit,
      &      '_ngets: Ritz estimates of the current KEV+NP Ritz values')
       end if
-c     
+c
       return
-c     
+c
 c     %---------------%
 c     | End of sngets |
 c     %---------------%
-c     
+c
       end

--- a/mathlibs/src/arpack/ssaitr.f
+++ b/mathlibs/src/arpack/ssaitr.f
@@ -364,9 +364,9 @@ c
  1000 continue
 c
          if (msglvl .gt. 2) then
-            call ivout (logfil, 1, j, ndigit, 
+            call ivout (logfil, 1, [j], ndigit, 
      &                  '_saitr: generating Arnoldi vector no.')
-            call svout (logfil, 1, rnorm, ndigit, 
+            call svout (logfil, 1, [rnorm], ndigit, 
      &                  '_saitr: B-norm of the current residual =')
          end if
 c 
@@ -384,7 +384,7 @@ c           | basis and continue the iteration.                 |
 c           %---------------------------------------------------%
 c
             if (msglvl .gt. 0) then
-               call ivout (logfil, 1, j, ndigit,
+               call ivout (logfil, 1, [j], ndigit,
      &                     '_saitr: ****** restart at step ******')
             end if
 c 
@@ -735,7 +735,7 @@ c
          end if
 c
          if (msglvl .gt. 0 .and. iter .gt. 0) then
-            call ivout (logfil, 1, j, ndigit,
+            call ivout (logfil, 1, [j], ndigit,
      &           '_saitr: Iterative refinement for Arnoldi residual')
             if (msglvl .gt. 2) then
                 xtemp(1) = rnorm

--- a/mathlibs/src/arpack/ssaitr.f
+++ b/mathlibs/src/arpack/ssaitr.f
@@ -3,8 +3,8 @@ c\BeginDoc
 c
 c\Name: ssaitr
 c
-c\Description: 
-c  Reverse communication interface for applying NP additional steps to 
+c\Description:
+c  Reverse communication interface for applying NP additional steps to
 c  a K step symmetric Arnoldi factorization.
 c
 c  Input:  OP*V_{k}  -  V_{k}*H = r_{k}*e_{k}^T
@@ -20,7 +20,7 @@ c  computed and returned.
 c
 c\Usage:
 c  call ssaitr
-c     ( IDO, BMAT, N, K, NP, MODE, RESID, RNORM, V, LDV, H, LDH, 
+c     ( IDO, BMAT, N, K, NP, MODE, RESID, RNORM, V, LDV, H, LDH,
 c       IPNTR, WORKD, INFO )
 c
 c\Arguments
@@ -76,13 +76,13 @@ c          On INPUT the B-norm of r_{k}.
 c          On OUTPUT the B-norm of the updated residual r_{k+p}.
 c
 c  V       Real N by K+NP array.  (INPUT/OUTPUT)
-c          On INPUT:  V contains the Arnoldi vectors in the first K 
+c          On INPUT:  V contains the Arnoldi vectors in the first K
 c          columns.
 c          On OUTPUT: V contains the new NP Arnoldi vectors in the next
 c          NP columns.  The first K columns are unchanged.
 c
 c  LDV     Integer.  (INPUT)
-c          Leading dimension of V exactly as declared in the calling 
+c          Leading dimension of V exactly as declared in the calling
 c          program.
 c
 c  H       Real (K+NP) by 2 array.  (INPUT/OUTPUT)
@@ -91,26 +91,26 @@ c          with the subdiagonal in the first column starting at H(2,1)
 c          and the main diagonal in the second column.
 c
 c  LDH     Integer.  (INPUT)
-c          Leading dimension of H exactly as declared in the calling 
+c          Leading dimension of H exactly as declared in the calling
 c          program.
 c
 c  IPNTR   Integer array of length 3.  (OUTPUT)
-c          Pointer to mark the starting locations in the WORK for 
+c          Pointer to mark the starting locations in the WORK for
 c          vectors used by the Arnoldi iteration.
 c          -------------------------------------------------------------
 c          IPNTR(1): pointer to the current operand vector X.
 c          IPNTR(2): pointer to the current result vector Y.
-c          IPNTR(3): pointer to the vector B * X when used in the 
+c          IPNTR(3): pointer to the vector B * X when used in the
 c                    shift-and-invert mode.  X is the current operand.
 c          -------------------------------------------------------------
-c          
+c
 c  WORKD   Real work array of length 3*N.  (REVERSE COMMUNICATION)
 c          Distributed array to be used in the basic Arnoldi iteration
-c          for reverse communication.  The calling program should not 
+c          for reverse communication.  The calling program should not
 c          use WORKD as temporary workspace during the iteration !!!!!!
 c          On INPUT, WORKD(1:N) = B*RESID where RESID is associated
-c          with the K step Arnoldi factorization. Used to save some 
-c          computation at the first step. 
+c          with the K step Arnoldi factorization. Used to save some
+c          computation at the first step.
 c          On OUTPUT, WORKD(1:N) = B*RESID where RESID is associated
 c          with the K+NP step Arnoldi factorization.
 c
@@ -139,7 +139,7 @@ c     sgemv   Level 2 BLAS routine for matrix vector multiplication.
 c     saxpy   Level 1 BLAS that computes a vector triad.
 c     sscal   Level 1 BLAS that scales a vector.
 c     scopy   Level 1 BLAS that copies one vector to another .
-c     sdot    Level 1 BLAS that computes the scalar product of two vectors. 
+c     sdot    Level 1 BLAS that computes the scalar product of two vectors.
 c     snrm2   Level 1 BLAS that computes the norm of a vector.
 c
 c\Author
@@ -147,29 +147,29 @@ c     Danny Sorensen               Phuong Vu
 c     Richard Lehoucq              CRPC / Rice University
 c     Dept. of Computational &     Houston, Texas
 c     Applied Mathematics
-c     Rice University           
-c     Houston, Texas            
-c 
+c     Rice University
+c     Houston, Texas
+c
 c\Revision history:
 c     xx/xx/93: Version ' 2.4'
 c
-c\SCCS Information: @(#) 
+c\SCCS Information: @(#)
 c FILE: saitr.F   SID: 2.6   DATE OF SID: 8/28/96   RELEASE: 2
 c
 c\Remarks
 c  The algorithm implemented is:
-c  
+c
 c  restart = .false.
-c  Given V_{k} = [v_{1}, ..., v_{k}], r_{k}; 
+c  Given V_{k} = [v_{1}, ..., v_{k}], r_{k};
 c  r_{k} contains the initial residual vector even for k = 0;
-c  Also assume that rnorm = || B*r_{k} || and B*r_{k} are already 
+c  Also assume that rnorm = || B*r_{k} || and B*r_{k} are already
 c  computed by the calling program.
 c
 c  betaj = rnorm ; p_{k+1} = B*r_{k} ;
 c  For  j = k+1, ..., k+np  Do
 c     1) if ( betaj < tol ) stop or restart depending on j.
 c        if ( restart ) generate a new starting vector.
-c     2) v_{j} = r(j-1)/betaj;  V_{j} = [V_{j-1}, v_{j}];  
+c     2) v_{j} = r(j-1)/betaj;  V_{j} = [V_{j-1}, v_{j}];
 c        p_{j} = p_{j}/betaj
 c     3) r_{j} = OP*v_{j} where OP is defined as in ssaupd
 c        For shift-invert mode p_{j} = B*v_{j} is already available.
@@ -184,7 +184,7 @@ c        If (rnorm > 0.717*wnorm) accept step and go back to 1)
 c     5) Re-orthogonalization step:
 c        s = V_{j}'*B*r_{j}
 c        r_{j} = r_{j} - V_{j}*s;  rnorm1 = || r_{j} ||
-c        alphaj = alphaj + s_{j};   
+c        alphaj = alphaj + s_{j};
 c     6) Iterative refinement step:
 c        If (rnorm1 > 0.717*rnorm) then
 c           rnorm = rnorm1
@@ -194,7 +194,7 @@ c           rnorm = rnorm1
 c           If this is the first time in step 6), go to 5)
 c           Else r_{j} lies in the span of V_{j} numerically.
 c              Set r_{j} = 0 and rnorm = 0; go to 1)
-c        EndIf 
+c        EndIf
 c  End Do
 c
 c\EndLib
@@ -202,7 +202,7 @@ c
 c-----------------------------------------------------------------------
 c
       subroutine ssaitr
-     &   (ido, bmat, n, k, np, mode, resid, rnorm, v, ldv, h, ldh, 
+     &   (ido, bmat, n, k, np, mode, resid, rnorm, v, ldv, h, ldh,
      &    ipntr, workd, info)
 c
 c     %----------------------------------------------------%
@@ -242,7 +242,7 @@ c     | Local Scalars |
 c     %---------------%
 c
       logical    first, orth1, orth2, rstart, step3, step4
-      integer    i, ierr, ipj, irj, ivj, iter, itry, j, msglvl, 
+      integer    i, ierr, ipj, irj, ivj, iter, itry, j, msglvl,
      &           infol, jj
       Real
      &           rnorm1, wnorm, safmin, temp1
@@ -251,7 +251,7 @@ c
      &           rnorm1, safmin, wnorm
 c
 c     %-----------------------%
-c     | Local Array Arguments | 
+c     | Local Array Arguments |
 c     %-----------------------%
 c
       Real
@@ -294,7 +294,7 @@ c
       end if
 c
       if (ido .eq. 0) then
-c 
+c
 c        %-------------------------------%
 c        | Initialize timing statistics  |
 c        | & message level for debugging |
@@ -302,7 +302,7 @@ c        %-------------------------------%
 c
          call second (t0)
          msglvl = msaitr
-c 
+c
 c        %------------------------------%
 c        | Initial call to this routine |
 c        %------------------------------%
@@ -313,14 +313,14 @@ c
          rstart = .false.
          orth1  = .false.
          orth2  = .false.
-c 
+c
 c        %--------------------------------%
 c        | Pointer to the current step of |
 c        | the factorization to build     |
 c        %--------------------------------%
 c
          j      = k + 1
-c 
+c
 c        %------------------------------------------%
 c        | Pointers used for reverse communication  |
 c        | when using WORKD.                        |
@@ -330,7 +330,7 @@ c
          irj    = ipj   + n
          ivj    = irj   + n
       end if
-c 
+c
 c     %-------------------------------------------------%
 c     | When in reverse communication mode one of:      |
 c     | STEP3, STEP4, ORTH1, ORTH2, RSTART              |
@@ -353,7 +353,7 @@ c
 c     %------------------------------%
 c     | Else this is the first step. |
 c     %------------------------------%
-c 
+c
 c     %--------------------------------------------------------------%
 c     |                                                              |
 c     |        A R N O L D I     I T E R A T I O N     L O O P       |
@@ -364,12 +364,12 @@ c
  1000 continue
 c
          if (msglvl .gt. 2) then
-            call ivout (logfil, 1, [j], ndigit, 
+            call ivout (logfil, 1, [j], ndigit,
      &                  '_saitr: generating Arnoldi vector no.')
-            call svout (logfil, 1, [rnorm], ndigit, 
+            call svout (logfil, 1, [rnorm], ndigit,
      &                  '_saitr: B-norm of the current residual =')
          end if
-c 
+c
 c        %---------------------------------------------------------%
 c        | Check for exact zero. Equivalent to determing whether a |
 c        | j-step Arnoldi factorization is present.                |
@@ -387,7 +387,7 @@ c
                call ivout (logfil, 1, [j], ndigit,
      &                     '_saitr: ****** restart at step ******')
             end if
-c 
+c
 c           %---------------------------------------------%
 c           | ITRY is the loop variable that controls the |
 c           | maximum amount of times that a restart is   |
@@ -406,7 +406,7 @@ c           | If in reverse communication mode and |
 c           | RSTART = .true. flow returns here.   |
 c           %--------------------------------------%
 c
-            call sgetv0 (ido, bmat, itry, .false., n, j, v, ldv, 
+            call sgetv0 (ido, bmat, itry, .false., n, j, v, ldv,
      &                   resid, rnorm, ipntr, workd, ierr)
             if (ido .ne. 99) go to 9000
             if (ierr .lt. 0) then
@@ -425,7 +425,7 @@ c
                ido = 99
                go to 9000
             end if
-c 
+c
    40    continue
 c
 c        %---------------------------------------------------------%
@@ -447,12 +447,12 @@ c            | To scale both v_{j} and p_{j} carefully |
 c            | use LAPACK routine SLASCL               |
 c            %-----------------------------------------%
 c
-             call slascl ('General', i, i, rnorm, one, n, 1, 
+             call slascl ('General', i, i, rnorm, one, n, 1,
      &                    v(1,j), n, infol)
-             call slascl ('General', i, i, rnorm, one, n, 1, 
+             call slascl ('General', i, i, rnorm, one, n, 1,
      &                    workd(ipj), n, infol)
          end if
-c 
+c
 c        %------------------------------------------------------%
 c        | STEP 3:  r_{j} = OP*v_{j}; Note that p_{j} = B*v_{j} |
 c        | Note that this is not quite yet r_{j}. See STEP 4    |
@@ -466,14 +466,14 @@ c
          ipntr(2) = irj
          ipntr(3) = ipj
          ido = 1
-c 
+c
 c        %-----------------------------------%
 c        | Exit in order to compute OP*v_{j} |
 c        %-----------------------------------%
-c 
+c
          go to 9000
    50    continue
-c 
+c
 c        %-----------------------------------%
 c        | Back from reverse communication;  |
 c        | WORKD(IRJ:IRJ+N-1) := OP*v_{j}.   |
@@ -481,7 +481,7 @@ c        %-----------------------------------%
 c
          call second (t3)
          tmvopx = tmvopx + (t3 - t2)
-c 
+c
          step3 = .false.
 c
 c        %------------------------------------------%
@@ -489,7 +489,7 @@ c        | Put another copy of OP*v_{j} into RESID. |
 c        %------------------------------------------%
 c
          call scopy (n, workd(irj), 1, resid, 1)
-c 
+c
 c        %-------------------------------------------%
 c        | STEP 4:  Finish extending the symmetric   |
 c        |          Arnoldi to length j. If MODE = 2 |
@@ -507,17 +507,17 @@ c
             ipntr(1) = irj
             ipntr(2) = ipj
             ido = 2
-c 
+c
 c           %-------------------------------------%
 c           | Exit in order to compute B*OP*v_{j} |
 c           %-------------------------------------%
-c 
+c
             go to 9000
          else if (bmat .eq. 'I') then
               call scopy(n, resid, 1 , workd(ipj), 1)
          end if
    60    continue
-c 
+c
 c        %-----------------------------------%
 c        | Back from reverse communication;  |
 c        | WORKD(IPJ:IPJ+N-1) := B*OP*v_{j}. |
@@ -526,7 +526,7 @@ c
          if (bmat .eq. 'G') then
             call second (t3)
             tmvbx = tmvbx + (t3 - t2)
-         end if 
+         end if
 c
          step4 = .false.
 c
@@ -545,7 +545,7 @@ c           %----------------------------------%
 c
             wnorm = sdot (n, resid, 1, workd(ivj), 1)
             wnorm = sqrt(abs(wnorm))
-         else if (bmat .eq. 'G') then         
+         else if (bmat .eq. 'G') then
             wnorm = sdot (n, resid, 1, workd(ipj), 1)
             wnorm = sqrt(abs(wnorm))
          else if (bmat .eq. 'I') then
@@ -567,19 +567,19 @@ c        | WORKD(IPJ:IPJ+N-1) contains B*OP*v_{j}.  |
 c        %------------------------------------------%
 c
          if (mode .ne. 2 ) then
-            call sgemv('T', n, j, one, v, ldv, workd(ipj), 1, zero, 
+            call sgemv('T', n, j, one, v, ldv, workd(ipj), 1, zero,
      &                  workd(irj), 1)
          else if (mode .eq. 2) then
-            call sgemv('T', n, j, one, v, ldv, workd(ivj), 1, zero, 
+            call sgemv('T', n, j, one, v, ldv, workd(ivj), 1, zero,
      &                  workd(irj), 1)
          end if
 c
 c        %--------------------------------------%
 c        | Orthgonalize r_{j} against V_{j}.    |
-c        | RESID contains OP*v_{j}. See STEP 3. | 
+c        | RESID contains OP*v_{j}. See STEP 3. |
 c        %--------------------------------------%
 c
-         call sgemv('N', n, j, -one, v, ldv, workd(irj), 1, one, 
+         call sgemv('N', n, j, -one, v, ldv, workd(irj), 1, one,
      &               resid, 1)
 c
 c        %--------------------------------------%
@@ -593,10 +593,10 @@ c
             h(j,1) = rnorm
          end if
          call second (t4)
-c 
+c
          orth1 = .true.
          iter  = 0
-c 
+c
          call second (t2)
          if (bmat .eq. 'G') then
             nbx = nbx + 1
@@ -604,17 +604,17 @@ c
             ipntr(1) = irj
             ipntr(2) = ipj
             ido = 2
-c 
+c
 c           %----------------------------------%
 c           | Exit in order to compute B*r_{j} |
 c           %----------------------------------%
-c 
+c
             go to 9000
          else if (bmat .eq. 'I') then
             call scopy (n, resid, 1, workd(ipj), 1)
          end if
    70    continue
-c 
+c
 c        %---------------------------------------------------%
 c        | Back from reverse communication if ORTH1 = .true. |
 c        | WORKD(IPJ:IPJ+N-1) := B*r_{j}.                    |
@@ -624,14 +624,14 @@ c
             call second (t3)
             tmvbx = tmvbx + (t3 - t2)
          end if
-c 
+c
          orth1 = .false.
 c
 c        %------------------------------%
 c        | Compute the B-norm of r_{j}. |
 c        %------------------------------%
 c
-         if (bmat .eq. 'G') then         
+         if (bmat .eq. 'G') then
             rnorm = sdot (n, resid, 1, workd(ipj), 1)
             rnorm = sqrt(abs(rnorm))
          else if (bmat .eq. 'I') then
@@ -655,7 +655,7 @@ c        %-----------------------------------------------------------%
 c
          if (rnorm .gt. 0.717*wnorm) go to 100
          nrorth = nrorth + 1
-c 
+c
 c        %---------------------------------------------------%
 c        | Enter the Iterative refinement phase. If further  |
 c        | refinement is necessary, loop back here. The loop |
@@ -668,7 +668,7 @@ c
          if (msglvl .gt. 2) then
             xtemp(1) = wnorm
             xtemp(2) = rnorm
-            call svout (logfil, 2, xtemp, ndigit, 
+            call svout (logfil, 2, xtemp, ndigit,
      &           '_saitr: re-orthonalization ; wnorm and rnorm are')
          end if
 c
@@ -677,7 +677,7 @@ c        | Compute V_{j}^T * B * r_{j}.                       |
 c        | WORKD(IRJ:IRJ+J-1) = v(:,1:J)'*WORKD(IPJ:IPJ+N-1). |
 c        %----------------------------------------------------%
 c
-         call sgemv ('T', n, j, one, v, ldv, workd(ipj), 1, 
+         call sgemv ('T', n, j, one, v, ldv, workd(ipj), 1,
      &               zero, workd(irj), 1)
 c
 c        %----------------------------------------------%
@@ -688,12 +688,12 @@ c        | v(:,1:J)*WORKD(IRJ:IRJ+J-1)*e'_j, but only   |
 c        | H(j,j) is updated.                           |
 c        %----------------------------------------------%
 c
-         call sgemv ('N', n, j, -one, v, ldv, workd(irj), 1, 
+         call sgemv ('N', n, j, -one, v, ldv, workd(irj), 1,
      &               one, resid, 1)
 c
          if (j .eq. 1  .or.  rstart) h(j,1) = zero
          h(j,2) = h(j,2) + workd(irj + j - 1)
-c 
+c
          orth2 = .true.
          call second (t2)
          if (bmat .eq. 'G') then
@@ -702,12 +702,12 @@ c
             ipntr(1) = irj
             ipntr(2) = ipj
             ido = 2
-c 
+c
 c           %-----------------------------------%
 c           | Exit in order to compute B*r_{j}. |
 c           | r_{j} is the corrected residual.  |
 c           %-----------------------------------%
-c 
+c
             go to 9000
          else if (bmat .eq. 'I') then
             call scopy (n, resid, 1, workd(ipj), 1)
@@ -726,8 +726,8 @@ c
 c        %-----------------------------------------------------%
 c        | Compute the B-norm of the corrected residual r_{j}. |
 c        %-----------------------------------------------------%
-c 
-         if (bmat .eq. 'G') then         
+c
+         if (bmat .eq. 'G') then
              rnorm1 = sdot (n, resid, 1, workd(ipj), 1)
              rnorm1 = sqrt(abs(rnorm1))
          else if (bmat .eq. 'I') then
@@ -744,7 +744,7 @@ c
      &           '_saitr: iterative refinement ; rnorm and rnorm1 are')
             end if
          end if
-c 
+c
 c        %-----------------------------------------%
 c        | Determine if we need to perform another |
 c        | step of re-orthogonalization.           |
@@ -757,7 +757,7 @@ c           | No need for further refinement |
 c           %--------------------------------%
 c
             rnorm = rnorm1
-c 
+c
          else
 c
 c           %-------------------------------------------%
@@ -779,7 +779,7 @@ c
   95        continue
             rnorm = zero
          end if
-c 
+c
 c        %----------------------------------------------%
 c        | Branch here directly if iterative refinement |
 c        | wasn't necessary or after at most NITER_REF  |
@@ -787,13 +787,13 @@ c        | steps of iterative refinement.               |
 c        %----------------------------------------------%
 c
   100    continue
-c 
+c
          rstart = .false.
          orth2  = .false.
-c 
+c
          call second (t5)
          titref = titref + (t5 - t4)
-c 
+c
 c        %----------------------------------------------------------%
 c        | Make sure the last off-diagonal element is non negative  |
 c        | If not perform a similarity transformation on H(1:j,1:j) |
@@ -802,13 +802,13 @@ c        %----------------------------------------------------------%
 c
          if (h(j,1) .lt. zero) then
             h(j,1) = -h(j,1)
-            if ( j .lt. k+np) then 
+            if ( j .lt. k+np) then
                call sscal(n, -one, v(1,j+1), 1)
             else
                call sscal(n, -one, resid, 1)
             end if
          end if
-c 
+c
 c        %------------------------------------%
 c        | STEP 6: Update  j = j+1;  Continue |
 c        %------------------------------------%
@@ -820,10 +820,10 @@ c
             ido = 99
 c
             if (msglvl .gt. 1) then
-               call svout (logfil, k+np, h(1,2), ndigit, 
+               call svout (logfil, k+np, h(1,2), ndigit,
      &         '_saitr: main diagonal of matrix H of step K+NP.')
                if (k+np .gt. 1) then
-               call svout (logfil, k+np-1, h(2,1), ndigit, 
+               call svout (logfil, k+np-1, h(2,1), ndigit,
      &         '_saitr: sub diagonal of matrix H of step K+NP.')
                end if
             end if
@@ -836,7 +836,7 @@ c        | Loop back to extend the factorization by another step. |
 c        %--------------------------------------------------------%
 c
       go to 1000
-c 
+c
 c     %---------------------------------------------------------------%
 c     |                                                               |
 c     |  E N D     O F     M A I N     I T E R A T I O N     L O O P  |

--- a/mathlibs/src/arpack/ssapps.f
+++ b/mathlibs/src/arpack/ssapps.f
@@ -261,9 +261,9 @@ c
             big   = abs(h(i,2)) + abs(h(i+1,2))
             if (h(i+1,1) .le. epsmch*big) then
                if (msglvl .gt. 0) then
-                  call ivout (logfil, 1, i, ndigit, 
+                  call ivout (logfil, 1, [i], ndigit, 
      &                 '_sapps: deflation at row/column no.')
-                  call ivout (logfil, 1, jj, ndigit, 
+                  call ivout (logfil, 1, [jj], ndigit, 
      &                 '_sapps: occured before shift number.')
                   call svout (logfil, 1, h(i+1,1), ndigit, 
      &                 '_sapps: the corresponding off diagonal element')
@@ -432,7 +432,7 @@ c
          big   = abs(h(i,2)) + abs(h(i+1,2))
          if (h(i+1,1) .le. epsmch*big) then
             if (msglvl .gt. 0) then
-               call ivout (logfil, 1, i, ndigit, 
+               call ivout (logfil, 1, [i], ndigit, 
      &              '_sapps: deflation at row/column no.')
                call svout (logfil, 1, h(i+1,1), ndigit, 
      &              '_sapps: the corresponding off diagonal element')

--- a/mathlibs/src/arpack/ssapps.f
+++ b/mathlibs/src/arpack/ssapps.f
@@ -12,8 +12,8 @@ c  apply NP shifts implicitly resulting in
 c
 c     A*(V_{k}*Q) - (V_{k}*Q)*(Q^T* H_{k}*Q) = r_{k+p}*e_{k+p}^T * Q
 c
-c  where Q is an orthogonal matrix of order KEV+NP. Q is the product of 
-c  rotations resulting from the NP bulge chasing sweeps.  The updated Arnoldi 
+c  where Q is an orthogonal matrix of order KEV+NP. Q is the product of
+c  rotations resulting from the NP bulge chasing sweeps.  The updated Arnoldi
 c  factorization becomes:
 c
 c     A*VNEW_{k} - VNEW_{k}*HNEW_{k} = rnew_{k}*e_{k}^T.
@@ -49,7 +49,7 @@ c  H       Real (KEV+NP) by 2 array.  (INPUT/OUTPUT)
 c          INPUT: H contains the symmetric tridiagonal matrix of the
 c          Arnoldi factorization with the subdiagonal in the 1st column
 c          starting at H(2,1) and the main diagonal in the 2nd column.
-c          OUTPUT: H contains the updated tridiagonal matrix in the 
+c          OUTPUT: H contains the updated tridiagonal matrix in the
 c          KEV leading submatrix.
 c
 c  LDH     Integer.  (INPUT)
@@ -85,12 +85,12 @@ c\References:
 c  1. D.C. Sorensen, "Implicit Application of Polynomial Filters in
 c     a k-Step Arnoldi Method", SIAM J. Matr. Anal. Apps., 13 (1992),
 c     pp 357-385.
-c  2. R.B. Lehoucq, "Analysis and Implementation of an Implicitly 
+c  2. R.B. Lehoucq, "Analysis and Implementation of an Implicitly
 c     Restarted Arnoldi Iteration", Rice University Technical Report
 c     TR95-13, Department of Computational and Applied Mathematics.
 c
 c\Routines called:
-c     ivout   ARPACK utility routine that prints integers. 
+c     ivout   ARPACK utility routine that prints integers.
 c     second  ARPACK utility routine for timing.
 c     svout   ARPACK utility routine that prints vectors.
 c     slamch  LAPACK routine that determines machine constants.
@@ -107,19 +107,19 @@ c     Danny Sorensen               Phuong Vu
 c     Richard Lehoucq              CRPC / Rice University
 c     Dept. of Computational &     Houston, Texas
 c     Applied Mathematics
-c     Rice University           
-c     Houston, Texas            
+c     Rice University
+c     Houston, Texas
 c
 c\Revision history:
 c     12/16/93: Version ' 2.1'
 c
-c\SCCS Information: @(#) 
+c\SCCS Information: @(#)
 c FILE: sapps.F   SID: 2.5   DATE OF SID: 4/19/96   RELEASE: 2
 c
 c\Remarks
 c  1. In this version, each shift is applied to all the subblocks of
-c     the tridiagonal matrix H and not just to the submatrix that it 
-c     comes from. This routine assumes that the subdiagonal elements 
+c     the tridiagonal matrix H and not just to the submatrix that it
+c     comes from. This routine assumes that the subdiagonal elements
 c     of H that are stored in h(1:kev+np,1) are nonegative upon input
 c     and enforce this condition upon output. This version incorporates
 c     deflation. See code for documentation.
@@ -149,7 +149,7 @@ c     | Array Arguments |
 c     %-----------------%
 c
       Real
-     &           h(ldh,2), q(ldq,kev+np), resid(n), shift(np), 
+     &           h(ldh,2), q(ldq,kev+np), resid(n), shift(np),
      &           v(ldv,kev+np), workd(2*n)
 c
 c     %------------%
@@ -175,7 +175,7 @@ c     %----------------------%
 c     | External Subroutines |
 c     %----------------------%
 c
-      external   saxpy, scopy, sscal, slacpy, slartg, slaset, svout, 
+      external   saxpy, scopy, sscal, slacpy, slartg, slaset, svout,
      &           ivout, second, sgemv
 c
 c     %--------------------%
@@ -215,9 +215,9 @@ c     %-------------------------------%
 c
       call second (t0)
       msglvl = msapps
-c 
-      kplusp = kev + np 
-c 
+c
+      kplusp = kev + np
+c
 c     %----------------------------------------------%
 c     | Initialize Q to the identity matrix of order |
 c     | kplusp used to accumulate the rotations.     |
@@ -230,7 +230,7 @@ c     | Quick return if there are no shifts to apply |
 c     %----------------------------------------------%
 c
       if (np .eq. 0) go to 9000
-c 
+c
 c     %----------------------------------------------------------%
 c     | Apply the np shifts implicitly. Apply each shift to the  |
 c     | whole matrix and not just to the submatrix from which it |
@@ -238,7 +238,7 @@ c     | comes.                                                   |
 c     %----------------------------------------------------------%
 c
       do 90 jj = 1, np
-c 
+c
          istart = itop
 c
 c        %----------------------------------------------------------%
@@ -261,11 +261,11 @@ c
             big   = abs(h(i,2)) + abs(h(i+1,2))
             if (h(i+1,1) .le. epsmch*big) then
                if (msglvl .gt. 0) then
-                  call ivout (logfil, 1, [i], ndigit, 
+                  call ivout (logfil, 1, [i], ndigit,
      &                 '_sapps: deflation at row/column no.')
-                  call ivout (logfil, 1, [jj], ndigit, 
+                  call ivout (logfil, 1, [jj], ndigit,
      &                 '_sapps: occured before shift number.')
-                  call svout (logfil, 1, h(i+1,1), ndigit, 
+                  call svout (logfil, 1, h(i+1,1), ndigit,
      &                 '_sapps: the corresponding off diagonal element')
                end if
                h(i+1,1) = zero
@@ -277,7 +277,7 @@ c
    40    continue
 c
          if (istart .lt. iend) then
-c 
+c
 c           %--------------------------------------------------------%
 c           | Construct the plane rotation G'(istart,istart+1,theta) |
 c           | that attempts to drive h(istart+1,1) to zero.          |
@@ -286,7 +286,7 @@ c
              f = h(istart,2) - shift(jj)
              g = h(istart+1,1)
              call slartg (f, g, c, s, r)
-c 
+c
 c            %-------------------------------------------------------%
 c            | Apply rotation to the left and right of H;            |
 c            | H <- G' * H * G,  where G = G(istart,istart+1,theta). |
@@ -296,11 +296,11 @@ c
              a1 = c*h(istart,2)   + s*h(istart+1,1)
              a2 = c*h(istart+1,1) + s*h(istart+1,2)
              a4 = c*h(istart+1,2) - s*h(istart+1,1)
-             a3 = c*h(istart+1,1) - s*h(istart,2) 
+             a3 = c*h(istart+1,1) - s*h(istart,2)
              h(istart,2)   = c*a1 + s*a2
              h(istart+1,2) = c*a4 - s*a3
              h(istart+1,1) = c*a3 + s*a4
-c 
+c
 c            %----------------------------------------------------%
 c            | Accumulate the rotation in the matrix Q;  Q <- Q*G |
 c            %----------------------------------------------------%
@@ -323,7 +323,7 @@ c            | zero.                                        |
 c            %----------------------------------------------%
 c
              do 70 i = istart+1, iend-1
-c 
+c
 c               %----------------------------------------------%
 c               | Construct the plane rotation G'(i,i+1,theta) |
 c               | that zeros the i-th bulge that was created   |
@@ -351,23 +351,23 @@ c
                    c = -c
                    s = -s
                 end if
-c 
+c
 c               %--------------------------------------------%
 c               | Apply rotation to the left and right of H; |
 c               | H <- G * H * G',  where G = G(i,i+1,theta) |
 c               %--------------------------------------------%
 c
                 h(i,1) = r
-c 
+c
                 a1 = c*h(i,2)   + s*h(i+1,1)
                 a2 = c*h(i+1,1) + s*h(i+1,2)
                 a3 = c*h(i+1,1) - s*h(i,2)
                 a4 = c*h(i+1,2) - s*h(i+1,1)
-c 
+c
                 h(i,2)   = c*a1 + s*a2
                 h(i+1,2) = c*a4 - s*a3
                 h(i+1,1) = c*a3 + s*a4
-c 
+c
 c               %----------------------------------------------------%
 c               | Accumulate the rotation in the matrix Q;  Q <- Q*G |
 c               %----------------------------------------------------%
@@ -425,16 +425,16 @@ c
 c     %------------------------------------------%
 c     | All shifts have been applied. Check for  |
 c     | more possible deflation that might occur |
-c     | after the last shift is applied.         |                               
+c     | after the last shift is applied.         |
 c     %------------------------------------------%
 c
       do 100 i = itop, kplusp-1
          big   = abs(h(i,2)) + abs(h(i+1,2))
          if (h(i+1,1) .le. epsmch*big) then
             if (msglvl .gt. 0) then
-               call ivout (logfil, 1, [i], ndigit, 
+               call ivout (logfil, 1, [i], ndigit,
      &              '_sapps: deflation at row/column no.')
-               call svout (logfil, 1, h(i+1,1), ndigit, 
+               call svout (logfil, 1, h(i+1,1), ndigit,
      &              '_sapps: the corresponding off diagonal element')
             end if
             h(i+1,1) = zero
@@ -447,13 +447,13 @@ c     | temporarily store the result in WORKD(N+1:2*N). |
 c     | This is not necessary if h(kev+1,1) = 0.         |
 c     %-------------------------------------------------%
 c
-      if ( h(kev+1,1) .gt. zero ) 
+      if ( h(kev+1,1) .gt. zero )
      &   call sgemv ('N', n, kplusp, one, v, ldv,
      &                q(1,kev+1), 1, zero, workd(n+1), 1)
-c 
+c
 c     %-------------------------------------------------------%
 c     | Compute column 1 to kev of (V*Q) in backward order    |
-c     | taking advantage that Q is an upper triangular matrix |    
+c     | taking advantage that Q is an upper triangular matrix |
 c     | with lower bandwidth np.                              |
 c     | Place results in v(:,kplusp-kev:kplusp) temporarily.  |
 c     %-------------------------------------------------------%
@@ -469,15 +469,15 @@ c     |  Move v(:,kplusp-kev+1:kplusp) into v(:,1:kev). |
 c     %-------------------------------------------------%
 c
       call slacpy ('All', n, kev, v(1,np+1), ldv, v, ldv)
-c 
+c
 c     %--------------------------------------------%
 c     | Copy the (kev+1)-st column of (V*Q) in the |
 c     | appropriate place if h(kev+1,1) .ne. zero. |
 c     %--------------------------------------------%
 c
-      if ( h(kev+1,1) .gt. zero ) 
+      if ( h(kev+1,1) .gt. zero )
      &     call scopy (n, workd(n+1), 1, v(1,kev+1), 1)
-c 
+c
 c     %-------------------------------------%
 c     | Update the residual vector:         |
 c     |    r <- sigmak*r + betak*v(:,kev+1) |
@@ -487,26 +487,26 @@ c     |    betak = e_{kev+1}'*H*e_{kev}     |
 c     %-------------------------------------%
 c
       call sscal (n, q(kplusp,kev), resid, 1)
-      if (h(kev+1,1) .gt. zero) 
+      if (h(kev+1,1) .gt. zero)
      &   call saxpy (n, h(kev+1,1), v(1,kev+1), 1, resid, 1)
 c
       if (msglvl .gt. 1) then
-         call svout (logfil, 1, q(kplusp,kev), ndigit, 
+         call svout (logfil, 1, q(kplusp,kev), ndigit,
      &      '_sapps: sigmak of the updated residual vector')
-         call svout (logfil, 1, h(kev+1,1), ndigit, 
+         call svout (logfil, 1, h(kev+1,1), ndigit,
      &      '_sapps: betak of the updated residual vector')
-         call svout (logfil, kev, h(1,2), ndigit, 
+         call svout (logfil, kev, h(1,2), ndigit,
      &      '_sapps: updated main diagonal of H for next iteration')
          if (kev .gt. 1) then
-         call svout (logfil, kev-1, h(2,1), ndigit, 
+         call svout (logfil, kev-1, h(2,1), ndigit,
      &      '_sapps: updated sub diagonal of H for next iteration')
          end if
       end if
 c
       call second (t1)
       tsapps = tsapps + (t1 - t0)
-c 
- 9000 continue 
+c
+ 9000 continue
       return
 c
 c     %---------------%

--- a/mathlibs/src/arpack/ssaup2.f
+++ b/mathlibs/src/arpack/ssaup2.f
@@ -402,13 +402,13 @@ c
          iter = iter + 1
 c
          if (msglvl .gt. 0) then
-            call ivout (logfil, 1, iter, ndigit, 
+            call ivout (logfil, 1, [iter], ndigit, 
      &           '_saup2: **** Start of major iteration number ****')
          end if
          if (msglvl .gt. 1) then
-            call ivout (logfil, 1, nev, ndigit, 
+            call ivout (logfil, 1, [nev], ndigit, 
      &     '_saup2: The length of the current Lanczos factorization')
-            call ivout (logfil, 1, np, ndigit, 
+            call ivout (logfil, 1, [np], ndigit, 
      &           '_saup2: Extend the Lanczos factorization by')
          end if
 c 
@@ -446,7 +446,7 @@ c
          update = .false.
 c
          if (msglvl .gt. 1) then
-            call svout (logfil, 1, rnorm, ndigit, 
+            call svout (logfil, 1, [rnorm], ndigit, 
      &           '_saup2: Current B-norm of residual for factorization')
          end if
 c 
@@ -694,7 +694,7 @@ c
          end if
 c
          if (msglvl .gt. 0) then
-            call ivout (logfil, 1, nconv, ndigit,
+            call ivout (logfil, 1, [nconv], ndigit,
      &           '_saup2: no. of "converged" Ritz values at this iter.')
             if (msglvl .gt. 1) then
                kp(1) = nev
@@ -742,7 +742,7 @@ c
          if (ishift .eq. 0) call scopy (np, workl, 1, ritz, 1)
 c
          if (msglvl .gt. 2) then
-            call ivout (logfil, 1, np, ndigit,
+            call ivout (logfil, 1, [np], ndigit,
      &                  '_saup2: The number of shifts to apply ')
             call svout (logfil, np, workl, ndigit,
      &                  '_saup2: shifts selected')
@@ -809,7 +809,7 @@ c
   130    continue
 c
          if (msglvl .gt. 2) then
-            call svout (logfil, 1, rnorm, ndigit, 
+            call svout (logfil, 1, [rnorm], ndigit, 
      &      '_saup2: B-norm of residual for NEV factorization')
             call svout (logfil, nev, h(1,2), ndigit,
      &           '_saup2: main diagonal of compressed H matrix')

--- a/mathlibs/src/arpack/ssaup2.f
+++ b/mathlibs/src/arpack/ssaup2.f
@@ -3,26 +3,26 @@ c\BeginDoc
 c
 c\Name: ssaup2
 c
-c\Description: 
+c\Description:
 c  Intermediate level interface called by ssaupd.
 c
 c\Usage:
-c  call ssaup2 
+c  call ssaup2
 c     ( IDO, BMAT, N, WHICH, NEV, NP, TOL, RESID, MODE, IUPD,
-c       ISHIFT, MXITER, V, LDV, H, LDH, RITZ, BOUNDS, Q, LDQ, WORKL, 
+c       ISHIFT, MXITER, V, LDV, H, LDH, RITZ, BOUNDS, Q, LDQ, WORKL,
 c       IPNTR, WORKD, INFO )
 c
 c\Arguments
 c
 c  IDO, BMAT, N, WHICH, NEV, TOL, RESID: same as defined in ssaupd.
 c  MODE, ISHIFT, MXITER: see the definition of IPARAM in ssaupd.
-c  
+c
 c  NP      Integer.  (INPUT/OUTPUT)
-c          Contains the number of implicit shifts to apply during 
-c          each Arnoldi/Lanczos iteration.  
-c          If ISHIFT=1, NP is adjusted dynamically at each iteration 
+c          Contains the number of implicit shifts to apply during
+c          each Arnoldi/Lanczos iteration.
+c          If ISHIFT=1, NP is adjusted dynamically at each iteration
 c          to accelerate convergence and prevent stagnation.
-c          This is also roughly equal to the number of matrix-vector 
+c          This is also roughly equal to the number of matrix-vector
 c          products (involving the operator OP) per Arnoldi iteration.
 c          The logic for adjusting is contained within the current
 c          subroutine.
@@ -31,7 +31,7 @@ c          to provide via reverse comunication. 0 < NP < NCV-NEV.
 c          NP may be less than NCV-NEV since a leading block of the current
 c          upper Tridiagonal matrix has split off and contains "unwanted"
 c          Ritz values.
-c          Upon termination of the IRA iteration, NP contains the number 
+c          Upon termination of the IRA iteration, NP contains the number
 c          of "converged" wanted Ritz values.
 c
 c  IUPD    Integer.  (INPUT)
@@ -42,18 +42,18 @@ c  V       Real N by (NEV+NP) array.  (INPUT/OUTPUT)
 c          The Lanczos basis vectors.
 c
 c  LDV     Integer.  (INPUT)
-c          Leading dimension of V exactly as declared in the calling 
+c          Leading dimension of V exactly as declared in the calling
 c          program.
 c
 c  H       Real (NEV+NP) by 2 array.  (OUTPUT)
 c          H is used to store the generated symmetric tridiagonal matrix
-c          The subdiagonal is stored in the first column of H starting 
+c          The subdiagonal is stored in the first column of H starting
 c          at H(2,1).  The main diagonal is stored in the second column
-c          of H starting at H(1,2). If ssaup2 converges store the 
+c          of H starting at H(1,2). If ssaup2 converges store the
 c          B-norm of the final residual vector in H(1,1).
 c
 c  LDH     Integer.  (INPUT)
-c          Leading dimension of H exactly as declared in the calling 
+c          Leading dimension of H exactly as declared in the calling
 c          program.
 c
 c  RITZ    Real array of length NEV+NP.  (OUTPUT)
@@ -63,33 +63,33 @@ c  BOUNDS  Real array of length NEV+NP.  (OUTPUT)
 c          BOUNDS(1:NEV) contain the error bounds corresponding to RITZ.
 c
 c  Q       Real (NEV+NP) by (NEV+NP) array.  (WORKSPACE)
-c          Private (replicated) work array used to accumulate the 
+c          Private (replicated) work array used to accumulate the
 c          rotation in the shift application step.
 c
 c  LDQ     Integer.  (INPUT)
 c          Leading dimension of Q exactly as declared in the calling
 c          program.
-c          
+c
 c  WORKL   Real array of length at least 3*(NEV+NP).  (INPUT/WORKSPACE)
 c          Private (replicated) array on each PE or array allocated on
-c          the front end.  It is used in the computation of the 
+c          the front end.  It is used in the computation of the
 c          tridiagonal eigenvalue problem, the calculation and
 c          application of the shifts and convergence checking.
 c          If ISHIFT .EQ. O and IDO .EQ. 3, the first NP locations
-c          of WORKL are used in reverse communication to hold the user 
+c          of WORKL are used in reverse communication to hold the user
 c          supplied shifts.
 c
 c  IPNTR   Integer array of length 3.  (OUTPUT)
-c          Pointer to mark the starting locations in the WORKD for 
+c          Pointer to mark the starting locations in the WORKD for
 c          vectors used by the Lanczos iteration.
 c          -------------------------------------------------------------
 c          IPNTR(1): pointer to the current operand vector X.
 c          IPNTR(2): pointer to the current result vector Y.
-c          IPNTR(3): pointer to the vector B * X when used in one of  
+c          IPNTR(3): pointer to the vector B * X when used in one of
 c                    the spectral transformation modes.  X is the current
 c                    operand.
 c          -------------------------------------------------------------
-c          
+c
 c  WORKD   Real work array of length 3*N.  (REVERSE COMMUNICATION)
 c          Distributed array to be used in the basic Lanczos iteration
 c          for reverse communication.  The user should not use WORKD
@@ -102,9 +102,9 @@ c          If INFO .NE. 0, RESID contains the initial residual vector,
 c                          possibly from a previous run.
 c          Error flag on output.
 c          =     0: Normal return.
-c          =     1: All possible eigenvalues of OP has been found.  
+c          =     1: All possible eigenvalues of OP has been found.
 c                   NP returns the size of the invariant subspace
-c                   spanning the operator OP. 
+c                   spanning the operator OP.
 c          =     2: No shifts could be applied.
 c          =    -8: Error return from trid. eigenvalue calculation;
 c                   This should never happen.
@@ -122,7 +122,7 @@ c\References:
 c  1. D.C. Sorensen, "Implicit Application of Polynomial Filters in
 c     a k-Step Arnoldi Method", SIAM J. Matr. Anal. Apps., 13 (1992),
 c     pp 357-385.
-c  2. R.B. Lehoucq, "Analysis and Implementation of an Implicitly 
+c  2. R.B. Lehoucq, "Analysis and Implementation of an Implicitly
 c     Restarted Arnoldi Iteration", Rice University Technical Report
 c     TR95-13, Department of Computational and Applied Mathematics.
 c  3. B.N. Parlett, "The Symmetric Eigenvalue Problem". Prentice-Hall,
@@ -132,15 +132,15 @@ c     Computer Physics Communications, 53 (1989), pp 169-179.
 c  5. B. Nour-Omid, B.N. Parlett, T. Ericson, P.S. Jensen, "How to
 c     Implement the Spectral Transformation", Math. Comp., 48 (1987),
 c     pp 663-673.
-c  6. R.G. Grimes, J.G. Lewis and H.D. Simon, "A Shifted Block Lanczos 
-c     Algorithm for Solving Sparse Symmetric Generalized Eigenproblems", 
+c  6. R.G. Grimes, J.G. Lewis and H.D. Simon, "A Shifted Block Lanczos
+c     Algorithm for Solving Sparse Symmetric Generalized Eigenproblems",
 c     SIAM J. Matr. Anal. Apps.,  January (1993).
 c  7. L. Reichel, W.B. Gragg, "Algorithm 686: FORTRAN Subroutines
 c     for Updating the QR decomposition", ACM TOMS, December 1990,
 c     Volume 16 Number 4, pp 369-377.
 c
 c\Routines called:
-c     sgetv0  ARPACK initial vector generation routine. 
+c     sgetv0  ARPACK initial vector generation routine.
 c     ssaitr  ARPACK Lanczos factorization routine.
 c     ssapps  ARPACK application of implicit shifts routine.
 c     ssconv  ARPACK convergence of Ritz values routine.
@@ -152,7 +152,7 @@ c     second  ARPACK utility routine for timing.
 c     svout   ARPACK utility routine that prints vectors.
 c     slamch  LAPACK routine that determines machine constants.
 c     scopy   Level 1 BLAS that copies one vector to another.
-c     sdot    Level 1 BLAS that computes the scalar product of two vectors. 
+c     sdot    Level 1 BLAS that computes the scalar product of two vectors.
 c     snrm2   Level 1 BLAS that computes the norm of a vector.
 c     sscal   Level 1 BLAS that scales a vector.
 c     sswap   Level 1 BLAS that swaps two vectors.
@@ -162,14 +162,14 @@ c     Danny Sorensen               Phuong Vu
 c     Richard Lehoucq              CRPC / Rice University
 c     Dept. of Computational &     Houston, Texas
 c     Applied Mathematics
-c     Rice University           
-c     Houston, Texas            
-c 
+c     Rice University
+c     Houston, Texas
+c
 c\Revision history:
 c     12/15/93: Version ' 2.4'
 c     xx/xx/95: Version ' 2.4'.  (R.B. Lehoucq)
 c
-c\SCCS Information: @(#) 
+c\SCCS Information: @(#)
 c FILE: saup2.F   SID: 2.6   DATE OF SID: 8/16/96   RELEASE: 2
 c
 c\EndLib
@@ -177,8 +177,8 @@ c
 c-----------------------------------------------------------------------
 c
       subroutine ssaup2
-     &   ( ido, bmat, n, which, nev, np, tol, resid, mode, iupd, 
-     &     ishift, mxiter, v, ldv, h, ldh, ritz, bounds, 
+     &   ( ido, bmat, n, which, nev, np, tol, resid, mode, iupd,
+     &     ishift, mxiter, v, ldv, h, ldh, ritz, bounds,
      &     q, ldq, workl, ipntr, workd, info )
 c
 c     %----------------------------------------------------%
@@ -204,8 +204,8 @@ c     %-----------------%
 c
       integer    ipntr(3)
       Real
-     &           bounds(nev+np), h(ldh,2), q(ldq,nev+np), resid(n), 
-     &           ritz(nev+np), v(ldv,nev+np), workd(3*n), 
+     &           bounds(nev+np), h(ldh,2), q(ldq,nev+np), resid(n),
+     &           ritz(nev+np), v(ldv,nev+np), workd(3*n),
      &           workl(3*(nev+np))
 c
 c     %------------%
@@ -222,8 +222,8 @@ c     %---------------%
 c
       character  wprime*2
       logical    cnorm, getv0, initv, update, ushift
-      integer    ierr, iter, j, kplusp, msglvl, nconv, nevbef, nev0, 
-     &           np0, nptemp, nevd2, nevm2, kp(3) 
+      integer    ierr, iter, j, kplusp, msglvl, nconv, nevbef, nev0,
+     &           np0, nptemp, nevd2, nevm2, kp(3)
       Real
      &           rnorm, temp, eps23
       save       cnorm, getv0, initv, update, ushift,
@@ -234,7 +234,7 @@ c     %----------------------%
 c     | External Subroutines |
 c     %----------------------%
 c
-      external   scopy, sgetv0, ssaitr, sscal, ssconv, sseigt, ssgets, 
+      external   scopy, sgetv0, ssaitr, sscal, ssconv, sseigt, ssgets,
      &           ssapps, ssortr, svout, ivout, second, sswap
 c
 c     %--------------------%
@@ -256,7 +256,7 @@ c     | Executable Statements |
 c     %-----------------------%
 c
       if (ido .eq. 0) then
-c 
+c
 c        %-------------------------------%
 c        | Initialize timing statistics  |
 c        | & message level for debugging |
@@ -292,7 +292,7 @@ c
          kplusp = nev0 + np0
          nconv  = 0
          iter   = 0
-c 
+c
 c        %--------------------------------------------%
 c        | Set flags for computing the first NEV steps |
 c        | of the Lanczos factorization.              |
@@ -315,7 +315,7 @@ c
             initv = .false.
          end if
       end if
-c 
+c
 c     %---------------------------------------------%
 c     | Get a possibly random starting vector and   |
 c     | force it into the range of the operator OP. |
@@ -332,7 +332,7 @@ c
          if (rnorm .eq. zero) then
 c
 c           %-----------------------------------------%
-c           | The initial vector is zero. Error exit. | 
+c           | The initial vector is zero. Error exit. |
 c           %-----------------------------------------%
 c
             info = -9
@@ -341,7 +341,7 @@ c
          getv0 = .false.
          ido  = 0
       end if
-c 
+c
 c     %------------------------------------------------------------%
 c     | Back from reverse communication: continue with update step |
 c     %------------------------------------------------------------%
@@ -360,14 +360,14 @@ c     | at the end of the current iteration |
 c     %-------------------------------------%
 c
       if (cnorm)  go to 100
-c 
+c
 c     %----------------------------------------------------------%
 c     | Compute the first NEV steps of the Lanczos factorization |
 c     %----------------------------------------------------------%
 c
-      call ssaitr (ido, bmat, n, 0, nev0, mode, resid, rnorm, v, ldv, 
+      call ssaitr (ido, bmat, n, 0, nev0, mode, resid, rnorm, v, ldv,
      &             h, ldh, ipntr, workd, info)
-c 
+c
 c     %---------------------------------------------------%
 c     | ido .ne. 99 implies use of reverse communication  |
 c     | to compute operations involving OP and possibly B |
@@ -388,7 +388,7 @@ c
          info = -9999
          go to 1200
       end if
-c 
+c
 c     %--------------------------------------------------------------%
 c     |                                                              |
 c     |           M A I N  LANCZOS  I T E R A T I O N  L O O P       |
@@ -396,22 +396,22 @@ c     |           Each iteration implicitly restarts the Lanczos     |
 c     |           factorization in place.                            |
 c     |                                                              |
 c     %--------------------------------------------------------------%
-c 
+c
  1000 continue
 c
          iter = iter + 1
 c
          if (msglvl .gt. 0) then
-            call ivout (logfil, 1, [iter], ndigit, 
+            call ivout (logfil, 1, [iter], ndigit,
      &           '_saup2: **** Start of major iteration number ****')
          end if
          if (msglvl .gt. 1) then
-            call ivout (logfil, 1, [nev], ndigit, 
+            call ivout (logfil, 1, [nev], ndigit,
      &     '_saup2: The length of the current Lanczos factorization')
-            call ivout (logfil, 1, [np], ndigit, 
+            call ivout (logfil, 1, [np], ndigit,
      &           '_saup2: Extend the Lanczos factorization by')
          end if
-c 
+c
 c        %------------------------------------------------------------%
 c        | Compute NP additional steps of the Lanczos factorization. |
 c        %------------------------------------------------------------%
@@ -420,9 +420,9 @@ c
    20    continue
          update = .true.
 c
-         call ssaitr (ido, bmat, n, nev, np, mode, resid, rnorm, v, 
+         call ssaitr (ido, bmat, n, nev, np, mode, resid, rnorm, v,
      &                ldv, h, ldh, ipntr, workd, info)
-c 
+c
 c        %---------------------------------------------------%
 c        | ido .ne. 99 implies use of reverse communication  |
 c        | to compute operations involving OP and possibly B |
@@ -434,7 +434,7 @@ c
 c
 c           %-----------------------------------------------------%
 c           | ssaitr was unable to build an Lanczos factorization |
-c           | of length NEV0+NP0. INFO is returned with the size  |  
+c           | of length NEV0+NP0. INFO is returned with the size  |
 c           | of the factorization built. Exit main loop.         |
 c           %-----------------------------------------------------%
 c
@@ -446,10 +446,10 @@ c
          update = .false.
 c
          if (msglvl .gt. 1) then
-            call svout (logfil, 1, [rnorm], ndigit, 
+            call svout (logfil, 1, [rnorm], ndigit,
      &           '_saup2: Current B-norm of residual for factorization')
          end if
-c 
+c
 c        %--------------------------------------------------------%
 c        | Compute the eigenvalues and corresponding error bounds |
 c        | of the current symmetric tridiagonal matrix.           |
@@ -483,7 +483,7 @@ c
          nev = nev0
          np = np0
          call ssgets (ishift, which, nev, np, ritz, bounds, workl)
-c 
+c
 c        %-------------------%
 c        | Convergence test. |
 c        %-------------------%
@@ -520,11 +520,11 @@ c
                nev = nev + 1
             end if
  30      continue
-c 
-         if ( (nconv .ge. nev0) .or. 
+c
+         if ( (nconv .ge. nev0) .or.
      &        (iter .gt. mxiter) .or.
      &        (np .eq. 0) ) then
-c     
+c
 c           %------------------------------------------------%
 c           | Prepare to exit. Put the converged Ritz values |
 c           | and corresponding bounds in RITZ(1:NCONV) and  |
@@ -547,7 +547,7 @@ c
                wprime = 'SA'
                call ssortr (wprime, .true., kplusp, ritz, bounds)
                nevd2 = nev / 2
-               nevm2 = nev - nevd2 
+               nevm2 = nev - nevd2
                if ( nev .gt. 1 ) then
                   call sswap ( min(nevd2,np), ritz(nevm2+1), 1,
      &                 ritz( max(kplusp-nevd2+1,kplusp-np+1) ), 1)
@@ -651,13 +651,13 @@ c
             end if
 c
 c           %------------------------------------%
-c           | Max iterations have been exceeded. | 
+c           | Max iterations have been exceeded. |
 c           %------------------------------------%
 c
             if (iter .gt. mxiter .and. nconv .lt. nev) info = 1
 c
 c           %---------------------%
-c           | No shifts to apply. | 
+c           | No shifts to apply. |
 c           %---------------------%
 c
             if (np .eq. 0 .and. nconv .lt. nev0) info = 2
@@ -681,13 +681,13 @@ c
                nev = 2
             end if
             np  = kplusp - nev
-c     
+c
 c           %---------------------------------------%
 c           | If the size of NEV was just increased |
 c           | resort the eigenvalues.               |
 c           %---------------------------------------%
-c     
-            if (nevbef .lt. nev) 
+c
+            if (nevbef .lt. nev)
      &         call ssgets (ishift, which, nev, np, ritz, bounds,
      &              workl)
 c
@@ -708,7 +708,7 @@ c
             end if
          end if
 
-c 
+c
          if (ishift .eq. 0) then
 c
 c           %-----------------------------------------------------%
@@ -731,8 +731,8 @@ c        | in WORKL(1:*NP)                   |
 c        %------------------------------------%
 c
          ushift = .false.
-c 
-c 
+c
+c
 c        %---------------------------------------------------------%
 c        | Move the NP shifts to the first NP locations of RITZ to |
 c        | free up WORKL.  This is for the non-exact shift case;   |
@@ -751,7 +751,7 @@ c
      &                  '_saup2: corresponding Ritz estimates')
              end if
          end if
-c 
+c
 c        %---------------------------------------------------------%
 c        | Apply the NP0 implicit shifts by QR bulge chasing.      |
 c        | Each shift is applied to the entire tridiagonal matrix. |
@@ -777,18 +777,18 @@ c
             ipntr(1) = n + 1
             ipntr(2) = 1
             ido = 2
-c 
+c
 c           %----------------------------------%
 c           | Exit in order to compute B*RESID |
 c           %----------------------------------%
-c 
+c
             go to 9000
          else if (bmat .eq. 'I') then
             call scopy (n, resid, 1, workd, 1)
          end if
-c 
+c
   100    continue
-c 
+c
 c        %----------------------------------%
 c        | Back from reverse communication; |
 c        | WORKD(1:N) := B*RESID            |
@@ -798,8 +798,8 @@ c
             call second (t3)
             tmvbx = tmvbx + (t3 - t2)
          end if
-c 
-         if (bmat .eq. 'G') then         
+c
+         if (bmat .eq. 'G') then
             rnorm = sdot (n, resid, 1, workd, 1)
             rnorm = sqrt(abs(rnorm))
          else if (bmat .eq. 'I') then
@@ -809,14 +809,14 @@ c
   130    continue
 c
          if (msglvl .gt. 2) then
-            call svout (logfil, 1, [rnorm], ndigit, 
+            call svout (logfil, 1, [rnorm], ndigit,
      &      '_saup2: B-norm of residual for NEV factorization')
             call svout (logfil, nev, h(1,2), ndigit,
      &           '_saup2: main diagonal of compressed H matrix')
             call svout (logfil, nev-1, h(2,1), ndigit,
      &           '_saup2: subdiagonal of compressed H matrix')
          end if
-c 
+c
       go to 1000
 c
 c     %---------------------------------------------------------------%
@@ -824,12 +824,12 @@ c     |                                                               |
 c     |  E N D     O F     M A I N     I T E R A T I O N     L O O P  |
 c     |                                                               |
 c     %---------------------------------------------------------------%
-c 
+c
  1100 continue
 c
       mxiter = iter
       nev = nconv
-c 
+c
  1200 continue
       ido = 99
 c
@@ -839,7 +839,7 @@ c     %------------%
 c
       call second (t1)
       tsaup2 = t1 - t0
-c 
+c
  9000 continue
       return
 c

--- a/mathlibs/src/arpack/ssaupd.f
+++ b/mathlibs/src/arpack/ssaupd.f
@@ -3,31 +3,31 @@ c\BeginDoc
 c
 c\Name: ssaupd
 c
-c\Description: 
+c\Description:
 c
-c  Reverse communication interface for the Implicitly Restarted Arnoldi 
-c  Iteration.  For symmetric problems this reduces to a variant of the Lanczos 
-c  method.  This method has been designed to compute approximations to a 
-c  few eigenpairs of a linear operator OP that is real and symmetric 
-c  with respect to a real positive semi-definite symmetric matrix B, 
+c  Reverse communication interface for the Implicitly Restarted Arnoldi
+c  Iteration.  For symmetric problems this reduces to a variant of the Lanczos
+c  method.  This method has been designed to compute approximations to a
+c  few eigenpairs of a linear operator OP that is real and symmetric
+c  with respect to a real positive semi-definite symmetric matrix B,
 c  i.e.
-c                   
-c       B*OP = (OP')*B.  
 c
-c  Another way to express this condition is 
+c       B*OP = (OP')*B.
+c
+c  Another way to express this condition is
 c
 c       < x,OPy > = < OPx,y >  where < z,w > = z'Bw  .
-c  
-c  In the standard eigenproblem B is the identity matrix.  
+c
+c  In the standard eigenproblem B is the identity matrix.
 c  ( A' denotes transpose of A)
 c
 c  The computed approximate eigenvalues are called Ritz values and
 c  the corresponding approximate eigenvectors are called Ritz vectors.
 c
-c  ssaupd is usually called iteratively to solve one of the 
+c  ssaupd is usually called iteratively to solve one of the
 c  following problems:
 c
-c  Mode 1:  A*x = lambda*x, A symmetric 
+c  Mode 1:  A*x = lambda*x, A symmetric
 c           ===> OP = A  and  B = I.
 c
 c  Mode 2:  A*x = lambda*M*x, A symmetric, M symmetric positive definite
@@ -35,10 +35,10 @@ c           ===> OP = inv[M]*A  and  B = M.
 c           ===> (If M can be factored see remark 3 below)
 c
 c  Mode 3:  K*x = lambda*M*x, K symmetric, M symmetric positive semi-definite
-c           ===> OP = (inv[K - sigma*M])*M  and  B = M. 
+c           ===> OP = (inv[K - sigma*M])*M  and  B = M.
 c           ===> Shift-and-Invert mode
 c
-c  Mode 4:  K*x = lambda*KG*x, K symmetric positive semi-definite, 
+c  Mode 4:  K*x = lambda*KG*x, K symmetric positive semi-definite,
 c           KG symmetric indefinite
 c           ===> OP = (inv[K - sigma*KG])*K  and  B = K.
 c           ===> Buckling mode
@@ -60,13 +60,13 @@ c        the accuracy requirements for the eigenvalue
 c        approximations.
 c
 c\Usage:
-c  call ssaupd 
+c  call ssaupd
 c     ( IDO, BMAT, N, WHICH, NEV, TOL, RESID, NCV, V, LDV, IPARAM,
 c       IPNTR, WORKD, WORKL, LWORKL, INFO )
 c
 c\Arguments
 c  IDO     Integer.  (INPUT/OUTPUT)
-c          Reverse communication flag.  IDO must be zero on the first 
+c          Reverse communication flag.  IDO must be zero on the first
 c          call to ssaupd.  IDO will be set internally to
 c          indicate the type of operation to be performed.  Control is
 c          then given back to the calling routine which has the
@@ -95,7 +95,7 @@ c                    IPNTR(11) is the pointer into WORKL for
 c                    placing the shifts. See remark 6 below.
 c          IDO = 99: done
 c          -------------------------------------------------------------
-c             
+c
 c  BMAT    Character*1.  (INPUT)
 c          BMAT specifies the type of the matrix B that defines the
 c          semi-inner product for the operator OP.
@@ -111,7 +111,7 @@ c
 c          'LA' - compute the NEV largest (algebraic) eigenvalues.
 c          'SA' - compute the NEV smallest (algebraic) eigenvalues.
 c          'LM' - compute the NEV largest (in magnitude) eigenvalues.
-c          'SM' - compute the NEV smallest (in magnitude) eigenvalues. 
+c          'SM' - compute the NEV smallest (in magnitude) eigenvalues.
 c          'BE' - compute NEV eigenvalues, half from each end of the
 c                 spectrum.  When NEV is odd, compute one more from the
 c                 high end than from the low end.
@@ -121,27 +121,27 @@ c  NEV     Integer.  (INPUT)
 c          Number of eigenvalues of OP to be computed. 0 < NEV < N.
 c
 c  TOL     Real scalar.  (INPUT)
-c          Stopping criterion: the relative accuracy of the Ritz value 
+c          Stopping criterion: the relative accuracy of the Ritz value
 c          is considered acceptable if BOUNDS(I) .LE. TOL*ABS(RITZ(I)).
 c          If TOL .LE. 0. is passed a default is set:
 c          DEFAULT = SLAMCH('EPS')  (machine precision as computed
 c                    by the LAPACK auxiliary subroutine SLAMCH).
 c
 c  RESID   Real array of length N.  (INPUT/OUTPUT)
-c          On INPUT: 
+c          On INPUT:
 c          If INFO .EQ. 0, a random initial residual vector is used.
 c          If INFO .NE. 0, RESID contains the initial residual vector,
 c                          possibly from a previous run.
 c          On OUTPUT:
-c          RESID contains the final residual vector. 
+c          RESID contains the final residual vector.
 c
 c  NCV     Integer.  (INPUT)
 c          Number of columns of the matrix V (less than or equal to N).
-c          This will indicate how many Lanczos vectors are generated 
-c          at each iteration.  After the startup phase in which NEV 
-c          Lanczos vectors are generated, the algorithm generates 
+c          This will indicate how many Lanczos vectors are generated
+c          at each iteration.  After the startup phase in which NEV
+c          Lanczos vectors are generated, the algorithm generates
 c          NCV-NEV Lanczos vectors at each subsequent update iteration.
-c          Most of the cost in generating each Lanczos vector is in the 
+c          Most of the cost in generating each Lanczos vector is in the
 c          matrix-vector product OP*x. (See remark 4 below).
 c
 c  V       Real N by NCV array.  (OUTPUT)
@@ -161,10 +161,10 @@ c                      reverse communication.  The NCV eigenvalues of
 c                      the current tridiagonal matrix T are returned in
 c                      the part of WORKL array corresponding to RITZ.
 c                      See remark 6 below.
-c          ISHIFT = 1: exact shifts with respect to the reduced 
-c                      tridiagonal matrix T.  This is equivalent to 
-c                      restarting the iteration with a starting vector 
-c                      that is a linear combination of Ritz vectors 
+c          ISHIFT = 1: exact shifts with respect to the reduced
+c                      tridiagonal matrix T.  This is equivalent to
+c                      restarting the iteration with a starting vector
+c                      that is a linear combination of Ritz vectors
 c                      associated with the "wanted" Ritz values.
 c          -------------------------------------------------------------
 c
@@ -172,8 +172,8 @@ c          IPARAM(2) = LEVEC
 c          No longer referenced. See remark 2 below.
 c
 c          IPARAM(3) = MXITER
-c          On INPUT:  maximum number of Arnoldi update iterations allowed. 
-c          On OUTPUT: actual number of Arnoldi update iterations taken. 
+c          On INPUT:  maximum number of Arnoldi update iterations allowed.
+c          On OUTPUT: actual number of Arnoldi update iterations taken.
 c
 c          IPARAM(4) = NB: blocksize to be used in the recurrence.
 c          The code currently works only for NB = 1.
@@ -183,11 +183,11 @@ c          This represents the number of Ritz values that satisfy
 c          the convergence criterion.
 c
 c          IPARAM(6) = IUPD
-c          No longer referenced. Implicit restarting is ALWAYS used. 
+c          No longer referenced. Implicit restarting is ALWAYS used.
 c
 c          IPARAM(7) = MODE
 c          On INPUT determines what type of eigenproblem is being solved.
-c          Must be 1,2,3,4,5; See under \Description of ssaupd for the 
+c          Must be 1,2,3,4,5; See under \Description of ssaupd for the
 c          five modes available.
 c
 c          IPARAM(8) = NP
@@ -199,7 +199,7 @@ c
 c          IPARAM(9) = NUMOP, IPARAM(10) = NUMOPB, IPARAM(11) = NUMREO,
 c          OUTPUT: NUMOP  = total number of OP*x operations,
 c                  NUMOPB = total number of B*x operations if BMAT='G',
-c                  NUMREO = total number of steps of re-orthogonalization.        
+c                  NUMREO = total number of steps of re-orthogonalization.
 c
 c  IPNTR   Integer array of length 11.  (OUTPUT)
 c          Pointer to mark the starting locations in the WORKD and WORKL
@@ -207,7 +207,7 @@ c          arrays for matrices/vectors used by the Lanczos iteration.
 c          -------------------------------------------------------------
 c          IPNTR(1): pointer to the current operand vector X in WORKD.
 c          IPNTR(2): pointer to the current result vector Y in WORKD.
-c          IPNTR(3): pointer to the vector B * X in WORKD when used in 
+c          IPNTR(3): pointer to the vector B * X in WORKD when used in
 c                    the shift-and-invert mode.
 c          IPNTR(4): pointer to the next available location in WORKL
 c                    that is untouched by the program.
@@ -224,14 +224,14 @@ c          IPNTR(10): pointer to the NCV by NCV matrix of eigenvectors
 c                     of the tridiagonal matrix T. Only referenced by
 c                     sseupd if RVEC = .TRUE. See Remarks.
 c          -------------------------------------------------------------
-c          
+c
 c  WORKD   Real work array of length 3*N.  (REVERSE COMMUNICATION)
 c          Distributed array to be used in the basic Arnoldi iteration
-c          for reverse communication.  The user should not use WORKD 
+c          for reverse communication.  The user should not use WORKD
 c          as temporary workspace during the iteration. Upon termination
 c          WORKD(1:N) contains B*RESID(1:N). If the Ritz vectors are desired
 c          subroutine sseupd uses this output.
-c          See Data Distribution Note below.  
+c          See Data Distribution Note below.
 c
 c  WORKL   Real work array of length LWORKL.  (OUTPUT/WORKSPACE)
 c          Private (replicated) array on each PE or array allocated on
@@ -247,13 +247,13 @@ c                          possibly from a previous run.
 c          Error flag on output.
 c          =  0: Normal exit.
 c          =  1: Maximum number of iterations taken.
-c                All possible eigenvalues of OP has been found. IPARAM(5)  
+c                All possible eigenvalues of OP has been found. IPARAM(5)
 c                returns the number of wanted converged Ritz values.
 c          =  2: No longer an informational error. Deprecated starting
 c                with release 2 of ARPACK.
-c          =  3: No shifts could be applied during a cycle of the 
-c                Implicitly restarted Arnoldi iteration. One possibility 
-c                is to increase the size of NCV relative to NEV. 
+c          =  3: No shifts could be applied during a cycle of the
+c                Implicitly restarted Arnoldi iteration. One possibility
+c                is to increase the size of NCV relative to NEV.
 c                See remark 4 below.
 c          = -1: N must be positive.
 c          = -2: NEV must be positive.
@@ -277,12 +277,12 @@ c                   enough workspace and array storage has been allocated.
 c
 c
 c\Remarks
-c  1. The converged Ritz values are always returned in ascending 
+c  1. The converged Ritz values are always returned in ascending
 c     algebraic order.  The computed Ritz values are approximate
 c     eigenvalues of OP.  The selection of WHICH should be made
-c     with this in mind when Mode = 3,4,5.  After convergence, 
-c     approximate eigenvalues of the original problem may be obtained 
-c     with the ARPACK subroutine sseupd. 
+c     with this in mind when Mode = 3,4,5.  After convergence,
+c     approximate eigenvalues of the original problem may be obtained
+c     with the ARPACK subroutine sseupd.
 c
 c  2. If the Ritz vectors corresponding to the converged Ritz values
 c     are needed, the user must call sseupd immediately following completion
@@ -290,7 +290,7 @@ c     of ssaupd. This is new starting with version 2.1 of ARPACK.
 c
 c  3. If M can be factored into a Cholesky factorization M = LL'
 c     then Mode = 2 should not be selected.  Instead one should use
-c     Mode = 1 with  OP = inv(L)*A*inv(L').  Appropriate triangular 
+c     Mode = 1 with  OP = inv(L)*A*inv(L').  Appropriate triangular
 c     linear systems should be solved with L and L' rather
 c     than computing inverses.  After convergence, an approximate
 c     eigenvector z of the original problem is recovered by solving
@@ -300,7 +300,7 @@ c  4. At present there is no a-priori analysis to guide the selection
 c     of NCV relative to NEV.  The only formal requrement is that NCV > NEV.
 c     However, it is recommended that NCV .ge. 2*NEV.  If many problems of
 c     the same type are to be solved, one should experiment with increasing
-c     NCV while keeping NEV fixed for a given test problem.  This will 
+c     NCV while keeping NEV fixed for a given test problem.  This will
 c     usually decrease the required number of OP*x operations but it
 c     also increases the work and storage required to maintain the orthogonal
 c     basis vectors.   The optimal "cross-over" with respect to CPU time
@@ -312,16 +312,16 @@ c     When IPARAM(7) = 2 OP = inv(B)*A. After computing A*X the user
 c     must overwrite X with A*X. Y is then the solution to the linear set
 c     of equations B*Y = A*X.
 c
-c  6. When IPARAM(1) = 0, and IDO = 3, the user needs to provide the 
-c     NP = IPARAM(8) shifts in locations: 
-c     1   WORKL(IPNTR(11))           
-c     2   WORKL(IPNTR(11)+1)         
-c                        .           
-c                        .           
-c                        .      
-c     NP  WORKL(IPNTR(11)+NP-1). 
+c  6. When IPARAM(1) = 0, and IDO = 3, the user needs to provide the
+c     NP = IPARAM(8) shifts in locations:
+c     1   WORKL(IPNTR(11))
+c     2   WORKL(IPNTR(11)+1)
+c                        .
+c                        .
+c                        .
+c     NP  WORKL(IPNTR(11)+NP-1).
 c
-c     The eigenvalues of the current tridiagonal matrix are located in 
+c     The eigenvalues of the current tridiagonal matrix are located in
 c     WORKL(IPNTR(6)) through WORKL(IPNTR(6)+NCV-1). They are in the
 c     order defined by WHICH. The associated Ritz estimates are located in
 c     WORKL(IPNTR(8)), WORKL(IPNTR(8)+1), ... , WORKL(IPNTR(8)+NCV-1).
@@ -347,7 +347,7 @@ c  ===============
 c  REAL       RESID(N), V(LDV,NCV), WORKD(N,3), WORKL(LWORKL)
 c  SHARED     RESID(BLOCK), V(BLOCK,:), WORKD(BLOCK,:)
 c  REPLICATED WORKL(LWORKL)
-c  
+c
 c
 c\BeginLib
 c
@@ -355,7 +355,7 @@ c\References:
 c  1. D.C. Sorensen, "Implicit Application of Polynomial Filters in
 c     a k-Step Arnoldi Method", SIAM J. Matr. Anal. Apps., 13 (1992),
 c     pp 357-385.
-c  2. R.B. Lehoucq, "Analysis and Implementation of an Implicitly 
+c  2. R.B. Lehoucq, "Analysis and Implementation of an Implicitly
 c     Restarted Arnoldi Iteration", Rice University Technical Report
 c     TR95-13, Department of Computational and Applied Mathematics.
 c  3. B.N. Parlett, "The Symmetric Eigenvalue Problem". Prentice-Hall,
@@ -365,8 +365,8 @@ c     Computer Physics Communications, 53 (1989), pp 169-179.
 c  5. B. Nour-Omid, B.N. Parlett, T. Ericson, P.S. Jensen, "How to
 c     Implement the Spectral Transformation", Math. Comp., 48 (1987),
 c     pp 663-673.
-c  6. R.G. Grimes, J.G. Lewis and H.D. Simon, "A Shifted Block Lanczos 
-c     Algorithm for Solving Sparse Symmetric Generalized Eigenproblems", 
+c  6. R.G. Grimes, J.G. Lewis and H.D. Simon, "A Shifted Block Lanczos
+c     Algorithm for Solving Sparse Symmetric Generalized Eigenproblems",
 c     SIAM J. Matr. Anal. Apps.,  January (1993).
 c  7. L. Reichel, W.B. Gragg, "Algorithm 686: FORTRAN Subroutines
 c     for Updating the QR decomposition", ACM TOMS, December 1990,
@@ -389,14 +389,14 @@ c     Danny Sorensen               Phuong Vu
 c     Richard Lehoucq              CRPC / Rice University
 c     Dept. of Computational &     Houston, Texas
 c     Applied Mathematics
-c     Rice University           
-c     Houston, Texas            
-c 
+c     Rice University
+c     Houston, Texas
+c
 c\Revision history:
 c     12/15/93: Version ' 2.4'
 c
-c\SCCS Information: @(#) 
-c FILE: saupd.F   SID: 2.7   DATE OF SID: 8/27/96   RELEASE: 2 
+c\SCCS Information: @(#)
+c FILE: saupd.F   SID: 2.7   DATE OF SID: 8/27/96   RELEASE: 2
 c
 c\Remarks
 c     1. None
@@ -406,7 +406,7 @@ c
 c-----------------------------------------------------------------------
 c
       subroutine ssaupd
-     &   ( ido, bmat, n, which, nev, tol, resid, ncv, v, ldv, iparam, 
+     &   ( ido, bmat, n, which, nev, tol, resid, ncv, v, ldv, iparam,
      &     ipntr, workd, workl, lworkl, info )
 c
 c     %----------------------------------------------------%
@@ -445,7 +445,7 @@ c     %---------------%
 c     | Local Scalars |
 c     %---------------%
 c
-      integer    bounds, ierr, ih, iq, ishift, iupd, iw, 
+      integer    bounds, ierr, ih, iq, ishift, iupd, iw,
      &           ldh, ldq, msglvl, mxiter, mode, nb,
      &           nev0, next, np, ritz, j
       save       bounds, ierr, ih, iq, ishift, iupd, iw,
@@ -469,7 +469,7 @@ c
 c     %-----------------------%
 c     | Executable Statements |
 c     %-----------------------%
-c 
+c
       if (ido .eq. 0) then
 c
 c        %-------------------------------%
@@ -511,7 +511,7 @@ c        | extend the length NEV Lanczos factorization. |
 c        %----------------------------------------------%
 c
          np     = ncv - nev
-c 
+c
          if (mxiter .le. 0)                     ierr = -4
          if (which .ne. 'LM' .and.
      &       which .ne. 'SM' .and.
@@ -530,7 +530,7 @@ c
          else if (nev .eq. 1 .and. which .eq. 'BE') then
                                                 ierr = -13
          end if
-c 
+c
 c        %------------%
 c        | Error Exit |
 c        %------------%
@@ -540,7 +540,7 @@ c
             ido  = 99
             go to 9000
          end if
-c 
+c
 c        %------------------------%
 c        | Set default parameters |
 c        %------------------------%
@@ -556,8 +556,8 @@ c        | size of the invariant subspace desired.      |
 c        %----------------------------------------------%
 c
          np     = ncv - nev
-         nev0   = nev 
-c 
+         nev0   = nev
+c
 c        %-----------------------------%
 c        | Zero out internal workspace |
 c        %-----------------------------%
@@ -565,7 +565,7 @@ c
          do 10 j = 1, ncv**2 + 8*ncv
             workl(j) = zero
  10      continue
-c 
+c
 c        %-------------------------------------------------------%
 c        | Pointer into WORKL for address of H, RITZ, BOUNDS, Q  |
 c        | etc... and the remaining workspace.                   |
@@ -598,7 +598,7 @@ c     %-------------------------------------------------------%
 c     | Carry out the Implicitly restarted Lanczos Iteration. |
 c     %-------------------------------------------------------%
 c
-      call ssaup2 
+      call ssaup2
      &   ( ido, bmat, n, which, nev0, np, tol, resid, mode, iupd,
      &     ishift, mxiter, v, ldv, workl(ih), ldh, workl(ritz),
      &     workl(bounds), workl(iq), ldq, workl(iw), ipntr, workd,
@@ -611,7 +611,7 @@ c     %--------------------------------------------------%
 c
       if (ido .eq. 3) iparam(8) = np
       if (ido .ne. 99) go to 9000
-c 
+c
       iparam(3) = mxiter
       iparam(5) = np
       iparam(9) = nopx
@@ -631,15 +631,15 @@ c
      &               '_saupd: number of update iterations taken')
          call ivout (logfil, 1, [np], ndigit,
      &               '_saupd: number of "converged" Ritz values')
-         call svout (logfil, np, workl(Ritz), ndigit, 
+         call svout (logfil, np, workl(Ritz), ndigit,
      &               '_saupd: final Ritz values')
-         call svout (logfil, np, workl(Bounds), ndigit, 
+         call svout (logfil, np, workl(Bounds), ndigit,
      &               '_saupd: corresponding error bounds')
-      end if 
+      end if
 c
       call second (t1)
       tsaupd = t1 - t0
-c 
+c
       if (msglvl .gt. 0) then
 c
 c        %--------------------------------------------------------%
@@ -677,9 +677,9 @@ c
      &      5x, 'Total time in applying the shifts          = ', f12.6,/
      &      5x, 'Total time in convergence testing          = ', f12.6)
       end if
-c 
+c
  9000 continue
-c 
+c
       return
 c
 c     %---------------%

--- a/mathlibs/src/arpack/ssaupd.f
+++ b/mathlibs/src/arpack/ssaupd.f
@@ -627,9 +627,9 @@ c
       if (info .eq. 2) info = 3
 c
       if (msglvl .gt. 0) then
-         call ivout (logfil, 1, mxiter, ndigit,
+         call ivout (logfil, 1, [mxiter], ndigit,
      &               '_saupd: number of update iterations taken')
-         call ivout (logfil, 1, np, ndigit,
+         call ivout (logfil, 1, [np], ndigit,
      &               '_saupd: number of "converged" Ritz values')
          call svout (logfil, np, workl(Ritz), ndigit, 
      &               '_saupd: final Ritz values')

--- a/mathlibs/src/arpack/sseupd.f
+++ b/mathlibs/src/arpack/sseupd.f
@@ -2,7 +2,7 @@ c\BeginDoc
 c
 c\Name: sseupd
 c
-c\Description: 
+c\Description:
 c
 c  This subroutine returns the converged approximations to eigenvalues
 c  of A*z = lambda*B*z and (optionally):
@@ -15,22 +15,22 @@ c
 c      (3) Both.
 c
 c  There is negligible additional cost to obtain eigenvectors.  An orthonormal
-c  (Lanczos) basis is always computed.  There is an additional storage cost 
-c  of n*nev if both are requested (in this case a separate array Z must be 
+c  (Lanczos) basis is always computed.  There is an additional storage cost
+c  of n*nev if both are requested (in this case a separate array Z must be
 c  supplied).
 c
 c  These quantities are obtained from the Lanczos factorization computed
 c  by SSAUPD for the linear operator OP prescribed by the MODE selection
 c  (see IPARAM(7) in SSAUPD documentation.)  SSAUPD must be called before
-c  this routine is called. These approximate eigenvalues and vectors are 
-c  commonly called Ritz values and Ritz vectors respectively.  They are 
-c  referred to as such in the comments that follow.   The computed orthonormal 
-c  basis for the invariant subspace corresponding to these Ritz values is 
+c  this routine is called. These approximate eigenvalues and vectors are
+c  commonly called Ritz values and Ritz vectors respectively.  They are
+c  referred to as such in the comments that follow.   The computed orthonormal
+c  basis for the invariant subspace corresponding to these Ritz values is
 c  referred to as a Lanczos basis.
 c
-c  See documentation in the header of the subroutine SSAUPD for a definition 
-c  of OP as well as other terms and the relation of computed Ritz values 
-c  and vectors of OP with respect to the given problem  A*z = lambda*B*z.  
+c  See documentation in the header of the subroutine SSAUPD for a definition
+c  of OP as well as other terms and the relation of computed Ritz values
+c  and vectors of OP with respect to the given problem  A*z = lambda*B*z.
 c
 c  The approximate eigenvalues of the original problem are returned in
 c  ascending algebraic order.  The user may elect to call this routine
@@ -39,19 +39,19 @@ c  There is also the option of computing a selected set of these vectors
 c  with a single call.
 c
 c\Usage:
-c  call sseupd 
+c  call sseupd
 c     ( RVEC, HOWMNY, SELECT, D, Z, LDZ, SIGMA, BMAT, N, WHICH, NEV, TOL,
 c       RESID, NCV, V, LDV, IPARAM, IPNTR, WORKD, WORKL, LWORKL, INFO )
 c
-c  RVEC    LOGICAL  (INPUT) 
-c          Specifies whether Ritz vectors corresponding to the Ritz value 
+c  RVEC    LOGICAL  (INPUT)
+c          Specifies whether Ritz vectors corresponding to the Ritz value
 c          approximations to the eigenproblem A*z = lambda*B*z are computed.
 c
 c             RVEC = .FALSE.     Compute Ritz values only.
 c
 c             RVEC = .TRUE.      Compute Ritz vectors.
 c
-c  HOWMNY  Character*1  (INPUT) 
+c  HOWMNY  Character*1  (INPUT)
 c          Specifies how many Ritz vectors are wanted and the form of Z
 c          the matrix of Ritz vectors. See remark 1 below.
 c          = 'A': compute NEV Ritz vectors;
@@ -61,7 +61,7 @@ c
 c  SELECT  Logical array of dimension NEV.  (INPUT)
 c          If HOWMNY = 'S', SELECT specifies the Ritz vectors to be
 c          computed. To select the Ritz vector corresponding to a
-c          Ritz value D(j), SELECT(j) must be set to .TRUE.. 
+c          Ritz value D(j), SELECT(j) must be set to .TRUE..
 c          If HOWMNY = 'A' , SELECT is not referenced.
 c
 c  D       Real array of dimension NEV.  (OUTPUT)
@@ -69,8 +69,8 @@ c          On exit, D contains the Ritz value approximations to the
 c          eigenvalues of A*z = lambda*B*z. The values are returned
 c          in ascending order. If IPARAM(7) = 3,4,5 then D represents
 c          the Ritz values of OP computed by ssaupd transformed to
-c          those of the original eigensystem A*z = lambda*B*z. If 
-c          IPARAM(7) = 1,2 then the Ritz values of OP are the same 
+c          those of the original eigensystem A*z = lambda*B*z. If
+c          IPARAM(7) = 1,2 then the Ritz values of OP are the same
 c          as the those of A*z = lambda*B*z.
 c
 c  Z       Real N by NEV array if HOWMNY = 'A'.  (OUTPUT)
@@ -78,7 +78,7 @@ c          On exit, Z contains the B-orthonormal Ritz vectors of the
 c          eigensystem A*z = lambda*B*z corresponding to the Ritz
 c          value approximations.
 c          If  RVEC = .FALSE. then Z is not referenced.
-c          NOTE: The array Z may be set equal to first NEV columns of the 
+c          NOTE: The array Z may be set equal to first NEV columns of the
 c          Arnoldi/Lanczos basis array V computed by SSAUPD.
 c
 c  LDZ     Integer.  (INPUT)
@@ -147,7 +147,7 @@ c\References:
 c  1. D.C. Sorensen, "Implicit Application of Polynomial Filters in
 c     a k-Step Arnoldi Method", SIAM J. Matr. Anal. Apps., 13 (1992),
 c     pp 357-385.
-c  2. R.B. Lehoucq, "Analysis and Implementation of an Implicitly 
+c  2. R.B. Lehoucq, "Analysis and Implementation of an Implicitly
 c     Restarted Arnoldi Iteration", Rice University Technical Report
 c     TR95-13, Department of Computational and Applied Mathematics.
 c  3. B.N. Parlett, "The Symmetric Eigenvalue Problem". Prentice-Hall,
@@ -157,19 +157,19 @@ c     Computer Physics Communications, 53 (1989), pp 169-179.
 c  5. B. Nour-Omid, B.N. Parlett, T. Ericson, P.S. Jensen, "How to
 c     Implement the Spectral Transformation", Math. Comp., 48 (1987),
 c     pp 663-673.
-c  6. R.G. Grimes, J.G. Lewis and H.D. Simon, "A Shifted Block Lanczos 
-c     Algorithm for Solving Sparse Symmetric Generalized Eigenproblems", 
+c  6. R.G. Grimes, J.G. Lewis and H.D. Simon, "A Shifted Block Lanczos
+c     Algorithm for Solving Sparse Symmetric Generalized Eigenproblems",
 c     SIAM J. Matr. Anal. Apps.,  January (1993).
 c  7. L. Reichel, W.B. Gragg, "Algorithm 686: FORTRAN Subroutines
 c     for Updating the QR decomposition", ACM TOMS, December 1990,
 c     Volume 16 Number 4, pp 369-377.
 c
 c\Remarks
-c  1. The converged Ritz values are always returned in increasing 
+c  1. The converged Ritz values are always returned in increasing
 c     (algebraic) order.
 c
 c  2. Currently only HOWMNY = 'A' is implemented. It is included at this
-c     stage for the user who wants to incorporate it. 
+c     stage for the user who wants to incorporate it.
 c
 c\Routines called:
 c     ssesrt  ARPACK routine that sorts an array X, and applies the
@@ -195,22 +195,22 @@ c\Authors
 c     Danny Sorensen               Phuong Vu
 c     Richard Lehoucq              CRPC / Rice University
 c     Chao Yang                    Houston, Texas
-c     Dept. of Computational & 
+c     Dept. of Computational &
 c     Applied Mathematics
-c     Rice University           
-c     Houston, Texas            
-c 
+c     Rice University
+c     Houston, Texas
+c
 c\Revision history:
 c     12/15/93: Version ' 2.1'
 c
-c\SCCS Information: @(#) 
+c\SCCS Information: @(#)
 c FILE: seupd.F   SID: 2.7   DATE OF SID: 8/27/96   RELEASE: 2
 c
 c\EndLib
 c
 c-----------------------------------------------------------------------
       subroutine sseupd (rvec, howmny, select, d, z, ldz, sigma, bmat,
-     &                   n, which, nev, tol, resid, ncv, v, ldv, iparam, 
+     &                   n, which, nev, tol, resid, ncv, v, ldv, iparam,
      &                   ipntr, workd, workl, lworkl, info )
 c
 c     %----------------------------------------------------%
@@ -227,7 +227,7 @@ c
       character  bmat, howmny, which*2
       logical    rvec, select(ncv)
       integer    info, ldz, ldv, lworkl, n, ncv, nev
-      Real     
+      Real
      &           sigma, tol
 c
 c     %-----------------%
@@ -236,7 +236,7 @@ c     %-----------------%
 c
       integer    iparam(7), ipntr(11)
       Real
-     &           d(nev), resid(n), v(ldv,ncv), z(ldz, nev), 
+     &           d(nev), resid(n), v(ldv,ncv), z(ldz, nev),
      &           workd(2*n), workl(lworkl)
 c
 c     %------------%
@@ -252,7 +252,7 @@ c     | Local Scalars |
 c     %---------------%
 c
       character  type*6
-      integer    bounds, ierr, ih, ihb, ihd, iq, iw, j, k, 
+      integer    bounds, ierr, ih, ihb, ihd, iq, iw, j, k,
      &           ldh, ldq, mode, msglvl, nconv, next, ritz,
      &           irz, ibd, ktrord, leftptr, rghtptr, ism, ilg
       Real
@@ -263,14 +263,14 @@ c     %--------------%
 c     | Local Arrays |
 c     %--------------%
 c
-      Real 
+      Real
      &           kv(2)
 c
 c     %----------------------%
 c     | External Subroutines |
 c     %----------------------%
 c
-      external   scopy, sger, sgeqr2, slacpy, sorm2r, sscal, 
+      external   scopy, sger, sgeqr2, slacpy, sorm2r, sscal,
      &           ssesrt, ssteqr, sswap, svout, ivout, ssortr
 c
 c     %--------------------%
@@ -290,7 +290,7 @@ c
 c     %-----------------------%
 c     | Executable Statements |
 c     %-----------------------%
-c 
+c
 c     %------------------------%
 c     | Set default parameters |
 c     %------------------------%
@@ -307,7 +307,7 @@ c
       if (nconv .eq. 0) go to 9000
       ierr = 0
 c
-      if (nconv .le. 0)                        ierr = -14 
+      if (nconv .le. 0)                        ierr = -14
       if (n .le. 0)                            ierr = -1
       if (nev .le. 0)                          ierr = -2
       if (ncv .le. nev .or.  ncv .gt. n)       ierr = -3
@@ -319,12 +319,12 @@ c
       if (bmat .ne. 'I' .and. bmat .ne. 'G')   ierr = -6
       if ( (howmny .ne. 'A' .and.
      &           howmny .ne. 'P' .and.
-     &           howmny .ne. 'S') .and. rvec ) 
+     &           howmny .ne. 'S') .and. rvec )
      &                                         ierr = -15
       if (rvec .and. howmny .eq. 'S')           ierr = -16
 c
       if (rvec .and. lworkl .lt. ncv**2+8*ncv) ierr = -7
-c     
+c
       if (mode .eq. 1 .or. mode .eq. 2) then
          type = 'REGULR'
       else if (mode .eq. 3 ) then
@@ -333,7 +333,7 @@ c
          type = 'BUCKLE'
       else if (mode .eq. 5 ) then
          type = 'CAYLEY'
-      else 
+      else
                                                ierr = -10
       end if
       if (mode .eq. 1 .and. bmat .eq. 'G')     ierr = -11
@@ -347,7 +347,7 @@ c
          info = ierr
          go to 9000
       end if
-c     
+c
 c     %-------------------------------------------------------%
 c     | Pointer into WORKL for address of H, RITZ, BOUNDS, Q  |
 c     | etc... and the remaining workspace.                   |
@@ -422,7 +422,7 @@ c     %---------------------------------%
 c     | Set machine dependent constant. |
 c     %---------------------------------%
 c
-      eps23 = slamch('Epsilon-Machine') 
+      eps23 = slamch('Epsilon-Machine')
       eps23 = eps23**(2.0E+0 / 3.0E+0)
 c
 c     %---------------------------------------%
@@ -489,7 +489,7 @@ c
              ism = max(nev,nconv) / 2
              ilg = ism + 1
              thres1 = workl(ism)
-             thres2 = workl(ilg) 
+             thres2 = workl(ilg)
 c
              if (msglvl .gt. 2) then
                 kv(1) = thres1
@@ -704,8 +704,8 @@ c
             call scopy (ncv, workl(bounds), 1, workl(ihb), 1)
          end if
 c
-      else 
-c 
+      else
+c
 c        %-------------------------------------------------------------%
 c        | *  Make a copy of all the Ritz values.                      |
 c        | *  Transform the Ritz values back to the original system.   |
@@ -722,13 +722,13 @@ c        |  They are only reordered.                                   |
 c        %-------------------------------------------------------------%
 c
          call scopy (ncv, workl(ihd), 1, workl(iw), 1)
-         if (type .eq. 'SHIFTI') then 
+         if (type .eq. 'SHIFTI') then
             do 40 k=1, ncv
                workl(ihd+k-1) = one / workl(ihd+k-1) + sigma
   40        continue
          else if (type .eq. 'BUCKLE') then
             do 50 k=1, ncv
-               workl(ihd+k-1) = sigma * workl(ihd+k-1) / 
+               workl(ihd+k-1) = sigma * workl(ihd+k-1) /
      &                          (workl(ihd+k-1) - one)
   50        continue
          else if (type .eq. 'CAYLEY') then
@@ -737,7 +737,7 @@ c
      &                          (workl(ihd+k-1) - one)
   60        continue
          end if
-c 
+c
 c        %-------------------------------------------------------------%
 c        | *  Store the wanted NCONV lambda values into D.             |
 c        | *  Sort the NCONV wanted lambda in WORKL(IHD:IHD+NCONV-1)   |
@@ -763,8 +763,8 @@ c
             call ssortr ('LA', .true., nconv, d, workl(ihb))
          end if
 c
-      end if 
-c 
+      end if
+c
 c     %------------------------------------------------%
 c     | Compute the Ritz vectors. Transform the wanted |
 c     | eigenvectors of the symmetric tridiagonal H by |
@@ -772,25 +772,25 @@ c     | the Lanczos basis matrix V.                    |
 c     %------------------------------------------------%
 c
       if (rvec .and. howmny .eq. 'A') then
-c    
+c
 c        %----------------------------------------------------------%
 c        | Compute the QR factorization of the matrix representing  |
 c        | the wanted invariant subspace located in the first NCONV |
 c        | columns of workl(iq,ldq).                                |
 c        %----------------------------------------------------------%
-c     
-         call sgeqr2 (ncv, nconv, workl(iq), ldq, workl(iw+ncv), 
+c
+         call sgeqr2 (ncv, nconv, workl(iq), ldq, workl(iw+ncv),
      &        workl(ihb), ierr)
 c
-c     
+c
 c        %--------------------------------------------------------%
-c        | * Postmultiply V by Q.                                 |   
+c        | * Postmultiply V by Q.                                 |
 c        | * Copy the first NCONV columns of VQ into Z.           |
 c        | The N by NCONV matrix Z is now a matrix representation |
 c        | of the approximate invariant subspace associated with  |
 c        | the Ritz values in workl(ihd).                         |
 c        %--------------------------------------------------------%
-c     
+c
          call sorm2r ('Right', 'Notranspose', n, ncv, nconv, workl(iq),
      &        ldq, workl(iw+ncv), v, ldv, workd(n+1), ierr)
          call slacpy ('All', n, nconv, v, ldv, z, ldz)
@@ -802,7 +802,7 @@ c        | eigenvector matrix. Remember, it's in factored form |
 c        %-----------------------------------------------------%
 c
          do 65 j = 1, ncv-1
-            workl(ihb+j-1) = zero 
+            workl(ihb+j-1) = zero
   65     continue
          workl(ihb+ncv-1) = one
          call sorm2r ('Left', 'Transpose', ncv, 1, nconv, workl(iq),
@@ -832,7 +832,7 @@ c        | *  Determine Ritz estimates of the lambda.      |
 c        %-------------------------------------------------%
 c
          call sscal (ncv, bnorm2, workl(ihb), 1)
-         if (type .eq. 'SHIFTI') then 
+         if (type .eq. 'SHIFTI') then
 c
             do 80 k=1, ncv
                workl(ihb+k-1) = abs( workl(ihb+k-1) ) / workl(iw+k-1)**2
@@ -841,14 +841,14 @@ c
          else if (type .eq. 'BUCKLE') then
 c
             do 90 k=1, ncv
-               workl(ihb+k-1) = sigma * abs( workl(ihb+k-1) ) / 
+               workl(ihb+k-1) = sigma * abs( workl(ihb+k-1) ) /
      &                          ( workl(iw+k-1)-one )**2
  90         continue
 c
          else if (type .eq. 'CAYLEY') then
 c
             do 100 k=1, ncv
-               workl(ihb+k-1) = abs( workl(ihb+k-1) / 
+               workl(ihb+k-1) = abs( workl(ihb+k-1) /
      &                          workl(iw+k-1)*(workl(iw+k-1)-one) )
  100        continue
 c
@@ -859,15 +859,15 @@ c
       if (type .ne. 'REGULR' .and. msglvl .gt. 1) then
          call svout (logfil, nconv, d, ndigit,
      &          '_seupd: Untransformed converged Ritz values')
-         call svout (logfil, nconv, workl(ihb), ndigit, 
+         call svout (logfil, nconv, workl(ihb), ndigit,
      &     '_seupd: Ritz estimates of the untransformed Ritz values')
       else if (msglvl .gt. 1) then
          call svout (logfil, nconv, d, ndigit,
      &          '_seupd: Converged Ritz values')
-         call svout (logfil, nconv, workl(ihb), ndigit, 
+         call svout (logfil, nconv, workl(ihb), ndigit,
      &     '_seupd: Associated Ritz estimates')
       end if
-c 
+c
 c     %-------------------------------------------------%
 c     | Ritz vector purification step. Formally perform |
 c     | one of inverse subspace iteration. Only used    |
@@ -886,7 +886,7 @@ c
             workl(iw+k) = workl(iq+k*ldq+ncv-1) / (workl(iw+k)-one)
  120     continue
 c
-      end if 
+      end if
 c
       if (type .ne. 'REGULR')
      &   call sger (n, nconv, one, resid, 1, workl(iw), 1, z, ldz)

--- a/mathlibs/src/arpack/sseupd.f
+++ b/mathlibs/src/arpack/sseupd.f
@@ -473,7 +473,7 @@ c
              thres1 = workl(ritz)
 c
              if (msglvl .gt. 2) then
-                call svout(logfil, 1, thres1, ndigit,
+                call svout(logfil, 1, [thres1], ndigit,
      &          '_seupd: Threshold eigenvalue used for re-ordering')
              end if
 c
@@ -570,9 +570,9 @@ c        | If KTRORD .ne. NCONV, something is wrong. |
 c        %-------------------------------------------%
 c
          if (msglvl .gt. 2) then
-             call ivout(logfil, 1, ktrord, ndigit,
+             call ivout(logfil, 1, [ktrord], ndigit,
      &            '_seupd: Number of specified eigenvalues')
-             call ivout(logfil, 1, nconv, ndigit,
+             call ivout(logfil, 1, [nconv], ndigit,
      &            '_seupd: Number of "converged" eigenvalues')
          end if
 c

--- a/mathlibs/src/arpack/ssgets.f
+++ b/mathlibs/src/arpack/ssgets.f
@@ -202,8 +202,8 @@ c
       tsgets = tsgets + (t1 - t0)
 c
       if (msglvl .gt. 0) then
-         call ivout (logfil, 1, kev, ndigit, '_sgets: KEV is')
-         call ivout (logfil, 1, np, ndigit, '_sgets: NP is')
+         call ivout (logfil, 1, [kev], ndigit, '_sgets: KEV is')
+         call ivout (logfil, 1, [np], ndigit, '_sgets: NP is')
          call svout (logfil, kev+np, ritz, ndigit,
      &        '_sgets: Eigenvalues of current H matrix')
          call svout (logfil, kev+np, bounds, ndigit, 

--- a/mathlibs/src/arpack/ssgets.f
+++ b/mathlibs/src/arpack/ssgets.f
@@ -3,13 +3,13 @@ c\BeginDoc
 c
 c\Name: ssgets
 c
-c\Description: 
+c\Description:
 c  Given the eigenvalues of the symmetric tridiagonal matrix H,
-c  computes the NP shifts AMU that are zeros of the polynomial of 
-c  degree NP which filters out components of the unwanted eigenvectors 
+c  computes the NP shifts AMU that are zeros of the polynomial of
+c  degree NP which filters out components of the unwanted eigenvectors
 c  corresponding to the AMU's based on some given criteria.
 c
-c  NOTE: This is called even in the case of user specified shifts in 
+c  NOTE: This is called even in the case of user specified shifts in
 c  order to sort the eigenvalues, and error bounds of H for later use.
 c
 c\Usage:
@@ -39,8 +39,8 @@ c          Number of implicit shifts to be computed.
 c
 c  RITZ    Real array of length KEV+NP.  (INPUT/OUTPUT)
 c          On INPUT, RITZ contains the eigenvalues of H.
-c          On OUTPUT, RITZ are sorted so that the unwanted eigenvalues 
-c          are in the first NP locations and the wanted part is in 
+c          On OUTPUT, RITZ are sorted so that the unwanted eigenvalues
+c          are in the first NP locations and the wanted part is in
 c          the last KEV locations.  When exact shifts are selected, the
 c          unwanted part corresponds to the shifts to be applied.
 c
@@ -49,7 +49,7 @@ c          Error bounds corresponding to the ordering in RITZ.
 c
 c  SHIFTS  Real array of length NP.  (INPUT/OUTPUT)
 c          On INPUT:  contains the user specified shifts if ISHIFT = 0.
-c          On OUTPUT: contains the shifts sorted into decreasing order 
+c          On OUTPUT: contains the shifts sorted into decreasing order
 c          of magnitude with respect to the Ritz estimates contained in
 c          BOUNDS. If ISHIFT = 0, SHIFTS is not modified on exit.
 c
@@ -75,13 +75,13 @@ c     Danny Sorensen               Phuong Vu
 c     Richard Lehoucq              CRPC / Rice University
 c     Dept. of Computational &     Houston, Texas
 c     Applied Mathematics
-c     Rice University           
-c     Houston, Texas            
+c     Rice University
+c     Houston, Texas
 c
 c\Revision history:
 c     xx/xx/93: Version ' 2.1'
 c
-c\SCCS Information: @(#) 
+c\SCCS Information: @(#)
 c FILE: sgets.F   SID: 2.4   DATE OF SID: 4/19/96   RELEASE: 2
 c
 c\Remarks
@@ -142,7 +142,7 @@ c
 c     %-----------------------%
 c     | Executable Statements |
 c     %-----------------------%
-c 
+c
 c     %-------------------------------%
 c     | Initialize timing statistics  |
 c     | & message level for debugging |
@@ -150,7 +150,7 @@ c     %-------------------------------%
 c
       call second (t0)
       msglvl = msgets
-c 
+c
       if (which .eq. 'BE') then
 c
 c        %-----------------------------------------------------%
@@ -163,11 +163,11 @@ c        | overlapping locations.                              |
 c        %-----------------------------------------------------%
 c
          call ssortr ('LA', .true., kev+np, ritz, bounds)
-         kevd2 = kev / 2 
+         kevd2 = kev / 2
          if ( kev .gt. 1 ) then
-            call sswap ( min(kevd2,np), ritz, 1, 
+            call sswap ( min(kevd2,np), ritz, 1,
      &                   ritz( max(kevd2,np)+1 ), 1)
-            call sswap ( min(kevd2,np), bounds, 1, 
+            call sswap ( min(kevd2,np), bounds, 1,
      &                   bounds( max(kevd2,np)+1 ), 1)
          end if
 c
@@ -185,7 +185,7 @@ c
       end if
 c
       if (ishift .eq. 1 .and. np .gt. 0) then
-c     
+c
 c        %-------------------------------------------------------%
 c        | Sort the unwanted Ritz values used as shifts so that  |
 c        | the ones with largest Ritz estimates are first.       |
@@ -193,11 +193,11 @@ c        | This will tend to minimize the effects of the         |
 c        | forward instability of the iteration when the shifts  |
 c        | are applied in subroutine ssapps.                     |
 c        %-------------------------------------------------------%
-c     
+c
          call ssortr ('SM', .true., np, bounds, ritz)
          call scopy (np, ritz, 1, shifts, 1)
       end if
-c 
+c
       call second (t1)
       tsgets = tsgets + (t1 - t0)
 c
@@ -206,10 +206,10 @@ c
          call ivout (logfil, 1, [np], ndigit, '_sgets: NP is')
          call svout (logfil, kev+np, ritz, ndigit,
      &        '_sgets: Eigenvalues of current H matrix')
-         call svout (logfil, kev+np, bounds, ndigit, 
+         call svout (logfil, kev+np, bounds, ndigit,
      &        '_sgets: Associated Ritz estimates')
       end if
-c 
+c
       return
 c
 c     %---------------%

--- a/mathlibs/src/arpack/zgetv0.f
+++ b/mathlibs/src/arpack/zgetv0.f
@@ -359,9 +359,9 @@ c     | Check for further orthogonalization. |
 c     %--------------------------------------%
 c
       if (msglvl .gt. 2) then
-          call dvout (logfil, 1, rnorm0, ndigit, 
+          call dvout (logfil, 1, [rnorm0], ndigit, 
      &                '_getv0: re-orthonalization ; rnorm0 is')
-          call dvout (logfil, 1, rnorm, ndigit, 
+          call dvout (logfil, 1, [rnorm], ndigit, 
      &                '_getv0: re-orthonalization ; rnorm is')
       end if
 c
@@ -392,7 +392,7 @@ c
    50 continue
 c
       if (msglvl .gt. 0) then
-         call dvout (logfil, 1, rnorm, ndigit,
+         call dvout (logfil, 1, [rnorm], ndigit,
      &        '_getv0: B-norm of initial / restarted starting vector')
       end if
       if (msglvl .gt. 2) then

--- a/mathlibs/src/arpack/zgetv0.f
+++ b/mathlibs/src/arpack/zgetv0.f
@@ -2,13 +2,13 @@ c\BeginDoc
 c
 c\Name: zgetv0
 c
-c\Description: 
+c\Description:
 c  Generate a random initial residual vector for the Arnoldi process.
-c  Force the residual vector to be in the range of the operator OP.  
+c  Force the residual vector to be in the range of the operator OP.
 c
 c\Usage:
 c  call zgetv0
-c     ( IDO, BMAT, ITRY, INITV, N, J, V, LDV, RESID, RNORM, 
+c     ( IDO, BMAT, ITRY, INITV, N, J, V, LDV, RESID, RNORM,
 c       IPNTR, WORKD, IERR )
 c
 c\Arguments
@@ -35,7 +35,7 @@ c          B = 'I' -> standard eigenvalue problem A*x = lambda*x
 c          B = 'G' -> generalized eigenvalue problem A*x = lambda*B*x
 c
 c  ITRY    Integer.  (INPUT)
-c          ITRY counts the number of times that zgetv0 is called.  
+c          ITRY counts the number of times that zgetv0 is called.
 c          It should be set to 1 on the initial call to zgetv0.
 c
 c  INITV   Logical variable.  (INPUT)
@@ -54,11 +54,11 @@ c          The first J-1 columns of V contain the current Arnoldi basis
 c          if this is a "restart".
 c
 c  LDV     Integer.  (INPUT)
-c          Leading dimension of V exactly as declared in the calling 
+c          Leading dimension of V exactly as declared in the calling
 c          program.
 c
 c  RESID   Complex*16 array of length N.  (INPUT/OUTPUT)
-c          Initial residual vector to be generated.  If RESID is 
+c          Initial residual vector to be generated.  If RESID is
 c          provided, force RESID into the range of the operator OP.
 c
 c  RNORM   Double precision scalar.  (OUTPUT)
@@ -91,19 +91,19 @@ c
 c\Routines called:
 c     second  ARPACK utility routine for timing.
 c     zvout   ARPACK utility routine that prints vectors.
-c     zlarnv  LAPACK routine for generating a random vector. 
+c     zlarnv  LAPACK routine for generating a random vector.
 c     zgemv   Level 2 BLAS routine for matrix vector multiplication.
 c     zcopy   Level 1 BLAS that copies one vector to another.
 c     zdotc   Level 1 BLAS that computes the scalar product of two vectors.
-c     dznrm2  Level 1 BLAS that computes the norm of a vector. 
+c     dznrm2  Level 1 BLAS that computes the norm of a vector.
 c
 c\Author
 c     Danny Sorensen               Phuong Vu
 c     Richard Lehoucq              CRPC / Rice University
 c     Dept. of Computational &     Houston, Texas
-c     Applied Mathematics 
-c     Rice University           
-c     Houston, Texas            
+c     Applied Mathematics
+c     Rice University
+c     Houston, Texas
 c
 c\SCCS Information: @(#)
 c FILE: getv0.F   SID: 2.3   DATE OF SID: 8/27/96   RELEASE: 2
@@ -112,10 +112,10 @@ c\EndLib
 c
 c-----------------------------------------------------------------------
 c
-      subroutine zgetv0 
-     &   ( ido, bmat, itry, initv, n, j, v, ldv, resid, rnorm, 
+      subroutine zgetv0
+     &   ( ido, bmat, itry, initv, n, j, v, ldv, resid, rnorm,
      &     ipntr, workd, ierr )
-c 
+c
 c     %----------------------------------------------------%
 c     | Include files for debugging and timing information |
 c     %----------------------------------------------------%
@@ -174,7 +174,7 @@ c     %--------------------%
 c     | External Functions |
 c     %--------------------%
 c
-      Double precision 
+      Double precision
      &           dznrm2, dlapy2
       Complex*16
      &           zdotc
@@ -205,7 +205,7 @@ c
       end if
 c
       if (ido .eq.  0) then
-c 
+c
 c        %-------------------------------%
 c        | Initialize timing statistics  |
 c        | & message level for debugging |
@@ -213,7 +213,7 @@ c        %-------------------------------%
 c
          call second (t0)
          msglvl = mgetv0
-c 
+c
          ierr   = 0
          iter   = 0
          first  = .FALSE.
@@ -232,7 +232,7 @@ c
             idist = 2
             call zlarnv (idist, iseed, n, resid)
          end if
-c 
+c
 c        %----------------------------------------------------------%
 c        | Force the starting vector into the range of OP to handle |
 c        | the generalized problem when B is possibly (singular).   |
@@ -248,7 +248,7 @@ c
             go to 9000
          end if
       end if
-c 
+c
 c     %----------------------------------------%
 c     | Back from computing B*(initial-vector) |
 c     %----------------------------------------%
@@ -260,10 +260,10 @@ c     | Back from computing B*(orthogonalized-vector) |
 c     %-----------------------------------------------%
 c
       if (orth)  go to 40
-c 
+c
       call second (t3)
       tmvopx = tmvopx + (t3 - t2)
-c 
+c
 c     %------------------------------------------------------%
 c     | Starting vector is now in the range of OP; r = OP*r; |
 c     | Compute B-norm of starting vector.                   |
@@ -281,14 +281,14 @@ c
       else if (bmat .eq. 'I') then
          call zcopy (n, resid, 1, workd, 1)
       end if
-c 
+c
    20 continue
 c
       if (bmat .eq. 'G') then
          call second (t3)
          tmvbx = tmvbx + (t3 - t2)
       end if
-c 
+c
       first = .FALSE.
       if (bmat .eq. 'G') then
           cnorm  = zdotc (n, resid, 1, workd, 1)
@@ -303,7 +303,7 @@ c     | Exit if this is the very first Arnoldi step |
 c     %---------------------------------------------%
 c
       if (j .eq. 1) go to 50
-c 
+c
 c     %----------------------------------------------------------------
 c     | Otherwise need to B-orthogonalize the starting vector against |
 c     | the current Arnoldi basis using Gram-Schmidt with iter. ref.  |
@@ -319,11 +319,11 @@ c
       orth = .TRUE.
    30 continue
 c
-      call zgemv ('C', n, j-1, one, v, ldv, workd, 1, 
+      call zgemv ('C', n, j-1, one, v, ldv, workd, 1,
      &            zero, workd(n+1), 1)
-      call zgemv ('N', n, j-1, -one, v, ldv, workd(n+1), 1, 
+      call zgemv ('N', n, j-1, -one, v, ldv, workd(n+1), 1,
      &            one, resid, 1)
-c 
+c
 c     %----------------------------------------------------------%
 c     | Compute the B-norm of the orthogonalized starting vector |
 c     %----------------------------------------------------------%
@@ -339,14 +339,14 @@ c
       else if (bmat .eq. 'I') then
          call zcopy (n, resid, 1, workd, 1)
       end if
-c 
+c
    40 continue
 c
       if (bmat .eq. 'G') then
          call second (t3)
          tmvbx = tmvbx + (t3 - t2)
       end if
-c 
+c
       if (bmat .eq. 'G') then
          cnorm = zdotc (n, resid, 1, workd, 1)
          rnorm = sqrt(dlapy2(dble(cnorm),dimag(cnorm)))
@@ -359,14 +359,14 @@ c     | Check for further orthogonalization. |
 c     %--------------------------------------%
 c
       if (msglvl .gt. 2) then
-          call dvout (logfil, 1, [rnorm0], ndigit, 
+          call dvout (logfil, 1, [rnorm0], ndigit,
      &                '_getv0: re-orthonalization ; rnorm0 is')
-          call dvout (logfil, 1, [rnorm], ndigit, 
+          call dvout (logfil, 1, [rnorm], ndigit,
      &                '_getv0: re-orthonalization ; rnorm is')
       end if
 c
       if (rnorm .gt. 0.717*rnorm0) go to 50
-c 
+c
       iter = iter + 1
       if (iter .le. 1) then
 c
@@ -388,7 +388,7 @@ c
          rnorm = rzero
          ierr = -1
       end if
-c 
+c
    50 continue
 c
       if (msglvl .gt. 0) then
@@ -400,10 +400,10 @@ c
      &        '_getv0: initial / restarted starting vector')
       end if
       ido = 99
-c 
+c
       call second (t1)
       tgetv0 = tgetv0 + (t1 - t0)
-c 
+c
  9000 continue
       return
 c

--- a/mathlibs/src/arpack/znaitr.f
+++ b/mathlibs/src/arpack/znaitr.f
@@ -2,8 +2,8 @@ c\BeginDoc
 c
 c\Name: znaitr
 c
-c\Description: 
-c  Reverse communication interface for applying NP additional steps to 
+c\Description:
+c  Reverse communication interface for applying NP additional steps to
 c  a K step nonsymmetric Arnoldi factorization.
 c
 c  Input:  OP*V_{k}  -  V_{k}*H = r_{k}*e_{k}^T
@@ -19,7 +19,7 @@ c  computed and returned.
 c
 c\Usage:
 c  call znaitr
-c     ( IDO, BMAT, N, K, NP, NB, RESID, RNORM, V, LDV, H, LDH, 
+c     ( IDO, BMAT, N, K, NP, NB, RESID, RNORM, V, LDV, H, LDH,
 c       IPNTR, WORKD, INFO )
 c
 c\Arguments
@@ -61,8 +61,8 @@ c  NP      Integer.  (INPUT)
 c          Number of additional Arnoldi steps to take.
 c
 c  NB      Integer.  (INPUT)
-c          Blocksize to be used in the recurrence.          
-c          Only work for NB = 1 right now.  The goal is to have a 
+c          Blocksize to be used in the recurrence.
+c          Only work for NB = 1 right now.  The goal is to have a
 c          program that implement both the block and non-block method.
 c
 c  RESID   Complex*16 array of length N.  (INPUT/OUTPUT)
@@ -74,37 +74,37 @@ c          B-norm of the starting residual on input.
 c          B-norm of the updated residual r_{k+p} on output.
 c
 c  V       Complex*16 N by K+NP array.  (INPUT/OUTPUT)
-c          On INPUT:  V contains the Arnoldi vectors in the first K 
+c          On INPUT:  V contains the Arnoldi vectors in the first K
 c          columns.
 c          On OUTPUT: V contains the new NP Arnoldi vectors in the next
 c          NP columns.  The first K columns are unchanged.
 c
 c  LDV     Integer.  (INPUT)
-c          Leading dimension of V exactly as declared in the calling 
+c          Leading dimension of V exactly as declared in the calling
 c          program.
 c
 c  H       Complex*16 (K+NP) by (K+NP) array.  (INPUT/OUTPUT)
 c          H is used to store the generated upper Hessenberg matrix.
 c
 c  LDH     Integer.  (INPUT)
-c          Leading dimension of H exactly as declared in the calling 
+c          Leading dimension of H exactly as declared in the calling
 c          program.
 c
 c  IPNTR   Integer array of length 3.  (OUTPUT)
-c          Pointer to mark the starting locations in the WORK for 
+c          Pointer to mark the starting locations in the WORK for
 c          vectors used by the Arnoldi iteration.
 c          -------------------------------------------------------------
 c          IPNTR(1): pointer to the current operand vector X.
 c          IPNTR(2): pointer to the current result vector Y.
-c          IPNTR(3): pointer to the vector B * X when used in the 
+c          IPNTR(3): pointer to the vector B * X when used in the
 c                    shift-and-invert mode.  X is the current operand.
 c          -------------------------------------------------------------
-c          
+c
 c  WORKD   Complex*16 work array of length 3*N.  (REVERSE COMMUNICATION)
 c          Distributed array to be used in the basic Arnoldi iteration
-c          for reverse communication.  The calling program should not 
+c          for reverse communication.  The calling program should not
 c          use WORKD as temporary workspace during the iteration !!!!!!
-c          On input, WORKD(1:N) = B*RESID and is used to save some 
+c          On input, WORKD(1:N) = B*RESID and is used to save some
 c          computation at the first step.
 c
 c  INFO    Integer.  (OUTPUT)
@@ -124,7 +124,7 @@ c\References:
 c  1. D.C. Sorensen, "Implicit Application of Polynomial Filters in
 c     a k-Step Arnoldi Method", SIAM J. Matr. Anal. Apps., 13 (1992),
 c     pp 357-385.
-c  2. R.B. Lehoucq, "Analysis and Implementation of an Implicitly 
+c  2. R.B. Lehoucq, "Analysis and Implementation of an Implicitly
 c     Restarted Arnoldi Iteration", Rice University Technical Report
 c     TR95-13, Department of Computational and Applied Mathematics.
 c
@@ -143,29 +143,29 @@ c     dlapy2  LAPACK routine to compute sqrt(x**2+y**2) carefully.
 c     zgemv   Level 2 BLAS routine for matrix vector multiplication.
 c     zaxpy   Level 1 BLAS that computes a vector triad.
 c     zcopy   Level 1 BLAS that copies one vector to another .
-c     zdotc   Level 1 BLAS that computes the scalar product of two vectors. 
+c     zdotc   Level 1 BLAS that computes the scalar product of two vectors.
 c     zscal   Level 1 BLAS that scales a vector.
-c     zdscal  Level 1 BLAS that scales a complex vector by a real number. 
+c     zdscal  Level 1 BLAS that scales a complex vector by a real number.
 c     dznrm2  Level 1 BLAS that computes the norm of a vector.
 c
 c\Author
 c     Danny Sorensen               Phuong Vu
 c     Richard Lehoucq              CRPC / Rice University
-c     Dept. of Computational &     Houston, Texas 
-c     Applied Mathematics 
-c     Rice University           
-c     Houston, Texas 
-c 
+c     Dept. of Computational &     Houston, Texas
+c     Applied Mathematics
+c     Rice University
+c     Houston, Texas
+c
 c\SCCS Information: @(#)
 c FILE: naitr.F   SID: 2.3   DATE OF SID: 8/27/96   RELEASE: 2
 c
 c\Remarks
 c  The algorithm implemented is:
-c  
+c
 c  restart = .false.
-c  Given V_{k} = [v_{1}, ..., v_{k}], r_{k}; 
+c  Given V_{k} = [v_{1}, ..., v_{k}], r_{k};
 c  r_{k} contains the initial residual vector even for k = 0;
-c  Also assume that rnorm = || B*r_{k} || and B*r_{k} are already 
+c  Also assume that rnorm = || B*r_{k} || and B*r_{k} are already
 c  computed by the calling program.
 c
 c  betaj = rnorm ; p_{k+1} = B*r_{k} ;
@@ -173,7 +173,7 @@ c  For  j = k+1, ..., k+np  Do
 c     1) if ( betaj < tol ) stop or restart depending on j.
 c        ( At present tol is zero )
 c        if ( restart ) generate a new starting vector.
-c     2) v_{j} = r(j-1)/betaj;  V_{j} = [V_{j-1}, v_{j}];  
+c     2) v_{j} = r(j-1)/betaj;  V_{j} = [V_{j-1}, v_{j}];
 c        p_{j} = p_{j}/betaj
 c     3) r_{j} = OP*v_{j} where OP is defined as in znaupd
 c        For shift-invert mode p_{j} = B*v_{j} is already available.
@@ -188,7 +188,7 @@ c        If (rnorm > 0.717*wnorm) accept step and go back to 1)
 c     5) Re-orthogonalization step:
 c        s = V_{j}'*B*r_{j}
 c        r_{j} = r_{j} - V_{j}*s;  rnorm1 = || r_{j} ||
-c        alphaj = alphaj + s_{j};   
+c        alphaj = alphaj + s_{j};
 c     6) Iterative refinement step:
 c        If (rnorm1 > 0.717*rnorm) then
 c           rnorm = rnorm1
@@ -198,7 +198,7 @@ c           rnorm = rnorm1
 c           If this is the first time in step 6), go to 5)
 c           Else r_{j} lies in the span of V_{j} numerically.
 c              Set r_{j} = 0 and rnorm = 0; go to 1)
-c        EndIf 
+c        EndIf
 c  End Do
 c
 c\EndLib
@@ -206,7 +206,7 @@ c
 c-----------------------------------------------------------------------
 c
       subroutine znaitr
-     &   (ido, bmat, n, k, np, nb, resid, rnorm, v, ldv, h, ldh, 
+     &   (ido, bmat, n, k, np, nb, resid, rnorm, v, ldv, h, ldh,
      &    ipntr, workd, info)
 c
 c     %----------------------------------------------------%
@@ -241,7 +241,7 @@ c
      &           one, zero
       Double precision
      &           rone, rzero
-      parameter (one = (1.0D+0, 0.0D+0), zero = (0.0D+0, 0.0D+0), 
+      parameter (one = (1.0D+0, 0.0D+0), zero = (0.0D+0, 0.0D+0),
      &           rone = 1.0D+0, rzero = 0.0D+0)
 c
 c     %--------------%
@@ -258,7 +258,7 @@ c
       logical    first, orth1, orth2, rstart, step3, step4
       integer    ierr, i, infol, ipj, irj, ivj, iter, itry, j, msglvl,
      &           jj
-      Double precision            
+      Double precision
      &           ovfl, smlnum, tst1, ulp, unfl, betaj,
      &           temp1, rnorm1, wnorm
       Complex*16
@@ -272,7 +272,7 @@ c     %----------------------%
 c     | External Subroutines |
 c     %----------------------%
 c
-      external   zaxpy, zcopy, zscal, zdscal, zgemv, zgetv0, 
+      external   zaxpy, zcopy, zscal, zdscal, zgemv, zgetv0,
      &           dlabad, zvout, zmout, ivout, second
 c
 c     %--------------------%
@@ -280,8 +280,8 @@ c     | External Functions |
 c     %--------------------%
 c
       Complex*16
-     &           zdotc 
-      Double precision            
+     &           zdotc
+      Double precision
      &           dlamch,  dznrm2, zlanhs, dlapy2
       external   zdotc, dznrm2, zlanhs, dlamch, dlapy2
 c
@@ -289,7 +289,7 @@ c     %---------------------%
 c     | Intrinsic Functions |
 c     %---------------------%
 c
-      intrinsic  dimag, dble, max, sqrt 
+      intrinsic  dimag, dble, max, sqrt
 c
 c     %-----------------%
 c     | Data statements |
@@ -320,7 +320,7 @@ c
       end if
 c
       if (ido .eq. 0) then
-c 
+c
 c        %-------------------------------%
 c        | Initialize timing statistics  |
 c        | & message level for debugging |
@@ -328,7 +328,7 @@ c        %-------------------------------%
 c
          call second (t0)
          msglvl = mcaitr
-c 
+c
 c        %------------------------------%
 c        | Initial call to this routine |
 c        %------------------------------%
@@ -344,7 +344,7 @@ c
          irj    = ipj   + n
          ivj    = irj   + n
       end if
-c 
+c
 c     %-------------------------------------------------%
 c     | When in reverse communication mode one of:      |
 c     | STEP3, STEP4, ORTH1, ORTH2, RSTART              |
@@ -374,16 +374,16 @@ c     |        A R N O L D I     I T E R A T I O N     L O O P       |
 c     |                                                              |
 c     | Note:  B*r_{j-1} is already in WORKD(1:N)=WORKD(IPJ:IPJ+N-1) |
 c     %--------------------------------------------------------------%
- 
+
  1000 continue
 c
          if (msglvl .gt. 1) then
-            call ivout (logfil, 1, [j], ndigit, 
+            call ivout (logfil, 1, [j], ndigit,
      &                  '_naitr: generating Arnoldi vector number')
-            call dvout (logfil, 1, [rnorm], ndigit, 
+            call dvout (logfil, 1, [rnorm], ndigit,
      &                  '_naitr: B-norm of the current residual is')
          end if
-c 
+c
 c        %---------------------------------------------------%
 c        | STEP 1: Check if the B norm of j-th residual      |
 c        | vector is zero. Equivalent to determine whether   |
@@ -403,13 +403,13 @@ c
                call ivout (logfil, 1, [j], ndigit,
      &                     '_naitr: ****** RESTART AT STEP ******')
             end if
-c 
+c
 c           %---------------------------------------------%
 c           | ITRY is the loop variable that controls the |
 c           | maximum amount of times that a restart is   |
 c           | attempted. NRSTRT is used by stat.h         |
 c           %---------------------------------------------%
-c 
+c
             betaj  = rzero
             nrstrt = nrstrt + 1
             itry   = 1
@@ -423,7 +423,7 @@ c           | If in reverse communication mode and |
 c           | RSTART = .true. flow returns here.   |
 c           %--------------------------------------%
 c
-            call zgetv0 (ido, bmat, itry, .false., n, j, v, ldv, 
+            call zgetv0 (ido, bmat, itry, .false., n, j, v, ldv,
      &                   resid, rnorm, ipntr, workd, ierr)
             if (ido .ne. 99) go to 9000
             if (ierr .lt. 0) then
@@ -442,7 +442,7 @@ c
                ido = 99
                go to 9000
             end if
-c 
+c
    40    continue
 c
 c        %---------------------------------------------------------%
@@ -466,7 +466,7 @@ c            %-----------------------------------------%
 c
              call zlascl ('General', i, i, rnorm, rone,
      &                    n, 1, v(1,j), n, infol)
-             call zlascl ('General', i, i, rnorm, rone,  
+             call zlascl ('General', i, i, rnorm, rone,
      &                    n, 1, workd(ipj), n, infol)
          end if
 c
@@ -483,14 +483,14 @@ c
          ipntr(2) = irj
          ipntr(3) = ipj
          ido = 1
-c 
+c
 c        %-----------------------------------%
 c        | Exit in order to compute OP*v_{j} |
 c        %-----------------------------------%
-c 
-         go to 9000 
+c
+         go to 9000
    50    continue
-c 
+c
 c        %----------------------------------%
 c        | Back from reverse communication; |
 c        | WORKD(IRJ:IRJ+N-1) := OP*v_{j}   |
@@ -499,7 +499,7 @@ c        %----------------------------------%
 c
          call second (t3)
          tmvopx = tmvopx + (t3 - t2)
- 
+
          step3 = .false.
 c
 c        %------------------------------------------%
@@ -507,7 +507,7 @@ c        | Put another copy of OP*v_{j} into RESID. |
 c        %------------------------------------------%
 c
          call zcopy (n, workd(irj), 1, resid, 1)
-c 
+c
 c        %---------------------------------------%
 c        | STEP 4:  Finish extending the Arnoldi |
 c        |          factorization to length j.   |
@@ -520,17 +520,17 @@ c
             ipntr(1) = irj
             ipntr(2) = ipj
             ido = 2
-c 
+c
 c           %-------------------------------------%
 c           | Exit in order to compute B*OP*v_{j} |
 c           %-------------------------------------%
-c 
+c
             go to 9000
          else if (bmat .eq. 'I') then
             call zcopy (n, resid, 1, workd(ipj), 1)
          end if
    60    continue
-c 
+c
 c        %----------------------------------%
 c        | Back from reverse communication; |
 c        | WORKD(IPJ:IPJ+N-1) := B*OP*v_{j} |
@@ -541,7 +541,7 @@ c
             call second (t3)
             tmvbx = tmvbx + (t3 - t2)
          end if
-c 
+c
          step4 = .false.
 c
 c        %-------------------------------------%
@@ -549,7 +549,7 @@ c        | The following is needed for STEP 5. |
 c        | Compute the B-norm of OP*v_{j}.     |
 c        %-------------------------------------%
 c
-         if (bmat .eq. 'G') then  
+         if (bmat .eq. 'G') then
              cnorm = zdotc (n, resid, 1, workd(ipj), 1)
              wnorm = sqrt( dlapy2(dble(cnorm),dimag(cnorm)) )
          else if (bmat .eq. 'I') then
@@ -569,13 +569,13 @@ c        %------------------------------------------%
 c        | Compute the j Fourier coefficients w_{j} |
 c        | WORKD(IPJ:IPJ+N-1) contains B*OP*v_{j}.  |
 c        %------------------------------------------%
-c 
+c
          call zgemv ('C', n, j, one, v, ldv, workd(ipj), 1,
      &               zero, h(1,j), 1)
 c
 c        %--------------------------------------%
 c        | Orthogonalize r_{j} against V_{j}.   |
-c        | RESID contains OP*v_{j}. See STEP 3. | 
+c        | RESID contains OP*v_{j}. See STEP 3. |
 c        %--------------------------------------%
 c
          call zgemv ('N', n, j, -one, v, ldv, h(1,j), 1,
@@ -584,9 +584,9 @@ c
          if (j .gt. 1) h(j,j-1) = dcmplx(betaj, rzero)
 c
          call second (t4)
-c 
+c
          orth1 = .true.
-c 
+c
          call second (t2)
          if (bmat .eq. 'G') then
             nbx = nbx + 1
@@ -594,17 +594,17 @@ c
             ipntr(1) = irj
             ipntr(2) = ipj
             ido = 2
-c 
+c
 c           %----------------------------------%
 c           | Exit in order to compute B*r_{j} |
 c           %----------------------------------%
-c 
+c
             go to 9000
          else if (bmat .eq. 'I') then
             call zcopy (n, resid, 1, workd(ipj), 1)
-         end if 
+         end if
    70    continue
-c 
+c
 c        %---------------------------------------------------%
 c        | Back from reverse communication if ORTH1 = .true. |
 c        | WORKD(IPJ:IPJ+N-1) := B*r_{j}.                    |
@@ -614,20 +614,20 @@ c
             call second (t3)
             tmvbx = tmvbx + (t3 - t2)
          end if
-c 
+c
          orth1 = .false.
 c
 c        %------------------------------%
 c        | Compute the B-norm of r_{j}. |
 c        %------------------------------%
 c
-         if (bmat .eq. 'G') then         
+         if (bmat .eq. 'G') then
             cnorm = zdotc (n, resid, 1, workd(ipj), 1)
             rnorm = sqrt( dlapy2(dble(cnorm),dimag(cnorm)) )
          else if (bmat .eq. 'I') then
             rnorm = dznrm2(n, resid, 1)
          end if
-c 
+c
 c        %-----------------------------------------------------------%
 c        | STEP 5: Re-orthogonalization / Iterative refinement phase |
 c        | Maximum NITER_ITREF tries.                                |
@@ -650,20 +650,20 @@ c
 c
          iter  = 0
          nrorth = nrorth + 1
-c 
+c
 c        %---------------------------------------------------%
 c        | Enter the Iterative refinement phase. If further  |
 c        | refinement is necessary, loop back here. The loop |
 c        | variable is ITER. Perform a step of Classical     |
 c        | Gram-Schmidt using all the Arnoldi vectors V_{j}  |
 c        %---------------------------------------------------%
-c 
+c
    80    continue
 c
          if (msglvl .gt. 2) then
             rtemp(1) = wnorm
             rtemp(2) = rnorm
-            call dvout (logfil, 2, rtemp, ndigit, 
+            call dvout (logfil, 2, rtemp, ndigit,
      &      '_naitr: re-orthogonalization; wnorm and rnorm are')
             call zvout (logfil, j, h(1,j), ndigit,
      &                  '_naitr: j-th column of H')
@@ -674,7 +674,7 @@ c        | Compute V_{j}^T * B * r_{j}.                       |
 c        | WORKD(IRJ:IRJ+J-1) = v(:,1:J)'*WORKD(IPJ:IPJ+N-1). |
 c        %----------------------------------------------------%
 c
-         call zgemv ('C', n, j, one, v, ldv, workd(ipj), 1, 
+         call zgemv ('C', n, j, one, v, ldv, workd(ipj), 1,
      &               zero, workd(irj), 1)
 c
 c        %---------------------------------------------%
@@ -684,10 +684,10 @@ c        | The correction to H is v(:,1:J)*H(1:J,1:J)  |
 c        | + v(:,1:J)*WORKD(IRJ:IRJ+J-1)*e'_j.         |
 c        %---------------------------------------------%
 c
-         call zgemv ('N', n, j, -one, v, ldv, workd(irj), 1, 
+         call zgemv ('N', n, j, -one, v, ldv, workd(irj), 1,
      &               one, resid, 1)
          call zaxpy (j, one, workd(irj), 1, h(1,j), 1)
-c 
+c
          orth2 = .true.
          call second (t2)
          if (bmat .eq. 'G') then
@@ -696,16 +696,16 @@ c
             ipntr(1) = irj
             ipntr(2) = ipj
             ido = 2
-c 
+c
 c           %-----------------------------------%
 c           | Exit in order to compute B*r_{j}. |
 c           | r_{j} is the corrected residual.  |
 c           %-----------------------------------%
-c 
+c
             go to 9000
          else if (bmat .eq. 'I') then
             call zcopy (n, resid, 1, workd(ipj), 1)
-         end if 
+         end if
    90    continue
 c
 c        %---------------------------------------------------%
@@ -715,19 +715,19 @@ c
          if (bmat .eq. 'G') then
             call second (t3)
             tmvbx = tmvbx + (t3 - t2)
-         end if 
+         end if
 c
 c        %-----------------------------------------------------%
 c        | Compute the B-norm of the corrected residual r_{j}. |
 c        %-----------------------------------------------------%
-c 
-         if (bmat .eq. 'G') then         
+c
+         if (bmat .eq. 'G') then
              cnorm  = zdotc (n, resid, 1, workd(ipj), 1)
              rnorm1 = sqrt( dlapy2(dble(cnorm),dimag(cnorm)) )
          else if (bmat .eq. 'I') then
              rnorm1 = dznrm2(n, resid, 1)
          end if
-c 
+c
          if (msglvl .gt. 0 .and. iter .gt. 0 ) then
             call ivout (logfil, 1, [j], ndigit,
      &           '_naitr: Iterative refinement for Arnoldi residual')
@@ -757,7 +757,7 @@ c           | angle of less than arcCOS(0.717)      |
 c           %---------------------------------------%
 c
             rnorm = rnorm1
-c 
+c
          else
 c
 c           %-------------------------------------------%
@@ -776,24 +776,24 @@ c           %-------------------------------------------------%
 c
             do 95 jj = 1, n
                resid(jj) = zero
-  95        continue 
+  95        continue
             rnorm = rzero
          end if
-c 
+c
 c        %----------------------------------------------%
 c        | Branch here directly if iterative refinement |
 c        | wasn't necessary or after at most NITER_REF  |
 c        | steps of iterative refinement.               |
 c        %----------------------------------------------%
-c 
+c
   100    continue
-c 
+c
          rstart = .false.
          orth2  = .false.
-c 
+c
          call second (t5)
          titref = titref + (t5 - t4)
-c 
+c
 c        %------------------------------------%
 c        | STEP 6: Update  j = j+1;  Continue |
 c        %------------------------------------%
@@ -804,27 +804,27 @@ c
             tcaitr = tcaitr + (t1 - t0)
             ido = 99
             do 110 i = max(1,k), k+np-1
-c     
+c
 c              %--------------------------------------------%
 c              | Check for splitting and deflation.         |
 c              | Use a standard test as in the QR algorithm |
 c              | REFERENCE: LAPACK subroutine zlahqr        |
 c              %--------------------------------------------%
-c     
+c
                tst1 = dlapy2(dble(h(i,i)),dimag(h(i,i)))
      &              + dlapy2(dble(h(i+1,i+1)), dimag(h(i+1,i+1)))
                if( tst1.eq.dble(zero) )
      &              tst1 = zlanhs( '1', k+np, h, ldh, workd(n+1) )
-               if( dlapy2(dble(h(i+1,i)),dimag(h(i+1,i))) .le. 
-     &                    max( ulp*tst1, smlnum ) ) 
+               if( dlapy2(dble(h(i+1,i)),dimag(h(i+1,i))) .le.
+     &                    max( ulp*tst1, smlnum ) )
      &             h(i+1,i) = zero
  110        continue
-c     
+c
             if (msglvl .gt. 2) then
-               call zmout (logfil, k+np, k+np, h, ldh, ndigit, 
+               call zmout (logfil, k+np, k+np, h, ldh, ndigit,
      &          '_naitr: Final upper Hessenberg matrix H of order K+NP')
             end if
-c     
+c
             go to 9000
          end if
 c
@@ -833,7 +833,7 @@ c        | Loop back to extend the factorization by another step. |
 c        %--------------------------------------------------------%
 c
       go to 1000
-c 
+c
 c     %---------------------------------------------------------------%
 c     |                                                               |
 c     |  E N D     O F     M A I N     I T E R A T I O N     L O O P  |

--- a/mathlibs/src/arpack/znaitr.f
+++ b/mathlibs/src/arpack/znaitr.f
@@ -378,9 +378,9 @@ c     %--------------------------------------------------------------%
  1000 continue
 c
          if (msglvl .gt. 1) then
-            call ivout (logfil, 1, j, ndigit, 
+            call ivout (logfil, 1, [j], ndigit, 
      &                  '_naitr: generating Arnoldi vector number')
-            call dvout (logfil, 1, rnorm, ndigit, 
+            call dvout (logfil, 1, [rnorm], ndigit, 
      &                  '_naitr: B-norm of the current residual is')
          end if
 c 
@@ -400,7 +400,7 @@ c           | basis and continue the iteration.                 |
 c           %---------------------------------------------------%
 c
             if (msglvl .gt. 0) then
-               call ivout (logfil, 1, j, ndigit,
+               call ivout (logfil, 1, [j], ndigit,
      &                     '_naitr: ****** RESTART AT STEP ******')
             end if
 c 
@@ -729,7 +729,7 @@ c
          end if
 c 
          if (msglvl .gt. 0 .and. iter .gt. 0 ) then
-            call ivout (logfil, 1, j, ndigit,
+            call ivout (logfil, 1, [j], ndigit,
      &           '_naitr: Iterative refinement for Arnoldi residual')
             if (msglvl .gt. 2) then
                 rtemp(1) = rnorm

--- a/mathlibs/src/arpack/znapps.f
+++ b/mathlibs/src/arpack/znapps.f
@@ -268,9 +268,9 @@ c
          sigma = shift(jj)
 c
          if (msglvl .gt. 2 ) then
-            call ivout (logfil, 1, jj, ndigit, 
+            call ivout (logfil, 1, [jj], ndigit, 
      &               '_napps: shift number.')
-            call zvout (logfil, 1, sigma, ndigit, 
+            call zvout (logfil, 1, [sigma], ndigit, 
      &               '_napps: Value of the shift ')
          end if
 c
@@ -291,9 +291,9 @@ c
             if ( abs(dble(h(i+1,i))) 
      &           .le. max(ulp*tst1, smlnum) )  then
                if (msglvl .gt. 0) then
-                  call ivout (logfil, 1, i, ndigit, 
+                  call ivout (logfil, 1, [i], ndigit, 
      &                 '_napps: matrix splitting at row/column no.')
-                  call ivout (logfil, 1, jj, ndigit, 
+                  call ivout (logfil, 1, [jj], ndigit, 
      &                 '_napps: matrix splitting with shift number.')
                   call zvout (logfil, 1, h(i+1,i), ndigit, 
      &                 '_napps: off diagonal element.')
@@ -307,9 +307,9 @@ c
    40    continue
 c
          if (msglvl .gt. 2) then
-             call ivout (logfil, 1, istart, ndigit, 
+             call ivout (logfil, 1, [istart], ndigit, 
      &                   '_napps: Start of current block ')
-             call ivout (logfil, 1, iend, ndigit, 
+             call ivout (logfil, 1, [iend], ndigit, 
      &                   '_napps: End of current block ')
          end if
 c
@@ -485,7 +485,7 @@ c
      &        '_napps: sigmak = (e_{kev+p}^T*Q)*e_{kev}')
          call zvout (logfil, 1, h(kev+1,kev), ndigit,
      &        '_napps: betak = e_{kev+1}^T*H*e_{kev}')
-         call ivout (logfil, 1, kev, ndigit, 
+         call ivout (logfil, 1, [kev], ndigit, 
      &               '_napps: Order of the final Hessenberg matrix ')
          if (msglvl .gt. 2) then
             call zmout (logfil, kev, kev, h, ldh, ndigit,

--- a/mathlibs/src/arpack/znapps.f
+++ b/mathlibs/src/arpack/znapps.f
@@ -19,7 +19,7 @@ c     A*VNEW_{k} - VNEW_{k}*HNEW_{k} = rnew_{k}*e_{k}^T.
 c
 c\Usage:
 c  call znapps
-c     ( N, KEV, NP, SHIFT, V, LDV, H, LDH, RESID, Q, LDQ, 
+c     ( N, KEV, NP, SHIFT, V, LDV, H, LDH, RESID, Q, LDQ,
 c       WORKL, WORKD )
 c
 c\Arguments
@@ -28,7 +28,7 @@ c          Problem size, i.e. size of matrix A.
 c
 c  KEV     Integer.  (INPUT/OUTPUT)
 c          KEV+NP is the size of the input matrix H.
-c          KEV is the size of the updated matrix HNEW. 
+c          KEV is the size of the updated matrix HNEW.
 c
 c  NP      Integer.  (INPUT)
 c          Number of implicit shifts to be applied.
@@ -46,7 +46,7 @@ c          Leading dimension of V exactly as declared in the calling
 c          program.
 c
 c  H       Complex*16 (KEV+NP) by (KEV+NP) array.  (INPUT/OUTPUT)
-c          On INPUT, H contains the current KEV+NP by KEV+NP upper 
+c          On INPUT, H contains the current KEV+NP by KEV+NP upper
 c          Hessenberg matrix of the Arnoldi factorization.
 c          On OUTPUT, H contains the updated KEV by KEV upper Hessenberg
 c          matrix in the KEV leading submatrix.
@@ -57,7 +57,7 @@ c          program.
 c
 c  RESID   Complex*16 array of length N.  (INPUT/OUTPUT)
 c          On INPUT, RESID contains the the residual vector r_{k+p}.
-c          On OUTPUT, RESID is the update residual vector rnew_{k} 
+c          On OUTPUT, RESID is the update residual vector rnew_{k}
 c          in the first KEV locations.
 c
 c  Q       Complex*16 KEV+NP by KEV+NP work array.  (WORKSPACE)
@@ -112,9 +112,9 @@ c\Author
 c     Danny Sorensen               Phuong Vu
 c     Richard Lehoucq              CRPC / Rice University
 c     Dept. of Computational &     Houston, Texas
-c     Applied Mathematics 
-c     Rice University           
-c     Houston, Texas 
+c     Applied Mathematics
+c     Rice University
+c     Houston, Texas
 c
 c\SCCS Information: @(#)
 c FILE: napps.F   SID: 2.2   DATE OF SID: 4/20/96   RELEASE: 2
@@ -132,7 +132,7 @@ c
 c-----------------------------------------------------------------------
 c
       subroutine znapps
-     &   ( n, kev, np, shift, v, ldv, h, ldh, resid, q, ldq, 
+     &   ( n, kev, np, shift, v, ldv, h, ldh, resid, q, ldq,
      &     workl, workd )
 c
 c     %----------------------------------------------------%
@@ -153,7 +153,7 @@ c     | Array Arguments |
 c     %-----------------%
 c
       Complex*16
-     &           h(ldh,kev+np), resid(n), shift(np), 
+     &           h(ldh,kev+np), resid(n), shift(np),
      &           v(ldv,kev+np), q(ldq,kev+np), workd(2*n), workl(kev+np)
 c
 c     %------------%
@@ -175,22 +175,22 @@ c
       logical    first
       Complex*16
      &           cdum, f, g, h11, h21, r, s, sigma, t
-      Double precision             
+      Double precision
      &           c,  ovfl, smlnum, ulp, unfl, tst1
-      save       first, ovfl, smlnum, ulp, unfl 
+      save       first, ovfl, smlnum, ulp, unfl
 c
 c     %----------------------%
 c     | External Subroutines |
 c     %----------------------%
 c
-      external   zaxpy, zcopy, zgemv, zscal, zlacpy, zlartg, 
+      external   zaxpy, zcopy, zgemv, zscal, zlacpy, zlartg,
      &           zvout, zlaset, dlabad, zmout, second, ivout
 c
 c     %--------------------%
 c     | External Functions |
 c     %--------------------%
 c
-      Double precision                 
+      Double precision
      &           zlanhs, dlamch, dlapy2
       external   zlanhs, dlamch, dlapy2
 c
@@ -204,7 +204,7 @@ c     %---------------------%
 c     | Statement Functions |
 c     %---------------------%
 c
-      Double precision     
+      Double precision
      &           zabs1
       zabs1( cdum ) = abs( dble( cdum ) ) + abs( dimag( cdum ) )
 c
@@ -242,9 +242,9 @@ c     %-------------------------------%
 c
       call second (t0)
       msglvl = mcapps
-c 
-      kplusp = kev + np 
-c 
+c
+      kplusp = kev + np
+c
 c     %--------------------------------------------%
 c     | Initialize Q to the identity to accumulate |
 c     | the rotations and reflections              |
@@ -268,9 +268,9 @@ c
          sigma = shift(jj)
 c
          if (msglvl .gt. 2 ) then
-            call ivout (logfil, 1, [jj], ndigit, 
+            call ivout (logfil, 1, [jj], ndigit,
      &               '_napps: shift number.')
-            call zvout (logfil, 1, [sigma], ndigit, 
+            call zvout (logfil, 1, [sigma], ndigit,
      &               '_napps: Value of the shift ')
          end if
 c
@@ -288,14 +288,14 @@ c
             tst1 = zabs1( h( i, i ) ) + zabs1( h( i+1, i+1 ) )
             if( tst1.eq.rzero )
      &         tst1 = zlanhs( '1', kplusp-jj+1, h, ldh, workl )
-            if ( abs(dble(h(i+1,i))) 
+            if ( abs(dble(h(i+1,i)))
      &           .le. max(ulp*tst1, smlnum) )  then
                if (msglvl .gt. 0) then
-                  call ivout (logfil, 1, [i], ndigit, 
+                  call ivout (logfil, 1, [i], ndigit,
      &                 '_napps: matrix splitting at row/column no.')
-                  call ivout (logfil, 1, [jj], ndigit, 
+                  call ivout (logfil, 1, [jj], ndigit,
      &                 '_napps: matrix splitting with shift number.')
-                  call zvout (logfil, 1, h(i+1,i), ndigit, 
+                  call zvout (logfil, 1, h(i+1,i), ndigit,
      &                 '_napps: off diagonal element.')
                end if
                iend = i
@@ -307,9 +307,9 @@ c
    40    continue
 c
          if (msglvl .gt. 2) then
-             call ivout (logfil, 1, [istart], ndigit, 
+             call ivout (logfil, 1, [istart], ndigit,
      &                   '_napps: Start of current block ')
-             call ivout (logfil, 1, [iend], ndigit, 
+             call ivout (logfil, 1, [iend], ndigit,
      &                   '_napps: End of current block ')
          end if
 c
@@ -325,7 +325,7 @@ c
          h21 = h(istart+1,istart)
          f = h11 - sigma
          g = h21
-c 
+c
          do 80 i = istart, iend-1
 c
 c           %------------------------------------------------------%
@@ -345,7 +345,7 @@ c
             do 50 j = i, kplusp
                t        =  c*h(i,j) + s*h(i+1,j)
                h(i+1,j) = -conjg(s)*h(i,j) + c*h(i+1,j)
-               h(i,j)   = t   
+               h(i,j)   = t
    50       continue
 c
 c           %---------------------------------------------%
@@ -355,7 +355,7 @@ c
             do 60 j = 1, min(i+2,iend)
                t        =  c*h(j,i) + conjg(s)*h(j,i+1)
                h(j,i+1) = -s*h(j,i) + c*h(j,i+1)
-               h(j,i)   = t   
+               h(j,i)   = t
    60       continue
 c
 c           %-----------------------------------------------------%
@@ -365,7 +365,7 @@ c
             do 70 j = 1, min(j+jj, kplusp)
                t        =   c*q(j,i) + conjg(s)*q(j,i+1)
                q(j,i+1) = - s*q(j,i) + c*q(j,i+1)
-               q(j,i)   = t   
+               q(j,i)   = t
    70       continue
 c
 c           %---------------------------%
@@ -381,7 +381,7 @@ c
 c        %-------------------------------%
 c        | Finished applying the shift.  |
 c        %-------------------------------%
-c 
+c
   100    continue
 c
 c        %---------------------------------------------------------%
@@ -428,7 +428,7 @@ c
          tst1 = zabs1( h( i, i ) ) + zabs1( h( i+1, i+1 ) )
          if( tst1 .eq. rzero )
      &       tst1 = zlanhs( '1', kev, h, ldh, workl )
-         if( dble( h( i+1,i ) ) .le. max( ulp*tst1, smlnum ) ) 
+         if( dble( h( i+1,i ) ) .le. max( ulp*tst1, smlnum ) )
      &       h(i+1,i) = zero
  130  continue
 c
@@ -441,9 +441,9 @@ c     | of H would be zero as in exact arithmetic.      |
 c     %-------------------------------------------------%
 c
       if ( dble( h(kev+1,kev) ) .gt. rzero )
-     &   call zgemv ('N', n, kplusp, one, v, ldv, q(1,kev+1), 1, zero, 
+     &   call zgemv ('N', n, kplusp, one, v, ldv, q(1,kev+1), 1, zero,
      &                workd(n+1), 1)
-c 
+c
 c     %----------------------------------------------------------%
 c     | Compute column 1 to kev of (V*Q) in backward order       |
 c     | taking advantage of the upper Hessenberg structure of Q. |
@@ -460,14 +460,14 @@ c     |  Move v(:,kplusp-kev+1:kplusp) into v(:,1:kev). |
 c     %-------------------------------------------------%
 c
       call zlacpy ('A', n, kev, v(1,kplusp-kev+1), ldv, v, ldv)
-c 
+c
 c     %--------------------------------------------------------------%
 c     | Copy the (kev+1)-st column of (V*Q) in the appropriate place |
 c     %--------------------------------------------------------------%
 c
       if ( dble( h(kev+1,kev) ) .gt. rzero )
      &   call zcopy (n, workd(n+1), 1, v(1,kev+1), 1)
-c 
+c
 c     %-------------------------------------%
 c     | Update the residual vector:         |
 c     |    r <- sigmak*r + betak*v(:,kev+1) |
@@ -485,7 +485,7 @@ c
      &        '_napps: sigmak = (e_{kev+p}^T*Q)*e_{kev}')
          call zvout (logfil, 1, h(kev+1,kev), ndigit,
      &        '_napps: betak = e_{kev+1}^T*H*e_{kev}')
-         call ivout (logfil, 1, [kev], ndigit, 
+         call ivout (logfil, 1, [kev], ndigit,
      &               '_napps: Order of the final Hessenberg matrix ')
          if (msglvl .gt. 2) then
             call zmout (logfil, kev, kev, h, ldh, ndigit,
@@ -497,7 +497,7 @@ c
  9000 continue
       call second (t1)
       tcapps = tcapps + (t1 - t0)
-c 
+c
       return
 c
 c     %---------------%

--- a/mathlibs/src/arpack/znaup2.f
+++ b/mathlibs/src/arpack/znaup2.f
@@ -2,13 +2,13 @@ c\BeginDoc
 c
 c\Name: znaup2
 c
-c\Description: 
+c\Description:
 c  Intermediate level interface called by znaupd.
 c
 c\Usage:
 c  call znaup2
 c     ( IDO, BMAT, N, WHICH, NEV, NP, TOL, RESID, MODE, IUPD,
-c       ISHIFT, MXITER, V, LDV, H, LDH, RITZ, BOUNDS, 
+c       ISHIFT, MXITER, V, LDV, H, LDH, RITZ, BOUNDS,
 c       Q, LDQ, WORKL, IPNTR, WORKD, RWORK, INFO )
 c
 c\Arguments
@@ -38,27 +38,27 @@ c          IUPD .EQ. 0: use explicit restart instead implicit update.
 c          IUPD .NE. 0: use implicit update.
 c
 c  V       Complex*16 N by (NEV+NP) array.  (INPUT/OUTPUT)
-c          The Arnoldi basis vectors are returned in the first NEV 
+c          The Arnoldi basis vectors are returned in the first NEV
 c          columns of V.
 c
 c  LDV     Integer.  (INPUT)
-c          Leading dimension of V exactly as declared in the calling 
+c          Leading dimension of V exactly as declared in the calling
 c          program.
 c
 c  H       Complex*16 (NEV+NP) by (NEV+NP) array.  (OUTPUT)
 c          H is used to store the generated upper Hessenberg matrix
 c
 c  LDH     Integer.  (INPUT)
-c          Leading dimension of H exactly as declared in the calling 
+c          Leading dimension of H exactly as declared in the calling
 c          program.
 c
 c  RITZ    Complex*16 array of length NEV+NP.  (OUTPUT)
 c          RITZ(1:NEV)  contains the computed Ritz values of OP.
 c
 c  BOUNDS  Complex*16 array of length NEV+NP.  (OUTPUT)
-c          BOUNDS(1:NEV) contain the error bounds corresponding to 
+c          BOUNDS(1:NEV) contain the error bounds corresponding to
 c          the computed Ritz values.
-c          
+c
 c  Q       Complex*16 (NEV+NP) by (NEV+NP) array.  (WORKSPACE)
 c          Private (replicated) work array used to accumulate the
 c          rotation in the shift application step.
@@ -67,7 +67,7 @@ c  LDQ     Integer.  (INPUT)
 c          Leading dimension of Q exactly as declared in the calling
 c          program.
 c
-c  WORKL   Complex*16 work array of length at least 
+c  WORKL   Complex*16 work array of length at least
 c          (NEV+NP)**2 + 3*(NEV+NP).  (WORKSPACE)
 c          Private (replicated) array on each PE or array allocated on
 c          the front end.  It is used in shifts calculation, shifts
@@ -75,15 +75,15 @@ c          application and convergence checking.
 c
 c
 c  IPNTR   Integer array of length 3.  (OUTPUT)
-c          Pointer to mark the starting locations in the WORKD for 
+c          Pointer to mark the starting locations in the WORKD for
 c          vectors used by the Arnoldi iteration.
 c          -------------------------------------------------------------
 c          IPNTR(1): pointer to the current operand vector X.
 c          IPNTR(2): pointer to the current result vector Y.
-c          IPNTR(3): pointer to the vector B * X when used in the 
+c          IPNTR(3): pointer to the vector B * X when used in the
 c                    shift-and-invert mode.  X is the current operand.
 c          -------------------------------------------------------------
-c          
+c
 c  WORKD   Complex*16 work array of length 3*N.  (WORKSPACE)
 c          Distributed array to be used in the basic Arnoldi iteration
 c          for reverse communication.  The user should not use WORKD
@@ -101,7 +101,7 @@ c                          possibly from a previous run.
 c          Error flag on output.
 c          =     0: Normal return.
 c          =     1: Maximum number of iterations taken.
-c                   All possible eigenvalues of OP has been found.  
+c                   All possible eigenvalues of OP has been found.
 c                   NP returns the number of converged Ritz values.
 c          =     2: No shifts could be applied.
 c          =    -8: Error return from LAPACK eigenvalue calculation;
@@ -123,15 +123,15 @@ c\References:
 c  1. D.C. Sorensen, "Implicit Application of Polynomial Filters in
 c     a k-Step Arnoldi Method", SIAM J. Matr. Anal. Apps., 13 (1992),
 c     pp 357-385.
-c  2. R.B. Lehoucq, "Analysis and Implementation of an Implicitly 
+c  2. R.B. Lehoucq, "Analysis and Implementation of an Implicitly
 c     Restarted Arnoldi Iteration", Rice University Technical Report
 c     TR95-13, Department of Computational and Applied Mathematics.
 c
 c\Routines called:
-c     zgetv0  ARPACK initial vector generation routine. 
+c     zgetv0  ARPACK initial vector generation routine.
 c     znaitr  ARPACK Arnoldi factorization routine.
 c     znapps  ARPACK application of implicit shifts routine.
-c     zneigh  ARPACK compute Ritz values and error bounds routine. 
+c     zneigh  ARPACK compute Ritz values and error bounds routine.
 c     zngets  ARPACK reorder Ritz values and error bounds routine.
 c     zsortc  ARPACK sorting routine.
 c     ivout   ARPACK utility routine that prints integers.
@@ -142,7 +142,7 @@ c     dvout   ARPACK utility routine that prints vectors.
 c     dlamch  LAPACK routine that determines machine constants.
 c     dlapy2  LAPACK routine to compute sqrt(x**2+y**2) carefully.
 c     zcopy   Level 1 BLAS that copies one vector to another .
-c     zdotc   Level 1 BLAS that computes the scalar product of two vectors. 
+c     zdotc   Level 1 BLAS that computes the scalar product of two vectors.
 c     zswap   Level 1 BLAS that swaps two vectors.
 c     dznrm2  Level 1 BLAS that computes the norm of a vector.
 c
@@ -151,10 +151,10 @@ c     Danny Sorensen               Phuong Vu
 c     Richard Lehoucq              CRPC / Rice Universitya
 c     Chao Yang                    Houston, Texas
 c     Dept. of Computational &
-c     Applied Mathematics 
-c     Rice University           
-c     Houston, Texas 
-c 
+c     Applied Mathematics
+c     Rice University
+c     Houston, Texas
+c
 c\SCCS Information: @(#)
 c FILE: naup2.F   SID: 2.5   DATE OF SID: 8/16/96   RELEASE: 2
 c
@@ -166,8 +166,8 @@ c
 c-----------------------------------------------------------------------
 c
       subroutine znaup2
-     &   ( ido, bmat, n, which, nev, np, tol, resid, mode, iupd, 
-     &     ishift, mxiter, v, ldv, h, ldh, ritz, bounds, 
+     &   ( ido, bmat, n, which, nev, np, tol, resid, mode, iupd,
+     &     ishift, mxiter, v, ldv, h, ldh, ritz, bounds,
      &     q, ldq, workl, ipntr, workd, rwork, info )
 c
 c     %----------------------------------------------------%
@@ -184,7 +184,7 @@ c
       character  bmat*1, which*2
       integer    ido, info, ishift, iupd, mode, ldh, ldq, ldv, mxiter,
      &           n, nev, np
-      Double precision  
+      Double precision
      &           tol
 c
 c     %-----------------%
@@ -193,10 +193,10 @@ c     %-----------------%
 c
       integer    ipntr(13)
       Complex*16
-     &           bounds(nev+np), h(ldh,nev+np), q(ldq,nev+np), 
-     &           resid(n), ritz(nev+np),  v(ldv,nev+np), 
+     &           bounds(nev+np), h(ldh,nev+np), q(ldq,nev+np),
+     &           resid(n), ritz(nev+np),  v(ldv,nev+np),
      &           workd(3*n), workl( (nev+np)*(nev+np+3) )
-       Double precision  
+       Double precision
      &           rwork(nev+np)
 c
 c     %------------%
@@ -215,7 +215,7 @@ c     | Local Scalars |
 c     %---------------%
 c
       logical    cnorm, getv0, initv, update, ushift
-      integer    ierr, iter, i, j, kplusp, msglvl, nconv, nevbef, nev0, 
+      integer    ierr, iter, i, j, kplusp, msglvl, nconv, nevbef, nev0,
      &           np0, nptemp
       Complex*16
      &           cmpnorm
@@ -223,8 +223,8 @@ c
      &           rtemp, eps23, rnorm
       character  wprime*2
 c
-      save       cnorm, getv0, initv, update, ushift, 
-     &           iter, kplusp, msglvl, nconv, nev0, np0, 
+      save       cnorm, getv0, initv, update, ushift,
+     &           iter, kplusp, msglvl, nconv, nev0, np0,
      &           eps23,rnorm
 c
 c
@@ -247,7 +247,7 @@ c     %--------------------%
 c
       Complex*16
      &           zdotc
-      Double precision  
+      Double precision
      &           dznrm2, dlamch, dlapy2
       external   zdotc, dznrm2, dlamch, dlapy2
 c
@@ -262,11 +262,11 @@ c     | Executable Statements |
 c     %-----------------------%
 c
       if (ido .eq. 0) then
-c 
+c
          call second (t0)
-c 
+c
          msglvl = mcaup2
-c 
+c
          nev0   = nev
          np0    = np
 c
@@ -282,7 +282,7 @@ c
          kplusp = nev + np
          nconv  = 0
          iter   = 0
-c 
+c
 c        %---------------------------------%
 c        | Get machine dependent constant. |
 c        %---------------------------------%
@@ -312,7 +312,7 @@ c
             initv = .false.
          end if
       end if
-c 
+c
 c     %---------------------------------------------%
 c     | Get a possibly random starting vector and   |
 c     | force it into the range of the operator OP. |
@@ -329,7 +329,7 @@ c
          if (rnorm .eq. rzero) then
 c
 c           %-----------------------------------------%
-c           | The initial vector is zero. Error exit. | 
+c           | The initial vector is zero. Error exit. |
 c           %-----------------------------------------%
 c
             info = -9
@@ -338,7 +338,7 @@ c
          getv0 = .false.
          ido  = 0
       end if
-c 
+c
 c     %-----------------------------------%
 c     | Back from reverse communication : |
 c     | continue with update step         |
@@ -358,12 +358,12 @@ c     | at the end of the current iteration |
 c     %-------------------------------------%
 c
       if (cnorm)  go to 100
-c 
+c
 c     %----------------------------------------------------------%
 c     | Compute the first NEV steps of the Arnoldi factorization |
 c     %----------------------------------------------------------%
 c
-      call znaitr (ido, bmat, n, 0, nev, mode, resid, rnorm, v, ldv, 
+      call znaitr (ido, bmat, n, 0, nev, mode, resid, rnorm, v, ldv,
      &             h, ldh, ipntr, workd, info)
 c
       if (ido .ne. 99) go to 9000
@@ -374,7 +374,7 @@ c
          info = -9999
          go to 1200
       end if
-c 
+c
 c     %--------------------------------------------------------------%
 c     |                                                              |
 c     |           M A I N  ARNOLDI  I T E R A T I O N  L O O P       |
@@ -382,16 +382,16 @@ c     |           Each iteration implicitly restarts the Arnoldi     |
 c     |           factorization in place.                            |
 c     |                                                              |
 c     %--------------------------------------------------------------%
-c 
+c
  1000 continue
 c
          iter = iter + 1
 c
          if (msglvl .gt. 0) then
-            call ivout (logfil, 1, [iter], ndigit, 
+            call ivout (logfil, 1, [iter], ndigit,
      &           '_naup2: **** Start of major iteration number ****')
          end if
-c 
+c
 c        %-----------------------------------------------------------%
 c        | Compute NP additional steps of the Arnoldi factorization. |
 c        | Adjust NP since NEV might have been updated by last call  |
@@ -401,9 +401,9 @@ c
          np  = kplusp - nev
 c
          if (msglvl .gt. 1) then
-            call ivout (logfil, 1, [nev], ndigit, 
+            call ivout (logfil, 1, [nev], ndigit,
      &     '_naup2: The length of the current Arnoldi factorization')
-            call ivout (logfil, 1, [np], ndigit, 
+            call ivout (logfil, 1, [np], ndigit,
      &           '_naup2: Extend the Arnoldi factorization by')
          end if
 c
@@ -429,10 +429,10 @@ c
          update = .false.
 c
          if (msglvl .gt. 1) then
-            call dvout (logfil, 1, [rnorm], ndigit, 
+            call dvout (logfil, 1, [rnorm], ndigit,
      &           '_naup2: Corresponding B-norm of the residual')
          end if
-c 
+c
 c        %--------------------------------------------------------%
 c        | Compute the eigenvalues and corresponding error bounds |
 c        | of the current upper Hessenberg matrix.                |
@@ -451,7 +451,7 @@ c        | Select the wanted Ritz values and their bounds    |
 c        | to be used in the convergence test.               |
 c        | The wanted part of the spectrum and corresponding |
 c        | error bounds are in the last NEV loc. of RITZ,    |
-c        | and BOUNDS respectively.                          | 
+c        | and BOUNDS respectively.                          |
 c        %---------------------------------------------------%
 c
          nev = nev0
@@ -474,7 +474,7 @@ c        | BOUNDS respectively.                              |
 c        %---------------------------------------------------%
 c
          call zngets (ishift, which, nev, np, ritz, bounds)
-c 
+c
 c        %------------------------------------------------------------%
 c        | Convergence test: currently we use the following criteria. |
 c        | The relative accuracy of a Ritz value is considered        |
@@ -488,22 +488,22 @@ c
 c
          do 25 i = 1, nev
             rtemp = max( eps23, dlapy2( dble(ritz(np+i)),
-     &                                  dimag(ritz(np+i)) ) ) 
-            if ( dlapy2(dble(bounds(np+i)),dimag(bounds(np+i))) 
+     &                                  dimag(ritz(np+i)) ) )
+            if ( dlapy2(dble(bounds(np+i)),dimag(bounds(np+i)))
      &                 .le. tol*rtemp ) then
                nconv = nconv + 1
             end if
    25    continue
-c 
+c
          if (msglvl .gt. 2) then
             kp(1) = nev
             kp(2) = np
             kp(3) = nconv
-            call ivout (logfil, 3, kp, ndigit, 
+            call ivout (logfil, 3, kp, ndigit,
      &                  '_naup2: NEV, NP, NCONV are')
             call zvout (logfil, kplusp, ritz, ndigit,
      &           '_naup2: The eigenvalues of H')
-            call zvout (logfil, kplusp, bounds, ndigit, 
+            call zvout (logfil, kplusp, bounds, ndigit,
      &          '_naup2: Ritz estimates of the current NCV Ritz values')
          end if
 c
@@ -524,8 +524,8 @@ c
                nev = nev + 1
             end if
  30      continue
-c     
-         if ( (nconv .ge. nev0) .or. 
+c
+         if ( (nconv .ge. nev0) .or.
      &        (iter .gt. mxiter) .or.
      &        (np .eq. 0) ) then
 c
@@ -536,7 +536,7 @@ c
      &                     ndigit,
      &             '_naup2: Ritz estimates computed by _neigh:')
             end if
-c     
+c
 c           %------------------------------------------------%
 c           | Prepare to exit. Put the converged Ritz values |
 c           | and corresponding bounds in RITZ(1:NCONV) and  |
@@ -572,7 +572,7 @@ c           | Scale the Ritz estimate of each Ritz value       |
 c           | by 1 / max(eps23, magnitude of the Ritz value).  |
 c           %--------------------------------------------------%
 c
-            do 35 j = 1, nev0 
+            do 35 j = 1, nev0
                 rtemp = max( eps23, dlapy2( dble(ritz(j)),
      &                                       dimag(ritz(j)) ) )
                 bounds(j) = bounds(j)/rtemp
@@ -615,13 +615,13 @@ c
             end if
 c
 c           %------------------------------------%
-c           | Max iterations have been exceeded. | 
+c           | Max iterations have been exceeded. |
 c           %------------------------------------%
 c
             if (iter .gt. mxiter .and. nconv .lt. nev0) info = 1
 c
 c           %---------------------%
-c           | No shifts to apply. | 
+c           | No shifts to apply. |
 c           %---------------------%
 c
             if (np .eq. 0 .and. nconv .lt. nev0)  info = 2
@@ -630,7 +630,7 @@ c
             go to 1100
 c
          else if ( (nconv .lt. nev0) .and. (ishift .eq. 1) ) then
-c     
+c
 c           %-------------------------------------------------%
 c           | Do not have all the requested eigenvalues yet.  |
 c           | To prevent possible stagnation, adjust the size |
@@ -645,24 +645,24 @@ c
                nev = 2
             end if
             np = kplusp - nev
-c     
+c
 c           %---------------------------------------%
 c           | If the size of NEV was just increased |
 c           | resort the eigenvalues.               |
 c           %---------------------------------------%
-c     
-            if (nevbef .lt. nev) 
+c
+            if (nevbef .lt. nev)
      &         call zngets (ishift, which, nev, np, ritz, bounds)
 c
-         end if              
-c     
+         end if
+c
          if (msglvl .gt. 0) then
-            call ivout (logfil, 1, [nconv], ndigit, 
+            call ivout (logfil, 1, [nconv], ndigit,
      &           '_naup2: no. of "converged" Ritz values at this iter.')
             if (msglvl .gt. 1) then
                kp(1) = nev
                kp(2) = np
-               call ivout (logfil, 2, kp, ndigit, 
+               call ivout (logfil, 2, kp, ndigit,
      &              '_naup2: NEV and NP are')
                call zvout (logfil, nev, ritz(np+1), ndigit,
      &              '_naup2: "wanted" Ritz values ')
@@ -686,7 +686,7 @@ c
          ushift = .false.
 c
          if ( ishift .ne. 1 ) then
-c 
+c
 c            %----------------------------------%
 c            | Move the NP shifts from WORKL to |
 c            | RITZ, to free up WORKL           |
@@ -696,12 +696,12 @@ c
              call zcopy (np, workl, 1, ritz, 1)
          end if
 c
-         if (msglvl .gt. 2) then 
-            call ivout (logfil, 1, [np], ndigit, 
+         if (msglvl .gt. 2) then
+            call ivout (logfil, 1, [np], ndigit,
      &                  '_naup2: The number of shifts to apply ')
             call zvout (logfil, np, ritz, ndigit,
      &                  '_naup2: values of the shifts')
-            if ( ishift .eq. 1 ) 
+            if ( ishift .eq. 1 )
      &          call zvout (logfil, np, bounds, ndigit,
      &                  '_naup2: Ritz estimates of the shifts')
          end if
@@ -713,7 +713,7 @@ c        | matrix H.                                               |
 c        | The first 2*N locations of WORKD are used as workspace. |
 c        %---------------------------------------------------------%
 c
-         call znapps (n, nev, np, ritz, v, ldv, 
+         call znapps (n, nev, np, ritz, v, ldv,
      &                h, ldh, resid, q, ldq, workl, workd)
 c
 c        %---------------------------------------------%
@@ -730,18 +730,18 @@ c
             ipntr(1) = n + 1
             ipntr(2) = 1
             ido = 2
-c 
+c
 c           %----------------------------------%
 c           | Exit in order to compute B*RESID |
 c           %----------------------------------%
-c 
+c
             go to 9000
          else if (bmat .eq. 'I') then
             call zcopy (n, resid, 1, workd, 1)
          end if
-c 
+c
   100    continue
-c 
+c
 c        %----------------------------------%
 c        | Back from reverse communication; |
 c        | WORKD(1:N) := B*RESID            |
@@ -751,8 +751,8 @@ c
             call second (t3)
             tmvbx = tmvbx + (t3 - t2)
          end if
-c 
-         if (bmat .eq. 'G') then         
+c
+         if (bmat .eq. 'G') then
             cmpnorm = zdotc (n, resid, 1, workd, 1)
             rnorm = sqrt(dlapy2(dble(cmpnorm),dimag(cmpnorm)))
          else if (bmat .eq. 'I') then
@@ -761,12 +761,12 @@ c
          cnorm = .false.
 c
          if (msglvl .gt. 2) then
-            call dvout (logfil, 1, [rnorm], ndigit, 
+            call dvout (logfil, 1, [rnorm], ndigit,
      &      '_naup2: B-norm of residual for compressed factorization')
             call zmout (logfil, nev, nev, h, ldh, ndigit,
      &        '_naup2: Compressed upper Hessenberg matrix H')
          end if
-c 
+c
       go to 1000
 c
 c     %---------------------------------------------------------------%
@@ -779,7 +779,7 @@ c
 c
       mxiter = iter
       nev = nconv
-c     
+c
  1200 continue
       ido = 99
 c
@@ -789,7 +789,7 @@ c     %------------%
 c
       call second (t1)
       tcaup2 = t1 - t0
-c     
+c
  9000 continue
 c
 c     %---------------%

--- a/mathlibs/src/arpack/znaup2.f
+++ b/mathlibs/src/arpack/znaup2.f
@@ -388,7 +388,7 @@ c
          iter = iter + 1
 c
          if (msglvl .gt. 0) then
-            call ivout (logfil, 1, iter, ndigit, 
+            call ivout (logfil, 1, [iter], ndigit, 
      &           '_naup2: **** Start of major iteration number ****')
          end if
 c 
@@ -401,9 +401,9 @@ c
          np  = kplusp - nev
 c
          if (msglvl .gt. 1) then
-            call ivout (logfil, 1, nev, ndigit, 
+            call ivout (logfil, 1, [nev], ndigit, 
      &     '_naup2: The length of the current Arnoldi factorization')
-            call ivout (logfil, 1, np, ndigit, 
+            call ivout (logfil, 1, [np], ndigit, 
      &           '_naup2: Extend the Arnoldi factorization by')
          end if
 c
@@ -429,7 +429,7 @@ c
          update = .false.
 c
          if (msglvl .gt. 1) then
-            call dvout (logfil, 1, rnorm, ndigit, 
+            call dvout (logfil, 1, [rnorm], ndigit, 
      &           '_naup2: Corresponding B-norm of the residual')
          end if
 c 
@@ -657,7 +657,7 @@ c
          end if              
 c     
          if (msglvl .gt. 0) then
-            call ivout (logfil, 1, nconv, ndigit, 
+            call ivout (logfil, 1, [nconv], ndigit, 
      &           '_naup2: no. of "converged" Ritz values at this iter.')
             if (msglvl .gt. 1) then
                kp(1) = nev
@@ -697,7 +697,7 @@ c
          end if
 c
          if (msglvl .gt. 2) then 
-            call ivout (logfil, 1, np, ndigit, 
+            call ivout (logfil, 1, [np], ndigit, 
      &                  '_naup2: The number of shifts to apply ')
             call zvout (logfil, np, ritz, ndigit,
      &                  '_naup2: values of the shifts')
@@ -761,7 +761,7 @@ c
          cnorm = .false.
 c
          if (msglvl .gt. 2) then
-            call dvout (logfil, 1, rnorm, ndigit, 
+            call dvout (logfil, 1, [rnorm], ndigit, 
      &      '_naup2: B-norm of residual for compressed factorization')
             call zmout (logfil, nev, nev, h, ldh, ndigit,
      &        '_naup2: Compressed upper Hessenberg matrix H')

--- a/mathlibs/src/arpack/znaupd.f
+++ b/mathlibs/src/arpack/znaupd.f
@@ -601,9 +601,9 @@ c
       if (info .eq. 2) info = 3
 c
       if (msglvl .gt. 0) then
-         call ivout (logfil, 1, mxiter, ndigit,
+         call ivout (logfil, 1, [mxiter], ndigit,
      &               '_naupd: Number of update iterations taken')
-         call ivout (logfil, 1, np, ndigit,
+         call ivout (logfil, 1, [np], ndigit,
      &               '_naupd: Number of wanted "converged" Ritz values')
          call zvout (logfil, np, workl(ritz), ndigit, 
      &               '_naupd: The final Ritz values')

--- a/mathlibs/src/arpack/znaupd.f
+++ b/mathlibs/src/arpack/znaupd.f
@@ -2,11 +2,11 @@ c\BeginDoc
 c
 c\Name: znaupd
 c
-c\Description: 
+c\Description:
 c  Reverse communication interface for the Implicitly Restarted Arnoldi
-c  iteration. This is intended to be used to find a few eigenpairs of a 
-c  complex linear operator OP with respect to a semi-inner product defined 
-c  by a hermitian positive semi-definite real matrix B. B may be the identity 
+c  iteration. This is intended to be used to find a few eigenpairs of a
+c  complex linear operator OP with respect to a semi-inner product defined
+c  by a hermitian positive semi-definite real matrix B. B may be the identity
 c  matrix.  NOTE: if both OP and B are real, then dsaupd or dnaupd should
 c  be used.
 c
@@ -14,7 +14,7 @@ c
 c  The computed approximate eigenvalues are called Ritz values and
 c  the corresponding approximate eigenvectors are called Ritz vectors.
 c
-c  znaupd is usually called iteratively to solve one of the 
+c  znaupd is usually called iteratively to solve one of the
 c  following problems:
 c
 c  Mode 1:  A*x = lambda*x.
@@ -25,10 +25,10 @@ c           ===> OP = inv[M]*A  and  B = M.
 c           ===> (If M can be factored see remark 3 below)
 c
 c  Mode 3:  A*x = lambda*M*x, M Hermitian semi-definite
-c           ===> OP =  inv[A - sigma*M]*M   and  B = M. 
-c           ===> shift-and-invert mode 
+c           ===> OP =  inv[A - sigma*M]*M   and  B = M.
+c           ===> shift-and-invert mode
 c           If OP*x = amu*x, then lambda = sigma + 1/amu.
-c  
+c
 c
 c  NOTE: The action of w <- inv[A - sigma*M]*v or w <- inv[M]*v
 c        should be accomplished either by a direct method
@@ -49,7 +49,7 @@ c       IPNTR, WORKD, WORKL, LWORKL, RWORK, INFO )
 c
 c\Arguments
 c  IDO     Integer.  (INPUT/OUTPUT)
-c          Reverse communication flag.  IDO must be zero on the first 
+c          Reverse communication flag.  IDO must be zero on the first
 c          call to znaupd.  IDO will be set internally to
 c          indicate the type of operation to be performed.  Control is
 c          then given back to the calling routine which has the
@@ -72,14 +72,14 @@ c                    need to be recomputed in forming OP * X.
 c          IDO =  2: compute  Y = M * X  where
 c                    IPNTR(1) is the pointer into WORKD for X,
 c                    IPNTR(2) is the pointer into WORKD for Y.
-c          IDO =  3: compute and return the shifts in the first 
+c          IDO =  3: compute and return the shifts in the first
 c                    NP locations of WORKL.
 c          IDO = 99: done
 c          -------------------------------------------------------------
-c          After the initialization phase, when the routine is used in 
-c          the "shift-and-invert" mode, the vector M * X is already 
+c          After the initialization phase, when the routine is used in
+c          the "shift-and-invert" mode, the vector M * X is already
 c          available and does not need to be recomputed in forming OP*X.
-c             
+c
 c  BMAT    Character*1.  (INPUT)
 c          BMAT specifies the type of the matrix B that defines the
 c          semi-inner product for the operator OP.
@@ -101,14 +101,14 @@ c  NEV     Integer.  (INPUT)
 c          Number of eigenvalues of OP to be computed. 0 < NEV < N-1.
 c
 c  TOL     Double precision  scalar.  (INPUT)
-c          Stopping criteria: the relative accuracy of the Ritz value 
+c          Stopping criteria: the relative accuracy of the Ritz value
 c          is considered acceptable if BOUNDS(I) .LE. TOL*ABS(RITZ(I))
 c          where ABS(RITZ(I)) is the magnitude when RITZ(I) is complex.
 c          DEFAULT = dlamch('EPS')  (machine precision as computed
 c                    by the LAPACK auxiliary subroutine dlamch).
 c
 c  RESID   Complex*16 array of length N.  (INPUT/OUTPUT)
-c          On INPUT: 
+c          On INPUT:
 c          If INFO .EQ. 0, a random initial residual vector is used.
 c          If INFO .NE. 0, RESID contains the initial residual vector,
 c                          possibly from a previous run.
@@ -118,15 +118,15 @@ c
 c  NCV     Integer.  (INPUT)
 c          Number of columns of the matrix V. NCV must satisfy the two
 c          inequalities 1 <= NCV-NEV and NCV <= N.
-c          This will indicate how many Arnoldi vectors are generated 
-c          at each iteration.  After the startup phase in which NEV 
-c          Arnoldi vectors are generated, the algorithm generates 
-c          approximately NCV-NEV Arnoldi vectors at each subsequent update 
-c          iteration. Most of the cost in generating each Arnoldi vector is 
+c          This will indicate how many Arnoldi vectors are generated
+c          at each iteration.  After the startup phase in which NEV
+c          Arnoldi vectors are generated, the algorithm generates
+c          approximately NCV-NEV Arnoldi vectors at each subsequent update
+c          iteration. Most of the cost in generating each Arnoldi vector is
 c          in the matrix-vector operation OP*x. (See remark 4 below.)
 c
 c  V       Complex*16 array N by NCV.  (OUTPUT)
-c          Contains the final set of Arnoldi basis vectors. 
+c          Contains the final set of Arnoldi basis vectors.
 c
 c  LDV     Integer.  (INPUT)
 c          Leading dimension of V exactly as declared in the calling program.
@@ -137,23 +137,23 @@ c          The shifts selected at each iteration are used to filter out
 c          the components of the unwanted eigenvector.
 c          -------------------------------------------------------------
 c          ISHIFT = 0: the shifts are to be provided by the user via
-c                      reverse communication.  The NCV eigenvalues of 
+c                      reverse communication.  The NCV eigenvalues of
 c                      the Hessenberg matrix H are returned in the part
 c                      of WORKL array corresponding to RITZ.
 c          ISHIFT = 1: exact shifts with respect to the current
-c                      Hessenberg matrix H.  This is equivalent to 
-c                      restarting the iteration from the beginning 
+c                      Hessenberg matrix H.  This is equivalent to
+c                      restarting the iteration from the beginning
 c                      after updating the starting vector with a linear
-c                      combination of Ritz vectors associated with the 
+c                      combination of Ritz vectors associated with the
 c                      "wanted" eigenvalues.
 c          ISHIFT = 2: other choice of internal shift to be defined.
 c          -------------------------------------------------------------
 c
-c          IPARAM(2) = No longer referenced 
+c          IPARAM(2) = No longer referenced
 c
 c          IPARAM(3) = MXITER
-c          On INPUT:  maximum number of Arnoldi update iterations allowed. 
-c          On OUTPUT: actual number of Arnoldi update iterations taken. 
+c          On INPUT:  maximum number of Arnoldi update iterations allowed.
+c          On OUTPUT: actual number of Arnoldi update iterations taken.
 c
 c          IPARAM(4) = NB: blocksize to be used in the recurrence.
 c          The code currently works only for NB = 1.
@@ -163,11 +163,11 @@ c          This represents the number of Ritz values that satisfy
 c          the convergence criterion.
 c
 c          IPARAM(6) = IUPD
-c          No longer referenced. Implicit restarting is ALWAYS used.  
+c          No longer referenced. Implicit restarting is ALWAYS used.
 c
 c          IPARAM(7) = MODE
 c          On INPUT determines what type of eigenproblem is being solved.
-c          Must be 1,2,3; See under \Description of znaupd for the 
+c          Must be 1,2,3; See under \Description of znaupd for the
 c          four modes available.
 c
 c          IPARAM(8) = NP
@@ -186,7 +186,7 @@ c          arrays for matrices/vectors used by the Arnoldi iteration.
 c          -------------------------------------------------------------
 c          IPNTR(1): pointer to the current operand vector X in WORKD.
 c          IPNTR(2): pointer to the current result vector Y in WORKD.
-c          IPNTR(3): pointer to the vector B * X in WORKD when used in 
+c          IPNTR(3): pointer to the vector B * X in WORKD when used in
 c                    the shift-and-invert mode.
 c          IPNTR(4): pointer to the next available location in WORKL
 c                    that is untouched by the program.
@@ -199,7 +199,7 @@ c          IPNTR(14): pointer to the NP shifts in WORKL. See Remark 5 below.
 c
 c          Note: IPNTR(9:13) is only referenced by zneupd. See Remark 2 below.
 c
-c          IPNTR(9): pointer to the NCV RITZ values of the 
+c          IPNTR(9): pointer to the NCV RITZ values of the
 c                    original system.
 c          IPNTR(10): Not Used
 c          IPNTR(11): pointer to the NCV corresponding error bounds.
@@ -210,12 +210,12 @@ c                     of the upper Hessenberg matrix H. Only referenced by
 c                     zneupd if RVEC = .TRUE. See Remark 2 below.
 c
 c          -------------------------------------------------------------
-c          
+c
 c  WORKD   Complex*16 work array of length 3*N.  (REVERSE COMMUNICATION)
 c          Distributed array to be used in the basic Arnoldi iteration
-c          for reverse communication.  The user should not use WORKD 
+c          for reverse communication.  The user should not use WORKD
 c          as temporary workspace during the iteration !!!!!!!!!!
-c          See Data Distribution Note below.  
+c          See Data Distribution Note below.
 c
 c  WORKL   Complex*16 work array of length LWORKL.  (OUTPUT/WORKSPACE)
 c          Private (replicated) array on each PE or array allocated on
@@ -236,18 +236,18 @@ c                          possibly from a previous run.
 c          Error flag on output.
 c          =  0: Normal exit.
 c          =  1: Maximum number of iterations taken.
-c                All possible eigenvalues of OP has been found. IPARAM(5)  
+c                All possible eigenvalues of OP has been found. IPARAM(5)
 c                returns the number of wanted converged Ritz values.
 c          =  2: No longer an informational error. Deprecated starting
 c                with release 2 of ARPACK.
-c          =  3: No shifts could be applied during a cycle of the 
-c                Implicitly restarted Arnoldi iteration. One possibility 
-c                is to increase the size of NCV relative to NEV. 
+c          =  3: No shifts could be applied during a cycle of the
+c                Implicitly restarted Arnoldi iteration. One possibility
+c                is to increase the size of NCV relative to NEV.
 c                See remark 4 below.
 c          = -1: N must be positive.
 c          = -2: NEV must be positive.
 c          = -3: NCV-NEV >= 2 and less than or equal to N.
-c          = -4: The maximum number of Arnoldi update iteration 
+c          = -4: The maximum number of Arnoldi update iteration
 c                must be greater than zero.
 c          = -5: WHICH must be one of 'LM', 'SM', 'LR', 'SR', 'LI', 'SI'
 c          = -6: BMAT must be one of 'I' or 'G'.
@@ -268,16 +268,16 @@ c  1. The computed Ritz values are approximate eigenvalues of OP. The
 c     selection of WHICH should be made with this in mind when using
 c     Mode = 3.  When operating in Mode = 3 setting WHICH = 'LM' will
 c     compute the NEV eigenvalues of the original problem that are
-c     closest to the shift SIGMA . After convergence, approximate eigenvalues 
+c     closest to the shift SIGMA . After convergence, approximate eigenvalues
 c     of the original problem may be obtained with the ARPACK subroutine zneupd.
 c
-c  2. If a basis for the invariant subspace corresponding to the converged Ritz 
-c     values is needed, the user must call zneupd immediately following 
+c  2. If a basis for the invariant subspace corresponding to the converged Ritz
+c     values is needed, the user must call zneupd immediately following
 c     completion of znaupd. This is new starting with release 2 of ARPACK.
 c
 c  3. If M can be factored into a Cholesky factorization M = LL'
 c     then Mode = 2 should not be selected.  Instead one should use
-c     Mode = 1 with  OP = inv(L)*A*inv(L').  Appropriate triangular 
+c     Mode = 1 with  OP = inv(L)*A*inv(L').  Appropriate triangular
 c     linear systems should be solved with L and L' rather
 c     than computing inverses.  After convergence, an approximate
 c     eigenvector z of the original problem is recovered by solving
@@ -287,11 +287,11 @@ c  4. At present there is no a-priori analysis to guide the selection
 c     of NCV relative to NEV.  The only formal requirement is that NCV > NEV + 1.
 c     However, it is recommended that NCV .ge. 2*NEV.  If many problems of
 c     the same type are to be solved, one should experiment with increasing
-c     NCV while keeping NEV fixed for a given test problem.  This will 
+c     NCV while keeping NEV fixed for a given test problem.  This will
 c     usually decrease the required number of OP*x operations but it
 c     also increases the work and storage required to maintain the orthogonal
 c     basis vectors.  The optimal "cross-over" with respect to CPU time
-c     is problem dependent and must be determined empirically. 
+c     is problem dependent and must be determined empirically.
 c     See Chapter 8 of Reference 2 for further information.
 c
 c  5. When IPARAM(1) = 0, and IDO = 3, the user needs to provide the
@@ -305,7 +305,7 @@ c     WORKL(IPNTR(8)+NCV-1).
 c
 c-----------------------------------------------------------------------
 c
-c\Data Distribution Note: 
+c\Data Distribution Note:
 c
 c  Fortran-D syntax:
 c  ================
@@ -324,10 +324,10 @@ c  ===============
 c  Complex*16 resid(n), v(ldv,ncv), workd(n,3), workl(lworkl)
 c  shared     resid(block), v(block,:), workd(block,:)
 c  replicated workl(lworkl)
-c  
+c
 c  CM2/CM5 syntax:
 c  ==============
-c  
+c
 c-----------------------------------------------------------------------
 c
 c     include   'ex-nonsym.doc'
@@ -343,7 +343,7 @@ c\References:
 c  1. D.C. Sorensen, "Implicit Application of Polynomial Filters in
 c     a k-Step Arnoldi Method", SIAM J. Matr. Anal. Apps., 13 (1992),
 c     pp 357-385.
-c  2. R.B. Lehoucq, "Analysis and Implementation of an Implicitly 
+c  2. R.B. Lehoucq, "Analysis and Implementation of an Implicitly
 c     Restarted Arnoldi Iteration", Rice University Technical Report
 c     TR95-13, Department of Computational and Applied Mathematics.
 c  3. B.N. Parlett & Y. Saad, "_Complex_ Shift and Invert Strategies for
@@ -363,10 +363,10 @@ c\Author
 c     Danny Sorensen               Phuong Vu
 c     Richard Lehoucq              CRPC / Rice University
 c     Dept. of Computational &     Houston, Texas
-c     Applied Mathematics 
-c     Rice University           
-c     Houston, Texas 
-c 
+c     Applied Mathematics
+c     Rice University
+c     Houston, Texas
+c
 c\SCCS Information: @(#)
 c FILE: naupd.F   SID: 2.4   DATE OF SID: 8/27/96   RELEASE: 2
 c
@@ -377,7 +377,7 @@ c
 c-----------------------------------------------------------------------
 c
       subroutine znaupd
-     &   ( ido, bmat, n, which, nev, tol, resid, ncv, v, ldv, iparam, 
+     &   ( ido, bmat, n, which, nev, tol, resid, ncv, v, ldv, iparam,
      &     ipntr, workd, workl, lworkl, rwork, info )
 c
 c     %----------------------------------------------------%
@@ -393,7 +393,7 @@ c     %------------------%
 c
       character  bmat*1, which*2
       integer    ido, info, ldv, lworkl, n, ncv, nev
-      Double precision 
+      Double precision
      &           tol
 c
 c     %-----------------%
@@ -403,7 +403,7 @@ c
       integer    iparam(11), ipntr(14)
       Complex*16
      &           resid(n), v(ldv,ncv), workd(3*n), workl(lworkl)
-      Double precision  
+      Double precision
      &           rwork(ncv)
 c
 c     %------------%
@@ -418,7 +418,7 @@ c     %---------------%
 c     | Local Scalars |
 c     %---------------%
 c
-      integer    bounds, ierr, ih, iq, ishift, iupd, iw, 
+      integer    bounds, ierr, ih, iq, ishift, iupd, iw,
      &           ldh, ldq, levec, mode, msglvl, mxiter, nb,
      &           nev0, next, np, ritz, j
       save       bounds, ih, iq, ishift, iupd, iw,
@@ -435,16 +435,16 @@ c     %--------------------%
 c     | External Functions |
 c     %--------------------%
 c
-      Double precision 
+      Double precision
      &           dlamch
       external   dlamch
 c
 c     %-----------------------%
 c     | Executable Statements |
 c     %-----------------------%
-c 
+c
       if (ido .eq. 0) then
-c 
+c
 c        %-------------------------------%
 c        | Initialize timing statistics  |
 c        | & message level for debugging |
@@ -496,7 +496,7 @@ c
          else if (mode .eq. 1 .and. bmat .eq. 'G') then
                                                 ierr = -11
          end if
-c 
+c
 c        %------------%
 c        | Error Exit |
 c        %------------%
@@ -506,14 +506,14 @@ c
             ido  = 99
             go to 9000
          end if
-c 
+c
 c        %------------------------%
 c        | Set default parameters |
 c        %------------------------%
 c
          if (nb .le. 0)				nb = 1
          if (tol .le. 0.0D+0 )			tol = dlamch('EpsMach')
-         if (ishift .ne. 0  .and.  
+         if (ishift .ne. 0  .and.
      &       ishift .ne. 1  .and.
      &       ishift .ne. 2) 			ishift = 1
 c
@@ -525,8 +525,8 @@ c        | size of the invariant subspace desired.      |
 c        %----------------------------------------------%
 c
          np     = ncv - nev
-         nev0   = nev 
-c 
+         nev0   = nev
+c
 c        %-----------------------------%
 c        | Zero out internal workspace |
 c        %-----------------------------%
@@ -534,7 +534,7 @@ c
          do 10 j = 1, 3*ncv**2 + 5*ncv
             workl(j) = zero
   10     continue
-c 
+c
 c        %-------------------------------------------------------------%
 c        | Pointer into WORKL for address of H, RITZ, BOUNDS, Q        |
 c        | etc... and the remaining workspace.                         |
@@ -572,12 +572,12 @@ c     %-------------------------------------------------------%
 c     | Carry out the Implicitly restarted Arnoldi Iteration. |
 c     %-------------------------------------------------------%
 c
-      call znaup2 
+      call znaup2
      &   ( ido, bmat, n, which, nev0, np, tol, resid, mode, iupd,
-     &     ishift, mxiter, v, ldv, workl(ih), ldh, workl(ritz), 
-     &     workl(bounds), workl(iq), ldq, workl(iw), 
+     &     ishift, mxiter, v, ldv, workl(ih), ldh, workl(ritz),
+     &     workl(bounds), workl(iq), ldq, workl(iw),
      &     ipntr, workd, rwork, info )
-c 
+c
 c     %--------------------------------------------------%
 c     | ido .ne. 99 implies use of reverse communication |
 c     | to compute operations involving OP.              |
@@ -585,7 +585,7 @@ c     %--------------------------------------------------%
 c
       if (ido .eq. 3) iparam(8) = np
       if (ido .ne. 99) go to 9000
-c 
+c
       iparam(3) = mxiter
       iparam(5) = np
       iparam(9) = nopx
@@ -605,9 +605,9 @@ c
      &               '_naupd: Number of update iterations taken')
          call ivout (logfil, 1, [np], ndigit,
      &               '_naupd: Number of wanted "converged" Ritz values')
-         call zvout (logfil, np, workl(ritz), ndigit, 
+         call zvout (logfil, np, workl(ritz), ndigit,
      &               '_naupd: The final Ritz values')
-         call zvout (logfil, np, workl(bounds), ndigit, 
+         call zvout (logfil, np, workl(bounds), ndigit,
      &               '_naupd: Associated Ritz estimates')
       end if
 c

--- a/mathlibs/src/arpack/zneupd.f
+++ b/mathlibs/src/arpack/zneupd.f
@@ -1,48 +1,48 @@
 c\BeginDoc
-c 
-c\Name: zneupd 
-c 
-c\Description: 
-c  This subroutine returns the converged approximations to eigenvalues 
-c  of A*z = lambda*B*z and (optionally): 
-c 
-c      (1) The corresponding approximate eigenvectors; 
-c 
-c      (2) An orthonormal basis for the associated approximate 
-c          invariant subspace; 
-c 
-c      (3) Both.  
 c
-c  There is negligible additional cost to obtain eigenvectors.  An orthonormal 
+c\Name: zneupd
+c
+c\Description:
+c  This subroutine returns the converged approximations to eigenvalues
+c  of A*z = lambda*B*z and (optionally):
+c
+c      (1) The corresponding approximate eigenvectors;
+c
+c      (2) An orthonormal basis for the associated approximate
+c          invariant subspace;
+c
+c      (3) Both.
+c
+c  There is negligible additional cost to obtain eigenvectors.  An orthonormal
 c  basis is always computed.  There is an additional storage cost of n*nev
-c  if both are requested (in this case a separate array Z must be supplied). 
+c  if both are requested (in this case a separate array Z must be supplied).
 c
 c  The approximate eigenvalues and eigenvectors of  A*z = lambda*B*z
 c  are derived from approximate eigenvalues and eigenvectors of
 c  of the linear operator OP prescribed by the MODE selection in the
 c  call to ZNAUPD.  ZNAUPD must be called before this routine is called.
 c  These approximate eigenvalues and vectors are commonly called Ritz
-c  values and Ritz vectors respectively.  They are referred to as such 
-c  in the comments that follow.   The computed orthonormal basis for the 
-c  invariant subspace corresponding to these Ritz values is referred to as a 
-c  Schur basis. 
-c 
+c  values and Ritz vectors respectively.  They are referred to as such
+c  in the comments that follow.   The computed orthonormal basis for the
+c  invariant subspace corresponding to these Ritz values is referred to as a
+c  Schur basis.
+c
 c  The definition of OP as well as other terms and the relation of computed
 c  Ritz values and vectors of OP with respect to the given problem
-c  A*z = lambda*B*z may be found in the header of ZNAUPD.  For a brief 
+c  A*z = lambda*B*z may be found in the header of ZNAUPD.  For a brief
 c  description, see definitions of IPARAM(7), MODE and WHICH in the
 c  documentation of ZNAUPD.
 c
 c\Usage:
-c  call zneupd 
-c     ( RVEC, HOWMNY, SELECT, D, Z, LDZ, SIGMA, WORKEV, BMAT, 
-c       N, WHICH, NEV, TOL, RESID, NCV, V, LDV, IPARAM, IPNTR, WORKD, 
+c  call zneupd
+c     ( RVEC, HOWMNY, SELECT, D, Z, LDZ, SIGMA, WORKEV, BMAT,
+c       N, WHICH, NEV, TOL, RESID, NCV, V, LDV, IPARAM, IPNTR, WORKD,
 c       WORKL, LWORKL, RWORK, INFO )
 c
 c\Arguments:
 c  RVEC    LOGICAL  (INPUT)
 c          Specifies whether a basis for the invariant subspace corresponding
-c          to the converged Ritz value approximations for the eigenproblem 
+c          to the converged Ritz value approximations for the eigenproblem
 c          A*z = lambda*B*z is computed.
 c
 c             RVEC = .FALSE.     Compute Ritz values only.
@@ -51,7 +51,7 @@ c             RVEC = .TRUE.      Compute Ritz vectors or Schur vectors.
 c                                See Remarks below.
 c
 c  HOWMNY  Character*1  (INPUT)
-c          Specifies the form of the basis for the invariant subspace 
+c          Specifies the form of the basis for the invariant subspace
 c          corresponding to the converged Ritz values that is to be computed.
 c
 c          = 'A': Compute NEV Ritz vectors;
@@ -62,34 +62,34 @@ c
 c  SELECT  Logical array of dimension NCV.  (INPUT)
 c          If HOWMNY = 'S', SELECT specifies the Ritz vectors to be
 c          computed. To select the  Ritz vector corresponding to a
-c          Ritz value D(j), SELECT(j) must be set to .TRUE.. 
-c          If HOWMNY = 'A' or 'P', SELECT need not be initialized 
+c          Ritz value D(j), SELECT(j) must be set to .TRUE..
+c          If HOWMNY = 'A' or 'P', SELECT need not be initialized
 c          but it is used as internal workspace.
 c
 c  D       Complex*16 array of dimension NEV+1.  (OUTPUT)
-c          On exit, D contains the  Ritz  approximations 
+c          On exit, D contains the  Ritz  approximations
 c          to the eigenvalues lambda for A*z = lambda*B*z.
 c
 c  Z       Complex*16 N by NEV array    (OUTPUT)
-c          On exit, if RVEC = .TRUE. and HOWMNY = 'A', then the columns of 
-c          Z represents approximate eigenvectors (Ritz vectors) corresponding 
+c          On exit, if RVEC = .TRUE. and HOWMNY = 'A', then the columns of
+c          Z represents approximate eigenvectors (Ritz vectors) corresponding
 c          to the NCONV=IPARAM(5) Ritz values for eigensystem
 c          A*z = lambda*B*z.
 c
 c          If RVEC = .FALSE. or HOWMNY = 'P', then Z is NOT REFERENCED.
 c
-c          NOTE: If if RVEC = .TRUE. and a Schur basis is not required, 
-c          the array Z may be set equal to first NEV+1 columns of the Arnoldi 
-c          basis array V computed by ZNAUPD.  In this case the Arnoldi basis 
+c          NOTE: If if RVEC = .TRUE. and a Schur basis is not required,
+c          the array Z may be set equal to first NEV+1 columns of the Arnoldi
+c          basis array V computed by ZNAUPD.  In this case the Arnoldi basis
 c          will be destroyed and overwritten with the eigenvector basis.
 c
 c  LDZ     Integer.  (INPUT)
 c          The leading dimension of the array Z.  If Ritz vectors are
-c          desired, then  LDZ .ge.  max( 1, N ) is required.  
+c          desired, then  LDZ .ge.  max( 1, N ) is required.
 c          In any case,  LDZ .ge. 1 is required.
 c
 c  SIGMA   Complex*16  (INPUT)
-c          If IPARAM(7) = 3 then SIGMA represents the shift. 
+c          If IPARAM(7) = 3 then SIGMA represents the shift.
 c          Not referenced if IPARAM(7) = 1 or 2.
 c
 c  WORKEV  Complex*16 work array of dimension 2*NCV.  (WORKSPACE)
@@ -97,12 +97,12 @@ c
 c  **** The remaining arguments MUST be the same as for the   ****
 c  **** call to ZNAUPD that was just completed.               ****
 c
-c  NOTE: The remaining arguments 
+c  NOTE: The remaining arguments
 c
-c           BMAT, N, WHICH, NEV, TOL, RESID, NCV, V, LDV, IPARAM, IPNTR, 
-c           WORKD, WORKL, LWORKL, RWORK, INFO 
+c           BMAT, N, WHICH, NEV, TOL, RESID, NCV, V, LDV, IPARAM, IPNTR,
+c           WORKD, WORKL, LWORKL, RWORK, INFO
 c
-c         must be passed directly to ZNEUPD following the last call 
+c         must be passed directly to ZNEUPD following the last call
 c         to ZNAUPD.  These arguments MUST NOT BE MODIFIED between
 c         the the last call to ZNAUPD and the call to ZNEUPD.
 c
@@ -128,7 +128,7 @@ c  WORKL   Double precision work array of length LWORKL.  (OUTPUT/WORKSPACE)
 c          WORKL(1:ncv*ncv+2*ncv) contains information obtained in
 c          znaupd.  They are not changed by zneupd.
 c          WORKL(ncv*ncv+2*ncv+1:3*ncv*ncv+4*ncv) holds the
-c          untransformed Ritz values, the untransformed error estimates of 
+c          untransformed Ritz values, the untransformed error estimates of
 c          the Ritz values, the upper triangular matrix for H, and the
 c          associated matrix representation of the invariant subspace for H.
 c
@@ -182,18 +182,18 @@ c\References:
 c  1. D.C. Sorensen, "Implicit Application of Polynomial Filters in
 c     a k-Step Arnoldi Method", SIAM J. Matr. Anal. Apps., 13 (1992),
 c     pp 357-385.
-c  2. R.B. Lehoucq, "Analysis and Implementation of an Implicitly 
+c  2. R.B. Lehoucq, "Analysis and Implementation of an Implicitly
 c     Restarted Arnoldi Iteration", Rice University Technical Report
 c     TR95-13, Department of Computational and Applied Mathematics.
 c  3. B. Nour-Omid, B. N. Parlett, T. Ericsson and P. S. Jensen,
 c     "How to Implement the Spectral Transformation", Math Comp.,
-c     Vol. 48, No. 178, April, 1987 pp. 664-673. 
+c     Vol. 48, No. 178, April, 1987 pp. 664-673.
 c
 c\Routines called:
 c     ivout   ARPACK utility routine that prints integers.
 c     zmout   ARPACK utility routine that prints matrices
 c     zvout   ARPACK utility routine that prints vectors.
-c     zgeqr2  LAPACK routine that computes the QR factorization of 
+c     zgeqr2  LAPACK routine that computes the QR factorization of
 c             a matrix.
 c     zlacpy  LAPACK matrix copy routine.
 c     zlahqr  LAPACK routine that computes the Schur form of a
@@ -202,7 +202,7 @@ c     zlaset  LAPACK matrix initialization routine.
 c     ztrevc  LAPACK routine to compute the eigenvectors of a matrix
 c             in upper triangular form.
 c     ztrsen  LAPACK routine that re-orders the Schur form.
-c     zunm2r  LAPACK routine that applies an orthogonal matrix in 
+c     zunm2r  LAPACK routine that applies an orthogonal matrix in
 c             factored form.
 c     dlamch  LAPACK routine that determines machine constants.
 c     ztrmm   Level 3 BLAS matrix times an upper triangular matrix.
@@ -214,23 +214,23 @@ c     dznrm2  Level 1 BLAS that computes the norm of a complex vector.
 c
 c\Remarks
 c
-c  1. Currently only HOWMNY = 'A' and 'P' are implemented. 
+c  1. Currently only HOWMNY = 'A' and 'P' are implemented.
 c
 c  2. Schur vectors are an orthogonal representation for the basis of
 c     Ritz vectors. Thus, their numerical properties are often superior.
 c     If RVEC = .true. then the relationship
 c             A * V(:,1:IPARAM(5)) = V(:,1:IPARAM(5)) * T, and
 c     V(:,1:IPARAM(5))' * V(:,1:IPARAM(5)) = I are approximately satisfied.
-c     Here T is the leading submatrix of order IPARAM(5) of the 
-c     upper triangular matrix stored workl(ipntr(12)). 
+c     Here T is the leading submatrix of order IPARAM(5) of the
+c     upper triangular matrix stored workl(ipntr(12)).
 c
 c\Authors
 c     Danny Sorensen               Phuong Vu
 c     Richard Lehoucq              CRPC / Rice University
-c     Chao Yang                    Houston, Texas 
-c     Dept. of Computational & 
-c     Applied Mathematics 
-c     Rice University 
+c     Chao Yang                    Houston, Texas
+c     Dept. of Computational &
+c     Applied Mathematics
+c     Rice University
 c     Houston, Texas
 c
 c\SCCS Information: @(#)
@@ -239,9 +239,9 @@ c
 c\EndLib
 c
 c-----------------------------------------------------------------------
-      subroutine zneupd (rvec, howmny, select, d, z, ldz, sigma, 
-     &                   workev, bmat, n, which, nev, tol, 
-     &                   resid, ncv, v, ldv, iparam, ipntr, workd, 
+      subroutine zneupd (rvec, howmny, select, d, z, ldz, sigma,
+     &                   workev, bmat, n, which, nev, tol,
+     &                   resid, ncv, v, ldv, iparam, ipntr, workd,
      &                   workl, lworkl, rwork, info)
 c
 c     %----------------------------------------------------%
@@ -258,9 +258,9 @@ c
       character  bmat, howmny, which*2
       logical    rvec
       integer    info, ldz, ldv, lworkl, n, ncv, nev
-      Complex*16     
+      Complex*16
      &           sigma
-      Double precision 
+      Double precision
      &           tol
 c
 c     %-----------------%
@@ -272,7 +272,7 @@ c
       Double precision
      &           rwork(ncv)
       Complex*16
-     &           d(nev), resid(n), v(ldv,ncv), z(ldz, nev), 
+     &           d(nev), resid(n), v(ldv,ncv), z(ldz, nev),
      &           workd(3*n), workl(lworkl), workev(2*ncv)
 c
 c     %------------%
@@ -288,8 +288,8 @@ c     | Local Scalars |
 c     %---------------%
 c
       character  type*6
-      integer    bounds, ierr, ih, ihbds, iheig, nconv, 
-     &           invsub, iuptri, iwev, j, 
+      integer    bounds, ierr, ih, ihbds, iheig, nconv,
+     &           invsub, iuptri, iwev, j,
      &           ldh, ldq, mode, msglvl, ritz, wr, k,
      &           irz, ibd, ktrord, outncv, iq
       Complex*16
@@ -305,7 +305,7 @@ c
       external   zcopy, zgeru, zgeqr2, zlacpy, zmout,
      &           zunm2r, ztrmm, zvout, ivout,
      &           zlahqr
-c  
+c
 c     %--------------------%
 c     | External Functions |
 c     %--------------------%
@@ -321,7 +321,7 @@ c
 c     %-----------------------%
 c     | Executable Statements |
 c     %-----------------------%
-c 
+c
 c     %------------------------%
 c     | Set default parameters |
 c     %------------------------%
@@ -372,12 +372,12 @@ c
       else if (howmny .eq. 'S' ) then
          ierr = -12
       end if
-c     
+c
       if (mode .eq. 1 .or. mode .eq. 2) then
          type = 'REGULR'
       else if (mode .eq. 3 ) then
          type = 'SHIFTI'
-      else 
+      else
                                               ierr = -10
       end if
       if (mode .eq. 1 .and. bmat .eq. 'G')    ierr = -11
@@ -390,7 +390,7 @@ c
          info = ierr
          go to 9000
       end if
-c 
+c
 c     %--------------------------------------------------------%
 c     | Pointer into WORKL for address of H, RITZ, WORKEV, Q   |
 c     | etc... and the remaining workspace.                    |
@@ -418,7 +418,7 @@ c     |                                      the invariant        |
 c     |                                      subspace for H.      |
 c     | GRAND total of NCV * ( 3 * NCV + 4 ) locations.           |
 c     %-----------------------------------------------------------%
-c     
+c
       ih     = ipntr(5)
       ritz   = ipntr(6)
       iq     = ipntr(7)
@@ -453,7 +453,7 @@ c     %------------------------------------%
 c
       rnorm = workl(ih+2)
       workl(ih+2) = zero
-c     
+c
       if (rvec) then
 c
 c        %-------------------------------------------%
@@ -479,13 +479,13 @@ c
 c
 c        %---------------------------------------------------------%
 c        | Check to see if all converged Ritz values appear at the |
-c        | at the top of the upper triangular matrix computed by   | 
-c        | _neigh in _naup2.  This is done in the following way:   | 
+c        | at the top of the upper triangular matrix computed by   |
+c        | _neigh in _naup2.  This is done in the following way:   |
 c        |                                                         |
 c        | 1) For each Ritz value from _neigh, compare it with the |
 c        |    threshold Ritz value computed above to determine     |
 c        |    whether it is a wanted one.                          |
-c        |                                                         | 
+c        |                                                         |
 c        | 2) If it is wanted, then check the corresponding Ritz   |
 c        |    estimate to see if it has converged.  If it has, set |
 c        |    correponding entry in the logical array SELECT to    |
@@ -509,7 +509,7 @@ c
                   if ( dlapy2(dble(workl(ibd+j)),
      &                 dimag(workl(ibd+j))) .le. tol*rtemp )
      &               select(j+1) = .true.
-               end if 
+               end if
             else if (which .eq. 'SM') then
                if ( dlapy2(dble(workl(irz+j)),
      &                      dimag(workl(irz+j))) .le. thres )  then
@@ -561,7 +561,7 @@ c
      &            '_neupd: Number of specified eigenvalues')
              call ivout(logfil, 1, [nconv], ndigit,
      &            '_neupd: Number of "converged" eigenvalues')
-         end if 
+         end if
 c
 c        if (ktrord .gt. nconv) then
 c
@@ -611,7 +611,7 @@ c           | Reorder the computed upper triangular matrix. |
 c           %-----------------------------------------------%
 c
             call ztrsen ('None', 'V', select, ncv, workl(iuptri), ldh,
-     &           workl(invsub), ldq, workl(iheig), nconv, conds, sep, 
+     &           workl(invsub), ldq, workl(iheig), nconv, conds, sep,
      &           workev, ncv, ierr)
 c
             if (ierr .eq. 1) then
@@ -639,7 +639,7 @@ c        | Ritz values.                                |
 c        %---------------------------------------------%
 c
          call zcopy (ncv, workl(invsub+ncv-1), ldq, workl(ihbds), 1)
-c 
+c
 c        %--------------------------------------------%
 c        | Place the computed eigenvalues of H into D |
 c        | if a spectral transformation was not used. |
@@ -664,14 +664,14 @@ c        | * Copy the first NCONV columns of VQ into Z.           |
 c        | * Postmultiply Z by R.                                 |
 c        | The N by NCONV matrix Z is now a matrix representation |
 c        | of the approximate invariant subspace associated with  |
-c        | the Ritz values in workl(iheig). The first NCONV       | 
+c        | the Ritz values in workl(iheig). The first NCONV       |
 c        | columns of V are now approximate Schur vectors         |
 c        | associated with the upper triangular matrix of order   |
 c        | NCONV in workl(iuptri).                                |
 c        %--------------------------------------------------------%
 c
-         call zunm2r ('Right', 'Notranspose', n, ncv, nconv, 
-     &        workl(invsub), ldq, workev, v, ldv, workd(n+1), 
+         call zunm2r ('Right', 'Notranspose', n, ncv, nconv,
+     &        workl(invsub), ldq, workev, v, ldv, workd(n+1),
      &        ierr)
          call zlacpy ('All', n, nconv, v, ldv, z, ldz)
 c
@@ -686,7 +686,7 @@ c           | Note that since Q is orthogonal, R is a diagonal  |
 c           | matrix consisting of plus or minus ones.          |
 c           %---------------------------------------------------%
 c
-            if ( dble( workl(invsub+(j-1)*ldq+j-1) ) .lt. 
+            if ( dble( workl(invsub+(j-1)*ldq+j-1) ) .lt.
      &                  dble(zero) ) then
                call zscal (nconv, -one, workl(iuptri+j-1), ldq)
                call zscal (nconv, -one, workl(iuptri+(j-1)*ldq), 1)
@@ -740,7 +740,7 @@ c                 | Note that the eigenvector matrix of T is |
 c                 | upper triangular, thus the length of the |
 c                 | inner product can be set to j.           |
 c                 %------------------------------------------%
-c 
+c
                   workev(j) = zdotc(j, workl(ihbds), 1,
      &                        workl(invsub+(j-1)*ldq), 1)
  40         continue
@@ -759,7 +759,7 @@ c
 c           %---------------------------------------%
 c           | Copy Ritz estimates into workl(ihbds) |
 c           %---------------------------------------%
-c 
+c
             call zcopy(nconv, workev, 1, workl(ihbds), 1)
 c
 c           %----------------------------------------------%
@@ -770,7 +770,7 @@ c
             call ztrmm ('Right', 'Upper', 'No transpose', 'Non-unit',
      &                  n, nconv, one, workl(invsub), ldq, z, ldz)
 c
-         end if 
+         end if
 c
       else
 c
@@ -793,25 +793,25 @@ c     %------------------------------------------------%
 c
       if (type .eq. 'REGULR') then
 c
-         if (rvec) 
+         if (rvec)
      &      call zscal(ncv, rnorm, workl(ihbds), 1)
-c      
+c
       else
-c     
+c
 c        %---------------------------------------%
 c        |   A spectral transformation was used. |
 c        | * Determine the Ritz estimates of the |
 c        |   Ritz values in the original system. |
 c        %---------------------------------------%
 c
-         if (rvec) 
+         if (rvec)
      &      call zscal(ncv, rnorm, workl(ihbds), 1)
-c    
+c
          do 50 k=1, ncv
             temp = workl(iheig+k-1)
             workl(ihbds+k-1) = workl(ihbds+k-1) / temp / temp
   50     continue
-c  
+c
       end if
 c
 c     %-----------------------------------------------------------%
@@ -821,7 +821,7 @@ c     |             lambda = 1/theta + sigma                      |
 c     | NOTES:                                                    |
 c     | *The Ritz vectors are not affected by the transformation. |
 c     %-----------------------------------------------------------%
-c    
+c
       if (type .eq. 'SHIFTI') then
          do 60 k=1, nconv
             d(k) = one / workl(iheig+k-1) + sigma
@@ -876,7 +876,7 @@ c
  9000 continue
 c
       return
-c     
+c
 c     %---------------%
 c     | End of zneupd |
 c     %---------------%

--- a/mathlibs/src/arpack/zneupd.f
+++ b/mathlibs/src/arpack/zneupd.f
@@ -473,7 +473,7 @@ c
             thres = dimag(workl(ritz))
          end if
          if (msglvl .gt. 2) then
-            call dvout(logfil, 1, thres, ndigit,
+            call dvout(logfil, 1, [thres], ndigit,
      &           '_neupd: Threshold eigenvalue used for re-ordering')
          end if
 c
@@ -557,9 +557,9 @@ c
  10      continue
 c
          if (msglvl .gt. 2) then
-             call ivout(logfil, 1, ktrord, ndigit,
+             call ivout(logfil, 1, [ktrord], ndigit,
      &            '_neupd: Number of specified eigenvalues')
-             call ivout(logfil, 1, nconv, ndigit,
+             call ivout(logfil, 1, [nconv], ndigit,
      &            '_neupd: Number of "converged" eigenvalues')
          end if 
 c

--- a/mathlibs/src/arpack/zngets.f
+++ b/mathlibs/src/arpack/zngets.f
@@ -161,8 +161,8 @@ c
       tcgets = tcgets + (t1 - t0)
 c
       if (msglvl .gt. 0) then
-         call ivout (logfil, 1, kev, ndigit, '_ngets: KEV is')
-         call ivout (logfil, 1, np, ndigit, '_ngets: NP is')
+         call ivout (logfil, 1, [kev], ndigit, '_ngets: KEV is')
+         call ivout (logfil, 1, [np], ndigit, '_ngets: NP is')
          call zvout (logfil, kev+np, ritz, ndigit,
      &        '_ngets: Eigenvalues of current H matrix ')
          call zvout (logfil, kev+np, bounds, ndigit, 

--- a/mathlibs/src/arpack/zngets.f
+++ b/mathlibs/src/arpack/zngets.f
@@ -2,9 +2,9 @@ c\BeginDoc
 c
 c\Name: zngets
 c
-c\Description: 
+c\Description:
 c  Given the eigenvalues of the upper Hessenberg matrix H,
-c  computes the NP shifts AMU that are zeros of the polynomial of 
+c  computes the NP shifts AMU that are zeros of the polynomial of
 c  degree NP which filters out components of the unwanted eigenvectors
 c  corresponding to the AMU's based on some given criteria.
 c
@@ -40,8 +40,8 @@ c  RITZ    Complex*16 array of length KEV+NP.  (INPUT/OUTPUT)
 c          On INPUT, RITZ contains the the eigenvalues of H.
 c          On OUTPUT, RITZ are sorted so that the unwanted
 c          eigenvalues are in the first NP locations and the wanted
-c          portion is in the last KEV locations.  When exact shifts are 
-c          selected, the unwanted part corresponds to the shifts to 
+c          portion is in the last KEV locations.  When exact shifts are
+c          selected, the unwanted part corresponds to the shifts to
 c          be applied. Also, if ISHIFT .eq. 1, the unwanted eigenvalues
 c          are further sorted so that the ones with largest Ritz values
 c          are first.
@@ -49,7 +49,7 @@ c
 c  BOUNDS  Complex*16 array of length KEV+NP.  (INPUT/OUTPUT)
 c          Error bounds corresponding to the ordering in RITZ.
 c
-c  
+c
 c
 c\EndDoc
 c
@@ -70,9 +70,9 @@ c\Author
 c     Danny Sorensen               Phuong Vu
 c     Richard Lehoucq              CRPC / Rice University
 c     Dept. of Computational &     Houston, Texas
-c     Applied Mathematics 
-c     Rice University           
-c     Houston, Texas 
+c     Applied Mathematics
+c     Rice University
+c     Houston, Texas
 c
 c\SCCS Information: @(#)
 c FILE: ngets.F   SID: 2.2   DATE OF SID: 4/20/96   RELEASE: 2
@@ -136,14 +136,14 @@ c     %-------------------------------%
 c     | Initialize timing statistics  |
 c     | & message level for debugging |
 c     %-------------------------------%
-c 
+c
       call second (t0)
       msglvl = mcgets
-c 
+c
       call zsortc (which, .true., kev+np, ritz, bounds)
-c     
+c
       if ( ishift .eq. 1 ) then
-c     
+c
 c        %-------------------------------------------------------%
 c        | Sort the unwanted Ritz values used as shifts so that  |
 c        | the ones with largest Ritz estimates are first        |
@@ -152,11 +152,11 @@ c        | forward instability of the iteration when the shifts  |
 c        | are applied in subroutine znapps.                     |
 c        | Be careful and use 'SM' since we want to sort BOUNDS! |
 c        %-------------------------------------------------------%
-c     
+c
          call zsortc ( 'SM', .true., np, bounds, ritz )
 c
       end if
-c     
+c
       call second (t1)
       tcgets = tcgets + (t1 - t0)
 c
@@ -165,14 +165,14 @@ c
          call ivout (logfil, 1, [np], ndigit, '_ngets: NP is')
          call zvout (logfil, kev+np, ritz, ndigit,
      &        '_ngets: Eigenvalues of current H matrix ')
-         call zvout (logfil, kev+np, bounds, ndigit, 
+         call zvout (logfil, kev+np, bounds, ndigit,
      &      '_ngets: Ritz estimates of the current KEV+NP Ritz values')
       end if
-c     
+c
       return
-c     
+c
 c     %---------------%
 c     | End of zngets |
 c     %---------------%
-c     
+c
       end

--- a/mathlibs/src/parpack/pcgetv0.f
+++ b/mathlibs/src/parpack/pcgetv0.f
@@ -405,9 +405,9 @@ c     | Check for further orthogonalization. |
 c     %--------------------------------------%
 c
       if (msglvl .gt. 2) then
-          call psvout (comm, logfil, 1, rnorm0, ndigit, 
+          call psvout (comm, logfil, 1, [rnorm0], ndigit, 
      &                '_getv0: re-orthonalization ; rnorm0 is')
-          call psvout (comm, logfil, 1, rnorm, ndigit, 
+          call psvout (comm, logfil, 1, [rnorm], ndigit, 
      &                '_getv0: re-orthonalization ; rnorm is')
       end if
 c
@@ -439,7 +439,7 @@ c
 c
       if (msglvl .gt. 0) then
          cnorm2 = cmplx(rnorm,rzero)
-         call pcvout (comm, logfil, 1, cnorm2, ndigit,
+         call pcvout (comm, logfil, 1, [cnorm2], ndigit,
      &        '_getv0: B-norm of initial / restarted starting vector')
       end if
       if (msglvl .gt. 2) then

--- a/mathlibs/src/parpack/pcgetv0.f
+++ b/mathlibs/src/parpack/pcgetv0.f
@@ -2,15 +2,15 @@ c\BeginDoc
 c
 c\Name: pcgetv0
 c
-c Message Passing Layer: MPI 
+c Message Passing Layer: MPI
 c
-c\Description: 
+c\Description:
 c  Generate a random initial residual vector for the Arnoldi process.
-c  Force the residual vector to be in the range of the operator OP.  
+c  Force the residual vector to be in the range of the operator OP.
 c
 c\Usage:
 c  call pcgetv0
-c     ( COMM, IDO, BMAT, ITRY, INITV, N, J, V, LDV, RESID, RNORM, 
+c     ( COMM, IDO, BMAT, ITRY, INITV, N, J, V, LDV, RESID, RNORM,
 c       IPNTR, WORKD, WORKL, IERR )
 c
 c\Arguments
@@ -39,7 +39,7 @@ c          B = 'I' -> standard eigenvalue problem A*x = lambda*x
 c          B = 'G' -> generalized eigenvalue problem A*x = lambda*B*x
 c
 c  ITRY    Integer.  (INPUT)
-c          ITRY counts the number of times that pcgetv0 is called.  
+c          ITRY counts the number of times that pcgetv0 is called.
 c          It should be set to 1 on the initial call to pcgetv0.
 c
 c  INITV   Logical variable.  (INPUT)
@@ -58,11 +58,11 @@ c          The first J-1 columns of V contain the current Arnoldi basis
 c          if this is a "restart".
 c
 c  LDV     Integer.  (INPUT)
-c          Leading dimension of V exactly as declared in the calling 
+c          Leading dimension of V exactly as declared in the calling
 c          program.
 c
 c  RESID   Complex  array of length N.  (INPUT/OUTPUT)
-c          Initial residual vector to be generated.  If RESID is 
+c          Initial residual vector to be generated.  If RESID is
 c          provided, force RESID into the range of the operator OP.
 c
 c  RNORM   Real  scalar.  (OUTPUT)
@@ -87,7 +87,7 @@ c
 c\BeginLib
 c
 c\Local variables:
-c     xxxxxx  Complex 
+c     xxxxxx  Complex
 c
 c\References:
 c  1. D.C. Sorensen, "Implicit Application of Polynomial Filters in
@@ -97,19 +97,19 @@ c
 c\Routines called:
 c     second   ARPACK utility routine for timing.
 c     pcvout   Parallel ARPACK utility routine that prints vectors.
-c     pclarnv  Parallel wrapper for LAPACK routine clarnv (generates a random vector). 
+c     pclarnv  Parallel wrapper for LAPACK routine clarnv (generates a random vector).
 c     cgemv    Level 2 BLAS routine for matrix vector multiplication.
 c     ccopy    Level 1 BLAS that copies one vector to another.
 c     cdotc    Level 1 BLAS that computes the scalar product of two vectors.
-c     pscnorm2 Parallel version of Level 1 BLAS that computes the norm of a vector. 
+c     pscnorm2 Parallel version of Level 1 BLAS that computes the norm of a vector.
 c
 c\Author
 c     Danny Sorensen               Phuong Vu
 c     Richard Lehoucq              CRPC / Rice University
 c     Dept. of Computational &     Houston, Texas
-c     Applied Mathematics 
-c     Rice University           
-c     Houston, Texas            
+c     Applied Mathematics
+c     Rice University
+c     Houston, Texas
 c
 c\Parallel Modifications
 c     Kristi Maschhoff
@@ -124,10 +124,10 @@ c\EndLib
 c
 c-----------------------------------------------------------------------
 c
-      subroutine pcgetv0 
-     &   ( comm, ido, bmat, itry, initv, n, j, v, ldv, resid, rnorm, 
+      subroutine pcgetv0
+     &   ( comm, ido, bmat, itry, initv, n, j, v, ldv, resid, rnorm,
      &     ipntr, workd, workl, ierr )
-c 
+c
       include   'mpif.h'
 c
 c     %---------------%
@@ -150,7 +150,7 @@ c
       character  bmat*1
       logical    initv
       integer    ido, ierr, itry, j, ldv, n
-      Real 
+      Real
      &           rnorm
 c
 c     %-----------------%
@@ -158,16 +158,16 @@ c     | Array Arguments |
 c     %-----------------%
 c
       integer    ipntr(3)
-      Complex 
+      Complex
      &           resid(n), v(ldv,j), workd(2*n), workl(2*j)
 c
 c     %------------%
 c     | Parameters |
 c     %------------%
 c
-      Complex 
+      Complex
      &           one, zero
-      Real 
+      Real
      &           rzero
       parameter  (one = (1.0, 0.0) , zero = (0.0, 0.0) ,
      &            rzero = 0.0 )
@@ -178,13 +178,13 @@ c     %------------------------%
 c
       logical    first, inits, orth
       integer    idist, iseed(4), iter, msglvl, jj, myid, igen
-      Real 
+      Real
      &           rnorm0
-      Complex 
+      Complex
      &           cnorm, cnorm2
       save       first, iseed, inits, iter, msglvl, orth, rnorm0
 c
-      Complex 
+      Complex
      &           cnorm_buf
 c
 c     %----------------------%
@@ -197,9 +197,9 @@ c     %--------------------%
 c     | External Functions |
 c     %--------------------%
 c
-      Real  
+      Real
      &           pscnorm2, slapy2
-      Complex 
+      Complex
      &           cdotc
       external   cdotc, pscnorm2, slapy2
 c
@@ -245,7 +245,7 @@ c
       end if
 c
       if (ido .eq.  0) then
-c 
+c
 c        %-------------------------------%
 c        | Initialize timing statistics  |
 c        | & message level for debugging |
@@ -253,7 +253,7 @@ c        %-------------------------------%
 c
          call second (t0)
          msglvl = mgetv0
-c 
+c
          ierr   = 0
          iter   = 0
          first  = .FALSE.
@@ -272,7 +272,7 @@ c
             idist = 2
             call pclarnv (comm, idist, iseed, n, resid)
          end if
-c 
+c
 c        %----------------------------------------------------------%
 c        | Force the starting vector into the range of OP to handle |
 c        | the generalized problem when B is possibly (singular).   |
@@ -288,7 +288,7 @@ c
             go to 9000
          end if
       end if
-c 
+c
 c     %----------------------------------------%
 c     | Back from computing B*(initial-vector) |
 c     %----------------------------------------%
@@ -300,10 +300,10 @@ c     | Back from computing B*(orthogonalized-vector) |
 c     %-----------------------------------------------%
 c
       if (orth)  go to 40
-c 
+c
       call second (t3)
       tmvopx = tmvopx + (t3 - t2)
-c 
+c
 c     %------------------------------------------------------%
 c     | Starting vector is now in the range of OP; r = OP*r; |
 c     | Compute B-norm of starting vector.                   |
@@ -321,14 +321,14 @@ c
       else if (bmat .eq. 'I') then
          call ccopy (n, resid, 1, workd, 1)
       end if
-c 
+c
    20 continue
 c
       if (bmat .eq. 'G') then
          call second (t3)
          tmvbx = tmvbx + (t3 - t2)
       end if
-c 
+c
       first = .FALSE.
       if (bmat .eq. 'G') then
           cnorm_buf = cdotc (n, resid, 1, workd, 1)
@@ -345,7 +345,7 @@ c     | Exit if this is the very first Arnoldi step |
 c     %---------------------------------------------%
 c
       if (j .eq. 1) go to 50
-c 
+c
 c     %----------------------------------------------------------------
 c     | Otherwise need to B-orthogonalize the starting vector against |
 c     | the current Arnoldi basis using Gram-Schmidt with iter. ref.  |
@@ -361,13 +361,13 @@ c
       orth = .TRUE.
    30 continue
 c
-      call cgemv ('C', n, j-1, one, v, ldv, workd, 1, 
+      call cgemv ('C', n, j-1, one, v, ldv, workd, 1,
      &            zero, workl(j+1), 1)
       call MPI_ALLREDUCE( workl(j+1), workl, j-1,
      &                    MPI_COMPLEX, MPI_SUM, comm, ierr)
-      call cgemv ('N', n, j-1, -one, v, ldv, workl, 1, 
+      call cgemv ('N', n, j-1, -one, v, ldv, workl, 1,
      &            one, resid, 1)
-c 
+c
 c     %----------------------------------------------------------%
 c     | Compute the B-norm of the orthogonalized starting vector |
 c     %----------------------------------------------------------%
@@ -383,14 +383,14 @@ c
       else if (bmat .eq. 'I') then
          call ccopy (n, resid, 1, workd, 1)
       end if
-c 
+c
    40 continue
 c
       if (bmat .eq. 'G') then
          call second (t3)
          tmvbx = tmvbx + (t3 - t2)
       end if
-c 
+c
       if (bmat .eq. 'G') then
          cnorm_buf = cdotc (n, resid, 1, workd, 1)
          call MPI_ALLREDUCE( cnorm_buf, cnorm, 1,
@@ -405,14 +405,14 @@ c     | Check for further orthogonalization. |
 c     %--------------------------------------%
 c
       if (msglvl .gt. 2) then
-          call psvout (comm, logfil, 1, [rnorm0], ndigit, 
+          call psvout (comm, logfil, 1, [rnorm0], ndigit,
      &                '_getv0: re-orthonalization ; rnorm0 is')
-          call psvout (comm, logfil, 1, [rnorm], ndigit, 
+          call psvout (comm, logfil, 1, [rnorm], ndigit,
      &                '_getv0: re-orthonalization ; rnorm is')
       end if
 c
       if (rnorm .gt. 0.717*rnorm0) go to 50
-c 
+c
       iter = iter + 1
       if (iter .le. 5 ) then
 c
@@ -434,7 +434,7 @@ c
          rnorm = rzero
          ierr = -1
       end if
-c 
+c
    50 continue
 c
       if (msglvl .gt. 0) then
@@ -447,10 +447,10 @@ c
      &        '_getv0: initial / restarted starting vector')
       end if
       ido = 99
-c 
+c
       call second (t1)
       tgetv0 = tgetv0 + (t1 - t0)
-c 
+c
  9000 continue
       return
 c

--- a/mathlibs/src/parpack/pcnaitr.f
+++ b/mathlibs/src/parpack/pcnaitr.f
@@ -404,9 +404,9 @@ c     %--------------------------------------------------------------%
  1000 continue
 c
          if (msglvl .gt. 1) then
-            call pivout (comm, logfil, 1, j, ndigit, 
+            call pivout (comm, logfil, 1, [j], ndigit, 
      &                  '_naitr: generating Arnoldi vector number')
-            call pcvout (comm, logfil, 1, rnorm, ndigit, 
+            call pdvout (comm, logfil, 1, [rnorm], ndigit, 
      &                  '_naitr: B-norm of the current residual is')
          end if
 c 
@@ -426,7 +426,7 @@ c           | basis and continue the iteration.                 |
 c           %---------------------------------------------------%
 c
             if (msglvl .gt. 0) then
-               call pivout (comm, logfil, 1, j, ndigit,
+               call pivout (comm, logfil, 1, [j], ndigit,
      &                     '_naitr: ****** RESTART AT STEP ******')
             end if
 c 
@@ -765,7 +765,7 @@ c
          end if
 c 
          if (msglvl .gt. 0 .and. iter .gt. 0 ) then
-            call pivout (comm, logfil, 1, j, ndigit,
+            call pivout (comm, logfil, 1, [j], ndigit,
      &           '_naitr: Iterative refinement for Arnoldi residual')
             if (msglvl .gt. 2) then
                 rtemp(1) = rnorm

--- a/mathlibs/src/parpack/pcnaitr.f
+++ b/mathlibs/src/parpack/pcnaitr.f
@@ -4,8 +4,8 @@ c\Name: pcnaitr
 c
 c Message Passing Layer: MPI
 c
-c\Description: 
-c  Reverse communication interface for applying NP additional steps to 
+c\Description:
+c  Reverse communication interface for applying NP additional steps to
 c  a K step nonsymmetric Arnoldi factorization.
 c
 c  Input:  OP*V_{k}  -  V_{k}*H = r_{k}*e_{k}^T
@@ -21,7 +21,7 @@ c  computed and returned.
 c
 c\Usage:
 c  call pcnaitr
-c     ( COMM, IDO, BMAT, N, K, NP, NB, RESID, RNORM, V, LDV, H, LDH, 
+c     ( COMM, IDO, BMAT, N, K, NP, NB, RESID, RNORM, V, LDV, H, LDH,
 c       IPNTR, WORKD, WORKL, INFO )
 c
 c\Arguments
@@ -65,8 +65,8 @@ c  NP      Integer.  (INPUT)
 c          Number of additional Arnoldi steps to take.
 c
 c  NB      Integer.  (INPUT)
-c          Blocksize to be used in the recurrence.          
-c          Only work for NB = 1 right now.  The goal is to have a 
+c          Blocksize to be used in the recurrence.
+c          Only work for NB = 1 right now.  The goal is to have a
 c          program that implement both the block and non-block method.
 c
 c  RESID   Complex array of length N.  (INPUT/OUTPUT)
@@ -78,37 +78,37 @@ c          B-norm of the starting residual on input.
 c          B-norm of the updated residual r_{k+p} on output.
 c
 c  V       Complex N by K+NP array.  (INPUT/OUTPUT)
-c          On INPUT:  V contains the Arnoldi vectors in the first K 
+c          On INPUT:  V contains the Arnoldi vectors in the first K
 c          columns.
 c          On OUTPUT: V contains the new NP Arnoldi vectors in the next
 c          NP columns.  The first K columns are unchanged.
 c
 c  LDV     Integer.  (INPUT)
-c          Leading dimension of V exactly as declared in the calling 
+c          Leading dimension of V exactly as declared in the calling
 c          program.
 c
 c  H       Complex (K+NP) by (K+NP) array.  (INPUT/OUTPUT)
 c          H is used to store the generated upper Hessenberg matrix.
 c
 c  LDH     Integer.  (INPUT)
-c          Leading dimension of H exactly as declared in the calling 
+c          Leading dimension of H exactly as declared in the calling
 c          program.
 c
 c  IPNTR   Integer array of length 3.  (OUTPUT)
-c          Pointer to mark the starting locations in the WORK for 
+c          Pointer to mark the starting locations in the WORK for
 c          vectors used by the Arnoldi iteration.
 c          -------------------------------------------------------------
 c          IPNTR(1): pointer to the current operand vector X.
 c          IPNTR(2): pointer to the current result vector Y.
-c          IPNTR(3): pointer to the vector B * X when used in the 
+c          IPNTR(3): pointer to the vector B * X when used in the
 c                    shift-and-invert mode.  X is the current operand.
 c          -------------------------------------------------------------
-c          
+c
 c  WORKD   Complex work array of length 3*N.  (REVERSE COMMUNICATION)
 c          Distributed array to be used in the basic Arnoldi iteration
-c          for reverse communication.  The calling program should not 
+c          for reverse communication.  The calling program should not
 c          use WORKD as temporary workspace during the iteration !!!!!!
-c          On input, WORKD(1:N) = B*RESID and is used to save some 
+c          On input, WORKD(1:N) = B*RESID and is used to save some
 c          computation at the first step.
 c
 c  WORKL   Complex work space used for Gram Schmidt orthogonalization
@@ -130,7 +130,7 @@ c\References:
 c  1. D.C. Sorensen, "Implicit Application of Polynomial Filters in
 c     a k-Step Arnoldi Method", SIAM J. Matr. Anal. Apps., 13 (1992),
 c     pp 357-385.
-c  2. R.B. Lehoucq, "Analysis and Implementation of an Implicitly 
+c  2. R.B. Lehoucq, "Analysis and Implementation of an Implicitly
 c     Restarted Arnoldi Iteration", Rice University Technical Report
 c     TR95-13, Department of Computational and Applied Mathematics.
 c
@@ -149,21 +149,21 @@ c     slapy2    LAPACK routine to compute sqrt(x**2+y**2) carefully.
 c     cgemv     Level 2 BLAS routine for matrix vector multiplication.
 c     caxpy     Level 1 BLAS that computes a vector triad.
 c     ccopy     Level 1 BLAS that copies one vector to another .
-c     cdotc     Level 1 BLAS that computes the scalar product of 
-c               two vectors. 
+c     cdotc     Level 1 BLAS that computes the scalar product of
+c               two vectors.
 c     cscal     Level 1 BLAS that scales a vector.
 c     csscal    Level 1 BLAS that scales a complex vector by a real number.
-c     pscnorm2  Parallel version of Level 1 BLAS that computes the 
+c     pscnorm2  Parallel version of Level 1 BLAS that computes the
 c               norm of a vector.
 c
 c\Author
 c     Danny Sorensen               Phuong Vu
 c     Richard Lehoucq              CRPC / Rice University
-c     Dept. of Computational &     Houston, Texas 
-c     Applied Mathematics 
-c     Rice University           
-c     Houston, Texas 
-c 
+c     Dept. of Computational &     Houston, Texas
+c     Applied Mathematics
+c     Rice University
+c     Houston, Texas
+c
 c\Parallel Modifications
 c     Kristi Maschhoff
 c
@@ -175,11 +175,11 @@ c FILE: naitr.F   SID: 1.3   DATE OF SID: 3/19/97
 c
 c\Remarks
 c  The algorithm implemented is:
-c  
+c
 c  restart = .false.
-c  Given V_{k} = [v_{1}, ..., v_{k}], r_{k}; 
+c  Given V_{k} = [v_{1}, ..., v_{k}], r_{k};
 c  r_{k} contains the initial residual vector even for k = 0;
-c  Also assume that rnorm = || B*r_{k} || and B*r_{k} are already 
+c  Also assume that rnorm = || B*r_{k} || and B*r_{k} are already
 c  computed by the calling program.
 c
 c  betaj = rnorm ; p_{k+1} = B*r_{k} ;
@@ -187,7 +187,7 @@ c  For  j = k+1, ..., k+np  Do
 c     1) if ( betaj < tol ) stop or restart depending on j.
 c        ( At present tol is zero )
 c        if ( restart ) generate a new starting vector.
-c     2) v_{j} = r(j-1)/betaj;  V_{j} = [V_{j-1}, v_{j}];  
+c     2) v_{j} = r(j-1)/betaj;  V_{j} = [V_{j-1}, v_{j}];
 c        p_{j} = p_{j}/betaj
 c     3) r_{j} = OP*v_{j} where OP is defined as in pcnaupd
 c        For shift-invert mode p_{j} = B*v_{j} is already available.
@@ -202,7 +202,7 @@ c        If (rnorm > 0.717*wnorm) accept step and go back to 1)
 c     5) Re-orthogonalization step:
 c        s = V_{j}'*B*r_{j}
 c        r_{j} = r_{j} - V_{j}*s;  rnorm1 = || r_{j} ||
-c        alphaj = alphaj + s_{j};   
+c        alphaj = alphaj + s_{j};
 c     6) Iterative refinement step:
 c        If (rnorm1 > 0.717*rnorm) then
 c           rnorm = rnorm1
@@ -212,7 +212,7 @@ c           rnorm = rnorm1
 c           If this is the first time in step 6), go to 5)
 c           Else r_{j} lies in the span of V_{j} numerically.
 c              Set r_{j} = 0 and rnorm = 0; go to 1)
-c        EndIf 
+c        EndIf
 c  End Do
 c
 c\EndLib
@@ -220,7 +220,7 @@ c
 c-----------------------------------------------------------------------
 c
       subroutine pcnaitr
-     &   (comm, ido, bmat, n, k, np, nb, resid, rnorm, v, ldv, h, ldh, 
+     &   (comm, ido, bmat, n, k, np, nb, resid, rnorm, v, ldv, h, ldh,
      &    ipntr, workd, workl, info)
 c
       include   'mpif.h'
@@ -298,7 +298,7 @@ c     %----------------------%
 c     | External Subroutines |
 c     %----------------------%
 c
-      external   caxpy, ccopy, cscal, cgemv, pcgetv0, slabad, 
+      external   caxpy, ccopy, cscal, cgemv, pcgetv0, slabad,
      &           csscal, pcvout, pcmout, pivout, second
 c
 c     %--------------------%
@@ -306,8 +306,8 @@ c     | External Functions |
 c     %--------------------%
 c
       Complex
-     &           cdotc 
-      Real            
+     &           cdotc
+      Real
      &           pslamch10, pscnorm2, clanhs, slapy2
       external   cdotc, pscnorm2, clanhs, pslamch10, slapy2
 c
@@ -315,7 +315,7 @@ c     %---------------------%
 c     | Intrinsic Functions |
 c     %---------------------%
 c
-      intrinsic  aimag, real, max, sqrt 
+      intrinsic  aimag, real, max, sqrt
 c
 c     %-----------------%
 c     | Data statements |
@@ -346,7 +346,7 @@ c
       end if
 c
       if (ido .eq. 0) then
-c 
+c
 c        %-------------------------------%
 c        | Initialize timing statistics  |
 c        | & message level for debugging |
@@ -354,7 +354,7 @@ c        %-------------------------------%
 c
          call second (t0)
          msglvl = mcaitr
-c 
+c
 c        %------------------------------%
 c        | Initial call to this routine |
 c        %------------------------------%
@@ -370,7 +370,7 @@ c
          irj    = ipj   + n
          ivj    = irj   + n
       end if
-c 
+c
 c     %-------------------------------------------------%
 c     | When in reverse communication mode one of:      |
 c     | STEP3, STEP4, ORTH1, ORTH2, RSTART              |
@@ -400,16 +400,16 @@ c     |        A R N O L D I     I T E R A T I O N     L O O P       |
 c     |                                                              |
 c     | Note:  B*r_{j-1} is already in WORKD(1:N)=WORKD(IPJ:IPJ+N-1) |
 c     %--------------------------------------------------------------%
- 
+
  1000 continue
 c
          if (msglvl .gt. 1) then
-            call pivout (comm, logfil, 1, [j], ndigit, 
+            call pivout (comm, logfil, 1, [j], ndigit,
      &                  '_naitr: generating Arnoldi vector number')
-            call pdvout (comm, logfil, 1, [rnorm], ndigit, 
+            call pdvout (comm, logfil, 1, [rnorm], ndigit,
      &                  '_naitr: B-norm of the current residual is')
          end if
-c 
+c
 c        %---------------------------------------------------%
 c        | STEP 1: Check if the B norm of j-th residual      |
 c        | vector is zero. Equivalent to determine whether   |
@@ -429,14 +429,14 @@ c
                call pivout (comm, logfil, 1, [j], ndigit,
      &                     '_naitr: ****** RESTART AT STEP ******')
             end if
-c 
+c
 c           %---------------------------------------------%
 c           | ITRY is the loop variable that controls the |
 c           | maximum amount of times that a restart is   |
 c           | attempted. NRSTRT is used by stat.h         |
 c           %---------------------------------------------%
 c
-            betaj  = rzero 
+            betaj  = rzero
             nrstrt = nrstrt + 1
             itry   = 1
    20       continue
@@ -449,7 +449,7 @@ c           | If in reverse communication mode and |
 c           | RSTART = .true. flow returns here.   |
 c           %--------------------------------------%
 c
-            call pcgetv0 (comm, ido, bmat, itry, .false., n, j, v, ldv, 
+            call pcgetv0 (comm, ido, bmat, itry, .false., n, j, v, ldv,
      &                   resid, rnorm, ipntr, workd, workl, ierr)
             if (ido .ne. 99) go to 9000
             if (ierr .lt. 0) then
@@ -468,7 +468,7 @@ c
                ido = 99
                go to 9000
             end if
-c 
+c
    40    continue
 c
 c        %---------------------------------------------------------%
@@ -509,14 +509,14 @@ c
          ipntr(2) = irj
          ipntr(3) = ipj
          ido = 1
-c 
+c
 c        %-----------------------------------%
 c        | Exit in order to compute OP*v_{j} |
 c        %-----------------------------------%
-c 
-         go to 9000 
+c
+         go to 9000
    50    continue
-c 
+c
 c        %----------------------------------%
 c        | Back from reverse communication; |
 c        | WORKD(IRJ:IRJ+N-1) := OP*v_{j}   |
@@ -525,7 +525,7 @@ c        %----------------------------------%
 c
          call second (t3)
          tmvopx = tmvopx + (t3 - t2)
- 
+
          step3 = .false.
 c
 c        %------------------------------------------%
@@ -533,7 +533,7 @@ c        | Put another copy of OP*v_{j} into RESID. |
 c        %------------------------------------------%
 c
          call ccopy (n, workd(irj), 1, resid, 1)
-c 
+c
 c        %---------------------------------------%
 c        | STEP 4:  Finish extending the Arnoldi |
 c        |          factorization to length j.   |
@@ -546,17 +546,17 @@ c
             ipntr(1) = irj
             ipntr(2) = ipj
             ido = 2
-c 
+c
 c           %-------------------------------------%
 c           | Exit in order to compute B*OP*v_{j} |
 c           %-------------------------------------%
-c 
+c
             go to 9000
          else if (bmat .eq. 'I') then
             call ccopy (n, resid, 1, workd(ipj), 1)
          end if
    60    continue
-c 
+c
 c        %----------------------------------%
 c        | Back from reverse communication; |
 c        | WORKD(IPJ:IPJ+N-1) := B*OP*v_{j} |
@@ -567,7 +567,7 @@ c
             call second (t3)
             tmvbx = tmvbx + (t3 - t2)
          end if
-c 
+c
          step4 = .false.
 c
 c        %-------------------------------------%
@@ -605,7 +605,7 @@ c
 c
 c        %--------------------------------------%
 c        | Orthogonalize r_{j} against V_{j}.   |
-c        | RESID contains OP*v_{j}. See STEP 3. | 
+c        | RESID contains OP*v_{j}. See STEP 3. |
 c        %--------------------------------------%
 c
          call cgemv ('N', n, j, -one, v, ldv, h(1,j), 1,
@@ -614,9 +614,9 @@ c
          if (j .gt. 1) h(j,j-1) = cmplx(betaj, rzero)
 c
          call second (t4)
-c 
+c
          orth1 = .true.
-c 
+c
          call second (t2)
          if (bmat .eq. 'G') then
             nbx = nbx + 1
@@ -624,17 +624,17 @@ c
             ipntr(1) = irj
             ipntr(2) = ipj
             ido = 2
-c 
+c
 c           %----------------------------------%
 c           | Exit in order to compute B*r_{j} |
 c           %----------------------------------%
-c 
+c
             go to 9000
          else if (bmat .eq. 'I') then
             call ccopy (n, resid, 1, workd(ipj), 1)
-         end if 
+         end if
    70    continue
-c 
+c
 c        %---------------------------------------------------%
 c        | Back from reverse communication if ORTH1 = .true. |
 c        | WORKD(IPJ:IPJ+N-1) := B*r_{j}.                    |
@@ -644,7 +644,7 @@ c
             call second (t3)
             tmvbx = tmvbx + (t3 - t2)
          end if
-c 
+c
          orth1 = .false.
 c
 c        %------------------------------%
@@ -659,7 +659,7 @@ c
          else if (bmat .eq. 'I') then
             rnorm = pscnorm2(comm, n, resid, 1)
          end if
-c 
+c
 c        %-----------------------------------------------------------%
 c        | STEP 5: Re-orthogonalization / Iterative refinement phase |
 c        | Maximum NITER_ITREF tries.                                |
@@ -682,20 +682,20 @@ c
 c
          iter  = 0
          nrorth = nrorth + 1
-c 
+c
 c        %---------------------------------------------------%
 c        | Enter the Iterative refinement phase. If further  |
 c        | refinement is necessary, loop back here. The loop |
 c        | variable is ITER. Perform a step of Classical     |
 c        | Gram-Schmidt using all the Arnoldi vectors V_{j}  |
 c        %---------------------------------------------------%
-c 
+c
    80    continue
 c
          if (msglvl .gt. 2) then
             rtemp(1) = wnorm
             rtemp(2) = rnorm
-            call psvout (comm, logfil, 2, rtemp, ndigit, 
+            call psvout (comm, logfil, 2, rtemp, ndigit,
      &      '_naitr: re-orthogonalization; wnorm and rnorm are')
             call pcvout (comm, logfil, j, h(1,j), ndigit,
      &                  '_naitr: j-th column of H')
@@ -718,10 +718,10 @@ c        | The correction to H is v(:,1:J)*H(1:J,1:J)  |
 c        | + v(:,1:J)*WORKD(IRJ:IRJ+J-1)*e'_j.         |
 c        %---------------------------------------------%
 c
-         call cgemv ('N', n, j, -one, v, ldv, workl(1), 1, 
+         call cgemv ('N', n, j, -one, v, ldv, workl(1), 1,
      &               one, resid, 1)
          call caxpy (j, one, workl(1), 1, h(1,j), 1)
-c 
+c
          orth2 = .true.
          call second (t2)
          if (bmat .eq. 'G') then
@@ -730,16 +730,16 @@ c
             ipntr(1) = irj
             ipntr(2) = ipj
             ido = 2
-c 
+c
 c           %-----------------------------------%
 c           | Exit in order to compute B*r_{j}. |
 c           | r_{j} is the corrected residual.  |
 c           %-----------------------------------%
-c 
+c
             go to 9000
          else if (bmat .eq. 'I') then
             call ccopy (n, resid, 1, workd(ipj), 1)
-         end if 
+         end if
    90    continue
 c
 c        %---------------------------------------------------%
@@ -749,12 +749,12 @@ c
          if (bmat .eq. 'G') then
             call second (t3)
             tmvbx = tmvbx + (t3 - t2)
-         end if 
+         end if
 c
 c        %-----------------------------------------------------%
 c        | Compute the B-norm of the corrected residual r_{j}. |
 c        %-----------------------------------------------------%
-c 
+c
          if (bmat .eq. 'G') then
              cnorm_buf = cdotc (n, resid, 1, workd(ipj), 1)
             call MPI_ALLREDUCE( cnorm_buf, cnorm, 1,
@@ -763,7 +763,7 @@ c
          else if (bmat .eq. 'I') then
              rnorm1 = pscnorm2(comm, n, resid, 1)
          end if
-c 
+c
          if (msglvl .gt. 0 .and. iter .gt. 0 ) then
             call pivout (comm, logfil, 1, [j], ndigit,
      &           '_naitr: Iterative refinement for Arnoldi residual')
@@ -793,7 +793,7 @@ c           | angle of less than arcCOS(0.717)      |
 c           %---------------------------------------%
 c
             rnorm = rnorm1
-c 
+c
          else
 c
 c           %-------------------------------------------%
@@ -815,21 +815,21 @@ c
   95        continue
             rnorm = rzero
          end if
-c 
+c
 c        %----------------------------------------------%
 c        | Branch here directly if iterative refinement |
 c        | wasn't necessary or after at most NITER_REF  |
 c        | steps of iterative refinement.               |
 c        %----------------------------------------------%
-c 
+c
   100    continue
-c 
+c
          rstart = .false.
          orth2  = .false.
-c 
+c
          call second (t5)
          titref = titref + (t5 - t4)
-c 
+c
 c        %------------------------------------%
 c        | STEP 6: Update  j = j+1;  Continue |
 c        %------------------------------------%
@@ -840,13 +840,13 @@ c
             tcaitr = tcaitr + (t1 - t0)
             ido = 99
             do 110 i = max(1,k), k+np-1
-c     
+c
 c              %--------------------------------------------%
 c              | Check for splitting and deflation.         |
 c              | Use a standard test as in the QR algorithm |
 c              | REFERENCE: LAPACK subroutine clahqr        |
 c              %--------------------------------------------%
-c     
+c
                tst1 = slapy2(real(h(i,i)),aimag(h(i,i)))
      &              + slapy2(real(h(i+1,i+1)), aimag(h(i+1,i+1)))
                if( tst1.eq.real(zero) )
@@ -855,12 +855,12 @@ c
      &                    max( ulp*tst1, smlnum ) )
      &             h(i+1,i) = zero
  110        continue
-c     
+c
             if (msglvl .gt. 2) then
-               call pcmout (comm, logfil, k+np, k+np, h, ldh, ndigit, 
+               call pcmout (comm, logfil, k+np, k+np, h, ldh, ndigit,
      &          '_naitr: Final upper Hessenberg matrix H of order K+NP')
             end if
-c     
+c
             go to 9000
          end if
 c
@@ -869,7 +869,7 @@ c        | Loop back to extend the factorization by another step. |
 c        %--------------------------------------------------------%
 c
       go to 1000
-c 
+c
 c     %---------------------------------------------------------------%
 c     |                                                               |
 c     |  E N D     O F     M A I N     I T E R A T I O N     L O O P  |

--- a/mathlibs/src/parpack/pcnapps.f
+++ b/mathlibs/src/parpack/pcnapps.f
@@ -21,7 +21,7 @@ c     A*VNEW_{k} - VNEW_{k}*HNEW_{k} = rnew_{k}*e_{k}^T.
 c
 c\Usage:
 c  call pcnapps
-c     ( COMM, N, KEV, NP, SHIFT, V, LDV, H, LDH, RESID, Q, LDQ, 
+c     ( COMM, N, KEV, NP, SHIFT, V, LDV, H, LDH, RESID, Q, LDQ,
 c       WORKL, WORKD )
 c
 c\Arguments
@@ -32,7 +32,7 @@ c          Problem size, i.e. size of matrix A.
 c
 c  KEV     Integer.  (INPUT/OUTPUT)
 c          KEV+NP is the size of the input matrix H.
-c          KEV is the size of the updated matrix HNEW. 
+c          KEV is the size of the updated matrix HNEW.
 c
 c  NP      Integer.  (INPUT)
 c          Number of implicit shifts to be applied.
@@ -50,7 +50,7 @@ c          Leading dimension of V exactly as declared in the calling
 c          program.
 c
 c  H       Complex (KEV+NP) by (KEV+NP) array.  (INPUT/OUTPUT)
-c          On INPUT, H contains the current KEV+NP by KEV+NP upper 
+c          On INPUT, H contains the current KEV+NP by KEV+NP upper
 c          Hessenberg matrix of the Arnoldi factorization.
 c          On OUTPUT, H contains the updated KEV by KEV upper Hessenberg
 c          matrix in the KEV leading submatrix.
@@ -61,7 +61,7 @@ c          program.
 c
 c  RESID   Complex array of length N.  (INPUT/OUTPUT)
 c          On INPUT, RESID contains the the residual vector r_{k+p}.
-c          On OUTPUT, RESID is the update residual vector rnew_{k} 
+c          On OUTPUT, RESID is the update residual vector rnew_{k}
 c          in the first KEV locations.
 c
 c  Q       Complex KEV+NP by KEV+NP work array.  (WORKSPACE)
@@ -116,9 +116,9 @@ c\Author
 c     Danny Sorensen               Phuong Vu
 c     Richard Lehoucq              CRPC / Rice University
 c     Dept. of Computational &     Houston, Texas
-c     Applied Mathematics 
-c     Rice University           
-c     Houston, Texas 
+c     Applied Mathematics
+c     Rice University
+c     Houston, Texas
 c
 c\Parallel Modifications
 c     Kristi Maschhoff
@@ -142,7 +142,7 @@ c
 c-----------------------------------------------------------------------
 c
       subroutine pcnapps
-     &   ( comm, n, kev, np, shift, v, ldv, h, ldh, resid, q, ldq, 
+     &   ( comm, n, kev, np, shift, v, ldv, h, ldh, resid, q, ldq,
      &     workl, workd )
 c
 c     %--------------------%
@@ -169,7 +169,7 @@ c     | Array Arguments |
 c     %-----------------%
 c
       Complex
-     &           h(ldh,kev+np), resid(n), shift(np), 
+     &           h(ldh,kev+np), resid(n), shift(np),
      &           v(ldv,kev+np), q(ldq,kev+np), workd(2*n), workl(kev+np)
 c
 c     %------------%
@@ -191,22 +191,22 @@ c
       logical    first
       Complex
      &           cdum, f, g, h11, h21, r, s, sigma, t
-      Real             
+      Real
      &           c,  ovfl, smlnum, ulp, unfl, tst1
-      save       first, ovfl, smlnum, ulp, unfl 
+      save       first, ovfl, smlnum, ulp, unfl
 c
 c     %----------------------%
 c     | External Subroutines |
 c     %----------------------%
 c
-      external   caxpy, ccopy, cgemv, cscal, clacpy, clartg, 
+      external   caxpy, ccopy, cgemv, cscal, clacpy, clartg,
      &           pcvout, claset, slabad, pcmout, second, pivout
 c
 c     %--------------------%
 c     | External Functions |
 c     %--------------------%
 c
-      Real                 
+      Real
      &           clanhs, pslamch10, slapy2
       external   clanhs, pslamch10, slapy2
 c
@@ -220,7 +220,7 @@ c     %---------------------%
 c     | Statement Functions |
 c     %---------------------%
 c
-      Real     
+      Real
      &           cabs1
       cabs1( cdum ) = abs( real( cdum ) ) + abs( aimag( cdum ) )
 c
@@ -258,9 +258,9 @@ c     %-------------------------------%
 c
       call second (t0)
       msglvl = mcapps
-c 
-      kplusp = kev + np 
-c 
+c
+      kplusp = kev + np
+c
 c     %--------------------------------------------%
 c     | Initialize Q to the identity to accumulate |
 c     | the rotations and reflections              |
@@ -284,9 +284,9 @@ c
          sigma = shift(jj)
 c
          if (msglvl .gt. 2 ) then
-            call pivout (comm, logfil, 1, [jj], ndigit, 
+            call pivout (comm, logfil, 1, [jj], ndigit,
      &               '_napps: shift number.')
-            call pcvout (comm, logfil, 1, [sigma], ndigit, 
+            call pcvout (comm, logfil, 1, [sigma], ndigit,
      &               '_napps: Value of the shift ')
          end if
 c
@@ -304,14 +304,14 @@ c
             tst1 = cabs1( h( i, i ) ) + cabs1( h( i+1, i+1 ) )
             if( tst1.eq.rzero )
      &         tst1 = clanhs( '1', kplusp-jj+1, h, ldh, workl )
-            if ( abs(real(h(i+1,i))) 
+            if ( abs(real(h(i+1,i)))
      &           .le. max(ulp*tst1, smlnum) )  then
                if (msglvl .gt. 0) then
-                  call pivout (comm, logfil, 1, [i], ndigit, 
+                  call pivout (comm, logfil, 1, [i], ndigit,
      &                 '_napps: matrix splitting at row/column no.')
-                  call pivout (comm, logfil, 1, [jj], ndigit, 
+                  call pivout (comm, logfil, 1, [jj], ndigit,
      &                 '_napps: matrix splitting with shift number.')
-                  call pcvout (comm, logfil, 1, h(i+1,i), ndigit, 
+                  call pcvout (comm, logfil, 1, h(i+1,i), ndigit,
      &                 '_napps: off diagonal element.')
                end if
                iend = i
@@ -323,9 +323,9 @@ c
    40    continue
 c
          if (msglvl .gt. 2) then
-             call pivout (comm, logfil, 1, [istart], ndigit, 
+             call pivout (comm, logfil, 1, [istart], ndigit,
      &                   '_napps: Start of current block ')
-             call pivout (comm, logfil, 1, [iend], ndigit, 
+             call pivout (comm, logfil, 1, [iend], ndigit,
      &                   '_napps: End of current block ')
          end if
 c
@@ -341,7 +341,7 @@ c
          h21 = h(istart+1,istart)
          f = h11 - sigma
          g = h21
-c 
+c
          do 80 i = istart, iend-1
 c
 c           %------------------------------------------------------%
@@ -361,7 +361,7 @@ c
             do 50 j = i, kplusp
                t        =  c*h(i,j) + s*h(i+1,j)
                h(i+1,j) = -conjg(s)*h(i,j) + c*h(i+1,j)
-               h(i,j)   = t   
+               h(i,j)   = t
    50       continue
 c
 c           %---------------------------------------------%
@@ -371,7 +371,7 @@ c
             do 60 j = 1, min(i+2,iend)
                t        =  c*h(j,i) + conjg(s)*h(j,i+1)
                h(j,i+1) = -s*h(j,i) + c*h(j,i+1)
-               h(j,i)   = t   
+               h(j,i)   = t
    60       continue
 c
 c           %-----------------------------------------------------%
@@ -381,7 +381,7 @@ c
             do 70 j = 1, min(i+jj, kplusp)
                t        =   c*q(j,i) + conjg(s)*q(j,i+1)
                q(j,i+1) = - s*q(j,i) + c*q(j,i+1)
-               q(j,i)   = t   
+               q(j,i)   = t
    70       continue
 c
 c           %---------------------------%
@@ -397,7 +397,7 @@ c
 c        %-------------------------------%
 c        | Finished applying the shift.  |
 c        %-------------------------------%
-c 
+c
   100    continue
 c
 c        %---------------------------------------------------------%
@@ -444,7 +444,7 @@ c
          tst1 = cabs1( h( i, i ) ) + cabs1( h( i+1, i+1 ) )
          if( tst1 .eq. rzero )
      &       tst1 = clanhs( '1', kev, h, ldh, workl )
-         if( real( h( i+1,i ) ) .le. max( ulp*tst1, smlnum ) ) 
+         if( real( h( i+1,i ) ) .le. max( ulp*tst1, smlnum ) )
      &       h(i+1,i) = zero
  130  continue
 c
@@ -457,9 +457,9 @@ c     | of H would be zero as in exact arithmetic.      |
 c     %-------------------------------------------------%
 c
       if ( real( h(kev+1,kev) ) .gt. rzero )
-     &   call cgemv ('N', n, kplusp, one, v, ldv, q(1,kev+1), 1, zero, 
+     &   call cgemv ('N', n, kplusp, one, v, ldv, q(1,kev+1), 1, zero,
      &                workd(n+1), 1)
-c 
+c
 c     %----------------------------------------------------------%
 c     | Compute column 1 to kev of (V*Q) in backward order       |
 c     | taking advantage of the upper Hessenberg structure of Q. |
@@ -476,14 +476,14 @@ c     |  Move v(:,kplusp-kev+1:kplusp) into v(:,1:kev). |
 c     %-------------------------------------------------%
 c
       call clacpy ('A', n, kev, v(1,kplusp-kev+1), ldv, v, ldv)
-c 
+c
 c     %--------------------------------------------------------------%
 c     | Copy the (kev+1)-st column of (V*Q) in the appropriate place |
 c     %--------------------------------------------------------------%
 c
       if ( real( h(kev+1,kev) ) .gt. rzero )
      &   call ccopy (n, workd(n+1), 1, v(1,kev+1), 1)
-c 
+c
 c     %-------------------------------------%
 c     | Update the residual vector:         |
 c     |    r <- sigmak*r + betak*v(:,kev+1) |
@@ -501,7 +501,7 @@ c
      &        '_napps: sigmak = (e_{kev+p}^T*Q)*e_{kev}')
          call pcvout (comm, logfil, 1, h(kev+1,kev), ndigit,
      &        '_napps: betak = e_{kev+1}^T*H*e_{kev}')
-         call pivout (comm, logfil, 1, [kev], ndigit, 
+         call pivout (comm, logfil, 1, [kev], ndigit,
      &               '_napps: Order of the final Hessenberg matrix ')
          if (msglvl .gt. 2) then
             call pcmout (comm, logfil, kev, kev, h, ldh, ndigit,
@@ -513,7 +513,7 @@ c
  9000 continue
       call second (t1)
       tcapps = tcapps + (t1 - t0)
-c 
+c
       return
 c
 c     %----------------%

--- a/mathlibs/src/parpack/pcnapps.f
+++ b/mathlibs/src/parpack/pcnapps.f
@@ -284,9 +284,9 @@ c
          sigma = shift(jj)
 c
          if (msglvl .gt. 2 ) then
-            call pivout (comm, logfil, 1, jj, ndigit, 
+            call pivout (comm, logfil, 1, [jj], ndigit, 
      &               '_napps: shift number.')
-            call pcvout (comm, logfil, 1, sigma, ndigit, 
+            call pcvout (comm, logfil, 1, [sigma], ndigit, 
      &               '_napps: Value of the shift ')
          end if
 c
@@ -307,9 +307,9 @@ c
             if ( abs(real(h(i+1,i))) 
      &           .le. max(ulp*tst1, smlnum) )  then
                if (msglvl .gt. 0) then
-                  call pivout (comm, logfil, 1, i, ndigit, 
+                  call pivout (comm, logfil, 1, [i], ndigit, 
      &                 '_napps: matrix splitting at row/column no.')
-                  call pivout (comm, logfil, 1, jj, ndigit, 
+                  call pivout (comm, logfil, 1, [jj], ndigit, 
      &                 '_napps: matrix splitting with shift number.')
                   call pcvout (comm, logfil, 1, h(i+1,i), ndigit, 
      &                 '_napps: off diagonal element.')
@@ -323,9 +323,9 @@ c
    40    continue
 c
          if (msglvl .gt. 2) then
-             call pivout (comm, logfil, 1, istart, ndigit, 
+             call pivout (comm, logfil, 1, [istart], ndigit, 
      &                   '_napps: Start of current block ')
-             call pivout (comm, logfil, 1, iend, ndigit, 
+             call pivout (comm, logfil, 1, [iend], ndigit, 
      &                   '_napps: End of current block ')
          end if
 c
@@ -501,7 +501,7 @@ c
      &        '_napps: sigmak = (e_{kev+p}^T*Q)*e_{kev}')
          call pcvout (comm, logfil, 1, h(kev+1,kev), ndigit,
      &        '_napps: betak = e_{kev+1}^T*H*e_{kev}')
-         call pivout (comm, logfil, 1, kev, ndigit, 
+         call pivout (comm, logfil, 1, [kev], ndigit, 
      &               '_napps: Order of the final Hessenberg matrix ')
          if (msglvl .gt. 2) then
             call pcmout (comm, logfil, kev, kev, h, ldh, ndigit,

--- a/mathlibs/src/parpack/pcnaup2.f
+++ b/mathlibs/src/parpack/pcnaup2.f
@@ -2,15 +2,15 @@ c\BeginDoc
 c
 c\Name: pcnaup2
 c
-c Message Passing Layer: MPI 
+c Message Passing Layer: MPI
 c
-c\Description: 
+c\Description:
 c  Intermediate level interface called by pcnaupd.
 c
 c\Usage:
 c  call pcnaup2
 c     ( COMM, IDO, BMAT, N, WHICH, NEV, NP, TOL, RESID, MODE, IUPD,
-c       ISHIFT, MXITER, V, LDV, H, LDH, RITZ, BOUNDS, 
+c       ISHIFT, MXITER, V, LDV, H, LDH, RITZ, BOUNDS,
 c       Q, LDQ, WORKL, IPNTR, WORKD, RWORK, INFO )
 c
 c\Arguments
@@ -40,27 +40,27 @@ c          IUPD .EQ. 0: use explicit restart instead implicit update.
 c          IUPD .NE. 0: use implicit update.
 c
 c  V       Complex  N by (NEV+NP) array.  (INPUT/OUTPUT)
-c          The Arnoldi basis vectors are returned in the first NEV 
+c          The Arnoldi basis vectors are returned in the first NEV
 c          columns of V.
 c
 c  LDV     Integer.  (INPUT)
-c          Leading dimension of V exactly as declared in the calling 
+c          Leading dimension of V exactly as declared in the calling
 c          program.
 c
 c  H       Complex  (NEV+NP) by (NEV+NP) array.  (OUTPUT)
 c          H is used to store the generated upper Hessenberg matrix
 c
 c  LDH     Integer.  (INPUT)
-c          Leading dimension of H exactly as declared in the calling 
+c          Leading dimension of H exactly as declared in the calling
 c          program.
 c
 c  RITZ    Complex  array of length NEV+NP.  (OUTPUT)
 c          RITZ(1:NEV)  contains the computed Ritz values of OP.
 c
 c  BOUNDS  Complex  array of length NEV+NP.  (OUTPUT)
-c          BOUNDS(1:NEV) contain the error bounds corresponding to 
+c          BOUNDS(1:NEV) contain the error bounds corresponding to
 c          the computed Ritz values.
-c          
+c
 c  Q       Complex  (NEV+NP) by (NEV+NP) array.  (WORKSPACE)
 c          Private (replicated) work array used to accumulate the
 c          rotation in the shift application step.
@@ -69,7 +69,7 @@ c  LDQ     Integer.  (INPUT)
 c          Leading dimension of Q exactly as declared in the calling
 c          program.
 c
-c  WORKL   Complex  work array of length at least 
+c  WORKL   Complex  work array of length at least
 c          (NEV+NP)**2 + 3*(NEV+NP).  (WORKSPACE)
 c          Private (replicated) array on each PE or array allocated on
 c          the front end.  It is used in shifts calculation, shifts
@@ -77,15 +77,15 @@ c          application and convergence checking.
 c
 c
 c  IPNTR   Integer array of length 3.  (OUTPUT)
-c          Pointer to mark the starting locations in the WORKD for 
+c          Pointer to mark the starting locations in the WORKD for
 c          vectors used by the Arnoldi iteration.
 c          -------------------------------------------------------------
 c          IPNTR(1): pointer to the current operand vector X.
 c          IPNTR(2): pointer to the current result vector Y.
-c          IPNTR(3): pointer to the vector B * X when used in the 
+c          IPNTR(3): pointer to the vector B * X when used in the
 c                    shift-and-invert mode.  X is the current operand.
 c          -------------------------------------------------------------
-c          
+c
 c  WORKD   Complex  work array of length 3*N.  (WORKSPACE)
 c          Distributed array to be used in the basic Arnoldi iteration
 c          for reverse communication.  The user should not use WORKD
@@ -103,7 +103,7 @@ c                          possibly from a previous run.
 c          Error flag on output.
 c          =     0: Normal return.
 c          =     1: Maximum number of iterations taken.
-c                   All possible eigenvalues of OP has been found.  
+c                   All possible eigenvalues of OP has been found.
 c                   NP returns the number of converged Ritz values.
 c          =     2: No shifts could be applied.
 c          =    -8: Error return from LAPACK eigenvalue calculation;
@@ -119,21 +119,21 @@ c
 c\BeginLib
 c
 c\Local variables:
-c     xxxxxx  Complex 
+c     xxxxxx  Complex
 c
 c\References:
 c  1. D.C. Sorensen, "Implicit Application of Polynomial Filters in
 c     a k-Step Arnoldi Method", SIAM J. Matr. Anal. Apps., 13 (1992),
 c     pp 357-385.
-c  2. R.B. Lehoucq, "Analysis and Implementation of an Implicitly 
+c  2. R.B. Lehoucq, "Analysis and Implementation of an Implicitly
 c     Restarted Arnoldi Iteration", Rice University Technical Report
 c     TR95-13, Department of Computational and Applied Mathematics.
 c
 c\Routines called:
-c     pcgetv0  Parallel ARPACK initial vector generation routine. 
+c     pcgetv0  Parallel ARPACK initial vector generation routine.
 c     pcnaitr  Parallel ARPACK Arnoldi factorization routine.
 c     pcnapps  Parallel ARPACK application of implicit shifts routine.
-c     pcneigh  Parallel ARPACK compute Ritz values and error bounds routine. 
+c     pcneigh  Parallel ARPACK compute Ritz values and error bounds routine.
 c     pcngets  Parallel ARPACK reorder Ritz values and error bounds routine.
 c     csortc   ARPACK sorting routine.
 c     pivout   Parallel ARPACK utility routine that prints integers.
@@ -144,7 +144,7 @@ c     psvout   ARPACK utility routine that prints vectors.
 c     pslamch  ScaLAPACK routine that determines machine constants.
 c     slapy2   LAPACK routine to compute sqrt(x**2+y**2) carefully.
 c     ccopy    Level 1 BLAS that copies one vector to another .
-c     cdotc    Level 1 BLAS that computes the scalar product of two vectors. 
+c     cdotc    Level 1 BLAS that computes the scalar product of two vectors.
 c     cswap    Level 1 BLAS that swaps two vectors.
 c     pscnorm2 Parallel version of Level 1 BLAS that computes the norm of a vector.
 c
@@ -152,10 +152,10 @@ c\Author
 c     Danny Sorensen               Phuong Vu
 c     Richard Lehoucq              CRPC / Rice University
 c     Dept. of Computational &     Houston, Texas
-c     Applied Mathematics 
-c     Rice University           
-c     Houston, Texas 
-c 
+c     Applied Mathematics
+c     Rice University
+c     Houston, Texas
+c
 c FILE: naup2.F   SID: 1.6   DATE OF SID: 06/01/00   RELEASE: 1
 c
 c\Remarks
@@ -166,8 +166,8 @@ c
 c-----------------------------------------------------------------------
 c
       subroutine pcnaup2
-     &   ( comm, ido, bmat, n, which, nev, np, tol, resid, mode, iupd, 
-     &     ishift, mxiter, v, ldv, h, ldh, ritz, bounds, 
+     &   ( comm, ido, bmat, n, which, nev, np, tol, resid, mode, iupd,
+     &     ishift, mxiter, v, ldv, h, ldh, ritz, bounds,
      &     q, ldq, workl, ipntr, workd, rwork, info )
 c
       include   'mpif.h'
@@ -192,7 +192,7 @@ c
       character  bmat*1, which*2
       integer    ido, info, ishift, iupd, mode, ldh, ldq, ldv, mxiter,
      &           n, nev, np
-      Real   
+      Real
      &           tol
 c
 c     %-----------------%
@@ -200,20 +200,20 @@ c     | Array Arguments |
 c     %-----------------%
 c
       integer    ipntr(13)
-      Complex 
-     &           bounds(nev+np), h(ldh,nev+np), q(ldq,nev+np), 
-     &           resid(n), ritz(nev+np),  v(ldv,nev+np), 
+      Complex
+     &           bounds(nev+np), h(ldh,nev+np), q(ldq,nev+np),
+     &           resid(n), ritz(nev+np),  v(ldv,nev+np),
      &           workd(3*n), workl( (nev+np)*(nev+np+3) )
-       Real   
+       Real
      &           rwork(nev+np)
 c
 c     %------------%
 c     | Parameters |
 c     %------------%
 c
-      Complex 
+      Complex
      &           one, zero
-      Real 
+      Real
      &           rzero
       parameter (one = (1.0, 0.0) , zero = (0.0, 0.0) ,
      &           rzero = 0.0 )
@@ -226,18 +226,18 @@ c
       integer    ierr ,  iter , kplusp, msglvl, nconv,
      &           nevbef, nev0 , np0   , nptemp, i    ,
      &           j
-      Complex 
+      Complex
      &           cmpnorm
-      Real 
+      Real
      &           rnorm,  eps23, rtemp
       character  wprime*2
 c
       save       cnorm,  getv0, initv , update, ushift,
-     &           rnorm,  iter , kplusp, msglvl, nconv, 
+     &           rnorm,  iter , kplusp, msglvl, nconv,
      &           nevbef, nev0 , np0,    eps23
 c
- 
-      Real 
+
+      Real
      &           cmpnorm_buf
 c
 c     %-----------------------%
@@ -257,9 +257,9 @@ c     %--------------------%
 c     | External functions |
 c     %--------------------%
 c
-      Complex 
+      Complex
      &           cdotc
-      Real   
+      Real
      &           pscnorm2, pslamch10, slapy2
       external   cdotc, pscnorm2, pslamch10, slapy2
 c
@@ -274,11 +274,11 @@ c     | Executable Statements |
 c     %-----------------------%
 c
       if (ido .eq. 0) then
-c 
+c
          call second (t0)
-c 
+c
          msglvl = mcaup2
-c 
+c
          nev0   = nev
          np0    = np
 c
@@ -294,7 +294,7 @@ c
          kplusp = nev + np
          nconv  = 0
          iter   = 0
-c 
+c
 c        %---------------------------------%
 c        | Get machine dependent constant. |
 c        %---------------------------------%
@@ -324,7 +324,7 @@ c
             initv = .false.
          end if
       end if
-c 
+c
 c     %---------------------------------------------%
 c     | Get a possibly random starting vector and   |
 c     | force it into the range of the operator OP. |
@@ -333,7 +333,7 @@ c
    10 continue
 c
       if (getv0) then
-         call pcgetv0 (comm, ido, bmat, 1, initv, n, 1, v, ldv, 
+         call pcgetv0 (comm, ido, bmat, 1, initv, n, 1, v, ldv,
      &                 resid, rnorm, ipntr, workd, workl, info)
 c
          if (ido .ne. 99) go to 9000
@@ -341,7 +341,7 @@ c
          if (rnorm .eq. rzero) then
 c
 c           %-----------------------------------------%
-c           | The initial vector is zero. Error exit. | 
+c           | The initial vector is zero. Error exit. |
 c           %-----------------------------------------%
 c
             info = -9
@@ -350,7 +350,7 @@ c
          getv0 = .false.
          ido  = 0
       end if
-c 
+c
 c     %-----------------------------------%
 c     | Back from reverse communication : |
 c     | continue with update step         |
@@ -370,13 +370,13 @@ c     | at the end of the current iteration |
 c     %-------------------------------------%
 c
       if (cnorm)  go to 100
-c 
+c
 c     %----------------------------------------------------------%
 c     | Compute the first NEV steps of the Arnoldi factorization |
 c     %----------------------------------------------------------%
 c
-      call pcnaitr (comm, ido, bmat, n, 0, nev, mode, 
-     &             resid, rnorm, v, ldv, 
+      call pcnaitr (comm, ido, bmat, n, 0, nev, mode,
+     &             resid, rnorm, v, ldv,
      &             h, ldh, ipntr, workd, workl, info)
 c
 c
@@ -388,7 +388,7 @@ c
          info = -9999
          go to 1200
       end if
-c 
+c
 c     %--------------------------------------------------------------%
 c     |                                                              |
 c     |           M A I N  ARNOLDI  I T E R A T I O N  L O O P       |
@@ -396,16 +396,16 @@ c     |           Each iteration implicitly restarts the Arnoldi     |
 c     |           factorization in place.                            |
 c     |                                                              |
 c     %--------------------------------------------------------------%
-c 
+c
  1000 continue
 c
          iter = iter + 1
 c
          if (msglvl .gt. 0) then
-            call pivout (comm, logfil, 1, [iter], ndigit, 
+            call pivout (comm, logfil, 1, [iter], ndigit,
      &           '_naup2: **** Start of major iteration number ****')
          end if
-c 
+c
 c        %-----------------------------------------------------------%
 c        | Compute NP additional steps of the Arnoldi factorization. |
 c        | Adjust NP since NEV might have been updated by last call  |
@@ -415,9 +415,9 @@ c
          np  = kplusp - nev
 c
          if (msglvl .gt. 1) then
-            call pivout (comm, logfil, 1, [nev], ndigit, 
+            call pivout (comm, logfil, 1, [nev], ndigit,
      &     '_naup2: The length of the current Arnoldi factorization')
-            call pivout (comm, logfil, 1, [np], ndigit, 
+            call pivout (comm, logfil, 1, [np], ndigit,
      &           '_naup2: Extend the Arnoldi factorization by')
          end if
 c
@@ -429,7 +429,7 @@ c
    20    continue
          update = .true.
 c
-         call pcnaitr (comm, ido, bmat, n, nev, np, mode, 
+         call pcnaitr (comm, ido, bmat, n, nev, np, mode,
      &                resid, rnorm, v, ldv,
      &                h, ldh, ipntr, workd, workl, info)
 c
@@ -444,10 +444,10 @@ c
          update = .false.
 c
          if (msglvl .gt. 1) then
-            call psvout (comm, logfil, 1, [rnorm], ndigit, 
+            call psvout (comm, logfil, 1, [rnorm], ndigit,
      &           '_naup2: Corresponding B-norm of the residual')
          end if
-c 
+c
 c        %--------------------------------------------------------%
 c        | Compute the eigenvalues and corresponding error bounds |
 c        | of the current upper Hessenberg matrix.                |
@@ -488,9 +488,9 @@ c        | bounds are in the last NEV loc. of RITZ           |
 c        | BOUNDS respectively.                              |
 c        %---------------------------------------------------%
 c
-         call pcngets ( comm, ishift, which, nev, np, ritz, 
+         call pcngets ( comm, ishift, which, nev, np, ritz,
      &                  bounds)
-c 
+c
 c        %------------------------------------------------------------%
 c        | Convergence test: currently we use the following criteria. |
 c        | The relative accuracy of a Ritz value is considered        |
@@ -510,16 +510,16 @@ c
                nconv = nconv + 1
             end if
    25    continue
-c 
+c
          if (msglvl .gt. 2) then
             kp(1) = nev
             kp(2) = np
             kp(3) = nconv
-            call pivout (comm, logfil, 3, kp, ndigit, 
+            call pivout (comm, logfil, 3, kp, ndigit,
      &                  '_naup2: NEV, NP, NCONV are')
             call pcvout (comm, logfil, kplusp, ritz, ndigit,
      &           '_naup2: The eigenvalues of H')
-            call pcvout (comm, logfil, kplusp, bounds, ndigit, 
+            call pcvout (comm, logfil, kplusp, bounds, ndigit,
      &          '_naup2: Ritz estimates of the current NCV Ritz values')
          end if
 c
@@ -540,20 +540,20 @@ c
                nev = nev + 1
             end if
  30      continue
-c     
-         if ( (nconv .ge. nev0) .or. 
+c
+         if ( (nconv .ge. nev0) .or.
      &        (iter .gt. mxiter) .or.
      &        (np .eq. 0) ) then
 c
             if (msglvl .gt. 4) then
-               call pcvout(comm, logfil, kplusp, 
+               call pcvout(comm, logfil, kplusp,
      &             workl(kplusp**2+1), ndigit,
      &             '_naup2: Eigenvalues computed by _neigh:')
-               call pcvout(comm, logfil, kplusp, 
+               call pcvout(comm, logfil, kplusp,
      &             workl(kplusp**2+kplusp+1), ndigit,
      &             '_naup2: Ritz eistmates computed by _neigh:')
             end if
-c     
+c
 c           %------------------------------------------------%
 c           | Prepare to exit. Put the converged Ritz values |
 c           | and corresponding bounds in RITZ(1:NCONV) and  |
@@ -632,13 +632,13 @@ c
             end if
 c
 c           %------------------------------------%
-c           | Max iterations have been exceeded. | 
+c           | Max iterations have been exceeded. |
 c           %------------------------------------%
 c
             if (iter .gt. mxiter .and. nconv .lt. nev0) info = 1
 c
 c           %---------------------%
-c           | No shifts to apply. | 
+c           | No shifts to apply. |
 c           %---------------------%
 c
             if (np .eq. 0 .and. nconv .lt. nev0) info = 2
@@ -647,7 +647,7 @@ c
             go to 1100
 c
          else if ( (nconv .lt. nev0) .and. (ishift .eq. 1) ) then
-c     
+c
 c           %-------------------------------------------------%
 c           | Do not have all the requested eigenvalues yet.  |
 c           | To prevent possible stagnation, adjust the size |
@@ -662,25 +662,25 @@ c
                nev = 2
             end if
             np = kplusp - nev
-c     
+c
 c           %---------------------------------------%
 c           | If the size of NEV was just increased |
 c           | resort the eigenvalues.               |
 c           %---------------------------------------%
-c     
-            if (nevbef .lt. nev) 
-     &         call pcngets (comm, ishift, which, nev, np, ritz, 
+c
+            if (nevbef .lt. nev)
+     &         call pcngets (comm, ishift, which, nev, np, ritz,
      &                       bounds)
 c
-         end if              
-c     
+         end if
+c
          if (msglvl .gt. 0) then
-            call pivout (comm, logfil, 1, [nconv], ndigit, 
+            call pivout (comm, logfil, 1, [nconv], ndigit,
      &           '_naup2: no. of "converged" Ritz values at this iter.')
             if (msglvl .gt. 1) then
                kp(1) = nev
                kp(2) = np
-               call pivout (comm, logfil, 2, kp, ndigit, 
+               call pivout (comm, logfil, 2, kp, ndigit,
      &              '_naup2: NEV and NP are')
                call pcvout (comm, logfil, nev, ritz(np+1), ndigit,
      &              '_naup2: "wanted" Ritz values ')
@@ -704,7 +704,7 @@ c
          ushift = .false.
 c
          if ( ishift .ne. 1 ) then
-c 
+c
 c            %----------------------------------%
 c            | Move the NP shifts from WORKL to |
 c            | RITZ, to free up WORKL           |
@@ -714,12 +714,12 @@ c
              call ccopy (np, workl, 1, ritz, 1)
          end if
 c
-         if (msglvl .gt. 2) then 
-            call pivout (comm, logfil, 1, [np], ndigit, 
+         if (msglvl .gt. 2) then
+            call pivout (comm, logfil, 1, [np], ndigit,
      &                  '_naup2: The number of shifts to apply ')
             call pcvout (comm, logfil, np, ritz, ndigit,
      &                  '_naup2: values of the shifts')
-            if ( ishift .eq. 1 ) 
+            if ( ishift .eq. 1 )
      &          call pcvout (comm, logfil, np, bounds, ndigit,
      &                  '_naup2: Ritz estimates of the shifts')
          end if
@@ -731,7 +731,7 @@ c        | matrix H.                                               |
 c        | The first 2*N locations of WORKD are used as workspace. |
 c        %---------------------------------------------------------%
 c
-         call pcnapps(comm, n, nev, np, ritz, v, ldv, 
+         call pcnapps(comm, n, nev, np, ritz, v, ldv,
      &                h, ldh, resid, q, ldq, workl, workd)
 c
 c        %---------------------------------------------%
@@ -748,18 +748,18 @@ c
             ipntr(1) = n + 1
             ipntr(2) = 1
             ido = 2
-c 
+c
 c           %----------------------------------%
 c           | Exit in order to compute B*RESID |
 c           %----------------------------------%
-c 
+c
             go to 9000
          else if (bmat .eq. 'I') then
             call ccopy (n, resid, 1, workd, 1)
          end if
-c 
+c
   100    continue
-c 
+c
 c        %----------------------------------%
 c        | Back from reverse communication; |
 c        | WORKD(1:N) := B*RESID            |
@@ -769,7 +769,7 @@ c
             call second (t3)
             tmvbx = tmvbx + (t3 - t2)
          end if
-c 
+c
          if (bmat .eq. 'G') then
             cmpnorm_buf = cdotc (n, resid, 1, workd, 1)
             call MPI_ALLREDUCE( cmpnorm_buf, cmpnorm, 1,
@@ -781,12 +781,12 @@ c
          cnorm = .false.
 c
          if (msglvl .gt. 2) then
-            call psvout (comm, logfil, 1, [rnorm], ndigit, 
+            call psvout (comm, logfil, 1, [rnorm], ndigit,
      &      '_naup2: B-norm of residual for compressed factorization')
             call pcmout (comm, logfil, nev, nev, h, ldh, ndigit,
      &        '_naup2: Compressed upper Hessenberg matrix H')
          end if
-c 
+c
       go to 1000
 c
 c     %---------------------------------------------------------------%
@@ -799,7 +799,7 @@ c
 c
       mxiter = iter
       nev = nconv
-c     
+c
  1200 continue
       ido = 99
 c
@@ -809,7 +809,7 @@ c     %------------%
 c
       call second (t1)
       tcaup2 = t1 - t0
-c     
+c
  9000 continue
 c
 c     %----------------%

--- a/mathlibs/src/parpack/pcnaup2.f
+++ b/mathlibs/src/parpack/pcnaup2.f
@@ -402,7 +402,7 @@ c
          iter = iter + 1
 c
          if (msglvl .gt. 0) then
-            call pivout (comm, logfil, 1, iter, ndigit, 
+            call pivout (comm, logfil, 1, [iter], ndigit, 
      &           '_naup2: **** Start of major iteration number ****')
          end if
 c 
@@ -415,9 +415,9 @@ c
          np  = kplusp - nev
 c
          if (msglvl .gt. 1) then
-            call pivout (comm, logfil, 1, nev, ndigit, 
+            call pivout (comm, logfil, 1, [nev], ndigit, 
      &     '_naup2: The length of the current Arnoldi factorization')
-            call pivout (comm, logfil, 1, np, ndigit, 
+            call pivout (comm, logfil, 1, [np], ndigit, 
      &           '_naup2: Extend the Arnoldi factorization by')
          end if
 c
@@ -444,7 +444,7 @@ c
          update = .false.
 c
          if (msglvl .gt. 1) then
-            call psvout (comm, logfil, 1, rnorm, ndigit, 
+            call psvout (comm, logfil, 1, [rnorm], ndigit, 
      &           '_naup2: Corresponding B-norm of the residual')
          end if
 c 
@@ -675,7 +675,7 @@ c
          end if              
 c     
          if (msglvl .gt. 0) then
-            call pivout (comm, logfil, 1, nconv, ndigit, 
+            call pivout (comm, logfil, 1, [nconv], ndigit, 
      &           '_naup2: no. of "converged" Ritz values at this iter.')
             if (msglvl .gt. 1) then
                kp(1) = nev
@@ -715,7 +715,7 @@ c
          end if
 c
          if (msglvl .gt. 2) then 
-            call pivout (comm, logfil, 1, np, ndigit, 
+            call pivout (comm, logfil, 1, [np], ndigit, 
      &                  '_naup2: The number of shifts to apply ')
             call pcvout (comm, logfil, np, ritz, ndigit,
      &                  '_naup2: values of the shifts')
@@ -781,7 +781,7 @@ c
          cnorm = .false.
 c
          if (msglvl .gt. 2) then
-            call psvout (comm, logfil, 1, rnorm, ndigit, 
+            call psvout (comm, logfil, 1, [rnorm], ndigit, 
      &      '_naup2: B-norm of residual for compressed factorization')
             call pcmout (comm, logfil, nev, nev, h, ldh, ndigit,
      &        '_naup2: Compressed upper Hessenberg matrix H')

--- a/mathlibs/src/parpack/pcnaupd.f
+++ b/mathlibs/src/parpack/pcnaupd.f
@@ -618,9 +618,9 @@ c
       if (info .eq. 2) info = 3
 c
       if (msglvl .gt. 0) then
-         call pivout (comm, logfil, 1, mxiter, ndigit,
+         call pivout (comm, logfil, 1, [mxiter], ndigit,
      &               '_naupd: Number of update iterations taken')
-         call pivout (comm, logfil, 1, np, ndigit,
+         call pivout (comm, logfil, 1, [np], ndigit,
      &               '_naupd: Number of wanted "converged" Ritz values')
          call pcvout (comm, logfil, np, workl(ritz), ndigit, 
      &               '_naupd: The final Ritz values')

--- a/mathlibs/src/parpack/pcnaupd.f
+++ b/mathlibs/src/parpack/pcnaupd.f
@@ -2,13 +2,13 @@ c\BeginDoc
 c
 c\Name: pcnaupd
 c
-c Message Passing Layer: MPI 
+c Message Passing Layer: MPI
 c
-c\Description: 
+c\Description:
 c  Reverse communication interface for the Implicitly Restarted Arnoldi
-c  iteration. This is intended to be used to find a few eigenpairs of a 
-c  complex linear operator OP with respect to a semi-inner product defined 
-c  by a hermitian positive semi-definite real matrix B. B may be the identity 
+c  iteration. This is intended to be used to find a few eigenpairs of a
+c  complex linear operator OP with respect to a semi-inner product defined
+c  by a hermitian positive semi-definite real matrix B. B may be the identity
 c  matrix.  NOTE: if both OP and B are real, then ssaupd or snaupd should
 c  be used.
 c
@@ -16,7 +16,7 @@ c
 c  The computed approximate eigenvalues are called Ritz values and
 c  the corresponding approximate eigenvectors are called Ritz vectors.
 c
-c  pcnaupd is usually called iteratively to solve one of the 
+c  pcnaupd is usually called iteratively to solve one of the
 c  following problems:
 c
 c  Mode 1:  A*x = lambda*x.
@@ -27,10 +27,10 @@ c           ===> OP = inv[M]*A  and  B = M.
 c           ===> (If M can be factored see remark 3 below)
 c
 c  Mode 3:  A*x = lambda*M*x, M symmetric semi-definite
-c           ===> OP =  inv[A - sigma*M]*M   and  B = M. 
-c           ===> shift-and-invert mode 
+c           ===> OP =  inv[A - sigma*M]*M   and  B = M.
+c           ===> shift-and-invert mode
 c           If OP*x = amu*x, then lambda = sigma + 1/amu.
-c  
+c
 c
 c  NOTE: The action of w <- inv[A - sigma*M]*v or w <- inv[M]*v
 c        should be accomplished either by a direct method
@@ -53,7 +53,7 @@ c\Arguments
 c  COMM    MPI  Communicator for the processor grid.  (INPUT)
 c
 c  IDO     Integer.  (INPUT/OUTPUT)
-c          Reverse communication flag.  IDO must be zero on the first 
+c          Reverse communication flag.  IDO must be zero on the first
 c          call to pcnaupd.  IDO will be set internally to
 c          indicate the type of operation to be performed.  Control is
 c          then given back to the calling routine which has the
@@ -76,14 +76,14 @@ c                    need to be recomputed in forming OP * X.
 c          IDO =  2: compute  Y = M * X  where
 c                    IPNTR(1) is the pointer into WORKD for X,
 c                    IPNTR(2) is the pointer into WORKD for Y.
-c          IDO =  3: compute and return the shifts in the first 
+c          IDO =  3: compute and return the shifts in the first
 c                    NP locations of WORKL.
 c          IDO = 99: done
 c          -------------------------------------------------------------
-c          After the initialization phase, when the routine is used in 
-c          the "shift-and-invert" mode, the vector M * X is already 
+c          After the initialization phase, when the routine is used in
+c          the "shift-and-invert" mode, the vector M * X is already
 c          available and does not need to be recomputed in forming OP*X.
-c             
+c
 c  BMAT    Character*1.  (INPUT)
 c          BMAT specifies the type of the matrix B that defines the
 c          semi-inner product for the operator OP.
@@ -105,14 +105,14 @@ c  NEV     Integer.  (INPUT)
 c          Number of eigenvalues of OP to be computed. 0 < NEV < N-1.
 c
 c  TOL     Real   scalar.  (INPUT)
-c          Stopping criteria: the relative accuracy of the Ritz value 
+c          Stopping criteria: the relative accuracy of the Ritz value
 c          is considered acceptable if BOUNDS(I) .LE. TOL*ABS(RITZ(I))
 c          where ABS(RITZ(I)) is the magnitude when RITZ(I) is complex.
 c          DEFAULT = pslamch(comm, 'EPS')  (machine precision as computed
 c                    by the ScaLAPACK auxiliary subroutine pslamch).
 c
 c  RESID   Complex  array of length N.  (INPUT/OUTPUT)
-c          On INPUT: 
+c          On INPUT:
 c          If INFO .EQ. 0, a random initial residual vector is used.
 c          If INFO .NE. 0, RESID contains the initial residual vector,
 c                          possibly from a previous run.
@@ -122,15 +122,15 @@ c
 c  NCV     Integer.  (INPUT)
 c          Number of columns of the matrix V. NCV must satisfy the two
 c          inequalities 1 <= NCV-NEV and NCV <= N.
-c          This will indicate how many Arnoldi vectors are generated 
-c          at each iteration.  After the startup phase in which NEV 
-c          Arnoldi vectors are generated, the algorithm generates 
-c          approximately NCV-NEV Arnoldi vectors at each subsequent update 
-c          iteration. Most of the cost in generating each Arnoldi vector is 
+c          This will indicate how many Arnoldi vectors are generated
+c          at each iteration.  After the startup phase in which NEV
+c          Arnoldi vectors are generated, the algorithm generates
+c          approximately NCV-NEV Arnoldi vectors at each subsequent update
+c          iteration. Most of the cost in generating each Arnoldi vector is
 c          in the matrix-vector operation OP*x. (See remark 4 below)
 c
 c  V       Complex  array N by NCV.  (OUTPUT)
-c          Contains the final set of Arnoldi basis vectors. 
+c          Contains the final set of Arnoldi basis vectors.
 c
 c  LDV     Integer.  (INPUT)
 c          Leading dimension of V exactly as declared in the calling program.
@@ -141,23 +141,23 @@ c          The shifts selected at each iteration are used to filter out
 c          the components of the unwanted eigenvector.
 c          -------------------------------------------------------------
 c          ISHIFT = 0: the shifts are to be provided by the user via
-c                      reverse communication.  The NCV eigenvalues of 
+c                      reverse communication.  The NCV eigenvalues of
 c                      the Hessenberg matrix H are returned in the part
 c                      of WORKL array corresponding to RITZ.
 c          ISHIFT = 1: exact shifts with respect to the current
-c                      Hessenberg matrix H.  This is equivalent to 
-c                      restarting the iteration from the beginning 
+c                      Hessenberg matrix H.  This is equivalent to
+c                      restarting the iteration from the beginning
 c                      after updating the starting vector with a linear
-c                      combination of Ritz vectors associated with the 
+c                      combination of Ritz vectors associated with the
 c                      "wanted" eigenvalues.
 c          ISHIFT = 2: other choice of internal shift to be defined.
 c          -------------------------------------------------------------
 c
-c          IPARAM(2) = No longer referenced 
+c          IPARAM(2) = No longer referenced
 c
 c          IPARAM(3) = MXITER
-c          On INPUT:  maximum number of Arnoldi update iterations allowed. 
-c          On OUTPUT: actual number of Arnoldi update iterations taken. 
+c          On INPUT:  maximum number of Arnoldi update iterations allowed.
+c          On OUTPUT: actual number of Arnoldi update iterations taken.
 c
 c          IPARAM(4) = NB: blocksize to be used in the recurrence.
 c          The code currently works only for NB = 1.
@@ -167,11 +167,11 @@ c          This represents the number of Ritz values that satisfy
 c          the convergence criterion.
 c
 c          IPARAM(6) = IUPD
-c          No longer referenced. Implicit restarting is ALWAYS used.  
+c          No longer referenced. Implicit restarting is ALWAYS used.
 c
 c          IPARAM(7) = MODE
 c          On INPUT determines what type of eigenproblem is being solved.
-c          Must be 1,2,3; See under \Description of pcnaupd for the 
+c          Must be 1,2,3; See under \Description of pcnaupd for the
 c          four modes available.
 c
 c          IPARAM(8) = NP
@@ -190,7 +190,7 @@ c          arrays for matrices/vectors used by the Arnoldi iteration.
 c          -------------------------------------------------------------
 c          IPNTR(1): pointer to the current operand vector X in WORKD.
 c          IPNTR(2): pointer to the current result vector Y in WORKD.
-c          IPNTR(3): pointer to the vector B * X in WORKD when used in 
+c          IPNTR(3): pointer to the vector B * X in WORKD when used in
 c                    the shift-and-invert mode.
 c          IPNTR(4): pointer to the next available location in WORKL
 c                    that is untouched by the program.
@@ -203,7 +203,7 @@ c          IPNTR(14): pointer to the NP shifts in WORKL. See Remark 5 below.
 c
 c          Note: IPNTR(9:13) is only referenced by pcneupd. See Remark 2 below.
 c
-c          IPNTR(9):  pointer to the NCV RITZ values of the 
+c          IPNTR(9):  pointer to the NCV RITZ values of the
 c                     original system.
 c          IPNTR(10): Not Used
 c          IPNTR(11): pointer to the NCV corresponding error bounds.
@@ -213,12 +213,12 @@ c          IPNTR(13): pointer to the NCV by NCV matrix of eigenvectors
 c                     of the upper Hessenberg matrix H. Only referenced by
 c                     cneupd if RVEC = .TRUE. See Remark 2 below.
 c          -------------------------------------------------------------
-c          
+c
 c  WORKD   Complex  work array of length 3*N.  (REVERSE COMMUNICATION)
 c          Distributed array to be used in the basic Arnoldi iteration
-c          for reverse communication.  The user should not use WORKD 
+c          for reverse communication.  The user should not use WORKD
 c          as temporary workspace during the iteration !!!!!!!!!!
-c          See Data Distribution Note below.  
+c          See Data Distribution Note below.
 c
 c  WORKL   Complex  work array of length LWORKL.  (OUTPUT/WORKSPACE)
 c          Private (replicated) array on each PE or array allocated on
@@ -239,18 +239,18 @@ c                          possibly from a previous run.
 c          Error flag on output.
 c          =  0: Normal exit.
 c          =  1: Maximum number of iterations taken.
-c                All possible eigenvalues of OP has been found. IPARAM(5)  
+c                All possible eigenvalues of OP has been found. IPARAM(5)
 c                returns the number of wanted converged Ritz values.
 c          =  2: No longer an informational error. Deprecated starting
 c                with release 2 of ARPACK.
-c          =  3: No shifts could be applied during a cycle of the 
-c                Implicitly restarted Arnoldi iteration. One possibility 
-c                is to increase the size of NCV relative to NEV. 
+c          =  3: No shifts could be applied during a cycle of the
+c                Implicitly restarted Arnoldi iteration. One possibility
+c                is to increase the size of NCV relative to NEV.
 c                See remark 4 below.
 c          = -1: N must be positive.
 c          = -2: NEV must be positive.
 c          = -3: NCV-NEV >= 2 and less than or equal to N.
-c          = -4: The maximum number of Arnoldi update iteration 
+c          = -4: The maximum number of Arnoldi update iteration
 c                must be greater than zero.
 c          = -5: WHICH must be one of 'LM', 'SM', 'LR', 'SR', 'LI', 'SI'
 c          = -6: BMAT must be one of 'I' or 'G'.
@@ -271,16 +271,16 @@ c  1. The computed Ritz values are approximate eigenvalues of OP. The
 c     selection of WHICH should be made with this in mind when using
 c     Mode = 3.  When operating in Mode = 3 setting WHICH = 'LM' will
 c     compute the NEV eigenvalues of the original problem that are
-c     closest to the shift SIGMA . After convergence, approximate eigenvalues 
+c     closest to the shift SIGMA . After convergence, approximate eigenvalues
 c     of the original problem may be obtained with the ARPACK subroutine pcneupd.
 c
-c  2. If a basis for the invariant subspace corresponding to the converged Ritz 
-c     values is needed, the user must call pcneupd immediately following 
+c  2. If a basis for the invariant subspace corresponding to the converged Ritz
+c     values is needed, the user must call pcneupd immediately following
 c     completion of pcnaupd. This is new starting with release 2 of ARPACK.
 c
 c  3. If M can be factored into a Cholesky factorization M = LL`
 c     then Mode = 2 should not be selected.  Instead one should use
-c     Mode = 1 with  OP = inv(L)*A*inv(L`).  Appropriate triangular 
+c     Mode = 1 with  OP = inv(L)*A*inv(L`).  Appropriate triangular
 c     linear systems should be solved with L and L` rather
 c     than computing inverses.  After convergence, an approximate
 c     eigenvector z of the original problem is recovered by solving
@@ -290,11 +290,11 @@ c  4. At present there is no a-priori analysis to guide the selection
 c     of NCV relative to NEV.  The only formal requrement is that NCV > NEV + 1.
 c     However, it is recommended that NCV .ge. 2*NEV.  If many problems of
 c     the same type are to be solved, one should experiment with increasing
-c     NCV while keeping NEV fixed for a given test problem.  This will 
+c     NCV while keeping NEV fixed for a given test problem.  This will
 c     usually decrease the required number of OP*x operations but it
 c     also increases the work and storage required to maintain the orthogonal
 c     basis vectors.  The optimal "cross-over" with respect to CPU time
-c     is problem dependent and must be determined empirically. 
+c     is problem dependent and must be determined empirically.
 c     See Chapter 8 of Reference 2 for further information.
 c
 c  5. When IPARAM(1) = 0, and IDO = 3, the user needs to provide the
@@ -308,7 +308,7 @@ c     WORKL(IPNTR(8)+NCV-1).
 c
 c-----------------------------------------------------------------------
 c
-c\Data Distribution Note: 
+c\Data Distribution Note:
 c
 c  Fortran-D syntax:
 c  ================
@@ -327,10 +327,10 @@ c  ===============
 c  Complex  resid(n), v(ldv,ncv), workd(n,3), workl(lworkl)
 c  shared     resid(block), v(block,:), workd(block,:)
 c  replicated workl(lworkl)
-c  
+c
 c  CM2/CM5 syntax:
 c  ==============
-c  
+c
 c-----------------------------------------------------------------------
 c
 c     include   'ex-nonsym.doc'
@@ -340,13 +340,13 @@ c
 c\BeginLib
 c
 c\Local variables:
-c     xxxxxx  Complex 
+c     xxxxxx  Complex
 c
 c\References:
 c  1. D.C. Sorensen, "Implicit Application of Polynomial Filters in
 c     a k-Step Arnoldi Method", SIAM J. Matr. Anal. Apps., 13 (1992),
 c     pp 357-385.
-c  2. R.B. Lehoucq, "Analysis and Implementation of an Implicitly 
+c  2. R.B. Lehoucq, "Analysis and Implementation of an Implicitly
 c     Restarted Arnoldi Iteration", Rice University Technical Report
 c     TR95-13, Department of Computational and Applied Mathematics.
 c  3. B.N. Parlett & Y. Saad, "_Complex_ Shift and Invert Strategies for
@@ -366,9 +366,9 @@ c\Author
 c     Danny Sorensen               Phuong Vu
 c     Richard Lehoucq              CRPC / Rice University
 c     Dept. of Computational &     Houston, Texas
-c     Applied Mathematics 
-c     Rice University           
-c     Houston, Texas 
+c     Applied Mathematics
+c     Rice University
+c     Houston, Texas
 c
 c\Parallel Modifications
 c     Kristi Maschhoff
@@ -386,7 +386,7 @@ c
 c-----------------------------------------------------------------------
 c
       subroutine pcnaupd
-     &   ( comm, ido, bmat, n, which, nev, tol, resid, ncv, v, ldv, 
+     &   ( comm, ido, bmat, n, which, nev, tol, resid, ncv, v, ldv,
      &     iparam, ipntr, workd, workl, lworkl, rwork, info )
 c
       include  'mpif.h'
@@ -410,7 +410,7 @@ c     %------------------%
 c
       character  bmat*1, which*2
       integer    ido, info, ldv, lworkl, n, ncv, nev
-      Real  
+      Real
      &           tol
 c
 c     %-----------------%
@@ -418,16 +418,16 @@ c     | Array Arguments |
 c     %-----------------%
 c
       integer    iparam(11), ipntr(14)
-      Complex 
+      Complex
      &           resid(n), v(ldv,ncv), workd(3*n), workl(lworkl)
-      Real   
+      Real
      &           rwork(ncv)
 c
 c     %------------%
 c     | Parameters |
 c     %------------%
 c
-      Complex 
+      Complex
      &           one, zero
       parameter (one = (1.0, 0.0) , zero = (0.0, 0.0) )
 c
@@ -435,7 +435,7 @@ c     %---------------%
 c     | Local Scalars |
 c     %---------------%
 c
-      integer    bounds, ierr, ih, iq, ishift, iupd, iw, 
+      integer    bounds, ierr, ih, iq, ishift, iupd, iw,
      &           ldh, ldq, levec, mode, msglvl, mxiter, nb,
      &           nev0, next, np, ritz, j
       save       bounds, ih, iq, ishift, iupd, iw,
@@ -452,16 +452,16 @@ c     %--------------------%
 c     | External Functions |
 c     %--------------------%
 c
-      Real  
+      Real
      &           pslamch10
       external   pslamch10
 c
 c     %-----------------------%
 c     | Executable Statements |
 c     %-----------------------%
-c 
+c
       if (ido .eq. 0) then
-c 
+c
 c        %-------------------------------%
 c        | Initialize timing statistics  |
 c        | & message level for debugging |
@@ -513,7 +513,7 @@ c
          else if (mode .eq. 1 .and. bmat .eq. 'G') then
                                                 ierr = -11
          end if
-c 
+c
 c        %------------%
 c        | Error Exit |
 c        %------------%
@@ -523,14 +523,14 @@ c
             ido  = 99
             go to 9000
          end if
-c 
+c
 c        %------------------------%
 c        | Set default parameters |
 c        %------------------------%
 c
          if (nb .le. 0)	nb = 1
          if (tol .le. 0.0  ) tol = pslamch10(comm, 'EpsMach')
-         if (ishift .ne. 0  .and.  
+         if (ishift .ne. 0  .and.
      &       ishift .ne. 1  .and.
      &       ishift .ne. 2)	ishift = 1
 c
@@ -542,8 +542,8 @@ c        | size of the invariant subspace desired.      |
 c        %----------------------------------------------%
 c
          np     = ncv - nev
-         nev0   = nev 
-c 
+         nev0   = nev
+c
 c        %-----------------------------%
 c        | Zero out internal workspace |
 c        %-----------------------------%
@@ -551,7 +551,7 @@ c
          do 10 j = 1, 3*ncv**2 + 5*ncv
             workl(j) = zero
   10     continue
-c 
+c
 c        %-------------------------------------------------------------%
 c        | Pointer into WORKL for address of H, RITZ, BOUNDS, Q        |
 c        | etc... and the remaining workspace.                         |
@@ -589,12 +589,12 @@ c     %-------------------------------------------------------%
 c     | Carry out the Implicitly restarted Arnoldi Iteration. |
 c     %-------------------------------------------------------%
 c
-      call pcnaup2 
+      call pcnaup2
      &   ( comm, ido, bmat, n, which, nev0, np, tol, resid, mode, iupd,
-     &     ishift, mxiter, v, ldv, workl(ih), ldh, workl(ritz), 
-     &     workl(bounds), workl(iq), ldq, workl(iw), 
+     &     ishift, mxiter, v, ldv, workl(ih), ldh, workl(ritz),
+     &     workl(bounds), workl(iq), ldq, workl(iw),
      &     ipntr, workd, rwork, info )
-c 
+c
 c     %--------------------------------------------------%
 c     | ido .ne. 99 implies use of reverse communication |
 c     | to compute operations involving OP.              |
@@ -602,7 +602,7 @@ c     %--------------------------------------------------%
 c
       if (ido .eq. 3) iparam(8) = np
       if (ido .ne. 99) go to 9000
-c 
+c
       iparam(3) = mxiter
       iparam(5) = np
       iparam(9) = nopx
@@ -622,9 +622,9 @@ c
      &               '_naupd: Number of update iterations taken')
          call pivout (comm, logfil, 1, [np], ndigit,
      &               '_naupd: Number of wanted "converged" Ritz values')
-         call pcvout (comm, logfil, np, workl(ritz), ndigit, 
+         call pcvout (comm, logfil, np, workl(ritz), ndigit,
      &               '_naupd: The final Ritz values')
-         call pcvout (comm, logfil, np, workl(bounds), ndigit, 
+         call pcvout (comm, logfil, np, workl(bounds), ndigit,
      &               '_naupd: Associated Ritz estimates')
       end if
 c

--- a/mathlibs/src/parpack/pcneupd.f
+++ b/mathlibs/src/parpack/pcneupd.f
@@ -1,44 +1,44 @@
 c\BeginDoc
-c 
-c\Name: pcneupd 
 c
-c Message Passing Layer: MPI 
+c\Name: pcneupd
 c
-c\Description: 
-c  This subroutine returns the converged approximations to eigenvalues 
-c  of A*z = lambda*B*z and (optionally): 
-c 
-c      (1) The corresponding approximate eigenvectors; 
-c 
-c      (2) An orthonormal basis for the associated approximate 
-c          invariant subspace; 
-c 
-c      (3) Both.  
+c Message Passing Layer: MPI
 c
-c  There is negligible additional cost to obtain eigenvectors.  An orthonormal 
+c\Description:
+c  This subroutine returns the converged approximations to eigenvalues
+c  of A*z = lambda*B*z and (optionally):
+c
+c      (1) The corresponding approximate eigenvectors;
+c
+c      (2) An orthonormal basis for the associated approximate
+c          invariant subspace;
+c
+c      (3) Both.
+c
+c  There is negligible additional cost to obtain eigenvectors.  An orthonormal
 c  basis is always computed.  There is an additional storage cost of n*nev
-c  if both are requested (in this case a separate array Z must be supplied). 
+c  if both are requested (in this case a separate array Z must be supplied).
 c
 c  The approximate eigenvalues and eigenvectors of  A*z = lambda*B*z
 c  are derived from approximate eigenvalues and eigenvectors of
 c  of the linear operator OP prescribed by the MODE selection in the
 c  call to PCNAUPD.  PCNAUPD must be called before this routine is called.
 c  These approximate eigenvalues and vectors are commonly called Ritz
-c  values and Ritz vectors respectively.  They are referred to as such 
-c  in the comments that follow.   The computed orthonormal basis for the 
-c  invariant subspace corresponding to these Ritz values is referred to as a 
-c  Schur basis. 
-c 
+c  values and Ritz vectors respectively.  They are referred to as such
+c  in the comments that follow.   The computed orthonormal basis for the
+c  invariant subspace corresponding to these Ritz values is referred to as a
+c  Schur basis.
+c
 c  The definition of OP as well as other terms and the relation of computed
 c  Ritz values and vectors of OP with respect to the given problem
-c  A*z = lambda*B*z may be found in the header of PCNAUPD.  For a brief 
+c  A*z = lambda*B*z may be found in the header of PCNAUPD.  For a brief
 c  description, see definitions of IPARAM(7), MODE and WHICH in the
 c  documentation of PCNAUPD.
 c
 c\Usage:
-c  call pcneupd 
-c     ( COMM, RVEC, HOWMNY, SELECT, D, Z, LDZ, SIGMA, WORKEV, BMAT, 
-c       N, WHICH, NEV, TOL, RESID, NCV, V, LDV, IPARAM, IPNTR, WORKD, 
+c  call pcneupd
+c     ( COMM, RVEC, HOWMNY, SELECT, D, Z, LDZ, SIGMA, WORKEV, BMAT,
+c       N, WHICH, NEV, TOL, RESID, NCV, V, LDV, IPARAM, IPNTR, WORKD,
 c       WORKL, LWORKL, RWORK, INFO )
 c
 c\Arguments
@@ -46,7 +46,7 @@ c  COMM    MPI  Communicator for the processor grid.  (INPUT)
 c
 c  RVEC    LOGICAL  (INPUT)
 c          Specifies whether a basis for the invariant subspace corresponding
-c          to the converged Ritz value approximations for the eigenproblem 
+c          to the converged Ritz value approximations for the eigenproblem
 c          A*z = lambda*B*z is computed.
 c
 c             RVEC = .FALSE.     Compute Ritz values only.
@@ -55,7 +55,7 @@ c             RVEC = .TRUE.      Compute Ritz vectors or Schur vectors.
 c                                See Remarks below.
 c
 c  HOWMNY  Character*1  (INPUT)
-c          Specifies the form of the basis for the invariant subspace 
+c          Specifies the form of the basis for the invariant subspace
 c          corresponding to the converged Ritz values that is to be computed.
 c
 c          = 'A': Compute NEV Ritz vectors;
@@ -66,34 +66,34 @@ c
 c  SELECT  Logical array of dimension NCV.  (INPUT)
 c          If HOWMNY = 'S', SELECT specifies the Ritz vectors to be
 c          computed. To select the  Ritz vector corresponding to a
-c          Ritz value D(j), SELECT(j) must be set to .TRUE.. 
-c          If HOWMNY = 'A' or 'P', SELECT need not be initialized 
+c          Ritz value D(j), SELECT(j) must be set to .TRUE..
+c          If HOWMNY = 'A' or 'P', SELECT need not be initialized
 c          but it is used as internal workspace.
 c
 c  D       Complex  array of dimension NEV+1.  (OUTPUT)
-c          On exit, D contains the  Ritz  approximations 
+c          On exit, D contains the  Ritz  approximations
 c          to the eigenvalues lambda for A*z = lambda*B*z.
 c
 c  Z       Complex  N by NEV array    (OUTPUT)
-c          On exit, if RVEC = .TRUE. and HOWMNY = 'A', then the columns of 
-c          Z represents approximate eigenvectors (Ritz vectors) corresponding 
+c          On exit, if RVEC = .TRUE. and HOWMNY = 'A', then the columns of
+c          Z represents approximate eigenvectors (Ritz vectors) corresponding
 c          to the NCONV=IPARAM(5) Ritz values for eigensystem
 c          A*z = lambda*B*z.
 c
 c          If RVEC = .FALSE. or HOWMNY = 'P', then Z is NOT REFERENCED.
 c
-c          NOTE: If if RVEC = .TRUE. and a Schur basis is not required, 
-c          the array Z may be set equal to first NEV+1 columns of the Arnoldi 
-c          basis array V computed by PCNAUPD.  In this case the Arnoldi basis 
+c          NOTE: If if RVEC = .TRUE. and a Schur basis is not required,
+c          the array Z may be set equal to first NEV+1 columns of the Arnoldi
+c          basis array V computed by PCNAUPD.  In this case the Arnoldi basis
 c          will be destroyed and overwritten with the eigenvector basis.
 c
 c  LDZ     Integer.  (INPUT)
 c          The leading dimension of the array Z.  If Ritz vectors are
-c          desired, then  LDZ .ge.  max( 1, N ) is required.  
+c          desired, then  LDZ .ge.  max( 1, N ) is required.
 c          In any case,  LDZ .ge. 1 is required.
 c
 c  SIGMA   Complex   (INPUT)
-c          If IPARAM(7) = 3 then SIGMA represents the shift. 
+c          If IPARAM(7) = 3 then SIGMA represents the shift.
 c          Not referenced if IPARAM(7) = 1 or 2.
 c
 c  WORKEV  Complex  work array of dimension 2*NCV.  (WORKSPACE)
@@ -101,12 +101,12 @@ c
 c  **** The remaining arguments MUST be the same as for the   ****
 c  **** call to PCNAUPD that was just completed.               ****
 c
-c  NOTE: The remaining arguments 
+c  NOTE: The remaining arguments
 c
-c           BMAT, N, WHICH, NEV, TOL, RESID, NCV, V, LDV, IPARAM, IPNTR, 
-c           WORKD, WORKL, LWORKL, RWORK, INFO 
+c           BMAT, N, WHICH, NEV, TOL, RESID, NCV, V, LDV, IPARAM, IPNTR,
+c           WORKD, WORKL, LWORKL, RWORK, INFO
 c
-c         must be passed directly to CNEUPD following the last call 
+c         must be passed directly to CNEUPD following the last call
 c         to PCNAUPD.  These arguments MUST NOT BE MODIFIED between
 c         the the last call to PCNAUPD and the call to CNEUPD.
 c
@@ -191,18 +191,18 @@ c\References:
 c  1. D.C. Sorensen, "Implicit Application of Polynomial Filters in
 c     a k-Step Arnoldi Method", SIAM J. Matr. Anal. Apps., 13 (1992),
 c     pp 357-385.
-c  2. R.B. Lehoucq, "Analysis and Implementation of an Implicitly 
+c  2. R.B. Lehoucq, "Analysis and Implementation of an Implicitly
 c     Restarted Arnoldi Iteration", Rice University Technical Report
 c     TR95-13, Department of Computational and Applied Mathematics.
 c  3. B. Nour-Omid, B. N. Parlett, T. Ericsson and P. S. Jensen,
 c     "How to Implement the Spectral Transformation", Math Comp.,
-c     Vol. 48, No. 178, April, 1987 pp. 664-673. 
+c     Vol. 48, No. 178, April, 1987 pp. 664-673.
 c
 c\Routines called:
 c     pivout  Parallel ARPACK utility routine that prints integers.
 c     pcmout  Parallel ARPACK utility routine that prints matrices
 c     pcvout  Parallel ARPACK utility routine that prints vectors.
-c     cgeqr2  LAPACK routine that computes the QR factorization of 
+c     cgeqr2  LAPACK routine that computes the QR factorization of
 c             a matrix.
 c     clacpy  LAPACK matrix copy routine.
 c     clahqr  LAPACK routine that computes the Schur form of a
@@ -211,7 +211,7 @@ c     claset  LAPACK matrix initialization routine.
 c     ctrevc  LAPACK routine to compute the eigenvectors of a matrix
 c             in upper triangular form.
 c     ctrsen  LAPACK routine that re-orders the Schur form.
-c     cunm2r  LAPACK routine that applies an orthogonal matrix in 
+c     cunm2r  LAPACK routine that applies an orthogonal matrix in
 c             factored form.
 c     pslamch ScaLAPACK routine that determines machine constants.
 c     ctrmm   Level 3 BLAS matrix times an upper triangular matrix.
@@ -223,23 +223,23 @@ c     scnrm2  Level 1 BLAS that computes the norm of a complex vector.
 c
 c\Remarks
 c
-c  1. Currently only HOWMNY = 'A' and 'P' are implemented. 
+c  1. Currently only HOWMNY = 'A' and 'P' are implemented.
 c
 c  2. Schur vectors are an orthogonal representation for the basis of
 c     Ritz vectors. Thus, their numerical properties are often superior.
 c     If RVEC = .true. then the relationship
 c             A * V(:,1:IPARAM(5)) = V(:,1:IPARAM(5)) * T, and
 c     V(:,1:IPARAM(5))` * V(:,1:IPARAM(5)) = I are approximately satisfied.
-c     Here T is the leading submatrix of order IPARAM(5) of the 
-c     upper triangular matrix stored workl(ipntr(12)). 
+c     Here T is the leading submatrix of order IPARAM(5) of the
+c     upper triangular matrix stored workl(ipntr(12)).
 c
 c\Authors
 c     Danny Sorensen               Phuong Vu
 c     Richard Lehoucq              CRPC / Rice University
-c     Chao Yang                    Houston, Texas 
-c     Dept. of Computational & 
-c     Applied Mathematics 
-c     Rice University 
+c     Chao Yang                    Houston, Texas
+c     Dept. of Computational &
+c     Applied Mathematics
+c     Rice University
 c     Houston, Texas
 c
 c\Parallel Modifications
@@ -254,7 +254,7 @@ c
 c\EndLib
 c
 c-----------------------------------------------------------------------
-      subroutine pcneupd 
+      subroutine pcneupd
      &         ( comm , rvec  , howmny, select, d    ,
      &           z    , ldz   , sigma , workev, bmat ,
      &           n    , which , nev   , tol   , resid,
@@ -281,9 +281,9 @@ c
       character  bmat, howmny, which*2
       logical    rvec
       integer    info, ldz, ldv, lworkl, n, ncv, nev
-      Complex      
+      Complex
      &           sigma
-      Real  
+      Real
      &           tol
 c
 c     %-----------------%
@@ -292,9 +292,9 @@ c     %-----------------%
 c
       integer    iparam(11), ipntr(14)
       logical    select(ncv)
-      Real 
+      Real
      &           rwork(ncv)
-      Complex 
+      Complex
      &           d(nev)     , resid(n)  , v(ldv,ncv)   ,
      &           z(ldz, nev), workd(3*n), workl(lworkl),
      &           workev(2*ncv)
@@ -303,7 +303,7 @@ c     %------------%
 c     | Parameters |
 c     %------------%
 c
-      Complex 
+      Complex
      &           one, zero
       parameter  (one = (1.0, 0.0) , zero = (0.0, 0.0) )
 c
@@ -317,9 +317,9 @@ c
      &           mode  , msglvl, ritz  , wr   , k     , irz   ,
      &           ibd   , outncv, iq    , np   , numcnv, jj    ,
      &           ishift
-      Complex 
+      Complex
      &           rnorm, temp, vl(1)
-      Real 
+      Real
      &           conds, sep, rtemp, eps23
       logical    reord
 c
@@ -330,16 +330,16 @@ c
       external   ccopy ,cgeru,cgeqr2,clacpy,pcmout,
      &           cunm2r,ctrmm,pcvout,pivout,
      &           clahqr
-c  
+c
 c     %--------------------%
 c     | External Functions |
 c     %--------------------%
 c
-      Real 
+      Real
      &           scnrm2,pslamch10,slapy2
       external   scnrm2,pslamch10,slapy2
 c
-      Complex 
+      Complex
      &           cdotc
       external   cdotc
 c
@@ -352,7 +352,7 @@ c
 c     %-----------------------%
 c     | Executable Statements |
 c     %-----------------------%
-c 
+c
 c     %------------------------%
 c     | Set default parameters |
 c     %------------------------%
@@ -403,12 +403,12 @@ c
       else if (howmny .eq. 'S' ) then
          ierr = -12
       end if
-c     
+c
       if (mode .eq. 1 .or. mode .eq. 2) then
          type = 'REGULR'
       else if (mode .eq. 3 ) then
          type = 'SHIFTI'
-      else 
+      else
                                               ierr = -10
       end if
       if (mode .eq. 1 .and. bmat .eq. 'G')    ierr = -11
@@ -421,7 +421,7 @@ c
          info = ierr
          go to 9000
       end if
-c 
+c
 c     %--------------------------------------------------------%
 c     | Pointer into WORKL for address of H, RITZ, WORKEV, Q   |
 c     | etc... and the remaining workspace.                    |
@@ -449,7 +449,7 @@ c     |                                      the invariant        |
 c     |                                      subspace for H.      |
 c     | GRAND total of NCV * ( 3 * NCV + 4 ) locations.           |
 c     %-----------------------------------------------------------%
-c     
+c
       ih     = ipntr(5)
       ritz   = ipntr(6)
       iq     = ipntr(7)
@@ -491,7 +491,7 @@ c
          call pcvout(comm, logfil, ncv, workl(ibd), ndigit,
      &   '_neupd: Ritz estimates passed in from _NAUPD.')
       end if
-c     
+c
       if (rvec) then
 c
          reord = .false.
@@ -562,7 +562,7 @@ c
      &            '_neupd: Number of specified eigenvalues')
              call pivout(comm, logfil, 1, [nconv], ndigit,
      &            '_neupd: Number of "converged" eigenvalues')
-         end if 
+         end if
 c
          if (numcnv .ne. nconv) then
             info = -15
@@ -596,7 +596,7 @@ c
             call pcvout(comm, logfil, ncv, workl(ihbds), ndigit,
      &           '_neupd: Last row of the Schur vector matrix')
             if (msglvl .gt. 3) then
-               call pcmout(comm, logfil, ncv, ncv, 
+               call pcmout(comm, logfil, ncv, ncv,
      &              workl(iuptri), ldh, ndigit,
      &              '_neupd: The upper triangular matrix ')
             end if
@@ -610,7 +610,7 @@ c
             call ctrsen('None'       , 'V'          , select      ,
      &                   ncv          , workl(iuptri), ldh         ,
      &                   workl(invsub), ldq          , workl(iheig),
-     &                   nconv        , conds        , sep         , 
+     &                   nconv        , conds        , sep         ,
      &                   workev, ncv, ierr)
 c
             if (ierr .eq. 1) then
@@ -622,7 +622,7 @@ c
                 call pcvout (comm, logfil, ncv, workl(iheig), ndigit,
      &           '_neupd: Eigenvalues of H--reordered')
                 if (msglvl .gt. 3) then
-                   call pcmout (comm, logfil, ncv, ncv, 
+                   call pcmout (comm, logfil, ncv, ncv,
      &                  workl(iuptri), ldq, ndigit,
      &              '_neupd: Triangular matrix after re-ordering')
                 end if
@@ -637,7 +637,7 @@ c        | Ritz values.                                |
 c        %---------------------------------------------%
 c
          call ccopy(ncv, workl(invsub+ncv-1), ldq, workl(ihbds), 1)
-c 
+c
 c        %--------------------------------------------%
 c        | Place the computed eigenvalues of H into D |
 c        | if a spectral transformation was not used. |
@@ -663,7 +663,7 @@ c        | * Copy the first NCONV columns of VQ into Z.           |
 c        | * Postmultiply Z by R.                                 |
 c        | The N by NCONV matrix Z is now a matrix representation |
 c        | of the approximate invariant subspace associated with  |
-c        | the Ritz values in workl(iheig). The first NCONV       | 
+c        | the Ritz values in workl(iheig). The first NCONV       |
 c        | columns of V are now approximate Schur vectors         |
 c        | associated with the upper triangular matrix of order   |
 c        | NCONV in workl(iuptri).                                |
@@ -686,7 +686,7 @@ c           | Note that since Q is orthogonal, R is a diagonal  |
 c           | matrix consisting of plus or minus ones.          |
 c           %---------------------------------------------------%
 c
-            if ( real ( workl(invsub+(j-1)*ldq+j-1) ) .lt. 
+            if ( real ( workl(invsub+(j-1)*ldq+j-1) ) .lt.
      &                  real (zero) ) then
                call cscal(nconv, -one, workl(iuptri+j-1), ldq)
                call cscal(nconv, -one, workl(iuptri+(j-1)*ldq), 1)
@@ -742,7 +742,7 @@ c                 | Note that the eigenvector matrix of T is |
 c                 | upper triangular, thus the length of the |
 c                 | inner product can be set to j.           |
 c                 %------------------------------------------%
-c 
+c
                   workev(j) = cdotc(j, workl(ihbds), 1,
      &                        workl(invsub+(j-1)*ldq), 1)
  40         continue
@@ -753,8 +753,8 @@ c
                call pcvout(comm, logfil, nconv, workl(ihbds), ndigit,
      &              '_neupd: Last row of the eigenvector matrix for T')
                if (msglvl .gt. 3) then
-                  call pcmout(comm, logfil, nconv, ncv, 
-     &                 workl(invsub), ldq, ndigit, 
+                  call pcmout(comm, logfil, nconv, ncv,
+     &                 workl(invsub), ldq, ndigit,
      &                 '_neupd: The eigenvector matrix for T')
                end if
             end if
@@ -762,7 +762,7 @@ c
 c           %---------------------------------------%
 c           | Copy Ritz estimates into workl(ihbds) |
 c           %---------------------------------------%
-c 
+c
             call ccopy(nconv, workev, 1, workl(ihbds), 1)
 c
 c           %----------------------------------------------%
@@ -775,7 +775,7 @@ c
      &                  one       , workl(invsub), ldq           ,
      &                  z         , ldz)
 c
-         end if 
+         end if
 c
       else
 c
@@ -798,25 +798,25 @@ c     %------------------------------------------------%
 c
       if (type .eq. 'REGULR') then
 c
-         if (rvec) 
+         if (rvec)
      &      call cscal(ncv, rnorm, workl(ihbds), 1)
-c      
+c
       else
-c     
+c
 c        %---------------------------------------%
 c        |   A spectral transformation was used. |
 c        | * Determine the Ritz estimates of the |
 c        |   Ritz values in the original system. |
 c        %---------------------------------------%
 c
-         if (rvec) 
+         if (rvec)
      &      call cscal(ncv, rnorm, workl(ihbds), 1)
-c    
+c
          do 50 k=1, ncv
             temp = workl(iheig+k-1)
             workl(ihbds+k-1) = workl(ihbds+k-1) / temp / temp
   50     continue
-c  
+c
       end if
 c
 c     %-----------------------------------------------------------%
@@ -826,7 +826,7 @@ c     |             lambda = 1/theta + sigma                      |
 c     | NOTES:                                                    |
 c     | *The Ritz vectors are not affected by the transformation. |
 c     %-----------------------------------------------------------%
-c    
+c
       if (type .eq. 'SHIFTI') then
          do 60 k=1, nconv
             d(k) = one / workl(iheig+k-1) + sigma
@@ -880,7 +880,7 @@ c
  9000 continue
 c
       return
-c     
+c
 c     %----------------%
 c     | End of pcneupd |
 c     %----------------%

--- a/mathlibs/src/parpack/pcneupd.f
+++ b/mathlibs/src/parpack/pcneupd.f
@@ -558,9 +558,9 @@ c        | caused by incorrect passing of the dnaupd data.           |
 c        %-----------------------------------------------------------%
 c
          if (msglvl .gt. 2) then
-             call pivout(comm, logfil, 1, numcnv, ndigit,
+             call pivout(comm, logfil, 1, [numcnv], ndigit,
      &            '_neupd: Number of specified eigenvalues')
-             call pivout(comm, logfil, 1, nconv, ndigit,
+             call pivout(comm, logfil, 1, [nconv], ndigit,
      &            '_neupd: Number of "converged" eigenvalues')
          end if 
 c

--- a/mathlibs/src/parpack/pcngets.f
+++ b/mathlibs/src/parpack/pcngets.f
@@ -4,9 +4,9 @@ c\Name: pcngets
 c
 c Message Passing Layer: MPI
 c
-c\Description: 
+c\Description:
 c  Given the eigenvalues of the upper Hessenberg matrix H,
-c  computes the NP shifts AMU that are zeros of the polynomial of 
+c  computes the NP shifts AMU that are zeros of the polynomial of
 c  degree NP which filters out components of the unwanted eigenvectors
 c  corresponding to the AMU's based on some given criteria.
 c
@@ -44,8 +44,8 @@ c  RITZ    Complex array of length KEV+NP.  (INPUT/OUTPUT)
 c          On INPUT, RITZ contains the the eigenvalues of H.
 c          On OUTPUT, RITZ are sorted so that the unwanted
 c          eigenvalues are in the first NP locations and the wanted
-c          portion is in the last KEV locations.  When exact shifts are 
-c          selected, the unwanted part corresponds to the shifts to 
+c          portion is in the last KEV locations.  When exact shifts are
+c          selected, the unwanted part corresponds to the shifts to
 c          be applied. Also, if ISHIFT .eq. 1, the unwanted eigenvalues
 c          are further sorted so that the ones with largest Ritz values
 c          are first.
@@ -53,7 +53,7 @@ c
 c  BOUNDS  Complex array of length KEV+NP.  (INPUT/OUTPUT)
 c          Error bounds corresponding to the ordering in RITZ.
 c
-c  
+c
 c
 c\EndDoc
 c
@@ -74,9 +74,9 @@ c\Author
 c     Danny Sorensen               Phuong Vu
 c     Richard Lehoucq              CRPC / Rice University
 c     Dept. of Computational &     Houston, Texas
-c     Applied Mathematics 
-c     Rice University           
-c     Houston, Texas 
+c     Applied Mathematics
+c     Rice University
+c     Houston, Texas
 c
 c\Parallel Modifications
 c     Kristi Maschhoff
@@ -84,7 +84,7 @@ c
 c\Revision history:
 c     Starting Point: Serial Complex Code FILE: ngets.F   SID: 2.1
 c
-c\SCCS Information: 
+c\SCCS Information:
 c FILE: ngets.F   SID: 1.2   DATE OF SID: 4/19/96
 c
 c\Remarks
@@ -152,14 +152,14 @@ c     %-------------------------------%
 c     | Initialize timing statistics  |
 c     | & message level for debugging |
 c     %-------------------------------%
-c 
+c
       call second (t0)
       msglvl = mcgets
-c 
+c
       call csortc (which, .true., kev+np, ritz, bounds)
-c     
+c
       if ( ishift .eq. 1 ) then
-c     
+c
 c        %-------------------------------------------------------%
 c        | Sort the unwanted Ritz values used as shifts so that  |
 c        | the ones with largest Ritz estimates are first        |
@@ -168,11 +168,11 @@ c        | forward instability of the iteration when the shifts  |
 c        | are applied in subroutine pcnapps.                    |
 c        | Be careful and use 'SM' since we want to sort BOUNDS! |
 c        %-------------------------------------------------------%
-c     
+c
          call csortc ( 'SM', .true., np, bounds, ritz )
 c
       end if
-c     
+c
       call second (t1)
       tcgets = tcgets + (t1 - t0)
 c
@@ -181,14 +181,14 @@ c
          call pivout (comm, logfil, 1, [np], ndigit, '_ngets: NP is')
          call pcvout (comm, logfil, kev+np, ritz, ndigit,
      &        '_ngets: Eigenvalues of current H matrix ')
-         call pcvout (comm, logfil, kev+np, bounds, ndigit, 
+         call pcvout (comm, logfil, kev+np, bounds, ndigit,
      &      '_ngets: Ritz estimates of the current KEV+NP Ritz values')
       end if
-c     
+c
       return
-c     
+c
 c     %----------------%
 c     | End of pcngets |
 c     %----------------%
-c     
+c
       end

--- a/mathlibs/src/parpack/pcngets.f
+++ b/mathlibs/src/parpack/pcngets.f
@@ -177,8 +177,8 @@ c
       tcgets = tcgets + (t1 - t0)
 c
       if (msglvl .gt. 0) then
-         call pivout (comm, logfil, 1, kev, ndigit, '_ngets: KEV is')
-         call pivout (comm, logfil, 1, np, ndigit, '_ngets: NP is')
+         call pivout (comm, logfil, 1, [kev], ndigit, '_ngets: KEV is')
+         call pivout (comm, logfil, 1, [np], ndigit, '_ngets: NP is')
          call pcvout (comm, logfil, kev+np, ritz, ndigit,
      &        '_ngets: Eigenvalues of current H matrix ')
          call pcvout (comm, logfil, kev+np, bounds, ndigit, 

--- a/mathlibs/src/parpack/pdgetv0.f
+++ b/mathlibs/src/parpack/pdgetv0.f
@@ -391,9 +391,9 @@ c     | Check for further orthogonalization. |
 c     %--------------------------------------%
 c
       if (msglvl .gt. 2) then
-          call pdvout (comm, logfil, 1, rnorm0, ndigit, 
+          call pdvout (comm, logfil, 1, [rnorm0], ndigit, 
      &                '_getv0: re-orthonalization ; rnorm0 is')
-          call pdvout (comm, logfil, 1, rnorm, ndigit, 
+          call pdvout (comm, logfil, 1, [rnorm], ndigit, 
      &                '_getv0: re-orthonalization ; rnorm is')
       end if
 c
@@ -424,7 +424,7 @@ c
    50 continue
 c
       if (msglvl .gt. 0) then
-         call pdvout (comm, logfil, 1, rnorm, ndigit,
+         call pdvout (comm, logfil, 1, [rnorm], ndigit,
      &        '_getv0: B-norm of initial / restarted starting vector')
       end if
       if (msglvl .gt. 2) then

--- a/mathlibs/src/parpack/pdnaitr.f
+++ b/mathlibs/src/parpack/pdnaitr.f
@@ -5,8 +5,8 @@ c\Name: pdnaitr
 c
 c Message Passing Layer: MPI
 c
-c\Description: 
-c  Reverse communication interface for applying NP additional steps to 
+c\Description:
+c  Reverse communication interface for applying NP additional steps to
 c  a K step nonsymmetric Arnoldi factorization.
 c
 c  Input:  OP*V_{k}  -  V_{k}*H = r_{k}*e_{k}^T
@@ -22,7 +22,7 @@ c  computed and returned.
 c
 c\Usage:
 c  call pdnaitr
-c     ( COMM, IDO, BMAT, N, K, NP, NB, RESID, RNORM, V, LDV, H, LDH, 
+c     ( COMM, IDO, BMAT, N, K, NP, NB, RESID, RNORM, V, LDV, H, LDH,
 c       IPNTR, WORKD, WORKL, INFO )
 c
 c\Arguments
@@ -66,8 +66,8 @@ c  NP      Integer.  (INPUT)
 c          Number of additional Arnoldi steps to take.
 c
 c  NB      Integer.  (INPUT)
-c          Blocksize to be used in the recurrence.          
-c          Only work for NB = 1 right now.  The goal is to have a 
+c          Blocksize to be used in the recurrence.
+c          Only work for NB = 1 right now.  The goal is to have a
 c          program that implement both the block and non-block method.
 c
 c  RESID   Double precision array of length N.  (INPUT/OUTPUT)
@@ -79,37 +79,37 @@ c          B-norm of the starting residual on input.
 c          B-norm of the updated residual r_{k+p} on output.
 c
 c  V       Double precision N by K+NP array.  (INPUT/OUTPUT)
-c          On INPUT:  V contains the Arnoldi vectors in the first K 
+c          On INPUT:  V contains the Arnoldi vectors in the first K
 c          columns.
 c          On OUTPUT: V contains the new NP Arnoldi vectors in the next
 c          NP columns.  The first K columns are unchanged.
 c
 c  LDV     Integer.  (INPUT)
-c          Leading dimension of V exactly as declared in the calling 
+c          Leading dimension of V exactly as declared in the calling
 c          program.
 c
 c  H       Double precision (K+NP) by (K+NP) array.  (INPUT/OUTPUT)
 c          H is used to store the generated upper Hessenberg matrix.
 c
 c  LDH     Integer.  (INPUT)
-c          Leading dimension of H exactly as declared in the calling 
+c          Leading dimension of H exactly as declared in the calling
 c          program.
 c
 c  IPNTR   Integer array of length 3.  (OUTPUT)
-c          Pointer to mark the starting locations in the WORK for 
+c          Pointer to mark the starting locations in the WORK for
 c          vectors used by the Arnoldi iteration.
 c          -------------------------------------------------------------
 c          IPNTR(1): pointer to the current operand vector X.
 c          IPNTR(2): pointer to the current result vector Y.
-c          IPNTR(3): pointer to the vector B * X when used in the 
+c          IPNTR(3): pointer to the vector B * X when used in the
 c                    shift-and-invert mode.  X is the current operand.
 c          -------------------------------------------------------------
-c          
+c
 c  WORKD   Double precision work array of length 3*N.  (REVERSE COMMUNICATION)
 c          Distributed array to be used in the basic Arnoldi iteration
-c          for reverse communication.  The calling program should not 
+c          for reverse communication.  The calling program should not
 c          use WORKD as temporary workspace during the iteration !!!!!!
-c          On input, WORKD(1:N) = B*RESID and is used to save some 
+c          On input, WORKD(1:N) = B*RESID and is used to save some
 c          computation at the first step.
 c
 c  WORKL   Double precision work space used for Gram Schmidt orthogonalization
@@ -131,7 +131,7 @@ c\References:
 c  1. D.C. Sorensen, "Implicit Application of Polynomial Filters in
 c     a k-Step Arnoldi Method", SIAM J. Matr. Anal. Apps., 13 (1992),
 c     pp 357-385.
-c  2. R.B. Lehoucq, "Analysis and Implementation of an Implicitly 
+c  2. R.B. Lehoucq, "Analysis and Implementation of an Implicitly
 c     Restarted Arnoldi Iteration", Rice University Technical Report
 c     TR95-13, Department of Computational and Applied Mathematics.
 c
@@ -149,7 +149,7 @@ c     dgemv    Level 2 BLAS routine for matrix vector multiplication.
 c     daxpy    Level 1 BLAS that computes a vector triad.
 c     dscal    Level 1 BLAS that scales a vector.
 c     dcopy    Level 1 BLAS that copies one vector to another .
-c     ddot     Level 1 BLAS that computes the scalar product of two vectors. 
+c     ddot     Level 1 BLAS that computes the scalar product of two vectors.
 c     pdnorm2  Parallel version of Level 1 BLAS that computes the norm of a vector.
 c
 c\Author
@@ -157,25 +157,25 @@ c     Danny Sorensen               Phuong Vu
 c     Richard Lehoucq              CRPC / Rice University
 c     Dept. of Computational &     Houston, Texas
 c     Applied Mathematics
-c     Rice University           
-c     Houston, Texas    
-c 
+c     Rice University
+c     Houston, Texas
+c
 c\Parallel Modifications
 c     Kristi Maschhoff
 c
 c\Revision history:
 c     Starting Point: Serial Code FILE: naitr.F   SID: 2.2
 c
-c\SCCS Information: 
-c FILE: naitr.F   SID: 1.3   DATE OF SID: 3/19/97   
+c\SCCS Information:
+c FILE: naitr.F   SID: 1.3   DATE OF SID: 3/19/97
 c
 c\Remarks
 c  The algorithm implemented is:
-c  
+c
 c  restart = .false.
-c  Given V_{k} = [v_{1}, ..., v_{k}], r_{k}; 
+c  Given V_{k} = [v_{1}, ..., v_{k}], r_{k};
 c  r_{k} contains the initial residual vector even for k = 0;
-c  Also assume that rnorm = || B*r_{k} || and B*r_{k} are already 
+c  Also assume that rnorm = || B*r_{k} || and B*r_{k} are already
 c  computed by the calling program.
 c
 c  betaj = rnorm ; p_{k+1} = B*r_{k} ;
@@ -183,7 +183,7 @@ c  For  j = k+1, ..., k+np  Do
 c     1) if ( betaj < tol ) stop or restart depending on j.
 c        ( At present tol is zero )
 c        if ( restart ) generate a new starting vector.
-c     2) v_{j} = r(j-1)/betaj;  V_{j} = [V_{j-1}, v_{j}];  
+c     2) v_{j} = r(j-1)/betaj;  V_{j} = [V_{j-1}, v_{j}];
 c        p_{j} = p_{j}/betaj
 c     3) r_{j} = OP*v_{j} where OP is defined as in pdnaupd
 c        For shift-invert mode p_{j} = B*v_{j} is already available.
@@ -198,7 +198,7 @@ c        If (rnorm > 0.717*wnorm) accept step and go back to 1)
 c     5) Re-orthogonalization step:
 c        s = V_{j}'*B*r_{j}
 c        r_{j} = r_{j} - V_{j}*s;  rnorm1 = || r_{j} ||
-c        alphaj = alphaj + s_{j};   
+c        alphaj = alphaj + s_{j};
 c     6) Iterative refinement step:
 c        If (rnorm1 > 0.717*rnorm) then
 c           rnorm = rnorm1
@@ -208,7 +208,7 @@ c           rnorm = rnorm1
 c           If this is the first time in step 6), go to 5)
 c           Else r_{j} lies in the span of V_{j} numerically.
 c              Set r_{j} = 0 and rnorm = 0; go to 1)
-c        EndIf 
+c        EndIf
 c  End Do
 c
 c\EndLib
@@ -216,7 +216,7 @@ c
 c-----------------------------------------------------------------------
 c
       subroutine pdnaitr
-     &   (comm, ido, bmat, n, k, np, nb, resid, rnorm, v, ldv, h, ldh, 
+     &   (comm, ido, bmat, n, k, np, nb, resid, rnorm, v, ldv, h, ldh,
      &    ipntr, workd, workl, info)
 c
       include   'mpif.h'
@@ -268,7 +268,7 @@ c
       integer    ierr, i, infol, ipj, irj, ivj, iter, itry, j, msglvl,
      &           jj
       Double precision
-     &           betaj, ovfl, temp1, rnorm1, smlnum, tst1, ulp, unfl, 
+     &           betaj, ovfl, temp1, rnorm1, smlnum, tst1, ulp, unfl,
      &           wnorm
       save       first, orth1, orth2, rstart, step3, step4,
      &           ierr, ipj, irj, ivj, iter, itry, j, msglvl, ovfl,
@@ -279,7 +279,7 @@ c
 c
 c
 c     %-----------------------%
-c     | Local Array Arguments | 
+c     | Local Array Arguments |
 c     %-----------------------%
 c
       Double precision
@@ -289,7 +289,7 @@ c     %----------------------%
 c     | External Subroutines |
 c     %----------------------%
 c
-      external   daxpy, dcopy, dscal, dgemv, pdgetv0, dlabad, 
+      external   daxpy, dcopy, dscal, dgemv, pdgetv0, dlabad,
      &           pdvout, pdmout, pivout, second
 c
 c     %--------------------%
@@ -335,7 +335,7 @@ c
       end if
 c
       if (ido .eq. 0) then
-c 
+c
 c        %-------------------------------%
 c        | Initialize timing statistics  |
 c        | & message level for debugging |
@@ -343,7 +343,7 @@ c        %-------------------------------%
 c
          call second (t0)
          msglvl = mnaitr
-c 
+c
 c        %------------------------------%
 c        | Initial call to this routine |
 c        %------------------------------%
@@ -359,7 +359,7 @@ c
          irj    = ipj   + n
          ivj    = irj   + n
       end if
-c 
+c
 c     %-------------------------------------------------%
 c     | When in reverse communication mode one of:      |
 c     | STEP3, STEP4, ORTH1, ORTH2, RSTART              |
@@ -389,16 +389,16 @@ c     |        A R N O L D I     I T E R A T I O N     L O O P       |
 c     |                                                              |
 c     | Note:  B*r_{j-1} is already in WORKD(1:N)=WORKD(IPJ:IPJ+N-1) |
 c     %--------------------------------------------------------------%
- 
+
  1000 continue
 c
          if (msglvl .gt. 1) then
-            call pivout (comm, logfil, 1, [j], ndigit, 
+            call pivout (comm, logfil, 1, [j], ndigit,
      &                  '_naitr: generating Arnoldi vector number')
-            call pdvout (comm, logfil, 1, [rnorm], ndigit, 
+            call pdvout (comm, logfil, 1, [rnorm], ndigit,
      &                  '_naitr: B-norm of the current residual is')
          end if
-c 
+c
 c        %---------------------------------------------------%
 c        | STEP 1: Check if the B norm of j-th residual      |
 c        | vector is zero. Equivalent to determing whether   |
@@ -418,13 +418,13 @@ c
                call pivout (comm, logfil, 1, [j], ndigit,
      &                     '_naitr: ****** RESTART AT STEP ******')
             end if
-c 
+c
 c           %---------------------------------------------%
 c           | ITRY is the loop variable that controls the |
 c           | maximum amount of times that a restart is   |
 c           | attempted. NRSTRT is used by stat.h         |
 c           %---------------------------------------------%
-c 
+c
             betaj  = zero
             nrstrt = nrstrt + 1
             itry   = 1
@@ -438,7 +438,7 @@ c           | If in reverse communication mode and |
 c           | RSTART = .true. flow returns here.   |
 c           %--------------------------------------%
 c
-            call pdgetv0 ( comm, ido, bmat, itry, .false., n, j, v, ldv, 
+            call pdgetv0 ( comm, ido, bmat, itry, .false., n, j, v, ldv,
      &                     resid, rnorm, ipntr, workd, workl, ierr)
             if (ido .ne. 99) go to 9000
             if (ierr .lt. 0) then
@@ -457,7 +457,7 @@ c
                ido = 99
                go to 9000
             end if
-c 
+c
    40    continue
 c
 c        %---------------------------------------------------------%
@@ -479,9 +479,9 @@ c            | To scale both v_{j} and p_{j} carefully |
 c            | use LAPACK routine SLASCL               |
 c            %-----------------------------------------%
 c
-             call dlascl ('General', i, i, rnorm, one, n, 1, 
+             call dlascl ('General', i, i, rnorm, one, n, 1,
      &                    v(1,j), n, infol)
-             call dlascl ('General', i, i, rnorm, one, n, 1, 
+             call dlascl ('General', i, i, rnorm, one, n, 1,
      &                    workd(ipj), n, infol)
          end if
 c
@@ -498,14 +498,14 @@ c
          ipntr(2) = irj
          ipntr(3) = ipj
          ido = 1
-c 
+c
 c        %-----------------------------------%
 c        | Exit in order to compute OP*v_{j} |
 c        %-----------------------------------%
-c 
-         go to 9000 
+c
+         go to 9000
    50    continue
-c 
+c
 c        %----------------------------------%
 c        | Back from reverse communication; |
 c        | WORKD(IRJ:IRJ+N-1) := OP*v_{j}   |
@@ -514,7 +514,7 @@ c        %----------------------------------%
 c
          call second (t3)
          tmvopx = tmvopx + (t3 - t2)
- 
+
          step3 = .false.
 c
 c        %------------------------------------------%
@@ -522,7 +522,7 @@ c        | Put another copy of OP*v_{j} into RESID. |
 c        %------------------------------------------%
 c
          call dcopy (n, workd(irj), 1, resid, 1)
-c 
+c
 c        %---------------------------------------%
 c        | STEP 4:  Finish extending the Arnoldi |
 c        |          factorization to length j.   |
@@ -535,17 +535,17 @@ c
             ipntr(1) = irj
             ipntr(2) = ipj
             ido = 2
-c 
+c
 c           %-------------------------------------%
 c           | Exit in order to compute B*OP*v_{j} |
 c           %-------------------------------------%
-c 
+c
             go to 9000
          else if (bmat .eq. 'I') then
             call dcopy (n, resid, 1, workd(ipj), 1)
          end if
    60    continue
-c 
+c
 c        %----------------------------------%
 c        | Back from reverse communication; |
 c        | WORKD(IPJ:IPJ+N-1) := B*OP*v_{j} |
@@ -556,7 +556,7 @@ c
             call second (t3)
             tmvbx = tmvbx + (t3 - t2)
          end if
-c 
+c
          step4 = .false.
 c
 c        %-------------------------------------%
@@ -594,7 +594,7 @@ c
 c
 c        %--------------------------------------%
 c        | Orthogonalize r_{j} against V_{j}.   |
-c        | RESID contains OP*v_{j}. See STEP 3. | 
+c        | RESID contains OP*v_{j}. See STEP 3. |
 c        %--------------------------------------%
 c
          call dgemv ('N', n, j, -one, v, ldv, h(1,j), 1,
@@ -603,7 +603,7 @@ c
          if (j .gt. 1) h(j,j-1) = betaj
 c
          call second (t4)
-c 
+c
          orth1 = .true.
 c
          call second (t2)
@@ -613,17 +613,17 @@ c
             ipntr(1) = irj
             ipntr(2) = ipj
             ido = 2
-c 
+c
 c           %----------------------------------%
 c           | Exit in order to compute B*r_{j} |
 c           %----------------------------------%
-c 
+c
             go to 9000
          else if (bmat .eq. 'I') then
             call dcopy (n, resid, 1, workd(ipj), 1)
-         end if 
+         end if
    70    continue
-c 
+c
 c        %---------------------------------------------------%
 c        | Back from reverse communication if ORTH1 = .true. |
 c        | WORKD(IPJ:IPJ+N-1) := B*r_{j}.                    |
@@ -633,7 +633,7 @@ c
             call second (t3)
             tmvbx = tmvbx + (t3 - t2)
          end if
-c 
+c
          orth1 = .false.
 c
 c        %------------------------------%
@@ -648,7 +648,7 @@ c
          else if (bmat .eq. 'I') then
             rnorm = pdnorm2( comm, n, resid, 1 )
          end if
-c 
+c
 c        %-----------------------------------------------------------%
 c        | STEP 5: Re-orthogonalization / Iterative refinement phase |
 c        | Maximum NITER_ITREF tries.                                |
@@ -670,20 +670,20 @@ c
          if (rnorm .gt. 0.717*wnorm) go to 100
          iter  = 0
          nrorth = nrorth + 1
-c 
+c
 c        %---------------------------------------------------%
 c        | Enter the Iterative refinement phase. If further  |
 c        | refinement is necessary, loop back here. The loop |
 c        | variable is ITER. Perform a step of Classical     |
 c        | Gram-Schmidt using all the Arnoldi vectors V_{j}  |
 c        %---------------------------------------------------%
-c 
+c
    80    continue
 c
          if (msglvl .gt. 2) then
             xtemp(1) = wnorm
             xtemp(2) = rnorm
-            call pdvout (comm, logfil, 2, xtemp, ndigit, 
+            call pdvout (comm, logfil, 2, xtemp, ndigit,
      &           '_naitr: re-orthonalization; wnorm and rnorm are')
             call pdvout (comm, logfil, j, h(1,j), ndigit,
      &                  '_naitr: j-th column of H')
@@ -706,10 +706,10 @@ c        | The correction to H is v(:,1:J)*H(1:J,1:J)  |
 c        | + v(:,1:J)*WORKD(IRJ:IRJ+J-1)*e'_j.         |
 c        %---------------------------------------------%
 c
-         call dgemv ('N', n, j, -one, v, ldv, workl(1), 1, 
+         call dgemv ('N', n, j, -one, v, ldv, workl(1), 1,
      &               one, resid, 1)
          call daxpy (j, one, workl(1), 1, h(1,j), 1)
-c 
+c
          orth2 = .true.
          call second (t2)
          if (bmat .eq. 'G') then
@@ -718,16 +718,16 @@ c
             ipntr(1) = irj
             ipntr(2) = ipj
             ido = 2
-c 
+c
 c           %-----------------------------------%
 c           | Exit in order to compute B*r_{j}. |
 c           | r_{j} is the corrected residual.  |
 c           %-----------------------------------%
-c 
+c
             go to 9000
          else if (bmat .eq. 'I') then
             call dcopy (n, resid, 1, workd(ipj), 1)
-         end if 
+         end if
    90    continue
 c
 c        %---------------------------------------------------%
@@ -742,7 +742,7 @@ c
 c        %-----------------------------------------------------%
 c        | Compute the B-norm of the corrected residual r_{j}. |
 c        %-----------------------------------------------------%
-c 
+c
          if (bmat .eq. 'G') then
            rnorm_buf = ddot (n, resid, 1, workd(ipj), 1)
            call MPI_ALLREDUCE( rnorm_buf, rnorm1, 1,
@@ -751,14 +751,14 @@ c
          else if (bmat .eq. 'I') then
            rnorm1 = pdnorm2( comm, n, resid, 1 )
          end if
-c 
+c
          if (msglvl .gt. 0 .and. iter .gt. 0) then
             call pivout (comm, logfil, 1, [j], ndigit,
      &           '_naitr: Iterative refinement for Arnoldi residual')
             if (msglvl .gt. 2) then
                 xtemp(1) = rnorm
                 xtemp(2) = rnorm1
-                call pdvout (comm, logfil, 2, xtemp, ndigit, 
+                call pdvout (comm, logfil, 2, xtemp, ndigit,
      &           '_naitr: iterative refinement ; rnorm and rnorm1 are')
             end if
          end if
@@ -781,7 +781,7 @@ c           | angle of less than arcCOS(0.717)      |
 c           %---------------------------------------%
 c
             rnorm = rnorm1
-c 
+c
          else
 c
 c           %-------------------------------------------%
@@ -803,21 +803,21 @@ c
   95        continue
             rnorm = zero
          end if
-c 
+c
 c        %----------------------------------------------%
 c        | Branch here directly if iterative refinement |
 c        | wasn't necessary or after at most NITER_REF  |
 c        | steps of iterative refinement.               |
 c        %----------------------------------------------%
-c 
+c
   100    continue
-c 
+c
          rstart = .false.
          orth2  = .false.
-c 
+c
          call second (t5)
          titref = titref + (t5 - t4)
-c 
+c
 c        %------------------------------------%
 c        | STEP 6: Update  j = j+1;  Continue |
 c        %------------------------------------%
@@ -828,25 +828,25 @@ c
             tnaitr = tnaitr + (t1 - t0)
             ido = 99
             do 110 i = max(1,k), k+np-1
-c     
+c
 c              %--------------------------------------------%
 c              | Check for splitting and deflation.         |
 c              | Use a standard test as in the QR algorithm |
 c              | REFERENCE: LAPACK subroutine dlahqr        |
 c              %--------------------------------------------%
-c     
+c
                tst1 = abs( h( i, i ) ) + abs( h( i+1, i+1 ) )
                if( tst1.eq.zero )
      &              tst1 = dlanhs( '1', k+np, h, ldh, workd(n+1) )
-               if( abs( h( i+1,i ) ).le.max( ulp*tst1, smlnum ) ) 
+               if( abs( h( i+1,i ) ).le.max( ulp*tst1, smlnum ) )
      &              h(i+1,i) = zero
  110        continue
-c     
+c
             if (msglvl .gt. 2) then
-               call pdmout (comm, logfil, k+np, k+np, h, ldh, ndigit, 
+               call pdmout (comm, logfil, k+np, k+np, h, ldh, ndigit,
      &          '_naitr: Final upper Hessenberg matrix H of order K+NP')
             end if
-c     
+c
             go to 9000
          end if
 c
@@ -855,7 +855,7 @@ c        | Loop back to extend the factorization by another step. |
 c        %--------------------------------------------------------%
 c
       go to 1000
-c 
+c
 c     %---------------------------------------------------------------%
 c     |                                                               |
 c     |  E N D     O F     M A I N     I T E R A T I O N     L O O P  |

--- a/mathlibs/src/parpack/pdnaitr.f
+++ b/mathlibs/src/parpack/pdnaitr.f
@@ -393,9 +393,9 @@ c     %--------------------------------------------------------------%
  1000 continue
 c
          if (msglvl .gt. 1) then
-            call pivout (comm, logfil, 1, j, ndigit, 
+            call pivout (comm, logfil, 1, [j], ndigit, 
      &                  '_naitr: generating Arnoldi vector number')
-            call pdvout (comm, logfil, 1, rnorm, ndigit, 
+            call pdvout (comm, logfil, 1, [rnorm], ndigit, 
      &                  '_naitr: B-norm of the current residual is')
          end if
 c 
@@ -415,7 +415,7 @@ c           | basis and continue the iteration.                 |
 c           %---------------------------------------------------%
 c
             if (msglvl .gt. 0) then
-               call pivout (comm, logfil, 1, j, ndigit,
+               call pivout (comm, logfil, 1, [j], ndigit,
      &                     '_naitr: ****** RESTART AT STEP ******')
             end if
 c 
@@ -753,7 +753,7 @@ c
          end if
 c 
          if (msglvl .gt. 0 .and. iter .gt. 0) then
-            call pivout (comm, logfil, 1, j, ndigit,
+            call pivout (comm, logfil, 1, [j], ndigit,
      &           '_naitr: Iterative refinement for Arnoldi residual')
             if (msglvl .gt. 2) then
                 xtemp(1) = rnorm

--- a/mathlibs/src/parpack/pdnapps.f
+++ b/mathlibs/src/parpack/pdnapps.f
@@ -276,11 +276,11 @@ c
          sigmai = shifti(jj)
 c
          if (msglvl .gt. 2 ) then
-            call pivout (comm, logfil, 1, jj, ndigit, 
+            call pivout (comm, logfil, 1, [jj], ndigit, 
      &               '_napps: shift number.')
-            call pdvout (comm, logfil, 1, sigmar, ndigit, 
+            call pdvout (comm, logfil, 1, [sigmar], ndigit, 
      &               '_napps: The real part of the shift ')
-            call pdvout (comm, logfil, 1, sigmai, ndigit, 
+            call pdvout (comm, logfil, 1, [sigmai], ndigit, 
      &               '_napps: The imaginary part of the shift ')
          end if
 c
@@ -345,9 +345,9 @@ c
      &         tst1 = dlanhs( '1', kplusp-jj+1, h, ldh, workl )
             if( abs( h( i+1,i ) ).le.max( ulp*tst1, smlnum ) ) then
                if (msglvl .gt. 0) then
-                  call pivout (comm, logfil, 1, i, ndigit, 
+                  call pivout (comm, logfil, 1, [i], ndigit, 
      &                 '_napps: matrix splitting at row/column no.')
-                  call pivout (comm, logfil, 1, jj, ndigit, 
+                  call pivout (comm, logfil, 1, [jj], ndigit, 
      &                 '_napps: matrix splitting with shift number.')
                   call pdvout (comm, logfil, 1, h(i+1,i), ndigit, 
      &                 '_napps: off diagonal element.')
@@ -361,9 +361,9 @@ c
    40    continue
 c
          if (msglvl .gt. 2) then
-             call pivout (comm, logfil, 1, istart, ndigit, 
+             call pivout (comm, logfil, 1, [istart], ndigit, 
      &                   '_napps: Start of current block ')
-             call pivout (comm, logfil, 1, iend, ndigit, 
+             call pivout (comm, logfil, 1, [iend], ndigit, 
      &                   '_napps: End of current block ')
          end if
 c
@@ -635,7 +635,7 @@ c
      &        '_napps: sigmak = (e_{kev+p}^T*Q)*e_{kev}')
          call pdvout (comm, logfil, 1, h(kev+1,kev), ndigit,
      &        '_napps: betak = e_{kev+1}^T*H*e_{kev}')
-         call pivout (comm, logfil, 1, kev, ndigit, 
+         call pivout (comm, logfil, 1, [kev], ndigit, 
      &               '_napps: Order of the final Hessenberg matrix ')
          if (msglvl .gt. 2) then
             call pdmout (comm, logfil, kev, kev, h, ldh, ndigit,

--- a/mathlibs/src/parpack/pdnapps.f
+++ b/mathlibs/src/parpack/pdnapps.f
@@ -22,7 +22,7 @@ c     A*VNEW_{k} - VNEW_{k}*HNEW_{k} = rnew_{k}*e_{k}^T.
 c
 c\Usage:
 c  call pdnapps
-c     ( COMM, N, KEV, NP, SHIFTR, SHIFTI, V, LDV, H, LDH, RESID, Q, LDQ, 
+c     ( COMM, N, KEV, NP, SHIFTR, SHIFTI, V, LDV, H, LDH, RESID, Q, LDQ,
 c       WORKL, WORKD )
 c
 c\Arguments
@@ -33,7 +33,7 @@ c          Problem size, i.e. size of matrix A.
 c
 c  KEV     Integer.  (INPUT/OUTPUT)
 c          KEV+NP is the size of the input matrix H.
-c          KEV is the size of the updated matrix HNEW.  KEV is only 
+c          KEV is the size of the updated matrix HNEW.  KEV is only
 c          updated on ouput when fewer than NP shifts are applied in
 c          order to keep the conjugate pair together.
 c
@@ -42,7 +42,7 @@ c          Number of implicit shifts to be applied.
 c
 c  SHIFTR, Double precision array of length NP.  (INPUT)
 c  SHIFTI  Real and imaginary part of the shifts to be applied.
-c          Upon, entry to pdnapps, the shifts must be sorted so that the 
+c          Upon, entry to pdnapps, the shifts must be sorted so that the
 c          conjugate pairs are in consecutive locations.
 c
 c  V       Double precision N by (KEV+NP) array.  (INPUT/OUTPUT)
@@ -55,7 +55,7 @@ c          Leading dimension of V exactly as declared in the calling
 c          program.
 c
 c  H       Double precision (KEV+NP) by (KEV+NP) array.  (INPUT/OUTPUT)
-c          On INPUT, H contains the current KEV+NP by KEV+NP upper 
+c          On INPUT, H contains the current KEV+NP by KEV+NP upper
 c          Hessenber matrix of the Arnoldi factorization.
 c          On OUTPUT, H contains the updated KEV by KEV upper Hessenberg
 c          matrix in the KEV leading submatrix.
@@ -66,7 +66,7 @@ c          program.
 c
 c  RESID   Double precision array of length N.  (INPUT/OUTPUT)
 c          On INPUT, RESID contains the the residual vector r_{k+p}.
-c          On OUTPUT, RESID is the update residual vector rnew_{k} 
+c          On OUTPUT, RESID is the update residual vector rnew_{k}
 c          in the first KEV locations.
 c
 c  Q       Double precision KEV+NP by KEV+NP work array.  (WORKSPACE)
@@ -120,8 +120,8 @@ c     Danny Sorensen               Phuong Vu
 c     Richard Lehoucq              CRPC / Rice University
 c     Dept. of Computational &     Houston, Texas
 c     Applied Mathematics
-c     Rice University           
-c     Houston, Texas    
+c     Rice University
+c     Houston, Texas
 c
 c\Parallel Modifications
 c     Kristi Maschhoff
@@ -129,8 +129,8 @@ c
 c\Revision history:
 c     Starting Point: Serial Code FILE: napps.F   SID: 2.2
 c
-c\SCCS Information: 
-c FILE: napps.F   SID: 1.5   DATE OF SID: 03/19/97   
+c\SCCS Information:
+c FILE: napps.F   SID: 1.5   DATE OF SID: 03/19/97
 c
 c\Remarks
 c  1. In this version, each shift is applied to all the sublocks of
@@ -144,7 +144,7 @@ c
 c-----------------------------------------------------------------------
 c
       subroutine pdnapps
-     &   ( comm, n, kev, np, shiftr, shifti, v, ldv, h, ldh, resid, 
+     &   ( comm, n, kev, np, shiftr, shifti, v, ldv, h, ldh, resid,
      &     q, ldq, workl, workd )
 c
 c     %--------------------%
@@ -171,7 +171,7 @@ c     | Array Arguments |
 c     %-----------------%
 c
       Double precision
-     &           h(ldh,kev+np), resid(n), shifti(np), shiftr(np), 
+     &           h(ldh,kev+np), resid(n), shifti(np), shiftr(np),
      &           v(ldv,kev+np), q(ldq,kev+np), workd(2*n), workl(kev+np)
 c
 c     %------------%
@@ -189,15 +189,15 @@ c
       integer    i, iend, ir, istart, j, jj, kplusp, msglvl, nr
       logical    cconj, first
       Double precision
-     &           c, f, g, h11, h12, h21, h22, h32, ovfl, r, s, sigmai, 
+     &           c, f, g, h11, h12, h21, h22, h32, ovfl, r, s, sigmai,
      &           sigmar, smlnum, ulp, unfl, u(3), t, tau, tst1
-      save       first, ovfl, smlnum, ulp, unfl 
+      save       first, ovfl, smlnum, ulp, unfl
 c
 c     %----------------------%
 c     | External Subroutines |
 c     %----------------------%
 c
-      external   daxpy, dcopy, dscal, dlacpy, dlarf, dlarfg, dlartg, 
+      external   daxpy, dcopy, dscal, dlacpy, dlarf, dlarfg, dlartg,
      &           dlaset, dlabad, second, pivout, pdvout, pdmout
 c
 c     %--------------------%
@@ -248,9 +248,9 @@ c     %-------------------------------%
 c
       call second (t0)
       msglvl = mnapps
-c 
-      kplusp = kev + np 
-c 
+c
+      kplusp = kev + np
+c
 c     %--------------------------------------------%
 c     | Initialize Q to the identity to accumulate |
 c     | the rotations and reflections              |
@@ -276,11 +276,11 @@ c
          sigmai = shifti(jj)
 c
          if (msglvl .gt. 2 ) then
-            call pivout (comm, logfil, 1, [jj], ndigit, 
+            call pivout (comm, logfil, 1, [jj], ndigit,
      &               '_napps: shift number.')
-            call pdvout (comm, logfil, 1, [sigmar], ndigit, 
+            call pdvout (comm, logfil, 1, [sigmar], ndigit,
      &               '_napps: The real part of the shift ')
-            call pdvout (comm, logfil, 1, [sigmai], ndigit, 
+            call pdvout (comm, logfil, 1, [sigmai], ndigit,
      &               '_napps: The imaginary part of the shift ')
          end if
 c
@@ -345,11 +345,11 @@ c
      &         tst1 = dlanhs( '1', kplusp-jj+1, h, ldh, workl )
             if( abs( h( i+1,i ) ).le.max( ulp*tst1, smlnum ) ) then
                if (msglvl .gt. 0) then
-                  call pivout (comm, logfil, 1, [i], ndigit, 
+                  call pivout (comm, logfil, 1, [i], ndigit,
      &                 '_napps: matrix splitting at row/column no.')
-                  call pivout (comm, logfil, 1, [jj], ndigit, 
+                  call pivout (comm, logfil, 1, [jj], ndigit,
      &                 '_napps: matrix splitting with shift number.')
-                  call pdvout (comm, logfil, 1, h(i+1,i), ndigit, 
+                  call pdvout (comm, logfil, 1, h(i+1,i), ndigit,
      &                 '_napps: off diagonal element.')
                end if
                iend = i
@@ -361,9 +361,9 @@ c
    40    continue
 c
          if (msglvl .gt. 2) then
-             call pivout (comm, logfil, 1, [istart], ndigit, 
+             call pivout (comm, logfil, 1, [istart], ndigit,
      &                   '_napps: Start of current block ')
-             call pivout (comm, logfil, 1, [iend], ndigit, 
+             call pivout (comm, logfil, 1, [iend], ndigit,
      &                   '_napps: End of current block ')
          end if
 c
@@ -378,7 +378,7 @@ c        | If istart + 1 = iend then no reason to apply a       |
 c        | complex conjugate pair of shifts on a 2 by 2 matrix. |
 c        %------------------------------------------------------%
 c
-         if ( istart + 1 .eq. iend .and. abs( sigmai ) .gt. zero ) 
+         if ( istart + 1 .eq. iend .and. abs( sigmai ) .gt. zero )
      &      go to 100
 c
          h11 = h(istart,istart)
@@ -391,7 +391,7 @@ c           %---------------------------------------------%
 c
             f = h11 - sigmar
             g = h21
-c 
+c
             do 80 i = istart, iend-1
 c
 c              %-----------------------------------------------------%
@@ -423,7 +423,7 @@ c
                do 50 j = i, kplusp
                   t        =  c*h(i,j) + s*h(i+1,j)
                   h(i+1,j) = -s*h(i,j) + c*h(i+1,j)
-                  h(i,j)   = t   
+                  h(i,j)   = t
    50          continue
 c
 c              %---------------------------------------------%
@@ -433,7 +433,7 @@ c
                do 60 j = 1, min(i+2,iend)
                   t        =  c*h(j,i) + s*h(j,i+1)
                   h(j,i+1) = -s*h(j,i) + c*h(j,i+1)
-                  h(j,i)   = t   
+                  h(j,i)   = t
    60          continue
 c
 c              %----------------------------------------------------%
@@ -443,7 +443,7 @@ c
                do 70 j = 1, min( i+jj, kplusp )
                   t        =   c*q(j,i) + s*q(j,i+1)
                   q(j,i+1) = - s*q(j,i) + c*q(j,i+1)
-                  q(j,i)   = t   
+                  q(j,i)   = t
    70          continue
 c
 c              %---------------------------%
@@ -459,7 +459,7 @@ c
 c           %-----------------------------------%
 c           | Finished applying the real shift. |
 c           %-----------------------------------%
-c 
+c
          else
 c
 c           %----------------------------------------------------%
@@ -475,9 +475,9 @@ c           | Compute 1st column of (H - shift*I)*(H - conj(shift)*I) |
 c           %---------------------------------------------------------%
 c
             s    = 2.0*sigmar
-            t = dlapy2 ( sigmar, sigmai ) 
+            t = dlapy2 ( sigmar, sigmai )
             u(1) = ( h11 * (h11 - s) + t * t ) / h21 + h12
-            u(2) = h11 + h22 - s 
+            u(2) = h11 + h22 - s
             u(3) = h32
 c
             do 90 i = istart, iend-1
@@ -517,7 +517,7 @@ c              %-----------------------------------------------------%
 c              | Accumulate the reflector in the matrix Q;  Q <- Q*G |
 c              %-----------------------------------------------------%
 c
-               call dlarf ('Right', kplusp, nr, u, 1, tau, 
+               call dlarf ('Right', kplusp, nr, u, 1, tau,
      &                     q(1,i), ldq, workl)
 c
 c              %----------------------------%
@@ -536,7 +536,7 @@ c           %--------------------------------------------%
 c           | Finished applying a complex pair of shifts |
 c           | to the current block                       |
 c           %--------------------------------------------%
-c 
+c
          end if
 c
   100    continue
@@ -593,7 +593,7 @@ c
       if (h(kev+1,kev) .gt. zero)
      &    call dgemv ('N', n, kplusp, one, v, ldv, q(1,kev+1), 1, zero,
      &                workd(n+1), 1)
-c 
+c
 c     %----------------------------------------------------------%
 c     | Compute column 1 to kev of (V*Q) in backward order       |
 c     | taking advantage of the upper Hessenberg structure of Q. |
@@ -610,7 +610,7 @@ c     |  Move v(:,kplusp-kev+1:kplusp) into v(:,1:kev). |
 c     %-------------------------------------------------%
 c
       call dlacpy ('A', n, kev, v(1,kplusp-kev+1), ldv, v, ldv)
-c 
+c
 c     %--------------------------------------------------------------%
 c     | Copy the (kev+1)-st column of (V*Q) in the appropriate place |
 c     %--------------------------------------------------------------%
@@ -635,19 +635,19 @@ c
      &        '_napps: sigmak = (e_{kev+p}^T*Q)*e_{kev}')
          call pdvout (comm, logfil, 1, h(kev+1,kev), ndigit,
      &        '_napps: betak = e_{kev+1}^T*H*e_{kev}')
-         call pivout (comm, logfil, 1, [kev], ndigit, 
+         call pivout (comm, logfil, 1, [kev], ndigit,
      &               '_napps: Order of the final Hessenberg matrix ')
          if (msglvl .gt. 2) then
             call pdmout (comm, logfil, kev, kev, h, ldh, ndigit,
      &      '_napps: updated Hessenberg matrix H for next iteration')
          end if
-c 
+c
       end if
-c 
+c
  9000 continue
       call second (t1)
       tnapps = tnapps + (t1 - t0)
-c 
+c
       return
 c
 c     %----------------%

--- a/mathlibs/src/parpack/pdnaup2.f
+++ b/mathlibs/src/parpack/pdnaup2.f
@@ -1,16 +1,16 @@
 c\BeginDoc
 c
-c\Name: pdnaup2 
+c\Name: pdnaup2
 c
-c Message Passing Layer: MPI 
+c Message Passing Layer: MPI
 c
-c\Description: 
+c\Description:
 c  Intermediate level interface called by pdnaupd .
 c
 c\Usage:
-c  call pdnaup2 
+c  call pdnaup2
 c     ( COMM, IDO, BMAT, N, WHICH, NEV, NP, TOL, RESID, MODE, IUPD,
-c       ISHIFT, MXITER, V, LDV, H, LDH, RITZR, RITZI, BOUNDS, 
+c       ISHIFT, MXITER, V, LDV, H, LDH, RITZR, RITZI, BOUNDS,
 c       Q, LDQ, WORKL, IPNTR, WORKD, INFO )
 c
 c\Arguments
@@ -19,22 +19,22 @@ c  COMM, IDO, BMAT, N, WHICH, NEV, TOL, RESID: same as defined in pdnaupd .
 c  MODE, ISHIFT, MXITER: see the definition of IPARAM in pdnaupd .
 c
 c  NP      Integer.  (INPUT/OUTPUT)
-c          Contains the number of implicit shifts to apply during 
-c          each Arnoldi iteration.  
-c          If ISHIFT=1, NP is adjusted dynamically at each iteration 
+c          Contains the number of implicit shifts to apply during
+c          each Arnoldi iteration.
+c          If ISHIFT=1, NP is adjusted dynamically at each iteration
 c          to accelerate convergence and prevent stagnation.
-c          This is also roughly equal to the number of matrix-vector 
+c          This is also roughly equal to the number of matrix-vector
 c          products (involving the operator OP) per Arnoldi iteration.
 c          The logic for adjusting is contained within the current
 c          subroutine.
 c          If ISHIFT=0, NP is the number of shifts the user needs
 c          to provide via reverse comunication. 0 < NP < NCV-NEV.
 c          NP may be less than NCV-NEV for two reasons. The first, is
-c          to keep complex conjugate pairs of "wanted" Ritz values 
+c          to keep complex conjugate pairs of "wanted" Ritz values
 c          together. The second, is that a leading block of the current
 c          upper Hessenberg matrix has split off and contains "unwanted"
 c          Ritz values.
-c          Upon termination of the IRA iteration, NP contains the number 
+c          Upon termination of the IRA iteration, NP contains the number
 c          of "converged" wanted Ritz values.
 c
 c  IUPD    Integer.  (INPUT)
@@ -42,18 +42,18 @@ c          IUPD .EQ. 0: use explicit restart instead implicit update.
 c          IUPD .NE. 0: use implicit update.
 c
 c  V       Double precision  N by (NEV+NP) array.  (INPUT/OUTPUT)
-c          The Arnoldi basis vectors are returned in the first NEV 
+c          The Arnoldi basis vectors are returned in the first NEV
 c          columns of V.
 c
 c  LDV     Integer.  (INPUT)
-c          Leading dimension of V exactly as declared in the calling 
+c          Leading dimension of V exactly as declared in the calling
 c          program.
 c
 c  H       Double precision  (NEV+NP) by (NEV+NP) array.  (OUTPUT)
 c          H is used to store the generated upper Hessenberg matrix
 c
 c  LDH     Integer.  (INPUT)
-c          Leading dimension of H exactly as declared in the calling 
+c          Leading dimension of H exactly as declared in the calling
 c          program.
 c
 c  RITZR,  Double precision  arrays of length NEV+NP.  (OUTPUT)
@@ -61,9 +61,9 @@ c  RITZI   RITZR(1:NEV) (resp. RITZI(1:NEV)) contains the real (resp.
 c          imaginary) part of the computed Ritz values of OP.
 c
 c  BOUNDS  Double precision  array of length NEV+NP.  (OUTPUT)
-c          BOUNDS(1:NEV) contain the error bounds corresponding to 
+c          BOUNDS(1:NEV) contain the error bounds corresponding to
 c          the computed Ritz values.
-c          
+c
 c  Q       Double precision  (NEV+NP) by (NEV+NP) array.  (WORKSPACE)
 c          Private (replicated) work array used to accumulate the
 c          rotation in the shift application step.
@@ -72,7 +72,7 @@ c  LDQ     Integer.  (INPUT)
 c          Leading dimension of Q exactly as declared in the calling
 c          program.
 c
-c  WORKL   Double precision  work array of length at least 
+c  WORKL   Double precision  work array of length at least
 c          (NEV+NP)**2 + 3*(NEV+NP).  (INPUT/WORKSPACE)
 c          Private (replicated) array on each PE or array allocated on
 c          the front end.  It is used in shifts calculation, shifts
@@ -84,19 +84,19 @@ c          estimates of the current Hessenberg matrix.  They are
 c          listed in the same order as returned from dneigh .
 c
 c          If ISHIFT .EQ. O and IDO .EQ. 3, the first 2*NP locations
-c          of WORKL are used in reverse communication to hold the user 
+c          of WORKL are used in reverse communication to hold the user
 c          supplied shifts.
 c
 c  IPNTR   Integer array of length 3.  (OUTPUT)
-c          Pointer to mark the starting locations in the WORKD for 
+c          Pointer to mark the starting locations in the WORKD for
 c          vectors used by the Arnoldi iteration.
 c          -------------------------------------------------------------
 c          IPNTR(1): pointer to the current operand vector X.
 c          IPNTR(2): pointer to the current result vector Y.
-c          IPNTR(3): pointer to the vector B * X when used in the 
+c          IPNTR(3): pointer to the vector B * X when used in the
 c                    shift-and-invert mode.  X is the current operand.
 c          -------------------------------------------------------------
-c          
+c
 c  WORKD   Double precision  work array of length 3*N.  (WORKSPACE)
 c          Distributed array to be used in the basic Arnoldi iteration
 c          for reverse communication.  The user should not use WORKD
@@ -110,7 +110,7 @@ c                          possibly from a previous run.
 c          Error flag on output.
 c          =     0: Normal return.
 c          =     1: Maximum number of iterations taken.
-c                   All possible eigenvalues of OP has been found.  
+c                   All possible eigenvalues of OP has been found.
 c                   NP returns the number of converged Ritz values.
 c          =     2: No shifts could be applied.
 c          =    -8: Error return from LAPACK eigenvalue calculation;
@@ -132,12 +132,12 @@ c\References:
 c  1. D.C. Sorensen, "Implicit Application of Polynomial Filters in
 c     a k-Step Arnoldi Method", SIAM J. Matr. Anal. Apps., 13 (1992),
 c     pp 357-385.
-c  2. R.B. Lehoucq, "Analysis and Implementation of an Implicitly 
+c  2. R.B. Lehoucq, "Analysis and Implementation of an Implicitly
 c     Restarted Arnoldi Iteration", Rice University Technical Report
 c     TR95-13, Department of Computational and Applied Mathematics.
 c
 c\Routines called:
-c     pdgetv0   Parallel ARPACK initial vector generation routine. 
+c     pdgetv0   Parallel ARPACK initial vector generation routine.
 c     pdnaitr   Parallel ARPACK Arnoldi factorization routine.
 c     pdnapps   Parallel ARPACK application of implicit shifts routine.
 c     dnconv    ARPACK convergence of Ritz values routine.
@@ -151,7 +151,7 @@ c     pdvout    ARPACK utility routine that prints vectors.
 c     pdlamch   ScaLAPACK routine that determines machine constants.
 c     dlapy2    LAPACK routine to compute sqrt(x**2+y**2) carefully.
 c     dcopy     Level 1 BLAS that copies one vector to another .
-c     ddot      Level 1 BLAS that computes the scalar product of two vectors. 
+c     ddot      Level 1 BLAS that computes the scalar product of two vectors.
 c     pdnorm2   Parallel version of Level 1 BLAS that computes the norm of a vector.
 c     dswap     Level 1 BLAS that swaps two vectors.
 c
@@ -160,14 +160,14 @@ c     Danny Sorensen               Phuong Vu
 c     Richard Lehoucq              Cray Research, Inc. &
 c     Dept. of Computational &     CRPC / Rice University
 c     Applied Mathematics          Houston, Texas
-c     Rice University           
-c     Houston, Texas    
-c 
+c     Rice University
+c     Houston, Texas
+c
 c\Revision history:
 c     Starting Point: Serial Code FILE: naup2.F   SID: 2.2
 c
-c\SCCS Information: 
-c FILE: naup2.F   SID: 1.5   DATE OF SID: 06/01/00   
+c\SCCS Information:
+c FILE: naup2.F   SID: 1.5   DATE OF SID: 06/01/00
 c
 c\Remarks
 c     1. None
@@ -176,9 +176,9 @@ c\EndLib
 c
 c-----------------------------------------------------------------------
 c
-      subroutine pdnaup2 
-     &   ( comm, ido, bmat, n, which, nev, np, tol, resid, mode, iupd, 
-     &     ishift, mxiter, v, ldv, h, ldh, ritzr, ritzi, bounds, 
+      subroutine pdnaup2
+     &   ( comm, ido, bmat, n, which, nev, np, tol, resid, mode, iupd,
+     &     ishift, mxiter, v, ldv, h, ldh, ritzr, ritzi, bounds,
      &     q, ldq, workl, ipntr, workd, info )
 c
       include   'mpif.h'
@@ -203,7 +203,7 @@ c
       character  bmat*1, which*2
       integer    ido, info, ishift, iupd, mode, ldh, ldq, ldv, mxiter,
      &           n, nev, np
-      Double precision 
+      Double precision
      &           tol
 c
 c     %-----------------%
@@ -211,16 +211,16 @@ c     | Array Arguments |
 c     %-----------------%
 c
       integer    ipntr(13)
-      Double precision 
+      Double precision
      &           bounds(nev+np), h(ldh,nev+np), q(ldq,nev+np), resid(n),
-     &           ritzi(nev+np), ritzr(nev+np), v(ldv,nev+np), 
+     &           ritzi(nev+np), ritzr(nev+np), v(ldv,nev+np),
      &           workd(3*n), workl( (nev+np)*(nev+np+3) )
 c
 c     %------------%
 c     | Parameters |
 c     %------------%
 c
-      Double precision 
+      Double precision
      &           one, zero
       parameter (one = 1.0 , zero = 0.0 )
 c
@@ -230,17 +230,17 @@ c     %---------------%
 c
       character  wprime*2
       logical    cnorm , getv0, initv , update, ushift
-      integer    ierr  , iter , kplusp, msglvl, nconv, 
+      integer    ierr  , iter , kplusp, msglvl, nconv,
      &           nevbef, nev0 , np0   , nptemp, numcnv,
      &           j
-      Double precision 
+      Double precision
      &           rnorm , temp , eps23
       save       cnorm , getv0, initv , update, ushift,
-     &           rnorm , iter , kplusp, msglvl, nconv, 
+     &           rnorm , iter , kplusp, msglvl, nconv,
      &           nevbef, nev0 , np0   , eps23 , numcnv
 c
- 
-      Double precision 
+
+      Double precision
      &           rnorm_buf
 c
 c     %-----------------------%
@@ -253,7 +253,7 @@ c     %----------------------%
 c     | External Subroutines |
 c     %----------------------%
 c
-      external   dcopy , pdgetv0 , pdnaitr , dnconv , 
+      external   dcopy , pdgetv0 , pdnaitr , dnconv ,
      &           pdneigh , pdngets , pdnapps ,
      &           pdvout , pivout, second
 c
@@ -261,7 +261,7 @@ c     %--------------------%
 c     | External Functions |
 c     %--------------------%
 c
-      Double precision 
+      Double precision
      &           ddot , pdnorm2 , dlapy2 , pdlamch10
       external   ddot , pdnorm2 , dlapy2 , pdlamch10
 c
@@ -276,11 +276,11 @@ c     | Executable Statements |
 c     %-----------------------%
 c
       if (ido .eq. 0) then
-c 
+c
          call second (t0)
-c 
+c
          msglvl = mnaup2
-c 
+c
 c        %-------------------------------------%
 c        | Get the machine dependent constant. |
 c        %-------------------------------------%
@@ -303,7 +303,7 @@ c
          kplusp = nev + np
          nconv  = 0
          iter   = 0
-c 
+c
 c        %---------------------------------------%
 c        | Set flags for computing the first NEV |
 c        | steps of the Arnoldi factorization.   |
@@ -326,7 +326,7 @@ c
             initv = .false.
          end if
       end if
-c 
+c
 c     %---------------------------------------------%
 c     | Get a possibly random starting vector and   |
 c     | force it into the range of the operator OP. |
@@ -335,7 +335,7 @@ c
    10 continue
 c
       if (getv0) then
-         call pdgetv0  (comm, ido, bmat, 1, initv, n, 1, v, ldv, 
+         call pdgetv0  (comm, ido, bmat, 1, initv, n, 1, v, ldv,
      &                resid, rnorm, ipntr, workd, workl, info)
 c
          if (ido .ne. 99) go to 9000
@@ -343,7 +343,7 @@ c
          if (rnorm .eq. zero) then
 c
 c           %-----------------------------------------%
-c           | The initial vector is zero. Error exit. | 
+c           | The initial vector is zero. Error exit. |
 c           %-----------------------------------------%
 c
             info = -9
@@ -352,7 +352,7 @@ c
          getv0 = .false.
          ido  = 0
       end if
-c 
+c
 c     %-----------------------------------%
 c     | Back from reverse communication : |
 c     | continue with update step         |
@@ -372,15 +372,15 @@ c     | at the end of the current iteration |
 c     %-------------------------------------%
 c
       if (cnorm)  go to 100
-c 
+c
 c     %----------------------------------------------------------%
 c     | Compute the first NEV steps of the Arnoldi factorization |
 c     %----------------------------------------------------------%
 c
-      call pdnaitr  (comm, ido, bmat, n, 0, nev, mode, 
-     &             resid, rnorm, v, ldv, h, ldh, ipntr, 
+      call pdnaitr  (comm, ido, bmat, n, 0, nev, mode,
+     &             resid, rnorm, v, ldv, h, ldh, ipntr,
      &             workd, workl, info)
-c 
+c
 c     %---------------------------------------------------%
 c     | ido .ne. 99 implies use of reverse communication  |
 c     | to compute operations involving OP and possibly B |
@@ -394,7 +394,7 @@ c
          info = -9999
          go to 1200
       end if
-c 
+c
 c     %--------------------------------------------------------------%
 c     |                                                              |
 c     |           M A I N  ARNOLDI  I T E R A T I O N  L O O P       |
@@ -402,16 +402,16 @@ c     |           Each iteration implicitly restarts the Arnoldi     |
 c     |           factorization in place.                            |
 c     |                                                              |
 c     %--------------------------------------------------------------%
-c 
+c
  1000 continue
 c
          iter = iter + 1
 c
          if (msglvl .gt. 0) then
-            call pivout (comm, logfil, 1, [iter], ndigit, 
+            call pivout (comm, logfil, 1, [iter], ndigit,
      &           '_naup2: **** Start of major iteration number ****')
          end if
-c 
+c
 c        %-----------------------------------------------------------%
 c        | Compute NP additional steps of the Arnoldi factorization. |
 c        | Adjust NP since NEV might have been updated by last call  |
@@ -421,9 +421,9 @@ c
          np  = kplusp - nev
 c
          if (msglvl .gt. 1) then
-            call pivout (comm, logfil, 1, [nev], ndigit, 
+            call pivout (comm, logfil, 1, [nev], ndigit,
      &     '_naup2: The length of the current Arnoldi factorization')
-            call pivout (comm, logfil, 1, [np], ndigit, 
+            call pivout (comm, logfil, 1, [np], ndigit,
      &           '_naup2: Extend the Arnoldi factorization by')
          end if
 c
@@ -435,10 +435,10 @@ c
    20    continue
          update = .true.
 c
-         call pdnaitr  (comm, ido, bmat, n, nev, np, mode, 
+         call pdnaitr  (comm, ido, bmat, n, nev, np, mode,
      &                resid, rnorm, v, ldv,
      &                h, ldh, ipntr, workd, workl, info)
-c 
+c
 c        %---------------------------------------------------%
 c        | ido .ne. 99 implies use of reverse communication  |
 c        | to compute operations involving OP and possibly B |
@@ -455,16 +455,16 @@ c
          update = .false.
 c
          if (msglvl .gt. 1) then
-            call pdvout  (comm, logfil, 1, [rnorm], ndigit, 
+            call pdvout  (comm, logfil, 1, [rnorm], ndigit,
      &           '_naup2: Corresponding B-norm of the residual')
          end if
-c 
+c
 c        %--------------------------------------------------------%
 c        | Compute the eigenvalues and corresponding error bounds |
 c        | of the current upper Hessenberg matrix.                |
 c        %--------------------------------------------------------%
 c
-         call pdneigh  ( comm, rnorm, kplusp, h, ldh, ritzr, ritzi, 
+         call pdneigh  ( comm, rnorm, kplusp, h, ldh, ritzr, ritzi,
      &                  bounds, q, ldq, workl, ierr)
 c
          if (ierr .ne. 0) then
@@ -497,30 +497,30 @@ c
          nev = nev0
          np = np0
          numcnv = nev
-         call pdngets  ( comm, ishift, which, nev, np, ritzr, ritzi, 
+         call pdngets  ( comm, ishift, which, nev, np, ritzr, ritzi,
      &                  bounds, workl, workl(np+1))
          if (nev .eq. nev0+1) numcnv = nev0+1
-c 
+c
 c        %-------------------%
 c        | Convergence test. |
 c        %-------------------%
 c
          call dcopy  (nev, bounds(np+1), 1, workl(2*np+1), 1)
-         call dnconv  (nev, ritzr(np+1), ritzi(np+1), workl(2*np+1), 
+         call dnconv  (nev, ritzr(np+1), ritzi(np+1), workl(2*np+1),
      &        tol, nconv)
-c 
+c
          if (msglvl .gt. 2) then
             kp(1) = nev
             kp(2) = np
             kp(3) = numcnv
             kp(4) = nconv
-            call pivout (comm, logfil, 4, kp, ndigit, 
+            call pivout (comm, logfil, 4, kp, ndigit,
      &                  '_naup2: NEV, NP, NUMCNV, NCONV are')
             call pdvout  (comm, logfil, kplusp, ritzr, ndigit,
      &           '_naup2: Real part of the eigenvalues of H')
             call pdvout  (comm, logfil, kplusp, ritzi, ndigit,
      &           '_naup2: Imaginary part of the eigenvalues of H')
-            call pdvout  (comm, logfil, kplusp, bounds, ndigit, 
+            call pdvout  (comm, logfil, kplusp, bounds, ndigit,
      &          '_naup2: Ritz estimates of the current NCV Ritz values')
          end if
 c
@@ -541,11 +541,11 @@ c
                nev = nev + 1
             end if
  30      continue
-c     
-         if ( (nconv .ge. numcnv) .or. 
+c
+         if ( (nconv .ge. numcnv) .or.
      &        (iter .gt. mxiter) .or.
      &        (np .eq. 0) ) then
-c     
+c
             if (msglvl .gt. 4) then
                call dvout (logfil, kplusp, workl(kplusp**2+1), ndigit,
      &             '_naup2: Real part of the eig computed by _neigh:')
@@ -556,7 +556,7 @@ c
      &                     ndigit,
      &             '_naup2: Ritz estimates computed by _neigh:')
             end if
-c     
+c
 c           %------------------------------------------------%
 c           | Prepare to exit. Put the converged Ritz values |
 c           | and corresponding bounds in RITZ(1:NCONV) and  |
@@ -568,7 +568,7 @@ c           %------------------------------------------%
 c           |  Use h( 3,1 ) as storage to communicate  |
 c           |  rnorm to _neupd if needed               |
 c           %------------------------------------------%
- 
+
             h(3,1) = rnorm
 c
 c           %----------------------------------------------%
@@ -656,13 +656,13 @@ c
             end if
 c
 c           %------------------------------------%
-c           | Max iterations have been exceeded. | 
+c           | Max iterations have been exceeded. |
 c           %------------------------------------%
 c
             if (iter .gt. mxiter .and. nconv .lt. numcnv) info = 1
 c
 c           %---------------------%
-c           | No shifts to apply. | 
+c           | No shifts to apply. |
 c           %---------------------%
 c
             if (np .eq. 0 .and. nconv .lt. numcnv) info = 2
@@ -671,7 +671,7 @@ c
             go to 1100
 c
          else if ( (nconv .lt. numcnv) .and. (ishift .eq. 1) ) then
-c     
+c
 c           %-------------------------------------------------%
 c           | Do not have all the requested eigenvalues yet.  |
 c           | To prevent possible stagnation, adjust the size |
@@ -686,25 +686,25 @@ c
                nev = 2
             end if
             np = kplusp - nev
-c     
+c
 c           %---------------------------------------%
 c           | If the size of NEV was just increased |
 c           | resort the eigenvalues.               |
 c           %---------------------------------------%
-c     
-            if (nevbef .lt. nev) 
-     &         call pdngets (comm, ishift, which, nev, np, ritzr, ritzi, 
+c
+            if (nevbef .lt. nev)
+     &         call pdngets (comm, ishift, which, nev, np, ritzr, ritzi,
      &                      bounds, workl, workl(np+1))
 c
-         end if              
-c     
+         end if
+c
          if (msglvl .gt. 0) then
-            call pivout (comm, logfil, 1, [nconv], ndigit, 
+            call pivout (comm, logfil, 1, [nconv], ndigit,
      &           '_naup2: no. of "converged" Ritz values at this iter.')
             if (msglvl .gt. 1) then
                kp(1) = nev
                kp(2) = np
-               call pivout (comm, logfil, 2, kp, ndigit, 
+               call pivout (comm, logfil, 2, kp, ndigit,
      &              '_naup2: NEV and NP are')
                call pdvout  (comm, logfil, nev, ritzr(np+1), ndigit,
      &              '_naup2: "wanted" Ritz values -- real part')
@@ -727,7 +727,7 @@ c
             ido = 3
             go to 9000
          end if
-c 
+c
    50    continue
 c
 c        %------------------------------------%
@@ -739,7 +739,7 @@ c
          ushift = .false.
 c
          if ( ishift .eq. 0 ) then
-c 
+c
 c            %----------------------------------%
 c            | Move the NP shifts from WORKL to |
 c            | RITZR, RITZI to free up WORKL    |
@@ -750,14 +750,14 @@ c
              call dcopy  (np, workl(np+1), 1, ritzi, 1)
          end if
 c
-         if (msglvl .gt. 2) then 
-            call pivout (comm, logfil, 1, [np], ndigit, 
+         if (msglvl .gt. 2) then
+            call pivout (comm, logfil, 1, [np], ndigit,
      &                  '_naup2: The number of shifts to apply ')
             call pdvout  (comm, logfil, np, ritzr, ndigit,
      &                  '_naup2: Real part of the shifts')
             call pdvout  (comm, logfil, np, ritzi, ndigit,
      &                  '_naup2: Imaginary part of the shifts')
-            if ( ishift .eq. 1 ) 
+            if ( ishift .eq. 1 )
      &          call pdvout  (comm, logfil, np, bounds, ndigit,
      &                  '_naup2: Ritz estimates of the shifts')
          end if
@@ -769,7 +769,7 @@ c        | matrix H.                                               |
 c        | The first 2*N locations of WORKD are used as workspace. |
 c        %---------------------------------------------------------%
 c
-         call pdnapps  (comm, n, nev, np, ritzr, ritzi, v, ldv, 
+         call pdnapps  (comm, n, nev, np, ritzr, ritzi, v, ldv,
      &                 h, ldh, resid, q, ldq, workl, workd)
 c
 c        %---------------------------------------------%
@@ -786,18 +786,18 @@ c
             ipntr(1) = n + 1
             ipntr(2) = 1
             ido = 2
-c 
+c
 c           %----------------------------------%
 c           | Exit in order to compute B*RESID |
 c           %----------------------------------%
-c 
+c
             go to 9000
          else if (bmat .eq. 'I') then
             call dcopy  (n, resid, 1, workd, 1)
          end if
-c 
+c
   100    continue
-c 
+c
 c        %----------------------------------%
 c        | Back from reverse communication; |
 c        | WORKD(1:N) := B*RESID            |
@@ -819,12 +819,12 @@ c
          cnorm = .false.
 c
          if (msglvl .gt. 2) then
-            call pdvout  (comm, logfil, 1, [rnorm], ndigit, 
+            call pdvout  (comm, logfil, 1, [rnorm], ndigit,
      &      '_naup2: B-norm of residual for compressed factorization')
             call pdmout  (comm, logfil, nev, nev, h, ldh, ndigit,
      &        '_naup2: Compressed upper Hessenberg matrix H')
          end if
-c 
+c
       go to 1000
 c
 c     %---------------------------------------------------------------%
@@ -837,7 +837,7 @@ c
 c
       mxiter = iter
       nev = numcnv
-c     
+c
  1200 continue
       ido = 99
 c
@@ -847,7 +847,7 @@ c     %------------%
 c
       call second (t1)
       tnaup2 = t1 - t0
-c     
+c
  9000 continue
 c
 c     %----------------%

--- a/mathlibs/src/parpack/pdnaup2.f
+++ b/mathlibs/src/parpack/pdnaup2.f
@@ -408,7 +408,7 @@ c
          iter = iter + 1
 c
          if (msglvl .gt. 0) then
-            call pivout (comm, logfil, 1, iter, ndigit, 
+            call pivout (comm, logfil, 1, [iter], ndigit, 
      &           '_naup2: **** Start of major iteration number ****')
          end if
 c 
@@ -421,9 +421,9 @@ c
          np  = kplusp - nev
 c
          if (msglvl .gt. 1) then
-            call pivout (comm, logfil, 1, nev, ndigit, 
+            call pivout (comm, logfil, 1, [nev], ndigit, 
      &     '_naup2: The length of the current Arnoldi factorization')
-            call pivout (comm, logfil, 1, np, ndigit, 
+            call pivout (comm, logfil, 1, [np], ndigit, 
      &           '_naup2: Extend the Arnoldi factorization by')
          end if
 c
@@ -455,7 +455,7 @@ c
          update = .false.
 c
          if (msglvl .gt. 1) then
-            call pdvout  (comm, logfil, 1, rnorm, ndigit, 
+            call pdvout  (comm, logfil, 1, [rnorm], ndigit, 
      &           '_naup2: Corresponding B-norm of the residual')
          end if
 c 
@@ -699,7 +699,7 @@ c
          end if              
 c     
          if (msglvl .gt. 0) then
-            call pivout (comm, logfil, 1, nconv, ndigit, 
+            call pivout (comm, logfil, 1, [nconv], ndigit, 
      &           '_naup2: no. of "converged" Ritz values at this iter.')
             if (msglvl .gt. 1) then
                kp(1) = nev
@@ -751,7 +751,7 @@ c
          end if
 c
          if (msglvl .gt. 2) then 
-            call pivout (comm, logfil, 1, np, ndigit, 
+            call pivout (comm, logfil, 1, [np], ndigit, 
      &                  '_naup2: The number of shifts to apply ')
             call pdvout  (comm, logfil, np, ritzr, ndigit,
      &                  '_naup2: Real part of the shifts')
@@ -819,7 +819,7 @@ c
          cnorm = .false.
 c
          if (msglvl .gt. 2) then
-            call pdvout  (comm, logfil, 1, rnorm, ndigit, 
+            call pdvout  (comm, logfil, 1, [rnorm], ndigit, 
      &      '_naup2: B-norm of residual for compressed factorization')
             call pdmout  (comm, logfil, nev, nev, h, ldh, ndigit,
      &        '_naup2: Compressed upper Hessenberg matrix H')

--- a/mathlibs/src/parpack/pdnaupd.f
+++ b/mathlibs/src/parpack/pdnaupd.f
@@ -1,22 +1,22 @@
 c\BeginDoc
 c
-c\Name: pdnaupd 
+c\Name: pdnaupd
 c
-c Message Passing Layer: MPI 
+c Message Passing Layer: MPI
 c
-c\Description: 
+c\Description:
 c  Reverse communication interface for the Implicitly Restarted Arnoldi
-c  iteration. This subroutine computes approximations to a few eigenpairs 
-c  of a linear operator "OP" with respect to a semi-inner product defined by 
-c  a symmetric positive semi-definite real matrix B. B may be the identity 
-c  matrix. NOTE: If the linear operator "OP" is real and symmetric 
-c  with respect to the real positive semi-definite symmetric matrix B, 
+c  iteration. This subroutine computes approximations to a few eigenpairs
+c  of a linear operator "OP" with respect to a semi-inner product defined by
+c  a symmetric positive semi-definite real matrix B. B may be the identity
+c  matrix. NOTE: If the linear operator "OP" is real and symmetric
+c  with respect to the real positive semi-definite symmetric matrix B,
 c  i.e. B*OP = (OP`)*B, then subroutine dsaupd  should be used instead.
 c
 c  The computed approximate eigenvalues are called Ritz values and
 c  the corresponding approximate eigenvectors are called Ritz vectors.
 c
-c  pdnaupd  is usually called iteratively to solve one of the 
+c  pdnaupd  is usually called iteratively to solve one of the
 c  following problems:
 c
 c  Mode 1:  A*x = lambda*x.
@@ -27,18 +27,18 @@ c           ===> OP = inv[M]*A  and  B = M.
 c           ===> (If M can be factored see remark 3 below)
 c
 c  Mode 3:  A*x = lambda*M*x, M symmetric semi-definite
-c           ===> OP = Real_Part{ inv[A - sigma*M]*M }  and  B = M. 
+c           ===> OP = Real_Part{ inv[A - sigma*M]*M }  and  B = M.
 c           ===> shift-and-invert mode (in real arithmetic)
-c           If OP*x = amu*x, then 
+c           If OP*x = amu*x, then
 c           amu = 1/2 * [ 1/(lambda-sigma) + 1/(lambda-conjg(sigma)) ].
 c           Note: If sigma is real, i.e. imaginary part of sigma is zero;
-c                 Real_Part{ inv[A - sigma*M]*M } == inv[A - sigma*M]*M 
-c                 amu == 1/(lambda-sigma). 
-c  
+c                 Real_Part{ inv[A - sigma*M]*M } == inv[A - sigma*M]*M
+c                 amu == 1/(lambda-sigma).
+c
 c  Mode 4:  A*x = lambda*M*x, M symmetric semi-definite
-c           ===> OP = Imaginary_Part{ inv[A - sigma*M]*M }  and  B = M. 
+c           ===> OP = Imaginary_Part{ inv[A - sigma*M]*M }  and  B = M.
 c           ===> shift-and-invert mode (in real arithmetic)
-c           If OP*x = amu*x, then 
+c           If OP*x = amu*x, then
 c           amu = 1/2i * [ 1/(lambda-sigma) - 1/(lambda-conjg(sigma)) ].
 c
 c  Both mode 3 and 4 give the same enhancement to eigenvalues close to
@@ -59,7 +59,7 @@ c        the accuracy requirements for the eigenvalue
 c        approximations.
 c
 c\Usage:
-c  call pdnaupd 
+c  call pdnaupd
 c     ( COMM, IDO, BMAT, N, WHICH, NEV, TOL, RESID, NCV, V, LDV, IPARAM,
 c       IPNTR, WORKD, WORKL, LWORKL, INFO )
 c
@@ -67,7 +67,7 @@ c\Arguments
 c  COMM    MPI  Communicator for the processor grid.  (INPUT)
 c
 c  IDO     Integer.  (INPUT/OUTPUT)
-c          Reverse communication flag.  IDO must be zero on the first 
+c          Reverse communication flag.  IDO must be zero on the first
 c          call to pdnaupd .  IDO will be set internally to
 c          indicate the type of operation to be performed.  Control is
 c          then given back to the calling routine which has the
@@ -90,13 +90,13 @@ c                    need to be recomputed in forming OP * X.
 c          IDO =  2: compute  Y = B * X  where
 c                    IPNTR(1) is the pointer into WORKD for X,
 c                    IPNTR(2) is the pointer into WORKD for Y.
-c          IDO =  3: compute the IPARAM(8) real and imaginary parts 
+c          IDO =  3: compute the IPARAM(8) real and imaginary parts
 c                    of the shifts where INPTR(14) is the pointer
 c                    into WORKL for placing the shifts. See Remark
 c                    5 below.
 c          IDO = 99: done
 c          -------------------------------------------------------------
-c             
+c
 c  BMAT    Character*1.  (INPUT)
 c          BMAT specifies the type of the matrix B that defines the
 c          semi-inner product for the operator OP.
@@ -118,14 +118,14 @@ c  NEV     Integer.  (INPUT)
 c          Number of eigenvalues of OP to be computed. 0 < NEV < N-1.
 c
 c  TOL     Double precision  scalar.  (INPUT)
-c          Stopping criterion: the relative accuracy of the Ritz value 
+c          Stopping criterion: the relative accuracy of the Ritz value
 c          is considered acceptable if BOUNDS(I) .LE. TOL*ABS(RITZ(I))
 c          where ABS(RITZ(I)) is the magnitude when RITZ(I) is complex.
 c          DEFAULT = DLAMCH ('EPS')  (machine precision as computed
 c                    by the LAPACK auxiliary subroutine DLAMCH ).
 c
 c  RESID   Double precision  array of length N.  (INPUT/OUTPUT)
-c          On INPUT: 
+c          On INPUT:
 c          If INFO .EQ. 0, a random initial residual vector is used.
 c          If INFO .NE. 0, RESID contains the initial residual vector,
 c                          possibly from a previous run.
@@ -135,17 +135,17 @@ c
 c  NCV     Integer.  (INPUT)
 c          Number of columns of the matrix V. NCV must satisfy the two
 c          inequalities 2 <= NCV-NEV and NCV <= N.
-c          This will indicate how many Arnoldi vectors are generated 
-c          at each iteration.  After the startup phase in which NEV 
-c          Arnoldi vectors are generated, the algorithm generates 
-c          approximately NCV-NEV Arnoldi vectors at each subsequent update 
-c          iteration. Most of the cost in generating each Arnoldi vector is 
-c          in the matrix-vector operation OP*x. 
-c          NOTE: 2 <= NCV-NEV in order that complex conjugate pairs of Ritz 
+c          This will indicate how many Arnoldi vectors are generated
+c          at each iteration.  After the startup phase in which NEV
+c          Arnoldi vectors are generated, the algorithm generates
+c          approximately NCV-NEV Arnoldi vectors at each subsequent update
+c          iteration. Most of the cost in generating each Arnoldi vector is
+c          in the matrix-vector operation OP*x.
+c          NOTE: 2 <= NCV-NEV in order that complex conjugate pairs of Ritz
 c          values are kept together. (See remark 4 below)
 c
 c  V       Double precision  array N by NCV.  (OUTPUT)
-c          Contains the final set of Arnoldi basis vectors. 
+c          Contains the final set of Arnoldi basis vectors.
 c
 c  LDV     Integer.  (INPUT)
 c          Leading dimension of V exactly as declared in the calling program.
@@ -158,11 +158,11 @@ c          -------------------------------------------------------------
 c          ISHIFT = 0: the shifts are provided by the user via
 c                      reverse communication.  The real and imaginary
 c                      parts of the NCV eigenvalues of the Hessenberg
-c                      matrix H are returned in the part of the WORKL 
-c                      array corresponding to RITZR and RITZI. See remark 
+c                      matrix H are returned in the part of the WORKL
+c                      array corresponding to RITZR and RITZI. See remark
 c                      5 below.
 c          ISHIFT = 1: exact shifts with respect to the current
-c                      Hessenberg matrix H.  This is equivalent to 
+c                      Hessenberg matrix H.  This is equivalent to
 c                      restarting the iteration with a starting vector
 c                      that is a linear combination of approximate Schur
 c                      vectors associated with the "wanted" Ritz values.
@@ -171,8 +171,8 @@ c
 c          IPARAM(2) = No longer referenced.
 c
 c          IPARAM(3) = MXITER
-c          On INPUT:  maximum number of Arnoldi update iterations allowed. 
-c          On OUTPUT: actual number of Arnoldi update iterations taken. 
+c          On INPUT:  maximum number of Arnoldi update iterations allowed.
+c          On OUTPUT: actual number of Arnoldi update iterations taken.
 c
 c          IPARAM(4) = NB: blocksize to be used in the recurrence.
 c          The code currently works only for NB = 1.
@@ -182,11 +182,11 @@ c          This represents the number of Ritz values that satisfy
 c          the convergence criterion.
 c
 c          IPARAM(6) = IUPD
-c          No longer referenced. Implicit restarting is ALWAYS used.  
+c          No longer referenced. Implicit restarting is ALWAYS used.
 c
 c          IPARAM(7) = MODE
 c          On INPUT determines what type of eigenproblem is being solved.
-c          Must be 1,2,3,4; See under \Description of pdnaupd  for the 
+c          Must be 1,2,3,4; See under \Description of pdnaupd  for the
 c          four modes available.
 c
 c          IPARAM(8) = NP
@@ -206,13 +206,13 @@ c          arrays for matrices/vectors used by the Arnoldi iteration.
 c          -------------------------------------------------------------
 c          IPNTR(1): pointer to the current operand vector X in WORKD.
 c          IPNTR(2): pointer to the current result vector Y in WORKD.
-c          IPNTR(3): pointer to the vector B * X in WORKD when used in 
+c          IPNTR(3): pointer to the vector B * X in WORKD when used in
 c                    the shift-and-invert mode.
 c          IPNTR(4): pointer to the next available location in WORKL
 c                    that is untouched by the program.
 c          IPNTR(5): pointer to the NCV by NCV upper Hessenberg matrix
 c                    H in WORKL.
-c          IPNTR(6): pointer to the real part of the ritz value array 
+c          IPNTR(6): pointer to the real part of the ritz value array
 c                    RITZR in WORKL.
 c          IPNTR(7): pointer to the imaginary part of the ritz value array
 c                    RITZI in WORKL.
@@ -222,9 +222,9 @@ c          IPNTR(14): pointer to the NP shifts in WORKL. See Remark 5 below.
 c
 c          Note: IPNTR(9:13) is only referenced by dneupd . See Remark 2 below.
 c
-c          IPNTR(9):  pointer to the real part of the NCV RITZ values of the 
+c          IPNTR(9):  pointer to the real part of the NCV RITZ values of the
 c                     original system.
-c          IPNTR(10): pointer to the imaginary part of the NCV RITZ values of 
+c          IPNTR(10): pointer to the imaginary part of the NCV RITZ values of
 c                     the original system.
 c          IPNTR(11): pointer to the NCV corresponding error bounds.
 c          IPNTR(12): pointer to the NCV by NCV upper quasi-triangular
@@ -233,15 +233,15 @@ c          IPNTR(13): pointer to the NCV by NCV matrix of eigenvectors
 c                     of the upper Hessenberg matrix H. Only referenced by
 c                     pdneupd  if RVEC = .TRUE. See Remark 2 below.
 c          -------------------------------------------------------------
-c          
+c
 c  WORKD   Double precision  work array of length 3*N.  (REVERSE COMMUNICATION)
 c          Distributed array to be used in the basic Arnoldi iteration
-c          for reverse communication.  The user should not use WORKD 
+c          for reverse communication.  The user should not use WORKD
 c          as temporary workspace during the iteration. Upon termination
 c          WORKD(1:N) contains B*RESID(1:N). If an invariant subspace
 c          associated with the converged Ritz values is desired, see remark
 c          2 below, subroutine dneupd  uses this output.
-c          See Data Distribution Note below.  
+c          See Data Distribution Note below.
 c
 c  WORKL   Double precision  work array of length LWORKL.  (OUTPUT/WORKSPACE)
 c          Private (replicated) array on each PE or array allocated on
@@ -257,18 +257,18 @@ c                          possibly from a previous run.
 c          Error flag on output.
 c          =  0: Normal exit.
 c          =  1: Maximum number of iterations taken.
-c                All possible eigenvalues of OP has been found. IPARAM(5)  
+c                All possible eigenvalues of OP has been found. IPARAM(5)
 c                returns the number of wanted converged Ritz values.
 c          =  2: No longer an informational error. Deprecated starting
 c                with release 2 of ARPACK.
-c          =  3: No shifts could be applied during a cycle of the 
-c                Implicitly restarted Arnoldi iteration. One possibility 
-c                is to increase the size of NCV relative to NEV. 
+c          =  3: No shifts could be applied during a cycle of the
+c                Implicitly restarted Arnoldi iteration. One possibility
+c                is to increase the size of NCV relative to NEV.
 c                See remark 4 below.
 c          = -1: N must be positive.
 c          = -2: NEV must be positive.
 c          = -3: NCV-NEV >= 2 and less than or equal to N.
-c          = -4: The maximum number of Arnoldi update iteration 
+c          = -4: The maximum number of Arnoldi update iteration
 c                must be greater than zero.
 c          = -5: WHICH must be one of 'LM', 'SM', 'LR', 'SR', 'LI', 'SI'
 c          = -6: BMAT must be one of 'I' or 'G'.
@@ -288,13 +288,13 @@ c     selection of WHICH should be made with this in mind when
 c     Mode = 3 and 4.  After convergence, approximate eigenvalues of the
 c     original problem may be obtained with the ARPACK subroutine dneupd .
 c
-c  2. If a basis for the invariant subspace corresponding to the converged Ritz 
-c     values is needed, the user must call dneupd  immediately following 
+c  2. If a basis for the invariant subspace corresponding to the converged Ritz
+c     values is needed, the user must call dneupd  immediately following
 c     completion of pdnaupd . This is new starting with release 2 of ARPACK.
 c
 c  3. If M can be factored into a Cholesky factorization M = LL`
 c     then Mode = 2 should not be selected.  Instead one should use
-c     Mode = 1 with  OP = inv(L)*A*inv(L`).  Appropriate triangular 
+c     Mode = 1 with  OP = inv(L)*A*inv(L`).  Appropriate triangular
 c     linear systems should be solved with L and L` rather
 c     than computing inverses.  After convergence, an approximate
 c     eigenvector z of the original problem is recovered by solving
@@ -304,15 +304,15 @@ c  4. At present there is no a-priori analysis to guide the selection
 c     of NCV relative to NEV.  The only formal requrement is that NCV > NEV + 2.
 c     However, it is recommended that NCV .ge. 2*NEV+1.  If many problems of
 c     the same type are to be solved, one should experiment with increasing
-c     NCV while keeping NEV fixed for a given test problem.  This will 
+c     NCV while keeping NEV fixed for a given test problem.  This will
 c     usually decrease the required number of OP*x operations but it
 c     also increases the work and storage required to maintain the orthogonal
 c     basis vectors.  The optimal "cross-over" with respect to CPU time
-c     is problem dependent and must be determined empirically. 
+c     is problem dependent and must be determined empirically.
 c     See Chapter 8 of Reference 2 for further information.
 c
-c  5. When IPARAM(1) = 0, and IDO = 3, the user needs to provide the 
-c     NP = IPARAM(8) real and imaginary parts of the shifts in locations 
+c  5. When IPARAM(1) = 0, and IDO = 3, the user needs to provide the
+c     NP = IPARAM(8) real and imaginary parts of the shifts in locations
 c         real part                  imaginary part
 c         -----------------------    --------------
 c     1   WORKL(IPNTR(14))           WORKL(IPNTR(14)+NP)
@@ -322,10 +322,10 @@ c                        .                          .
 c                        .                          .
 c     NP  WORKL(IPNTR(14)+NP-1)      WORKL(IPNTR(14)+2*NP-1).
 c
-c     Only complex conjugate pairs of shifts may be applied and the pairs 
-c     must be placed in consecutive locations. The real part of the 
-c     eigenvalues of the current upper Hessenberg matrix are located in 
-c     WORKL(IPNTR(6)) through WORKL(IPNTR(6)+NCV-1) and the imaginary part 
+c     Only complex conjugate pairs of shifts may be applied and the pairs
+c     must be placed in consecutive locations. The real part of the
+c     eigenvalues of the current upper Hessenberg matrix are located in
+c     WORKL(IPNTR(6)) through WORKL(IPNTR(6)+NCV-1) and the imaginary part
 c     in WORKL(IPNTR(7)) through WORKL(IPNTR(7)+NCV-1). They are ordered
 c     according to the order defined by WHICH. The complex conjugate
 c     pairs are kept together and the associated Ritz estimates are located in
@@ -333,7 +333,7 @@ c     WORKL(IPNTR(8)), WORKL(IPNTR(8)+1), ... , WORKL(IPNTR(8)+NCV-1).
 c
 c-----------------------------------------------------------------------
 c
-c\Data Distribution Note: 
+c\Data Distribution Note:
 c
 c  Fortran-D syntax:
 c  ================
@@ -352,10 +352,10 @@ c  ===============
 c  Double precision   resid(n), v(ldv,ncv), workd(n,3), workl(lworkl)
 c  shared     resid(block), v(block,:), workd(block,:)
 c  replicated workl(lworkl)
-c  
+c
 c  CM2/CM5 syntax:
 c  ==============
-c  
+c
 c-----------------------------------------------------------------------
 c
 c     include   'ex-nonsym.doc'
@@ -371,7 +371,7 @@ c\References:
 c  1. D.C. Sorensen, "Implicit Application of Polynomial Filters in
 c     a k-Step Arnoldi Method", SIAM J. Matr. Anal. Apps., 13 (1992),
 c     pp 357-385.
-c  2. R.B. Lehoucq, "Analysis and Implementation of an Implicitly 
+c  2. R.B. Lehoucq, "Analysis and Implementation of an Implicitly
 c     Restarted Arnoldi Iteration", Rice University Technical Report
 c     TR95-13, Department of Computational and Applied Mathematics.
 c  3. B.N. Parlett & Y. Saad, "Complex Shift and Invert Strategies for
@@ -391,8 +391,8 @@ c     Danny Sorensen               Phuong Vu
 c     Richard Lehoucq              Cray Research, Inc. &
 c     Dept. of Computational &     CRPC / Rice University
 c     Applied Mathematics          Houston, Texas
-c     Rice University           
-c     Houston, Texas            
+c     Rice University
+c     Houston, Texas
 c
 c\Parallel Modifications
 c     Kristi Maschhoff
@@ -400,8 +400,8 @@ c
 c\Revision history:
 c     Starting Point: Serial Code FILE: naupd.F   SID: 2.2
 c
-c\SCCS Information: 
-c FILE: naupd.F   SID: 1.9   DATE OF SID: 04/10/01   
+c\SCCS Information:
+c FILE: naupd.F   SID: 1.9   DATE OF SID: 04/10/01
 c
 c\Remarks
 c
@@ -409,8 +409,8 @@ c\EndLib
 c
 c-----------------------------------------------------------------------
 c
-      subroutine pdnaupd 
-     &   ( comm, ido, bmat, n, which, nev, tol, resid, ncv, v, ldv, 
+      subroutine pdnaupd
+     &   ( comm, ido, bmat, n, which, nev, tol, resid, ncv, v, ldv,
      &     iparam, ipntr, workd, workl, lworkl, info )
 c
       include  'mpif.h'
@@ -419,7 +419,7 @@ c     %------------------%
 c     | MPI Variables    |
 c     %------------------%
 c
-      integer    comm, myid 
+      integer    comm, myid
 c
 c     %----------------------------------------------------%
 c     | Include files for debugging and timing information |
@@ -434,7 +434,7 @@ c     %------------------%
 c
       character  bmat*1, which*2
       integer    ido, info, ldv, lworkl, n, ncv, nev
-      Double precision 
+      Double precision
      &           tol
 c
 c     %-----------------%
@@ -442,14 +442,14 @@ c     | Array Arguments |
 c     %-----------------%
 c
       integer    iparam(11), ipntr(14)
-      Double precision 
+      Double precision
      &           resid(n), v(ldv,ncv), workd(3*n), workl(lworkl)
 c
 c     %------------%
 c     | Parameters |
 c     %------------%
 c
-      Double precision 
+      Double precision
      &           one, zero
       parameter (one = 1.0 , zero = 0.0 )
 c
@@ -457,7 +457,7 @@ c     %---------------%
 c     | Local Scalars |
 c     %---------------%
 c
-      integer    bounds, ierr, ih, iq, ishift, iupd, iw, 
+      integer    bounds, ierr, ih, iq, ishift, iupd, iw,
      &           ldh, ldq, levec, mode, msglvl, mxiter, nb,
      &           nev0, next, np, ritzi, ritzr, j
       save       bounds, ih, iq, ishift, iupd, iw, ldh, ldq,
@@ -468,28 +468,28 @@ c     %----------------------%
 c     | External Subroutines |
 c     %----------------------%
 c
-      external   pdnaup2 , pdvout , pivout, second, dstatn 
+      external   pdnaup2 , pdvout , pivout, second, dstatn
 c
 c     %--------------------%
 c     | External Functions |
 c     %--------------------%
 c
-      Double precision 
+      Double precision
      &           pdlamch10
       external   pdlamch10
 c
 c     %-----------------------%
 c     | Executable Statements |
 c     %-----------------------%
-c 
+c
       if (ido .eq. 0) then
-c 
+c
 c        %-------------------------------%
 c        | Initialize timing statistics  |
 c        | & message level for debugging |
 c        %-------------------------------%
 c
-         call dstatn 
+         call dstatn
          call second (t0)
          msglvl = mnaupd
 c
@@ -537,7 +537,7 @@ c
          else if (ishift .lt. 0 .or. ishift .gt. 1) then
                                                 ierr = -12
          end if
-c 
+c
 c        %------------%
 c        | Error Exit |
 c        %------------%
@@ -547,7 +547,7 @@ c
             ido  = 99
             go to 9000
          end if
-c 
+c
 c        %------------------------%
 c        | Set default parameters |
 c        %------------------------%
@@ -563,8 +563,8 @@ c        | size of the invariant subspace desired.      |
 c        %----------------------------------------------%
 c
          np     = ncv - nev
-         nev0   = nev 
-c 
+         nev0   = nev
+c
 c        %-----------------------------%
 c        | Zero out internal workspace |
 c        %-----------------------------%
@@ -572,7 +572,7 @@ c
          do 10 j = 1, 3*ncv**2 + 6*ncv
             workl(j) = zero
  10      continue
-c 
+c
 c        %-------------------------------------------------------------%
 c        | Pointer into WORKL for address of H, RITZ, BOUNDS, Q        |
 c        | etc... and the remaining workspace.                         |
@@ -605,7 +605,7 @@ c
          ipntr(6) = ritzr
          ipntr(7) = ritzi
          ipntr(8) = bounds
-         ipntr(14) = iw 
+         ipntr(14) = iw
 c
       end if
 c
@@ -613,12 +613,12 @@ c     %-------------------------------------------------------%
 c     | Carry out the Implicitly restarted Arnoldi Iteration. |
 c     %-------------------------------------------------------%
 c
-      call pdnaup2  
+      call pdnaup2
      &   ( comm, ido, bmat, n, which, nev0, np, tol, resid, mode, iupd,
-     &     ishift, mxiter, v, ldv, workl(ih), ldh, workl(ritzr), 
-     &     workl(ritzi), workl(bounds), workl(iq), ldq, workl(iw), 
+     &     ishift, mxiter, v, ldv, workl(ih), ldh, workl(ritzr),
+     &     workl(ritzi), workl(bounds), workl(iq), ldq, workl(iw),
      &     ipntr, workd, info )
-c 
+c
 c     %--------------------------------------------------%
 c     | ido .ne. 99 implies use of reverse communication |
 c     | to compute operations involving OP or shifts.    |
@@ -626,7 +626,7 @@ c     %--------------------------------------------------%
 c
       if (ido .eq. 3) iparam(8) = np
       if (ido .ne. 99) go to 9000
-c 
+c
       iparam(3) = mxiter
       iparam(5) = np
       iparam(9) = nopx
@@ -646,11 +646,11 @@ c
      &               '_naupd: Number of update iterations taken')
          call pivout (comm, logfil, 1, [np], ndigit,
      &               '_naupd: Number of wanted "converged" Ritz values')
-         call pdvout  (comm, logfil, np, workl(ritzr), ndigit, 
+         call pdvout  (comm, logfil, np, workl(ritzr), ndigit,
      &               '_naupd: Real part of the final Ritz values')
-         call pdvout  (comm, logfil, np, workl(ritzi), ndigit, 
+         call pdvout  (comm, logfil, np, workl(ritzi), ndigit,
      &               '_naupd: Imaginary part of the final Ritz values')
-         call pdvout  (comm, logfil, np, workl(bounds), ndigit, 
+         call pdvout  (comm, logfil, np, workl(bounds), ndigit,
      &               '_naupd: Associated Ritz estimates')
       end if
 c

--- a/mathlibs/src/parpack/pdnaupd.f
+++ b/mathlibs/src/parpack/pdnaupd.f
@@ -642,9 +642,9 @@ c
       if (info .eq. 2) info = 3
 c
       if (msglvl .gt. 0) then
-         call pivout (comm, logfil, 1, mxiter, ndigit,
+         call pivout (comm, logfil, 1, [mxiter], ndigit,
      &               '_naupd: Number of update iterations taken')
-         call pivout (comm, logfil, 1, np, ndigit,
+         call pivout (comm, logfil, 1, [np], ndigit,
      &               '_naupd: Number of wanted "converged" Ritz values')
          call pdvout  (comm, logfil, np, workl(ritzr), ndigit, 
      &               '_naupd: Real part of the final Ritz values')

--- a/mathlibs/src/parpack/pdneupd.f
+++ b/mathlibs/src/parpack/pdneupd.f
@@ -617,9 +617,9 @@ c        | caused by incorrect passing of the dnaupd data.           |
 c        %-----------------------------------------------------------%
 c
          if (msglvl .gt. 2) then
-             call pivout(comm, logfil, 1, numcnv, ndigit,
+             call pivout(comm, logfil, 1, [numcnv], ndigit,
      &            '_neupd: Number of specified eigenvalues')
-             call pivout(comm, logfil, 1, nconv, ndigit,
+             call pivout(comm, logfil, 1, [nconv], ndigit,
      &            '_neupd: Number of "converged" eigenvalues')
          end if
 c

--- a/mathlibs/src/parpack/pdneupd.f
+++ b/mathlibs/src/parpack/pdneupd.f
@@ -1,10 +1,10 @@
 c\BeginDoc
 c
-c\Name: pdneupd 
+c\Name: pdneupd
 c
-c Message Passing Layer: MPI 
+c Message Passing Layer: MPI
 c
-c\Description: 
+c\Description:
 c
 c  This subroutine returns the converged approximations to eigenvalues
 c  of A*z = lambda*B*z and (optionally):
@@ -30,36 +30,36 @@ c  in the comments that follow.  The computed orthonormal basis for the
 c  invariant subspace corresponding to these Ritz values is referred to as a
 c  Schur basis.
 c
-c  See documentation in the header of the subroutine PDNAUPD  for 
+c  See documentation in the header of the subroutine PDNAUPD  for
 c  definition of OP as well as other terms and the relation of computed
 c  Ritz values and Ritz vectors of OP with respect to the given problem
-c  A*z = lambda*B*z.  For a brief description, see definitions of 
+c  A*z = lambda*B*z.  For a brief description, see definitions of
 c  IPARAM(7), MODE and WHICH in the documentation of PDNAUPD .
 c
 c\Usage:
-c  call pdneupd  
-c     ( COMM, RVEC, HOWMNY, SELECT, DR, DI, Z, LDZ, SIGMAR, SIGMAI, 
-c       WORKEV, BMAT, N, WHICH, NEV, TOL, RESID, NCV, V, LDV, IPARAM, 
+c  call pdneupd
+c     ( COMM, RVEC, HOWMNY, SELECT, DR, DI, Z, LDZ, SIGMAR, SIGMAI,
+c       WORKEV, BMAT, N, WHICH, NEV, TOL, RESID, NCV, V, LDV, IPARAM,
 c       IPNTR, WORKD, WORKL, LWORKL, INFO )
 c
 c\Arguments
 c  COMM    MPI  Communicator for the processor grid.  (INPUT)
 c
-c  RVEC    LOGICAL  (INPUT) 
-c          Specifies whether a basis for the invariant subspace corresponding 
-c          to the converged Ritz value approximations for the eigenproblem 
+c  RVEC    LOGICAL  (INPUT)
+c          Specifies whether a basis for the invariant subspace corresponding
+c          to the converged Ritz value approximations for the eigenproblem
 c          A*z = lambda*B*z is computed.
 c
 c             RVEC = .FALSE.     Compute Ritz values only.
 c
 c             RVEC = .TRUE.      Compute the Ritz vectors or Schur vectors.
-c                                See Remarks below. 
-c 
-c  HOWMNY  Character*1  (INPUT) 
-c          Specifies the form of the basis for the invariant subspace 
+c                                See Remarks below.
+c
+c  HOWMNY  Character*1  (INPUT)
+c          Specifies the form of the basis for the invariant subspace
 c          corresponding to the converged Ritz values that is to be computed.
 c
-c          = 'A': Compute NEV Ritz vectors; 
+c          = 'A': Compute NEV Ritz vectors;
 c          = 'P': Compute NEV Schur vectors;
 c          = 'S': compute some of the Ritz vectors, specified
 c                 by the logical array SELECT.
@@ -67,43 +67,43 @@ c
 c  SELECT  Logical array of dimension NCV.  (INPUT)
 c          If HOWMNY = 'S', SELECT specifies the Ritz vectors to be
 c          computed. To select the Ritz vector corresponding to a
-c          Ritz value (DR(j), DI(j)), SELECT(j) must be set to .TRUE.. 
+c          Ritz value (DR(j), DI(j)), SELECT(j) must be set to .TRUE..
 c          If HOWMNY = 'A' or 'P', SELECT is used as internal workspace.
 c
 c  DR      Double precision  array of dimension NEV+1.  (OUTPUT)
-c          If IPARAM(7) = 1,2 or 3 and SIGMAI=0.0  then on exit: DR contains 
-c          the real part of the Ritz  approximations to the eigenvalues of 
-c          A*z = lambda*B*z. 
+c          If IPARAM(7) = 1,2 or 3 and SIGMAI=0.0  then on exit: DR contains
+c          the real part of the Ritz  approximations to the eigenvalues of
+c          A*z = lambda*B*z.
 c          If IPARAM(7) = 3, 4 and SIGMAI is not equal to zero, then on exit:
-c          DR contains the real part of the Ritz values of OP computed by 
+c          DR contains the real part of the Ritz values of OP computed by
 c          PDNAUPD . A further computation must be performed by the user
 c          to transform the Ritz values computed for OP by PDNAUPD  to those
 c          of the original system A*z = lambda*B*z. See remark 3 below.
 c
 c  DI      Double precision  array of dimension NEV+1.  (OUTPUT)
-c          On exit, DI contains the imaginary part of the Ritz value 
+c          On exit, DI contains the imaginary part of the Ritz value
 c          approximations to the eigenvalues of A*z = lambda*B*z associated
 c          with DR.
 c
-c          NOTE: When Ritz values are complex, they will come in complex 
-c                conjugate pairs.  If eigenvectors are requested, the 
-c                corresponding Ritz vectors will also come in conjugate 
-c                pairs and the real and imaginary parts of these are 
-c                represented in two consecutive columns of the array Z 
+c          NOTE: When Ritz values are complex, they will come in complex
+c                conjugate pairs.  If eigenvectors are requested, the
+c                corresponding Ritz vectors will also come in conjugate
+c                pairs and the real and imaginary parts of these are
+c                represented in two consecutive columns of the array Z
 c                (see below).
 c
 c  Z       Double precision  N by NEV+1 array if RVEC = .TRUE. and HOWMNY = 'A'. (OUTPUT)
-c          On exit, if RVEC = .TRUE. and HOWMNY = 'A', then the columns of 
-c          Z represent approximate eigenvectors (Ritz vectors) corresponding 
-c          to the NCONV=IPARAM(5) Ritz values for eigensystem 
-c          A*z = lambda*B*z. 
-c 
-c          The complex Ritz vector associated with the Ritz value 
-c          with positive imaginary part is stored in two consecutive 
-c          columns.  The first column holds the real part of the Ritz 
-c          vector and the second column holds the imaginary part.  The 
-c          Ritz vector associated with the Ritz value with negative 
-c          imaginary part is simply the complex conjugate of the Ritz vector 
+c          On exit, if RVEC = .TRUE. and HOWMNY = 'A', then the columns of
+c          Z represent approximate eigenvectors (Ritz vectors) corresponding
+c          to the NCONV=IPARAM(5) Ritz values for eigensystem
+c          A*z = lambda*B*z.
+c
+c          The complex Ritz vector associated with the Ritz value
+c          with positive imaginary part is stored in two consecutive
+c          columns.  The first column holds the real part of the Ritz
+c          vector and the second column holds the imaginary part.  The
+c          Ritz vector associated with the Ritz value with negative
+c          imaginary part is simply the complex conjugate of the Ritz vector
 c          associated with the positive imaginary part.
 c
 c          If  RVEC = .FALSE. or HOWMNY = 'P', then Z is not referenced.
@@ -118,11 +118,11 @@ c          The leading dimension of the array Z.  If Ritz vectors are
 c          desired, then  LDZ >= max( 1, N ).  In any case,  LDZ >= 1.
 c
 c  SIGMAR  Double precision   (INPUT)
-c          If IPARAM(7) = 3 or 4, represents the real part of the shift. 
+c          If IPARAM(7) = 3 or 4, represents the real part of the shift.
 c          Not referenced if IPARAM(7) = 1 or 2.
 c
 c  SIGMAI  Double precision   (INPUT)
-c          If IPARAM(7) = 3 or 4, represents the imaginary part of the shift. 
+c          If IPARAM(7) = 3 or 4, represents the imaginary part of the shift.
 c          Not referenced if IPARAM(7) = 1 or 2. See remark 3 below.
 c
 c  WORKEV  Double precision  work array of dimension 3*NCV.  (WORKSPACE)
@@ -185,12 +185,12 @@ c          Error flag on output.
 c
 c          =  0: Normal exit.
 c
-c          =  1: The Schur form computed by LAPACK routine dlahqr 
+c          =  1: The Schur form computed by LAPACK routine dlahqr
 c                could not be reordered by LAPACK routine dtrsen .
-c                Re-enter subroutine pdneupd  with IPARAM(5)=NCV and 
-c                increase the size of the arrays DR and DI to have 
-c                dimension at least dimension NCV and allocate at least NCV 
-c                columns for Z. NOTE: Not necessary if Z and V share 
+c                Re-enter subroutine pdneupd  with IPARAM(5)=NCV and
+c                increase the size of the arrays DR and DI to have
+c                dimension at least dimension NCV and allocate at least NCV
+c                columns for Z. NOTE: Not necessary if Z and V share
 c                the same space. Please notify the authors if this error
 c                occurs.
 c
@@ -222,7 +222,7 @@ c\References:
 c  1. D.C. Sorensen, "Implicit Application of Polynomial Filters in
 c     a k-Step Arnoldi Method", SIAM J. Matr. Anal. Apps., 13 (1992),
 c     pp 357-385.
-c  2. R.B. Lehoucq, "Analysis and Implementation of an Implicitly 
+c  2. R.B. Lehoucq, "Analysis and Implementation of an Implicitly
 c     Restarted Arnoldi Iteration", Rice University Technical Report
 c     TR95-13, Department of Computational and Applied Mathematics.
 c  3. B.N. Parlett & Y. Saad, "Complex Shift and Invert Strategies for
@@ -233,7 +233,7 @@ c\Routines called:
 c     pivout  Parallel ARPACK utility routine that prints integers.
 c     pdmout   Parallel ARPACK utility routine that prints matrices
 c     pdvout   Parallel ARPACK utility routine that prints vectors.
-c     dgeqr2   LAPACK routine that computes the QR factorization of 
+c     dgeqr2   LAPACK routine that computes the QR factorization of
 c             a matrix.
 c     dlacpy   LAPACK matrix copy routine.
 c     dlahqr   LAPACK routine to compute the real Schur form of an
@@ -241,7 +241,7 @@ c             upper Hessenberg matrix.
 c     pdlamch  ScaLAPACK routine that determines machine constants.
 c     dlapy2   LAPACK routine to compute sqrt(x**2+y**2) carefully.
 c     dlaset   LAPACK matrix initialization routine.
-c     dorm2r   LAPACK routine that applies an orthogonal matrix in 
+c     dorm2r   LAPACK routine that applies an orthogonal matrix in
 c             factored form.
 c     dtrevc   LAPACK routine to compute the eigenvectors of a matrix
 c             in upper quasi-triangular form.
@@ -263,9 +263,9 @@ c     Ritz vectors. Thus, their numerical properties are often superior.
 c     If RVEC = .TRUE. then the relationship
 c             A * V(:,1:IPARAM(5)) = V(:,1:IPARAM(5)) * T, and
 c     V(:,1:IPARAM(5))` * V(:,1:IPARAM(5)) = I are approximately satisfied.
-c     Here T is the leading submatrix of order IPARAM(5) of the real 
+c     Here T is the leading submatrix of order IPARAM(5) of the real
 c     upper quasi-triangular matrix stored workl(ipntr(12)). That is,
-c     T is block upper triangular with 1-by-1 and 2-by-2 diagonal blocks; 
+c     T is block upper triangular with 1-by-1 and 2-by-2 diagonal blocks;
 c     each 2-by-2 diagonal block has its diagonal elements equal and its
 c     off-diagonal elements of opposite sign.  Corresponding to each 2-by-2
 c     diagonal block is a complex conjugate pair of Ritz values. The real
@@ -273,11 +273,11 @@ c     Ritz values are stored on the diagonal of T.
 c
 c  3. If IPARAM(7) = 3 or 4 and SIGMAI is not equal zero, then the user must
 c     form the IPARAM(5) Rayleigh quotients in order to transform the Ritz
-c     values computed by PDNAUPD  for OP to those of A*z = lambda*B*z. 
+c     values computed by PDNAUPD  for OP to those of A*z = lambda*B*z.
 c     Set RVEC = .true. and HOWMNY = 'A', and
-c     compute 
+c     compute
 c           Z(:,I)` * A * Z(:,I) if DI(I) = 0.
-c     If DI(I) is not equal to zero and DI(I+1) = - D(I), 
+c     If DI(I) is not equal to zero and DI(I+1) = - D(I),
 c     then the desired real and imaginary parts of the Ritz value are
 c           Z(:,I)` * A * Z(:,I) +  Z(:,I+1)` * A * Z(:,I+1),
 c           Z(:,I)` * A * Z(:,I+1) -  Z(:,I+1)` * A * Z(:,I), respectively.
@@ -288,12 +288,12 @@ c     2 above.
 c
 c\Authors
 c     Danny Sorensen               Phuong Vu
-c     Richard Lehoucq              CRPC / Rice University 
+c     Richard Lehoucq              CRPC / Rice University
 c     Chao Yang                    Houston, Texas
 c     Dept. of Computational &
-c     Applied Mathematics          
-c     Rice University           
-c     Houston, Texas            
+c     Applied Mathematics
+c     Rice University
+c     Houston, Texas
 c
 c\Parallel Modifications
 c     Kristi Maschhoff
@@ -307,7 +307,7 @@ c
 c\EndLib
 c
 c-----------------------------------------------------------------------
-      subroutine pdneupd  
+      subroutine pdneupd
      &         (comm , rvec , howmny, select, dr    , di  ,
      &          z    , ldz  , sigmar, sigmai, workev, bmat,
      &          n    , which, nev   , tol   , resid ,
@@ -334,7 +334,7 @@ c
       character  bmat, howmny, which*2
       logical    rvec
       integer    info, ldz, ldv, lworkl, n, ncv, nev
-      Double precision      
+      Double precision
      &           sigmar, sigmai, tol
 c
 c     %-----------------%
@@ -343,7 +343,7 @@ c     %-----------------%
 c
       integer    iparam(11), ipntr(14)
       logical    select(ncv)
-      Double precision 
+      Double precision
      &           dr(nev+1)    , di(nev+1)    , resid(n)  ,
      &           v(ldv,ncv)   , z(ldz,*)     , workd(3*n),
      &           workl(lworkl), workev(3*ncv)
@@ -352,7 +352,7 @@ c     %------------%
 c     | Parameters |
 c     %------------%
 c
-      Double precision 
+      Double precision
      &           one, zero
       parameter (one = 1.0 , zero = 0.0 )
 c
@@ -362,7 +362,7 @@ c     %---------------%
 c
       character  type*6
       integer    bounds, ierr, ih, ihbds,
-     &           iheigr, iheigi, iconj , nconv   , 
+     &           iheigr, iheigi, iconj , nconv   ,
      &           invsub, iuptri, iwev  , iwork(1),
      &           j     , k     , ldh   , ldq     ,
      &           mode  , msglvl, outncv, ritzr   ,
@@ -370,7 +370,7 @@ c
      &           iri   , ibd   , ishift, numcnv  ,
      &           np    , jj
       logical    reord
-      Double precision 
+      Double precision
      &           conds  , rnorm, sep  , temp,
      &           vl(1,1), temp1, eps23
 c
@@ -387,7 +387,7 @@ c     %--------------------%
 c     | External Functions |
 c     %--------------------%
 c
-      Double precision 
+      Double precision
      &           dlapy2 , dnrm2 , pdlamch10
       external   dlapy2 , dnrm2 , pdlamch10
 c
@@ -400,7 +400,7 @@ c
 c     %-----------------------%
 c     | Executable Statements |
 c     %-----------------------%
-c 
+c
 c     %------------------------%
 c     | Set default parameters |
 c     %------------------------%
@@ -449,7 +449,7 @@ c
       else if (howmny .eq. 'S' ) then
          ierr = -12
       end if
-c     
+c
       if (mode .eq. 1 .or. mode .eq. 2) then
          type = 'REGULR'
       else if (mode .eq. 3 .and. sigmai .eq. zero) then
@@ -458,7 +458,7 @@ c
          type = 'REALPT'
       else if (mode .eq. 4 ) then
          type = 'IMAGPT'
-      else 
+      else
                                               ierr = -10
       end if
       if (mode .eq. 1 .and. bmat .eq. 'G')    ierr = -11
@@ -471,7 +471,7 @@ c
          info = ierr
          go to 9000
       end if
-c 
+c
 c     %--------------------------------------------------------%
 c     | Pointer into WORKL for address of H, RITZ, BOUNDS, Q   |
 c     | etc... and the remaining workspace.                    |
@@ -498,7 +498,7 @@ c     |       associated matrix representation of the invariant   |
 c     |       subspace for H.                                     |
 c     | GRAND total of NCV * ( 3 * NCV + 6 ) locations.           |
 c     %-----------------------------------------------------------%
-c     
+c
       ih     = ipntr(5)
       ritzr  = ipntr(6)
       ritzi  = ipntr(7)
@@ -634,7 +634,7 @@ c        | of the upper Hessenberg matrix returned by PDNAUPD .       |
 c        | Make a copy of the upper Hessenberg matrix.               |
 c        | Initialize the Schur vector matrix Q to the identity.     |
 c        %-----------------------------------------------------------%
-c     
+c
          call dcopy (ldh*ncv, workl(ih), 1, workl(iuptri), 1)
          call dlaset ('All', ncv, ncv, zero, one, workl(invsub), ldq)
          call dlahqr (.true.       , .true.       , ncv, 1            ,
@@ -642,12 +642,12 @@ c
      &               workl(iheigi), 1            , ncv, workl(invsub),
      &               ldq          , ierr)
          call dcopy  (ncv, workl(invsub+ncv-1), ldq, workl(ihbds), 1)
-c     
+c
          if (ierr .ne. 0) then
             info = -8
             go to 9000
          end if
-c     
+c
          if (msglvl .gt. 1) then
             call pdvout  (comm, logfil, ncv, workl(iheigr), ndigit,
      &           '_neupd: Real part of the eigenvalues of H')
@@ -656,18 +656,18 @@ c
             call pdvout  (comm, logfil, ncv, workl(ihbds), ndigit,
      &           '_neupd: Last row of the Schur vector matrix')
             if (msglvl .gt. 3) then
-               call pdmout  (comm, logfil, ncv, ncv, 
-     &              workl(iuptri), ldh, ndigit, 
+               call pdmout  (comm, logfil, ncv, ncv,
+     &              workl(iuptri), ldh, ndigit,
      &              '_neupd: The upper quasi-triangular matrix ')
             end if
-         end if 
+         end if
 c
          if (reord) then
-c     
+c
 c           %-----------------------------------------------------%
-c           | Reorder the computed upper quasi-triangular matrix. | 
+c           | Reorder the computed upper quasi-triangular matrix. |
 c           %-----------------------------------------------------%
-c     
+c
             call dtrsen ('None'       , 'V'          , select       ,
      &                   ncv          , workl(iuptri), ldh          ,
      &                   workl(invsub), ldq          , workl(iheigr),
@@ -686,7 +686,7 @@ c
                 call pdvout (comm, logfil, ncv, workl(iheigi), ndigit,
      &           '_neupd: Imag part of the eigenvalues of H--reordered')
                 if (msglvl .gt. 3) then
-                   call pdmout (comm, logfil, ncv, ncv, 
+                   call pdmout (comm, logfil, ncv, ncv,
      &             workl(iuptri), ldq, ndigit,
      &             '_neupd: Quasi-triangular matrix after re-ordering')
                 end if
@@ -707,23 +707,23 @@ c        | Place the computed eigenvalues of H into DR and DI |
 c        | if a spectral transformation was not used.         |
 c        %----------------------------------------------------%
 c
-         if (type .eq. 'REGULR') then 
+         if (type .eq. 'REGULR') then
             call dcopy (nconv, workl(iheigr), 1, dr, 1)
             call dcopy (nconv, workl(iheigi), 1, di, 1)
          end if
-c     
+c
 c        %----------------------------------------------------------%
 c        | Compute the QR factorization of the matrix representing  |
 c        | the wanted invariant subspace located in the first NCONV |
 c        | columns of workl(invsub,ldq).                            |
 c        %----------------------------------------------------------%
-c     
+c
          call dgeqr2 (ncv, nconv , workl(invsub),
      &               ldq, workev, workev(ncv+1),
      &               ierr)
 c
 c        %---------------------------------------------------------%
-c        | * Postmultiply V by Q using dorm2r .                     |   
+c        | * Postmultiply V by Q using dorm2r .                     |
 c        | * Copy the first NCONV columns of VQ into Z.            |
 c        | * Postmultiply Z by R.                                  |
 c        | The N by NCONV matrix Z is now a matrix representation  |
@@ -733,7 +733,7 @@ c        | The first NCONV columns of V are now approximate Schur  |
 c        | vectors associated with the real upper quasi-triangular |
 c        | matrix of order NCONV in workl(iuptri)                  |
 c        %---------------------------------------------------------%
-c     
+c
          call dorm2r ('Right', 'Notranspose', n            ,
      &                ncv    , nconv        , workl(invsub),
      &                ldq    , workev       , v            ,
@@ -741,7 +741,7 @@ c
          call dlacpy ('All', n, nconv, v, ldv, z, ldz)
 c
          do 20 j=1, nconv
-c     
+c
 c           %---------------------------------------------------%
 c           | Perform both a column and row scaling if the      |
 c           | diagonal element of workl(invsub,ldq) is negative |
@@ -750,21 +750,21 @@ c           | quasi-triangular form of workl(iuptri,ldq)        |
 c           | Note that since Q is orthogonal, R is a diagonal  |
 c           | matrix consisting of plus or minus ones           |
 c           %---------------------------------------------------%
-c     
+c
             if (workl(invsub+(j-1)*ldq+j-1) .lt. zero) then
                call dscal (nconv, -one, workl(iuptri+j-1), ldq)
                call dscal (nconv, -one, workl(iuptri+(j-1)*ldq), 1)
             end if
-c     
+c
  20      continue
-c     
+c
          if (howmny .eq. 'A') then
-c     
+c
 c           %--------------------------------------------%
-c           | Compute the NCONV wanted eigenvectors of T | 
+c           | Compute the NCONV wanted eigenvectors of T |
 c           | located in workl(iuptri,ldq).              |
 c           %--------------------------------------------%
-c     
+c
             do 30 j=1, ncv
                if (j .le. nconv) then
                   select(j) = .true.
@@ -783,7 +783,7 @@ c
                 info = -9
                 go to 9000
             end if
-c     
+c
 c           %------------------------------------------------%
 c           | Scale the returning eigenvectors so that their |
 c           | Euclidean norms are all one. LAPACK subroutine |
@@ -791,21 +791,21 @@ c           | dtrevc  returns each eigenvector normalized so  |
 c           | that the element of largest magnitude has      |
 c           | magnitude 1;                                   |
 c           %------------------------------------------------%
-c     
+c
             iconj = 0
             do 40 j=1, nconv
 c
                if ( workl(iheigi+j-1) .eq. zero ) then
-c     
+c
 c                 %----------------------%
 c                 | real eigenvalue case |
 c                 %----------------------%
-c     
+c
                   temp = dnrm2 ( ncv, workl(invsub+(j-1)*ldq), 1 )
-                  call dscal  ( ncv, one / temp, 
+                  call dscal  ( ncv, one / temp,
      &                 workl(invsub+(j-1)*ldq), 1 )
                else
-c     
+c
 c                 %-------------------------------------------%
 c                 | Complex conjugate pair case. Note that    |
 c                 | since the real and imaginary part of      |
@@ -813,18 +813,18 @@ c                 | the eigenvector are stored in consecutive |
 c                 | columns, we further normalize by the      |
 c                 | square root of two.                       |
 c                 %-------------------------------------------%
-c     
+c
                   if (iconj .eq. 0) then
                      temp = dlapy2 (dnrm2 (ncv,
      &                                   workl(invsub+(j-1)*ldq),
-     &                                   1 ), 
+     &                                   1 ),
      &                             dnrm2 (ncv,
      &                                   workl(invsub+j*ldq),
      &                                   1)
-     &                             )  
-                     call dscal (ncv, one/temp, 
+     &                             )
+                     call dscal (ncv, one/temp,
      &                          workl(invsub+(j-1)*ldq), 1)
-                     call dscal (ncv, one/temp, 
+                     call dscal (ncv, one/temp,
      &                          workl(invsub+j*ldq), 1)
                      iconj = 1
                   else
@@ -864,12 +864,12 @@ c
                call pdvout (comm, logfil, ncv, workl(ihbds), ndigit,
      &              '_neupd: Last row of the eigenvector matrix for T')
                if (msglvl .gt. 3) then
-                  call pdmout (comm, logfil, ncv, ncv, 
-     &               workl(invsub), ldq, ndigit, 
+                  call pdmout (comm, logfil, ncv, ncv,
+     &               workl(invsub), ldq, ndigit,
      &               '_neupd: The eigenvector matrix for T')
                end if
             end if
-c     
+c
 c
 c           %---------------------------------------%
 c           | Copy Ritz estimates into workl(ihbds) |
@@ -882,32 +882,32 @@ c           | Compute the QR factorization of the eigenvector matrix  |
 c           | associated with leading portion of T in the first NCONV |
 c           | columns of workl(invsub,ldq).                           |
 c           %---------------------------------------------------------%
-c     
+c
             call dgeqr2 (ncv, nconv , workl(invsub),
      &                   ldq, workev, workev(ncv+1),
      &                   ierr)
-c     
+c
 c           %----------------------------------------------%
-c           | * Postmultiply Z by Q.                       |   
+c           | * Postmultiply Z by Q.                       |
 c           | * Postmultiply Z by R.                       |
-c           | The N by NCONV matrix Z is now contains the  | 
+c           | The N by NCONV matrix Z is now contains the  |
 c           | Ritz vectors associated with the Ritz values |
 c           | in workl(iheigr) and workl(iheigi).          |
 c           %----------------------------------------------%
-c     
+c
             call dorm2r ('Right', 'Notranspose', n            ,
      &                   ncv    , nconv        , workl(invsub),
      &                   ldq    , workev       , z            ,
      &                   ldz    , workd(n+1)   , ierr)
-c     
+c
             call dtrmm ('Right'   , 'Upper'      , 'No transpose',
      &                  'Non-unit', n            , nconv         ,
      &                  one       , workl(invsub), ldq           ,
      &                  z         , ldz)
-c     
+c
          end if
-c     
-      else 
+c
+      else
 c
 c        %------------------------------------------------------%
 c        | An approximate invariant subspace is not needed.     |
@@ -920,7 +920,7 @@ c
          call dcopy (nconv, workl(ritzi), 1, workl(iheigi), 1)
          call dcopy (nconv, workl(bounds), 1, workl(ihbds), 1)
       end if
-c 
+c
 c     %------------------------------------------------%
 c     | Transform the Ritz values and possibly vectors |
 c     | and corresponding error bounds of OP to those  |
@@ -931,23 +931,23 @@ c
 c
          if (rvec)
      &      call dscal (ncv, rnorm, workl(ihbds), 1)
-c    
-      else 
-c     
+c
+      else
+c
 c        %---------------------------------------%
 c        |   A spectral transformation was used. |
 c        | * Determine the Ritz estimates of the |
 c        |   Ritz values in the original system. |
 c        %---------------------------------------%
-c     
+c
          if (type .eq. 'SHIFTI') then
 c
             if (rvec)
      &         call dscal (ncv, rnorm, workl(ihbds), 1)
             do 50 k=1, ncv
-               temp = dlapy2 (workl(iheigr+k-1), 
+               temp = dlapy2 (workl(iheigr+k-1),
      &                       workl(iheigi+k-1) )
-               workl(ihbds+k-1) = abs( workl(ihbds+k-1) ) 
+               workl(ihbds+k-1) = abs( workl(ihbds+k-1) )
      &                          / temp / temp
  50         continue
 c
@@ -962,26 +962,26 @@ c
  70         continue
 c
          end if
-c     
+c
 c        %-----------------------------------------------------------%
 c        | *  Transform the Ritz values back to the original system. |
 c        |    For TYPE = 'SHIFTI' the transformation is              |
 c        |             lambda = 1/theta + sigma                      |
 c        |    For TYPE = 'REALPT' or 'IMAGPT' the user must from     |
-c        |    Rayleigh quotients or a projection. See remark 3 above.| 
+c        |    Rayleigh quotients or a projection. See remark 3 above.|
 c        | NOTES:                                                    |
 c        | *The Ritz vectors are not affected by the transformation. |
 c        %-----------------------------------------------------------%
-c     
-         if (type .eq. 'SHIFTI') then 
+c
+         if (type .eq. 'SHIFTI') then
 c
             do 80 k=1, ncv
-               temp = dlapy2 (workl(iheigr+k-1), 
+               temp = dlapy2 (workl(iheigr+k-1),
      &                       workl(iheigi+k-1) )
-               workl(iheigr+k-1) = workl(iheigr+k-1) / temp / temp 
-     &                           + sigmar   
+               workl(iheigr+k-1) = workl(iheigr+k-1) / temp / temp
+     &                           + sigmar
                workl(iheigi+k-1) = -workl(iheigi+k-1) / temp / temp
-     &                           + sigmai   
+     &                           + sigmai
  80         continue
 c
             call dcopy (nconv, workl(iheigr), 1, dr, 1)
@@ -1011,7 +1011,7 @@ c
       end if
 c
       end if
-c 
+c
 c     %-------------------------------------------------%
 c     | Eigenvector Purification step. Formally perform |
 c     | one of inverse subspace iteration. Only used    |
@@ -1038,13 +1038,13 @@ c
      &                   /  workl(iheigr+j-1)
             else if (iconj .eq. 0) then
                temp = dlapy2 ( workl(iheigr+j-1), workl(iheigi+j-1) )
-               workev(j) = ( workl(invsub+(j-1)*ldq+ncv-1) * 
+               workev(j) = ( workl(invsub+(j-1)*ldq+ncv-1) *
      &                       workl(iheigr+j-1) +
-     &                       workl(invsub+j*ldq+ncv-1) * 
+     &                       workl(invsub+j*ldq+ncv-1) *
      &                       workl(iheigi+j-1) ) / temp / temp
-               workev(j+1) = ( workl(invsub+j*ldq+ncv-1) * 
+               workev(j+1) = ( workl(invsub+j*ldq+ncv-1) *
      &                         workl(iheigr+j-1) -
-     &                         workl(invsub+(j-1)*ldq+ncv-1) * 
+     &                         workl(invsub+(j-1)*ldq+ncv-1) *
      &                         workl(iheigi+j-1) ) / temp / temp
                iconj = 1
             else
@@ -1064,7 +1064,7 @@ c
  9000 continue
 c
       return
-c     
+c
 c     %----------------%
 c     | End of PDNEUPD  |
 c     %----------------%

--- a/mathlibs/src/parpack/pdngets.f
+++ b/mathlibs/src/parpack/pdngets.f
@@ -226,8 +226,8 @@ c
       tngets = tngets + (t1 - t0)
 c
       if (msglvl .gt. 0) then
-         call pivout (comm, logfil, 1, kev, ndigit, '_ngets: KEV is')
-         call pivout (comm, logfil, 1, np, ndigit, '_ngets: NP is')
+         call pivout (comm, logfil, 1, [kev], ndigit, '_ngets: KEV is')
+         call pivout (comm, logfil, 1, [np], ndigit, '_ngets: NP is')
          call pdvout (comm, logfil, kev+np, ritzr, ndigit,
      &        '_ngets: Eigenvalues of current H matrix -- real part')
          call pdvout (comm, logfil, kev+np, ritzi, ndigit,

--- a/mathlibs/src/parpack/pdngets.f
+++ b/mathlibs/src/parpack/pdngets.f
@@ -5,9 +5,9 @@ c\Name: pdngets
 c
 c Message Passing Layer: MPI
 c
-c\Description: 
+c\Description:
 c  Given the eigenvalues of the upper Hessenberg matrix H,
-c  computes the NP shifts AMU that are zeros of the polynomial of 
+c  computes the NP shifts AMU that are zeros of the polynomial of
 c  degree NP which filters out components of the unwanted eigenvectors
 c  corresponding to the AMU's based on some given criteria.
 c
@@ -46,12 +46,12 @@ c           OUTPUT: Possibly decreases NP by one to keep complex conjugate
 c           pairs together.
 c
 c  RITZR,  Double precision array of length KEV+NP.  (INPUT/OUTPUT)
-c  RITZI   On INPUT, RITZR and RITZI contain the real and imaginary 
+c  RITZI   On INPUT, RITZR and RITZI contain the real and imaginary
 c          parts of the eigenvalues of H.
 c          On OUTPUT, RITZR and RITZI are sorted so that the unwanted
 c          eigenvalues are in the first NP locations and the wanted
-c          portion is in the last KEV locations.  When exact shifts are 
-c          selected, the unwanted part corresponds to the shifts to 
+c          portion is in the last KEV locations.  When exact shifts are
+c          selected, the unwanted part corresponds to the shifts to
 c          be applied. Also, if ISHIFT .eq. 1, the unwanted eigenvalues
 c          are further sorted so that the ones with largest Ritz values
 c          are first.
@@ -60,7 +60,7 @@ c  BOUNDS  Double precision array of length KEV+NP.  (INPUT/OUTPUT)
 c          Error bounds corresponding to the ordering in RITZ.
 c
 c  SHIFTR, SHIFTI  *** USE deprecated as of version 2.1. ***
-c  
+c
 c
 c\EndDoc
 c
@@ -80,8 +80,8 @@ c     Danny Sorensen               Phuong Vu
 c     Richard Lehoucq              CRPC / Rice University
 c     Dept. of Computational &     Houston, Texas
 c     Applied Mathematics
-c     Rice University           
-c     Houston, Texas    
+c     Rice University
+c     Houston, Texas
 c
 c\Parallel Modifications
 c     Kristi Maschhoff
@@ -89,8 +89,8 @@ c
 c\Revision history:
 c     Starting Point: Serial Code FILE: ngets.F   SID: 2.2
 c
-c\SCCS Information: 
-c FILE: ngets.F   SID: 1.2   DATE OF SID: 2/22/96   
+c\SCCS Information:
+c FILE: ngets.F   SID: 1.2   DATE OF SID: 2/22/96
 c
 c\Remarks
 c     1. xxxx
@@ -99,8 +99,8 @@ c\EndLib
 c
 c-----------------------------------------------------------------------
 c
-      subroutine pdngets 
-     &                 ( comm, ishift, which, kev, np, ritzr, ritzi, 
+      subroutine pdngets
+     &                 ( comm, ishift, which, kev, np, ritzr, ritzi,
      &                   bounds, shiftr, shifti )
 c
 c     %--------------------%
@@ -128,7 +128,7 @@ c     | Array Arguments |
 c     %-----------------%
 c
       Double precision
-     &           bounds(kev+np), ritzr(kev+np), ritzi(kev+np), 
+     &           bounds(kev+np), ritzr(kev+np), ritzi(kev+np),
      &           shiftr(1), shifti(1)
 c
 c     %------------%
@@ -165,10 +165,10 @@ c     %-------------------------------%
 c     | Initialize timing statistics  |
 c     | & message level for debugging |
 c     %-------------------------------%
-c 
+c
       call second (t0)
       msglvl = mngets
-c 
+c
 c     %----------------------------------------------------%
 c     | LM, SM, LR, SR, LI, SI case.                       |
 c     | Sort the eigenvalues of H into the desired order   |
@@ -192,16 +192,16 @@ c
       else if (which .eq. 'SI') then
          call dsortc ('SM', .true., kev+np, ritzr, ritzi, bounds)
       end if
-c      
+c
       call dsortc (which, .true., kev+np, ritzr, ritzi, bounds)
-c     
+c
 c     %-------------------------------------------------------%
 c     | Increase KEV by one if the ( ritzr(np),ritzi(np) )    |
 c     | = ( ritzr(np+1),-ritzi(np+1) ) and ritz(np) .ne. zero |
 c     | Accordingly decrease NP by one. In other words keep   |
 c     | complex conjugate pairs together.                     |
 c     %-------------------------------------------------------%
-c     
+c
       if (       ( ritzr(np+1) - ritzr(np) ) .eq. zero
      &     .and. ( ritzi(np+1) + ritzi(np) ) .eq. zero ) then
          np = np - 1
@@ -209,7 +209,7 @@ c
       end if
 c
       if ( ishift .eq. 1 ) then
-c     
+c
 c        %-------------------------------------------------------%
 c        | Sort the unwanted Ritz values used as shifts so that  |
 c        | the ones with largest Ritz estimates are first        |
@@ -218,10 +218,10 @@ c        | forward instability of the iteration when they shifts |
 c        | are applied in subroutine pdnapps.                    |
 c        | Be careful and use 'SR' since we want to sort BOUNDS! |
 c        %-------------------------------------------------------%
-c     
+c
          call dsortc ( 'SR', .true., np, bounds, ritzr, ritzi )
       end if
-c     
+c
       call second (t1)
       tngets = tngets + (t1 - t0)
 c
@@ -232,14 +232,14 @@ c
      &        '_ngets: Eigenvalues of current H matrix -- real part')
          call pdvout (comm, logfil, kev+np, ritzi, ndigit,
      &        '_ngets: Eigenvalues of current H matrix -- imag part')
-         call pdvout (comm, logfil, kev+np, bounds, ndigit, 
+         call pdvout (comm, logfil, kev+np, bounds, ndigit,
      &      '_ngets: Ritz estimates of the current KEV+NP Ritz values')
       end if
-c     
+c
       return
-c     
+c
 c     %----------------%
 c     | End of pdngets |
 c     %----------------%
-c     
+c
       end

--- a/mathlibs/src/parpack/pdsaitr.f
+++ b/mathlibs/src/parpack/pdsaitr.f
@@ -392,9 +392,9 @@ c
  1000 continue
 c
          if (msglvl .gt. 2) then
-            call pivout (comm, logfil, 1, j, ndigit, 
+            call pivout (comm, logfil, 1, [j], ndigit, 
      &                  '_saitr: generating Arnoldi vector no.')
-            call pdvout (comm, logfil, 1, rnorm, ndigit, 
+            call pdvout (comm, logfil, 1, [rnorm], ndigit, 
      &                  '_saitr: B-norm of the current residual =')
          end if
 c
@@ -412,7 +412,7 @@ c           | basis and continue the iteration.                 |
 c           %---------------------------------------------------%
 c
             if (msglvl .gt. 0) then
-               call pivout (comm, logfil, 1, j, ndigit,
+               call pivout (comm, logfil, 1, [j], ndigit,
      &                     '_saitr: ****** restart at step ******')
             end if
 c 
@@ -777,7 +777,7 @@ c
          end if
 c 
          if (msglvl .gt. 0 .and. iter .gt. 0) then
-            call pivout (comm, logfil, 1, j, ndigit,
+            call pivout (comm, logfil, 1, [j], ndigit,
      &           '_naitr: Iterative refinement for Arnoldi residual')
             if (msglvl .gt. 2) then
                 xtemp(1) = rnorm

--- a/mathlibs/src/parpack/pdsaitr.f
+++ b/mathlibs/src/parpack/pdsaitr.f
@@ -5,8 +5,8 @@ c\Name: pdsaitr
 c
 c Message Passing Layer: MPI
 c
-c\Description: 
-c  Reverse communication interface for applying NP additional steps to 
+c\Description:
+c  Reverse communication interface for applying NP additional steps to
 c  a K step symmetric Arnoldi factorization.
 c
 c  Input:  OP*V_{k}  -  V_{k}*H = r_{k}*e_{k}^T
@@ -22,7 +22,7 @@ c  computed and returned.
 c
 c\Usage:
 c  call pdsaitr
-c     ( COMM, IDO, BMAT, N, K, NP, MODE, RESID, RNORM, V, LDV, H, LDH, 
+c     ( COMM, IDO, BMAT, N, K, NP, MODE, RESID, RNORM, V, LDV, H, LDH,
 c       IPNTR, WORKD, WORKL, INFO )
 c
 c\Arguments
@@ -80,13 +80,13 @@ c          On INPUT the B-norm of r_{k}.
 c          On OUTPUT the B-norm of the updated residual r_{k+p}.
 c
 c  V       Double precision N by K+NP array.  (INPUT/OUTPUT)
-c          On INPUT:  V contains the Arnoldi vectors in the first K 
+c          On INPUT:  V contains the Arnoldi vectors in the first K
 c          columns.
 c          On OUTPUT: V contains the new NP Arnoldi vectors in the next
 c          NP columns.  The first K columns are unchanged.
 c
 c  LDV     Integer.  (INPUT)
-c          Leading dimension of V exactly as declared in the calling 
+c          Leading dimension of V exactly as declared in the calling
 c          program.
 c
 c  H       Double precision (K+NP) by 2 array.  (INPUT/OUTPUT)
@@ -95,26 +95,26 @@ c          with the subdiagonal in the first column starting at H(2,1)
 c          and the main diagonal in the second column.
 c
 c  LDH     Integer.  (INPUT)
-c          Leading dimension of H exactly as declared in the calling 
+c          Leading dimension of H exactly as declared in the calling
 c          program.
 c
 c  IPNTR   Integer array of length 3.  (OUTPUT)
-c          Pointer to mark the starting locations in the WORK for 
+c          Pointer to mark the starting locations in the WORK for
 c          vectors used by the Arnoldi iteration.
 c          -------------------------------------------------------------
 c          IPNTR(1): pointer to the current operand vector X.
 c          IPNTR(2): pointer to the current result vector Y.
-c          IPNTR(3): pointer to the vector B * X when used in the 
+c          IPNTR(3): pointer to the vector B * X when used in the
 c                    shift-and-invert mode.  X is the current operand.
 c          -------------------------------------------------------------
-c          
+c
 c  WORKD   Double precision work array of length 3*N.  (REVERSE COMMUNICATION)
 c          Distributed array to be used in the basic Arnoldi iteration
-c          for reverse communication.  The calling program should not 
+c          for reverse communication.  The calling program should not
 c          use WORKD as temporary workspace during the iteration !!!!!!
 c          On INPUT, WORKD(1:N) = B*RESID where RESID is associated
-c          with the K step Arnoldi factorization. Used to save some 
-c          computation at the first step. 
+c          with the K step Arnoldi factorization. Used to save some
+c          computation at the first step.
 c          On OUTPUT, WORKD(1:N) = B*RESID where RESID is associated
 c          with the K+NP step Arnoldi factorization.
 c
@@ -145,7 +145,7 @@ c     dgemv    Level 2 BLAS routine for matrix vector multiplication.
 c     daxpy    Level 1 BLAS that computes a vector triad.
 c     dscal    Level 1 BLAS that scales a vector.
 c     dcopy    Level 1 BLAS that copies one vector to another .
-c     ddot     Level 1 BLAS that computes the scalar product of two vectors. 
+c     ddot     Level 1 BLAS that computes the scalar product of two vectors.
 c     pdnorm2  Parallel version of Level 1 BLAS that computes the norm of a vector.
 c
 c\Author
@@ -153,32 +153,32 @@ c     Danny Sorensen               Phuong Vu
 c     Richard Lehoucq              CRPC / Rice University
 c     Dept. of Computational &     Houston, Texas
 c     Applied Mathematics
-c     Rice University           
-c     Houston, Texas            
-c 
+c     Rice University
+c     Houston, Texas
+c
 c\Parallel Modifications
 c     Kristi Maschhoff
 c
 c\Revision history:
 c     Starting Point: Serial Code FILE: saitr.F   SID: 2.3
 c
-c\SCCS Information: 
-c FILE: saitr.F   SID: 1.3   DATE OF SID: 3/19/97   
+c\SCCS Information:
+c FILE: saitr.F   SID: 1.3   DATE OF SID: 3/19/97
 c
 c\Remarks
 c  The algorithm implemented is:
-c  
+c
 c  restart = .false.
-c  Given V_{k} = [v_{1}, ..., v_{k}], r_{k}; 
+c  Given V_{k} = [v_{1}, ..., v_{k}], r_{k};
 c  r_{k} contains the initial residual vector even for k = 0;
-c  Also assume that rnorm = || B*r_{k} || and B*r_{k} are already 
+c  Also assume that rnorm = || B*r_{k} || and B*r_{k} are already
 c  computed by the calling program.
 c
 c  betaj = rnorm ; p_{k+1} = B*r_{k} ;
 c  For  j = k+1, ..., k+np  Do
 c     1) if ( betaj < tol ) stop or restart depending on j.
 c        if ( restart ) generate a new starting vector.
-c     2) v_{j} = r(j-1)/betaj;  V_{j} = [V_{j-1}, v_{j}];  
+c     2) v_{j} = r(j-1)/betaj;  V_{j} = [V_{j-1}, v_{j}];
 c        p_{j} = p_{j}/betaj
 c     3) r_{j} = OP*v_{j} where OP is defined as in pdsaupd
 c        For shift-invert mode p_{j} = B*v_{j} is already available.
@@ -193,7 +193,7 @@ c        If (rnorm > 0.717*wnorm) accept step and go back to 1)
 c     5) Re-orthogonalization step:
 c        s = V_{j}'*B*r_{j}
 c        r_{j} = r_{j} - V_{j}*s;  rnorm1 = || r_{j} ||
-c        alphaj = alphaj + s_{j};   
+c        alphaj = alphaj + s_{j};
 c     6) Iterative refinement step:
 c        If (rnorm1 > 0.717*rnorm) then
 c           rnorm = rnorm1
@@ -203,7 +203,7 @@ c           rnorm = rnorm1
 c           If this is the first time in step 6), go to 5)
 c           Else r_{j} lies in the span of V_{j} numerically.
 c              Set r_{j} = 0 and rnorm = 0; go to 1)
-c        EndIf 
+c        EndIf
 c  End Do
 c
 c\EndLib
@@ -211,7 +211,7 @@ c
 c-----------------------------------------------------------------------
 c
       subroutine pdsaitr
-     &   (comm, ido, bmat, n, k, np, mode, resid, rnorm, v, ldv, h, ldh, 
+     &   (comm, ido, bmat, n, k, np, mode, resid, rnorm, v, ldv, h, ldh,
      &    ipntr, workd, workl, info)
 c
       include   'mpif.h'
@@ -272,7 +272,7 @@ c
      &           rnorm_buf
 c
 c     %-----------------------%
-c     | Local Array Arguments | 
+c     | Local Array Arguments |
 c     %-----------------------%
 c
       Double precision
@@ -322,7 +322,7 @@ c
       end if
 c
       if (ido .eq. 0) then
-c 
+c
 c        %-------------------------------%
 c        | Initialize timing statistics  |
 c        | & message level for debugging |
@@ -330,7 +330,7 @@ c        %-------------------------------%
 c
          call second (t0)
          msglvl = msaitr
-c 
+c
 c        %------------------------------%
 c        | Initial call to this routine |
 c        %------------------------------%
@@ -341,14 +341,14 @@ c
          rstart = .false.
          orth1  = .false.
          orth2  = .false.
-c 
+c
 c        %--------------------------------%
 c        | Pointer to the current step of |
 c        | the factorization to build     |
 c        %--------------------------------%
 c
          j      = k + 1
-c 
+c
 c        %------------------------------------------%
 c        | Pointers used for reverse communication  |
 c        | when using WORKD.                        |
@@ -358,7 +358,7 @@ c
          irj    = ipj   + n
          ivj    = irj   + n
       end if
-c 
+c
 c     %-------------------------------------------------%
 c     | When in reverse communication mode one of:      |
 c     | STEP3, STEP4, ORTH1, ORTH2, RSTART              |
@@ -381,7 +381,7 @@ c
 c     %------------------------------%
 c     | Else this is the first step. |
 c     %------------------------------%
-c 
+c
 c     %--------------------------------------------------------------%
 c     |                                                              |
 c     |        A R N O L D I     I T E R A T I O N     L O O P       |
@@ -392,9 +392,9 @@ c
  1000 continue
 c
          if (msglvl .gt. 2) then
-            call pivout (comm, logfil, 1, [j], ndigit, 
+            call pivout (comm, logfil, 1, [j], ndigit,
      &                  '_saitr: generating Arnoldi vector no.')
-            call pdvout (comm, logfil, 1, [rnorm], ndigit, 
+            call pdvout (comm, logfil, 1, [rnorm], ndigit,
      &                  '_saitr: B-norm of the current residual =')
          end if
 c
@@ -415,7 +415,7 @@ c
                call pivout (comm, logfil, 1, [j], ndigit,
      &                     '_saitr: ****** restart at step ******')
             end if
-c 
+c
 c           %---------------------------------------------%
 c           | ITRY is the loop variable that controls the |
 c           | maximum amount of times that a restart is   |
@@ -434,7 +434,7 @@ c           | If in reverse communication mode and |
 c           | RSTART = .true. flow returns here.   |
 c           %--------------------------------------%
 c
-            call pdgetv0 (comm, ido, bmat, itry, .false., n, j, v, ldv, 
+            call pdgetv0 (comm, ido, bmat, itry, .false., n, j, v, ldv,
      &                   resid, rnorm, ipntr, workd, workl, ierr)
             if (ido .ne. 99) go to 9000
             if (ierr .lt. 0) then
@@ -453,7 +453,7 @@ c
                ido = 99
                go to 9000
             end if
-c 
+c
    40    continue
 c
 c        %---------------------------------------------------------%
@@ -475,12 +475,12 @@ c            | To scale both v_{j} and p_{j} carefully |
 c            | use LAPACK routine SLASCL               |
 c            %-----------------------------------------%
 c
-             call dlascl ('General', i, i, rnorm, one, n, 1, 
+             call dlascl ('General', i, i, rnorm, one, n, 1,
      &                    v(1,j), n, infol)
-             call dlascl ('General', i, i, rnorm, one, n, 1, 
+             call dlascl ('General', i, i, rnorm, one, n, 1,
      &                    workd(ipj), n, infol)
          end if
-c 
+c
 c        %------------------------------------------------------%
 c        | STEP 3:  r_{j} = OP*v_{j}; Note that p_{j} = B*v_{j} |
 c        | Note that this is not quite yet r_{j}. See STEP 4    |
@@ -494,14 +494,14 @@ c
          ipntr(2) = irj
          ipntr(3) = ipj
          ido = 1
-c 
+c
 c        %-----------------------------------%
 c        | Exit in order to compute OP*v_{j} |
 c        %-----------------------------------%
-c 
+c
          go to 9000
    50    continue
-c 
+c
 c        %-----------------------------------%
 c        | Back from reverse communication;  |
 c        | WORKD(IRJ:IRJ+N-1) := OP*v_{j}.   |
@@ -509,7 +509,7 @@ c        %-----------------------------------%
 c
          call second (t3)
          tmvopx = tmvopx + (t3 - t2)
-c 
+c
          step3 = .false.
 c
 c        %------------------------------------------%
@@ -517,7 +517,7 @@ c        | Put another copy of OP*v_{j} into RESID. |
 c        %------------------------------------------%
 c
          call dcopy (n, workd(irj), 1, resid, 1)
-c 
+c
 c        %-------------------------------------------%
 c        | STEP 4:  Finish extending the symmetric   |
 c        |          Arnoldi to length j. If MODE = 2 |
@@ -535,17 +535,17 @@ c
             ipntr(1) = irj
             ipntr(2) = ipj
             ido = 2
-c 
+c
 c           %-------------------------------------%
 c           | Exit in order to compute B*OP*v_{j} |
 c           %-------------------------------------%
-c 
+c
             go to 9000
          else if (bmat .eq. 'I') then
               call dcopy(n, resid, 1 , workd(ipj), 1)
          end if
    60    continue
-c 
+c
 c        %-----------------------------------%
 c        | Back from reverse communication;  |
 c        | WORKD(IPJ:IPJ+N-1) := B*OP*v_{j}. |
@@ -554,7 +554,7 @@ c
          if (bmat .eq. 'G') then
             call second (t3)
             tmvbx = tmvbx + (t3 - t2)
-         end if 
+         end if
 c
          step4 = .false.
 c
@@ -599,12 +599,12 @@ c        | WORKD(IPJ:IPJ+N-1) contains B*OP*v_{j}.  |
 c        %------------------------------------------%
 c
          if (mode .ne. 2 ) then
-            call dgemv('T', n, j, one, v, ldv, workd(ipj), 1, zero, 
+            call dgemv('T', n, j, one, v, ldv, workd(ipj), 1, zero,
      &                  workl(j+1), 1)
             call MPI_ALLREDUCE( workl(j+1), workl(1), j,
      &                  MPI_DOUBLE_PRECISION, MPI_SUM, comm, ierr)
          else if (mode .eq. 2) then
-            call dgemv('T', n, j, one, v, ldv, workd(ivj), 1, zero, 
+            call dgemv('T', n, j, one, v, ldv, workd(ivj), 1, zero,
      &                  workl(j+1), 1)
             call MPI_ALLREDUCE( workl(j+1), workl(1), j,
      &                  MPI_DOUBLE_PRECISION, MPI_SUM, comm, ierr)
@@ -612,10 +612,10 @@ c
 c
 c        %--------------------------------------%
 c        | Orthgonalize r_{j} against V_{j}.    |
-c        | RESID contains OP*v_{j}. See STEP 3. | 
+c        | RESID contains OP*v_{j}. See STEP 3. |
 c        %--------------------------------------%
 c
-         call dgemv('N', n, j, -one, v, ldv, workl(1), 1, one, 
+         call dgemv('N', n, j, -one, v, ldv, workl(1), 1, one,
      &               resid, 1)
 c
 c        %--------------------------------------%
@@ -629,10 +629,10 @@ c
             h(j,1) = rnorm
          end if
          call second (t4)
-c 
+c
          orth1 = .true.
          iter  = 0
-c 
+c
          call second (t2)
          if (bmat .eq. 'G') then
             nbx = nbx + 1
@@ -640,17 +640,17 @@ c
             ipntr(1) = irj
             ipntr(2) = ipj
             ido = 2
-c 
+c
 c           %----------------------------------%
 c           | Exit in order to compute B*r_{j} |
 c           %----------------------------------%
-c 
+c
             go to 9000
          else if (bmat .eq. 'I') then
             call dcopy (n, resid, 1, workd(ipj), 1)
          end if
    70    continue
-c 
+c
 c        %---------------------------------------------------%
 c        | Back from reverse communication if ORTH1 = .true. |
 c        | WORKD(IPJ:IPJ+N-1) := B*r_{j}.                    |
@@ -660,7 +660,7 @@ c
             call second (t3)
             tmvbx = tmvbx + (t3 - t2)
          end if
-c 
+c
          orth1 = .false.
 c
 c        %------------------------------%
@@ -693,7 +693,7 @@ c        %-----------------------------------------------------------%
 c
          if (rnorm .gt. 0.717*wnorm) go to 100
          nrorth = nrorth + 1
-c 
+c
 c        %---------------------------------------------------%
 c        | Enter the Iterative refinement phase. If further  |
 c        | refinement is necessary, loop back here. The loop |
@@ -706,7 +706,7 @@ c
          if (msglvl .gt. 2) then
             xtemp(1) = wnorm
             xtemp(2) = rnorm
-            call pdvout (comm, logfil, 2, xtemp, ndigit, 
+            call pdvout (comm, logfil, 2, xtemp, ndigit,
      &           '_naitr: re-orthonalization ; wnorm and rnorm are')
          end if
 c
@@ -728,12 +728,12 @@ c        | v(:,1:J)*WORKD(IRJ:IRJ+J-1)*e'_j, but only   |
 c        | H(j,j) is updated.                           |
 c        %----------------------------------------------%
 c
-         call dgemv ('N', n, j, -one, v, ldv, workl(1), 1, 
+         call dgemv ('N', n, j, -one, v, ldv, workl(1), 1,
      &               one, resid, 1)
 c
          if (j .eq. 1  .or.  rstart) h(j,1) = zero
          h(j,2) = h(j,2) + workl(j)
-c 
+c
          orth2 = .true.
          call second (t2)
          if (bmat .eq. 'G') then
@@ -742,12 +742,12 @@ c
             ipntr(1) = irj
             ipntr(2) = ipj
             ido = 2
-c 
+c
 c           %-----------------------------------%
 c           | Exit in order to compute B*r_{j}. |
 c           | r_{j} is the corrected residual.  |
 c           %-----------------------------------%
-c 
+c
             go to 9000
          else if (bmat .eq. 'I') then
             call dcopy (n, resid, 1, workd(ipj), 1)
@@ -766,7 +766,7 @@ c
 c        %-----------------------------------------------------%
 c        | Compute the B-norm of the corrected residual r_{j}. |
 c        %-----------------------------------------------------%
-c 
+c
          if (bmat .eq. 'G') then
            rnorm_buf = ddot (n, resid, 1, workd(ipj), 1)
            call MPI_ALLREDUCE( rnorm_buf, rnorm1, 1,
@@ -775,7 +775,7 @@ c
          else if (bmat .eq. 'I') then
            rnorm1 = pdnorm2( comm, n, resid, 1 )
          end if
-c 
+c
          if (msglvl .gt. 0 .and. iter .gt. 0) then
             call pivout (comm, logfil, 1, [j], ndigit,
      &           '_naitr: Iterative refinement for Arnoldi residual')
@@ -799,7 +799,7 @@ c           | No need for further refinement |
 c           %--------------------------------%
 c
             rnorm = rnorm1
-c 
+c
          else
 c
 c           %-------------------------------------------%
@@ -821,7 +821,7 @@ c
   95        continue
             rnorm = zero
          end if
-c 
+c
 c        %----------------------------------------------%
 c        | Branch here directly if iterative refinement |
 c        | wasn't necessary or after at most NITER_REF  |
@@ -829,13 +829,13 @@ c        | steps of iterative refinement.               |
 c        %----------------------------------------------%
 c
   100    continue
-c 
+c
          rstart = .false.
          orth2  = .false.
-c 
+c
          call second (t5)
          titref = titref + (t5 - t4)
-c 
+c
 c        %----------------------------------------------------------%
 c        | Make sure the last off-diagonal element is non negative  |
 c        | If not perform a similarity transformation on H(1:j,1:j) |
@@ -850,7 +850,7 @@ c
                call dscal(n, -one, resid, 1)
             end if
          end if
-c 
+c
 c        %------------------------------------%
 c        | STEP 6: Update  j = j+1;  Continue |
 c        %------------------------------------%
@@ -862,10 +862,10 @@ c
             ido = 99
 c
             if (msglvl .gt. 1) then
-               call pdvout (comm, logfil, k+np, h(1,2), ndigit, 
+               call pdvout (comm, logfil, k+np, h(1,2), ndigit,
      &         '_saitr: main diagonal of matrix H of step K+NP.')
                if (k+np .gt. 1) then
-               call pdvout (comm, logfil, k+np-1, h(2,1), ndigit, 
+               call pdvout (comm, logfil, k+np-1, h(2,1), ndigit,
      &         '_saitr: sub diagonal of matrix H of step K+NP.')
                end if
             end if
@@ -878,7 +878,7 @@ c        | Loop back to extend the factorization by another step. |
 c        %--------------------------------------------------------%
 c
       go to 1000
-c 
+c
 c     %---------------------------------------------------------------%
 c     |                                                               |
 c     |  E N D     O F     M A I N     I T E R A T I O N     L O O P  |

--- a/mathlibs/src/parpack/pdsapps.f
+++ b/mathlibs/src/parpack/pdsapps.f
@@ -272,9 +272,9 @@ c
             big   = abs(h(i,2)) + abs(h(i+1,2))
             if (h(i+1,1) .le. epsmch*big) then
                if (msglvl .gt. 0) then
-                  call pivout (comm, logfil, 1, i, ndigit, 
+                  call pivout (comm, logfil, 1, [i], ndigit, 
      &                 '_sapps: deflation at row/column no.')
-                  call pivout (comm, logfil, 1, jj, ndigit, 
+                  call pivout (comm, logfil, 1, [jj], ndigit, 
      &                 '_sapps: occured before shift number.')
                   call pdvout (comm, logfil, 1, h(i+1,1), ndigit, 
      &                 '_sapps: the corresponding off diagonal element')
@@ -443,7 +443,7 @@ c
          big   = abs(h(i,2)) + abs(h(i+1,2))
          if (h(i+1,1) .le. epsmch*big) then
             if (msglvl .gt. 0) then
-               call pivout (comm, logfil, 1, i, ndigit, 
+               call pivout (comm, logfil, 1, [i], ndigit, 
      &              '_sapps: deflation at row/column no.')
                call pdvout (comm, logfil, 1, h(i+1,1), ndigit, 
      &              '_sapps: the corresponding off diagonal element')

--- a/mathlibs/src/parpack/pdsapps.f
+++ b/mathlibs/src/parpack/pdsapps.f
@@ -12,8 +12,8 @@ c  apply NP shifts implicitly resulting in
 c
 c     A*(V_{k}*Q) - (V_{k}*Q)*(Q^T* H_{k}*Q) = r_{k+p}*e_{k+p}^T * Q
 c
-c  where Q is an orthogonal matrix of order KEV+NP. Q is the product of 
-c  rotations resulting from the NP bulge chasing sweeps.  The updated Arnoldi 
+c  where Q is an orthogonal matrix of order KEV+NP. Q is the product of
+c  rotations resulting from the NP bulge chasing sweeps.  The updated Arnoldi
 c  factorization becomes:
 c
 c     A*VNEW_{k} - VNEW_{k}*HNEW_{k} = rnew_{k}*e_{k}^T.
@@ -51,7 +51,7 @@ c  H       Double precision (KEV+NP) by 2 array.  (INPUT/OUTPUT)
 c          INPUT: H contains the symmetric tridiagonal matrix of the
 c          Arnoldi factorization with the subdiagonal in the 1st column
 c          starting at H(2,1) and the main diagonal in the 2nd column.
-c          OUTPUT: H contains the updated tridiagonal matrix in the 
+c          OUTPUT: H contains the updated tridiagonal matrix in the
 c          KEV leading submatrix.
 c
 c  LDH     Integer.  (INPUT)
@@ -87,12 +87,12 @@ c\References:
 c  1. D.C. Sorensen, "Implicit Application of Polynomial Filters in
 c     a k-Step Arnoldi Method", SIAM J. Matr. Anal. Apps., 13 (1992),
 c     pp 357-385.
-c  2. R.B. Lehoucq, "Analysis and Implementation of an Implicitly 
+c  2. R.B. Lehoucq, "Analysis and Implementation of an Implicitly
 c     Restarted Arnoldi Iteration", Rice University Technical Report
 c     TR95-13, Department of Computational and Applied Mathematics.
 c
 c\Routines called:
-c     pivout  Parallel ARPACK utility routine that prints integers. 
+c     pivout  Parallel ARPACK utility routine that prints integers.
 c     second  ARPACK utility routine for timing.
 c     pdvout  Parallel ARPACK utility routine that prints vectors.
 c     pdlamch ScaLAPACK routine that determines machine constants.
@@ -109,8 +109,8 @@ c     Danny Sorensen               Phuong Vu
 c     Richard Lehoucq              CRPC / Rice University
 c     Dept. of Computational &     Houston, Texas
 c     Applied Mathematics
-c     Rice University           
-c     Houston, Texas            
+c     Rice University
+c     Houston, Texas
 c
 c\Parallel Modifications
 c     Kristi Maschhoff
@@ -123,8 +123,8 @@ c FILE: sapps.F   SID: 1.3   DATE OF SID: 3/19/97
 c
 c\Remarks
 c  1. In this version, each shift is applied to all the subblocks of
-c     the tridiagonal matrix H and not just to the submatrix that it 
-c     comes from. This routine assumes that the subdiagonal elements 
+c     the tridiagonal matrix H and not just to the submatrix that it
+c     comes from. This routine assumes that the subdiagonal elements
 c     of H that are stored in h(1:kev+np,1) are nonegative upon input
 c     and enforce this condition upon output. This version incorporates
 c     deflation. See code for documentation.
@@ -160,7 +160,7 @@ c     | Array Arguments |
 c     %-----------------%
 c
       Double precision
-     &           h(ldh,2), q(ldq,kev+np), resid(n), shift(np), 
+     &           h(ldh,2), q(ldq,kev+np), resid(n), shift(np),
      &           v(ldv,kev+np), workd(2*n)
 c
 c     %------------%
@@ -186,7 +186,7 @@ c     %----------------------%
 c     | External Subroutines |
 c     %----------------------%
 c
-      external   daxpy, dcopy, dscal, dlacpy, dlartg, dlaset, pdvout, 
+      external   daxpy, dcopy, dscal, dlacpy, dlartg, dlaset, pdvout,
      &           pivout, second, dgemv
 c
 c     %--------------------%
@@ -226,9 +226,9 @@ c     %-------------------------------%
 c
       call second (t0)
       msglvl = msapps
-c 
-      kplusp = kev + np 
-c 
+c
+      kplusp = kev + np
+c
 c     %----------------------------------------------%
 c     | Initialize Q to the identity matrix of order |
 c     | kplusp used to accumulate the rotations.     |
@@ -241,7 +241,7 @@ c     | Quick return if there are no shifts to apply |
 c     %----------------------------------------------%
 c
       if (np .eq. 0) go to 9000
-c 
+c
 c     %----------------------------------------------------------%
 c     | Apply the np shifts implicitly. Apply each shift to the  |
 c     | whole matrix and not just to the submatrix from which it |
@@ -249,7 +249,7 @@ c     | comes.                                                   |
 c     %----------------------------------------------------------%
 c
       do 90 jj = 1, np
-c 
+c
          istart = itop
 c
 c        %----------------------------------------------------------%
@@ -272,11 +272,11 @@ c
             big   = abs(h(i,2)) + abs(h(i+1,2))
             if (h(i+1,1) .le. epsmch*big) then
                if (msglvl .gt. 0) then
-                  call pivout (comm, logfil, 1, [i], ndigit, 
+                  call pivout (comm, logfil, 1, [i], ndigit,
      &                 '_sapps: deflation at row/column no.')
-                  call pivout (comm, logfil, 1, [jj], ndigit, 
+                  call pivout (comm, logfil, 1, [jj], ndigit,
      &                 '_sapps: occured before shift number.')
-                  call pdvout (comm, logfil, 1, h(i+1,1), ndigit, 
+                  call pdvout (comm, logfil, 1, h(i+1,1), ndigit,
      &                 '_sapps: the corresponding off diagonal element')
                end if
                h(i+1,1) = zero
@@ -288,7 +288,7 @@ c
    40    continue
 c
          if (istart .lt. iend) then
-c 
+c
 c           %--------------------------------------------------------%
 c           | Construct the plane rotation G'(istart,istart+1,theta) |
 c           | that attempts to drive h(istart+1,1) to zero.          |
@@ -297,7 +297,7 @@ c
              f = h(istart,2) - shift(jj)
              g = h(istart+1,1)
              call dlartg (f, g, c, s, r)
-c 
+c
 c            %-------------------------------------------------------%
 c            | Apply rotation to the left and right of H;            |
 c            | H <- G' * H * G,  where G = G(istart,istart+1,theta). |
@@ -307,11 +307,11 @@ c
              a1 = c*h(istart,2)   + s*h(istart+1,1)
              a2 = c*h(istart+1,1) + s*h(istart+1,2)
              a4 = c*h(istart+1,2) - s*h(istart+1,1)
-             a3 = c*h(istart+1,1) - s*h(istart,2) 
+             a3 = c*h(istart+1,1) - s*h(istart,2)
              h(istart,2)   = c*a1 + s*a2
              h(istart+1,2) = c*a4 - s*a3
              h(istart+1,1) = c*a3 + s*a4
-c 
+c
 c            %----------------------------------------------------%
 c            | Accumulate the rotation in the matrix Q;  Q <- Q*G |
 c            %----------------------------------------------------%
@@ -334,7 +334,7 @@ c            | zero.                                        |
 c            %----------------------------------------------%
 c
              do 70 i = istart+1, iend-1
-c 
+c
 c               %----------------------------------------------%
 c               | Construct the plane rotation G'(i,i+1,theta) |
 c               | that zeros the i-th bulge that was created   |
@@ -362,28 +362,28 @@ c
                    c = -c
                    s = -s
                 end if
-c 
+c
 c               %--------------------------------------------%
 c               | Apply rotation to the left and right of H; |
 c               | H <- G * H * G',  where G = G(i,i+1,theta) |
 c               %--------------------------------------------%
 c
                 h(i,1) = r
-c 
+c
                 a1 = c*h(i,2)   + s*h(i+1,1)
                 a2 = c*h(i+1,1) + s*h(i+1,2)
                 a3 = c*h(i+1,1) - s*h(i,2)
                 a4 = c*h(i+1,2) - s*h(i+1,1)
-c 
+c
                 h(i,2)   = c*a1 + s*a2
                 h(i+1,2) = c*a4 - s*a3
                 h(i+1,1) = c*a3 + s*a4
-c 
+c
 c               %----------------------------------------------------%
 c               | Accumulate the rotation in the matrix Q;  Q <- Q*G |
 c               %----------------------------------------------------%
 c
-                do 50 j = 1, min( i+jj, kplusp ) 
+                do 50 j = 1, min( i+jj, kplusp )
                    a1       =   c*q(j,i) + s*q(j,i+1)
                    q(j,i+1) = - s*q(j,i) + c*q(j,i+1)
                    q(j,i)   = a1
@@ -436,16 +436,16 @@ c
 c     %------------------------------------------%
 c     | All shifts have been applied. Check for  |
 c     | more possible deflation that might occur |
-c     | after the last shift is applied.         |                               
+c     | after the last shift is applied.         |
 c     %------------------------------------------%
 c
       do 100 i = itop, kplusp-1
          big   = abs(h(i,2)) + abs(h(i+1,2))
          if (h(i+1,1) .le. epsmch*big) then
             if (msglvl .gt. 0) then
-               call pivout (comm, logfil, 1, [i], ndigit, 
+               call pivout (comm, logfil, 1, [i], ndigit,
      &              '_sapps: deflation at row/column no.')
-               call pdvout (comm, logfil, 1, h(i+1,1), ndigit, 
+               call pdvout (comm, logfil, 1, h(i+1,1), ndigit,
      &              '_sapps: the corresponding off diagonal element')
             end if
             h(i+1,1) = zero
@@ -458,13 +458,13 @@ c     | temporarily store the result in WORKD(N+1:2*N). |
 c     | This is not necessary if h(kev+1,1) = 0.         |
 c     %-------------------------------------------------%
 c
-      if ( h(kev+1,1) .gt. zero ) 
+      if ( h(kev+1,1) .gt. zero )
      &   call dgemv ('N', n, kplusp, one, v, ldv,
      &                q(1,kev+1), 1, zero, workd(n+1), 1)
-c 
+c
 c     %-------------------------------------------------------%
 c     | Compute column 1 to kev of (V*Q) in backward order    |
-c     | taking advantage that Q is an upper triangular matrix |    
+c     | taking advantage that Q is an upper triangular matrix |
 c     | with lower bandwidth np.                              |
 c     | Place results in v(:,kplusp-kev:kplusp) temporarily.  |
 c     %-------------------------------------------------------%
@@ -480,15 +480,15 @@ c     |  Move v(:,kplusp-kev+1:kplusp) into v(:,1:kev). |
 c     %-------------------------------------------------%
 c
       call dlacpy ('All', n, kev, v(1,np+1), ldv, v, ldv)
-c 
+c
 c     %--------------------------------------------%
 c     | Copy the (kev+1)-st column of (V*Q) in the |
 c     | appropriate place if h(kev+1,1) .ne. zero. |
 c     %--------------------------------------------%
 c
-      if ( h(kev+1,1) .gt. zero ) 
+      if ( h(kev+1,1) .gt. zero )
      &     call dcopy (n, workd(n+1), 1, v(1,kev+1), 1)
-c 
+c
 c     %-------------------------------------%
 c     | Update the residual vector:         |
 c     |    r <- sigmak*r + betak*v(:,kev+1) |
@@ -498,26 +498,26 @@ c     |    betak = e_{kev+1}'*H*e_{kev}     |
 c     %-------------------------------------%
 c
       call dscal (n, q(kplusp,kev), resid, 1)
-      if (h(kev+1,1) .gt. zero) 
+      if (h(kev+1,1) .gt. zero)
      &   call daxpy (n, h(kev+1,1), v(1,kev+1), 1, resid, 1)
 c
       if (msglvl .gt. 1) then
-         call pdvout (comm, logfil, 1, q(kplusp,kev), ndigit, 
+         call pdvout (comm, logfil, 1, q(kplusp,kev), ndigit,
      &      '_sapps: sigmak of the updated residual vector')
-         call pdvout (comm, logfil, 1, h(kev+1,1), ndigit, 
+         call pdvout (comm, logfil, 1, h(kev+1,1), ndigit,
      &      '_sapps: betak of the updated residual vector')
-         call pdvout (comm, logfil, kev, h(1,2), ndigit, 
+         call pdvout (comm, logfil, kev, h(1,2), ndigit,
      &      '_sapps: updated main diagonal of H for next iteration')
          if (kev .gt. 1) then
-         call pdvout (comm, logfil, kev-1, h(2,1), ndigit, 
+         call pdvout (comm, logfil, kev-1, h(2,1), ndigit,
      &      '_sapps: updated sub diagonal of H for next iteration')
          end if
       end if
 c
       call second (t1)
       tsapps = tsapps + (t1 - t0)
-c 
- 9000 continue 
+c
+ 9000 continue
       return
 c
 c     %----------------%

--- a/mathlibs/src/parpack/pdsaup2.f
+++ b/mathlibs/src/parpack/pdsaup2.f
@@ -5,26 +5,26 @@ c\Name: pdsaup2
 c
 c Message Passing Layer: MPI
 c
-c\Description: 
+c\Description:
 c  Intermediate level interface called by pdsaupd.
 c
 c\Usage:
-c  call pdsaup2 
+c  call pdsaup2
 c     ( COMM, IDO, BMAT, N, WHICH, NEV, NP, TOL, RESID, MODE, IUPD,
-c       ISHIFT, MXITER, V, LDV, H, LDH, RITZ, BOUNDS, Q, LDQ, WORKL, 
+c       ISHIFT, MXITER, V, LDV, H, LDH, RITZ, BOUNDS, Q, LDQ, WORKL,
 c       IPNTR, WORKD, INFO )
 c
 c\Arguments
 c
 c  COMM, IDO, BMAT, N, WHICH, NEV, TOL, RESID: same as defined in pdsaupd.
 c  MODE, ISHIFT, MXITER: see the definition of IPARAM in pdsaupd.
-c  
+c
 c  NP      Integer.  (INPUT/OUTPUT)
-c          Contains the number of implicit shifts to apply during 
-c          each Arnoldi/Lanczos iteration.  
-c          If ISHIFT=1, NP is adjusted dynamically at each iteration 
+c          Contains the number of implicit shifts to apply during
+c          each Arnoldi/Lanczos iteration.
+c          If ISHIFT=1, NP is adjusted dynamically at each iteration
 c          to accelerate convergence and prevent stagnation.
-c          This is also roughly equal to the number of matrix-vector 
+c          This is also roughly equal to the number of matrix-vector
 c          products (involving the operator OP) per Arnoldi iteration.
 c          The logic for adjusting is contained within the current
 c          subroutine.
@@ -33,7 +33,7 @@ c          to provide via reverse comunication. 0 < NP < NCV-NEV.
 c          NP may be less than NCV-NEV since a leading block of the current
 c          upper Tridiagonal matrix has split off and contains "unwanted"
 c          Ritz values.
-c          Upon termination of the IRA iteration, NP contains the number 
+c          Upon termination of the IRA iteration, NP contains the number
 c          of "converged" wanted Ritz values.
 c
 c  IUPD    Integer.  (INPUT)
@@ -44,18 +44,18 @@ c  V       Double precision N by (NEV+NP) array.  (INPUT/OUTPUT)
 c          The Lanczos basis vectors.
 c
 c  LDV     Integer.  (INPUT)
-c          Leading dimension of V exactly as declared in the calling 
+c          Leading dimension of V exactly as declared in the calling
 c          program.
 c
 c  H       Double precision (NEV+NP) by 2 array.  (OUTPUT)
 c          H is used to store the generated symmetric tridiagonal matrix
-c          The subdiagonal is stored in the first column of H starting 
+c          The subdiagonal is stored in the first column of H starting
 c          at H(2,1).  The main diagonal is stored in the second column
-c          of H starting at H(1,2). If pdsaup2 converges store the 
+c          of H starting at H(1,2). If pdsaup2 converges store the
 c          B-norm of the final residual vector in H(1,1).
 c
 c  LDH     Integer.  (INPUT)
-c          Leading dimension of H exactly as declared in the calling 
+c          Leading dimension of H exactly as declared in the calling
 c          program.
 c
 c  RITZ    Double precision array of length NEV+NP.  (OUTPUT)
@@ -65,33 +65,33 @@ c  BOUNDS  Double precision array of length NEV+NP.  (OUTPUT)
 c          BOUNDS(1:NEV) contain the error bounds corresponding to RITZ.
 c
 c  Q       Double precision (NEV+NP) by (NEV+NP) array.  (WORKSPACE)
-c          Private (replicated) work array used to accumulate the 
+c          Private (replicated) work array used to accumulate the
 c          rotation in the shift application step.
 c
 c  LDQ     Integer.  (INPUT)
 c          Leading dimension of Q exactly as declared in the calling
 c          program.
-c          
+c
 c  WORKL   Double precision array of length at least 3*(NEV+NP).  (INPUT/WORKSPACE)
 c          Private (replicated) array on each PE or array allocated on
-c          the front end.  It is used in the computation of the 
+c          the front end.  It is used in the computation of the
 c          tridiagonal eigenvalue problem, the calculation and
 c          application of the shifts and convergence checking.
 c          If ISHIFT .EQ. O and IDO .EQ. 3, the first NP locations
-c          of WORKL are used in reverse communication to hold the user 
+c          of WORKL are used in reverse communication to hold the user
 c          supplied shifts.
 c
 c  IPNTR   Integer array of length 3.  (OUTPUT)
-c          Pointer to mark the starting locations in the WORKD for 
+c          Pointer to mark the starting locations in the WORKD for
 c          vectors used by the Lanczos iteration.
 c          -------------------------------------------------------------
 c          IPNTR(1): pointer to the current operand vector X.
 c          IPNTR(2): pointer to the current result vector Y.
-c          IPNTR(3): pointer to the vector B * X when used in one of  
+c          IPNTR(3): pointer to the vector B * X when used in one of
 c                    the spectral transformation modes.  X is the current
 c                    operand.
 c          -------------------------------------------------------------
-c          
+c
 c  WORKD   Double precision work array of length 3*N.  (REVERSE COMMUNICATION)
 c          Distributed array to be used in the basic Lanczos iteration
 c          for reverse communication.  The user should not use WORKD
@@ -104,9 +104,9 @@ c          If INFO .NE. 0, RESID contains the initial residual vector,
 c                          possibly from a previous run.
 c          Error flag on output.
 c          =     0: Normal return.
-c          =     1: All possible eigenvalues of OP has been found.  
+c          =     1: All possible eigenvalues of OP has been found.
 c                   NP returns the size of the invariant subspace
-c                   spanning the operator OP. 
+c                   spanning the operator OP.
 c          =     2: No shifts could be applied.
 c          =    -8: Error return from trid. eigenvalue calculation;
 c                   This should never happen.
@@ -124,7 +124,7 @@ c\References:
 c  1. D.C. Sorensen, "Implicit Application of Polynomial Filters in
 c     a k-Step Arnoldi Method", SIAM J. Matr. Anal. Apps., 13 (1992),
 c     pp 357-385.
-c  2. R.B. Lehoucq, "Analysis and Implementation of an Implicitly 
+c  2. R.B. Lehoucq, "Analysis and Implementation of an Implicitly
 c     Restarted Arnoldi Iteration", Rice University Technical Report
 c     TR95-13, Department of Computational and Applied Mathematics.
 c  3. B.N. Parlett, "The Symmetric Eigenvalue Problem". Prentice-Hall,
@@ -134,15 +134,15 @@ c     Computer Physics Communications, 53 (1989), pp 169-179.
 c  5. B. Nour-Omid, B.N. Parlett, T. Ericson, P.S. Jensen, "How to
 c     Implement the Spectral Transformation", Math. Comp., 48 (1987),
 c     pp 663-673.
-c  6. R.G. Grimes, J.G. Lewis and H.D. Simon, "A Shifted Block Lanczos 
-c     Algorithm for Solving Sparse Symmetric Generalized Eigenproblems", 
+c  6. R.G. Grimes, J.G. Lewis and H.D. Simon, "A Shifted Block Lanczos
+c     Algorithm for Solving Sparse Symmetric Generalized Eigenproblems",
 c     SIAM J. Matr. Anal. Apps.,  January (1993).
 c  7. L. Reichel, W.B. Gragg, "Algorithm 686: FORTRAN Subroutines
 c     for Updating the QR decomposition", ACM TOMS, December 1990,
 c     Volume 16 Number 4, pp 369-377.
 c
 c\Routines called:
-c     pdgetv0  Parallel ARPACK initial vector generation routine. 
+c     pdgetv0  Parallel ARPACK initial vector generation routine.
 c     pdsaitr  Parallel ARPACK Lanczos factorization routine.
 c     pdsapps  Parallel ARPACK application of implicit shifts routine.
 c     dsconv   ARPACK convergence of Ritz values routine.
@@ -167,25 +167,25 @@ c     Danny Sorensen               Phuong Vu
 c     Richard Lehoucq              CRPC / Rice University
 c     Dept. of Computational &     Houston, Texas
 c     Applied Mathematics
-c     Rice University           
-c     Houston, Texas            
+c     Rice University
+c     Houston, Texas
 c
 c\Parallel Modifications
 c     Kristi Maschhoff
 c
 c\Revision history:
 c     Starting Point: Serial Code FILE: saup2.F   SID: 2.4
-c 
-c\SCCS Information: 
-c FILE: saup2.F   SID: 1.5   DATE OF SID: 05/20/98   
+c
+c\SCCS Information:
+c FILE: saup2.F   SID: 1.5   DATE OF SID: 05/20/98
 c
 c\EndLib
 c
 c-----------------------------------------------------------------------
 c
       subroutine pdsaup2
-     &   ( comm, ido, bmat, n, which, nev, np, tol, resid, mode, iupd, 
-     &     ishift, mxiter, v, ldv, h, ldh, ritz, bounds, 
+     &   ( comm, ido, bmat, n, which, nev, np, tol, resid, mode, iupd,
+     &     ishift, mxiter, v, ldv, h, ldh, ritz, bounds,
      &     q, ldq, workl, ipntr, workd, info )
 c
       include   'mpif.h'
@@ -220,8 +220,8 @@ c     %-----------------%
 c
       integer    ipntr(3)
       Double precision
-     &           bounds(nev+np), h(ldh,2), q(ldq,nev+np), resid(n), 
-     &           ritz(nev+np), v(ldv,nev+np), workd(3*n), 
+     &           bounds(nev+np), h(ldh,2), q(ldq,nev+np), resid(n),
+     &           ritz(nev+np), v(ldv,nev+np), workd(3*n),
      &           workl(3*(nev+np))
 c
 c     %------------%
@@ -238,8 +238,8 @@ c     %---------------%
 c
       character  wprime*2
       logical    cnorm, getv0, initv, update, ushift
-      integer    ierr, iter, j, kplusp, msglvl, nconv, nevbef, nev0, 
-     &           np0, nptemp, nevd2, nevm2, kp(3) 
+      integer    ierr, iter, j, kplusp, msglvl, nconv, nevbef, nev0,
+     &           np0, nptemp, nevd2, nevm2, kp(3)
       Double precision
      &           rnorm, temp, eps23
       save       cnorm, getv0, initv, update, ushift,
@@ -254,7 +254,7 @@ c     %----------------------%
 c     | External Subroutines |
 c     %----------------------%
 c
-      external   dcopy, pdgetv0, pdsaitr, dscal, dsconv, 
+      external   dcopy, pdgetv0, pdsaitr, dscal, dsconv,
      &           pdseigt, pdsgets, pdsapps,
      &           dsortr, pdvout, pivout, second
 c
@@ -277,7 +277,7 @@ c     | Executable Statements |
 c     %-----------------------%
 c
       if (ido .eq. 0) then
-c 
+c
 c        %-------------------------------%
 c        | Initialize timing statistics  |
 c        | & message level for debugging |
@@ -313,7 +313,7 @@ c
          kplusp = nev0 + np0
          nconv  = 0
          iter   = 0
-c 
+c
 c        %---------------------------------------------%
 c        | Set flags for computing the first NEV steps |
 c        | of the Lanczos factorization.               |
@@ -336,7 +336,7 @@ c
             initv = .false.
          end if
       end if
-c 
+c
 c     %---------------------------------------------%
 c     | Get a possibly random starting vector and   |
 c     | force it into the range of the operator OP. |
@@ -345,7 +345,7 @@ c
    10 continue
 c
       if (getv0) then
-         call pdgetv0 ( comm, ido, bmat, 1, initv, n, 1, v, ldv, 
+         call pdgetv0 ( comm, ido, bmat, 1, initv, n, 1, v, ldv,
      &                  resid, rnorm, ipntr, workd, workl, info)
 c
          if (ido .ne. 99) go to 9000
@@ -353,7 +353,7 @@ c
          if (rnorm .eq. zero) then
 c
 c           %-----------------------------------------%
-c           | The initial vector is zero. Error exit. | 
+c           | The initial vector is zero. Error exit. |
 c           %-----------------------------------------%
 c
             info = -9
@@ -362,7 +362,7 @@ c
          getv0 = .false.
          ido  = 0
       end if
-c 
+c
 c     %------------------------------------------------------------%
 c     | Back from reverse communication: continue with update step |
 c     %------------------------------------------------------------%
@@ -381,15 +381,15 @@ c     | at the end of the current iteration |
 c     %-------------------------------------%
 c
       if (cnorm)  go to 100
-c 
+c
 c     %----------------------------------------------------------%
 c     | Compute the first NEV steps of the Lanczos factorization |
 c     %----------------------------------------------------------%
 c
-      call pdsaitr (comm, ido, bmat, n, 0, nev0, mode, 
+      call pdsaitr (comm, ido, bmat, n, 0, nev0, mode,
      &              resid, rnorm, v, ldv, h, ldh, ipntr,
      &              workd, workl, info)
-c 
+c
 c     %---------------------------------------------------%
 c     | ido .ne. 99 implies use of reverse communication  |
 c     | to compute operations involving OP and possibly B |
@@ -410,7 +410,7 @@ c
          info = -9999
          go to 1200
       end if
-c 
+c
 c     %--------------------------------------------------------------%
 c     |                                                              |
 c     |           M A I N  LANCZOS  I T E R A T I O N  L O O P       |
@@ -418,22 +418,22 @@ c     |           Each iteration implicitly restarts the Lanczos     |
 c     |           factorization in place.                            |
 c     |                                                              |
 c     %--------------------------------------------------------------%
-c 
+c
  1000 continue
 c
          iter = iter + 1
 c
          if (msglvl .gt. 0) then
-            call pivout (comm, logfil, 1, [iter], ndigit, 
+            call pivout (comm, logfil, 1, [iter], ndigit,
      &           '_saup2: **** Start of major iteration number ****')
          end if
          if (msglvl .gt. 1) then
-            call pivout (comm, logfil, 1, [nev], ndigit, 
+            call pivout (comm, logfil, 1, [nev], ndigit,
      &     '_saup2: The length of the current Lanczos factorization')
-            call pivout (comm, logfil, 1, [np], ndigit, 
+            call pivout (comm, logfil, 1, [np], ndigit,
      &           '_saup2: Extend the Lanczos factorization by')
          end if
-c 
+c
 c        %------------------------------------------------------------%
 c        | Compute NP additional steps of the Lanczos factorization.  |
 c        %------------------------------------------------------------%
@@ -442,10 +442,10 @@ c
    20    continue
          update = .true.
 c
-         call pdsaitr (comm, ido, bmat, n, nev, np, mode, 
+         call pdsaitr (comm, ido, bmat, n, nev, np, mode,
      &                 resid, rnorm, v, ldv, h, ldh, ipntr,
      &                 workd, workl, info)
-c 
+c
 c        %---------------------------------------------------%
 c        | ido .ne. 99 implies use of reverse communication  |
 c        | to compute operations involving OP and possibly B |
@@ -457,7 +457,7 @@ c
 c
 c           %-----------------------------------------------------%
 c           | pdsaitr was unable to build an Lanczos factorization|
-c           | of length NEV0+NP0. INFO is returned with the size  |  
+c           | of length NEV0+NP0. INFO is returned with the size  |
 c           | of the factorization built. Exit main loop.         |
 c           %-----------------------------------------------------%
 c
@@ -469,16 +469,16 @@ c
          update = .false.
 c
          if (msglvl .gt. 1) then
-            call pdvout (comm, logfil, 1, [rnorm], ndigit, 
+            call pdvout (comm, logfil, 1, [rnorm], ndigit,
      &           '_saup2: Current B-norm of residual for factorization')
          end if
-c 
+c
 c        %--------------------------------------------------------%
 c        | Compute the eigenvalues and corresponding error bounds |
 c        | of the current symmetric tridiagonal matrix.           |
 c        %--------------------------------------------------------%
 c
-         call pdseigt ( comm, rnorm, kplusp, h, ldh, ritz, bounds, 
+         call pdseigt ( comm, rnorm, kplusp, h, ldh, ritz, bounds,
      &                  workl, ierr)
 c
          if (ierr .ne. 0) then
@@ -506,7 +506,7 @@ c        %---------------------------------------------------%
 c
          nev = nev0
          np = np0
-         call pdsgets ( comm, ishift, which, nev, np, ritz, 
+         call pdsgets ( comm, ishift, which, nev, np, ritz,
      &                  bounds, workl)
 c
 c        %-------------------%
@@ -545,11 +545,11 @@ c
                nev = nev + 1
             end if
  30      continue
-c 
-         if ( (nconv .ge. nev0) .or. 
+c
+         if ( (nconv .ge. nev0) .or.
      &        (iter .gt. mxiter) .or.
      &        (np .eq. 0) ) then
-c     
+c
 c           %------------------------------------------------%
 c           | Prepare to exit. Put the converged Ritz values |
 c           | and corresponding bounds in RITZ(1:NCONV) and  |
@@ -656,7 +656,7 @@ c              | Ritz values according to WHICH so that the   |
 c              | "threshold" value appears at the front of    |
 c              | ritz.                                        |
 c              %----------------------------------------------%
- 
+
                call dsortr(which, .true., nconv, ritz, bounds)
 c
             end if
@@ -676,13 +676,13 @@ c
             end if
 c
 c           %------------------------------------%
-c           | Max iterations have been exceeded. | 
+c           | Max iterations have been exceeded. |
 c           %------------------------------------%
 c
             if (iter .gt. mxiter .and. nconv .lt. nev) info = 1
 c
 c           %---------------------%
-c           | No shifts to apply. | 
+c           | No shifts to apply. |
 c           %---------------------%
 c
             if (np .eq. 0 .and. nconv .lt. nev0) info = 2
@@ -706,14 +706,14 @@ c
                nev = 2
             end if
             np  = kplusp - nev
-c     
+c
 c           %---------------------------------------%
 c           | If the size of NEV was just increased |
 c           | resort the eigenvalues.               |
 c           %---------------------------------------%
-c     
-            if (nevbef .lt. nev) 
-     &         call pdsgets ( comm, ishift, which, nev, np, 
+c
+            if (nevbef .lt. nev)
+     &         call pdsgets ( comm, ishift, which, nev, np,
      &                        ritz, bounds, workl)
 c
          end if
@@ -724,7 +724,7 @@ c
             if (msglvl .gt. 1) then
                kp(1) = nev
                kp(2) = np
-               call pivout (comm, logfil, 2, kp, ndigit, 
+               call pivout (comm, logfil, 2, kp, ndigit,
      &              '_saup2: NEV and NP .')
                call pdvout (comm, logfil, nev, ritz(np+1), ndigit,
      &              '_saup2: "wanted" Ritz values.')
@@ -732,7 +732,7 @@ c
      &              '_saup2: Ritz estimates of the "wanted" values ')
             end if
          end if
-c 
+c
          if (ishift .eq. 0) then
 c
 c           %-----------------------------------------------------%
@@ -755,8 +755,8 @@ c        | in WORKL(1:NP)                     |
 c        %------------------------------------%
 c
          ushift = .false.
-c 
-c 
+c
+c
 c        %---------------------------------------------------------%
 c        | Move the NP shifts to the first NP locations of RITZ to |
 c        | free up WORKL.  This is for the non-exact shift case;   |
@@ -784,7 +784,7 @@ c        | After pdsapps is done, we have a Lanczos                |
 c        | factorization of length NEV.                            |
 c        %---------------------------------------------------------%
 c
-         call pdsapps ( comm, n, nev, np, ritz, v, ldv, h, ldh, resid, 
+         call pdsapps ( comm, n, nev, np, ritz, v, ldv, h, ldh, resid,
      &                  q, ldq, workd)
 c
 c        %---------------------------------------------%
@@ -801,18 +801,18 @@ c
             ipntr(1) = n + 1
             ipntr(2) = 1
             ido = 2
-c 
+c
 c           %----------------------------------%
 c           | Exit in order to compute B*RESID |
 c           %----------------------------------%
-c 
+c
             go to 9000
          else if (bmat .eq. 'I') then
             call dcopy (n, resid, 1, workd, 1)
          end if
-c 
+c
   100    continue
-c 
+c
 c        %----------------------------------%
 c        | Back from reverse communication; |
 c        | WORKD(1:N) := B*RESID            |
@@ -822,7 +822,7 @@ c
             call second (t3)
             tmvbx = tmvbx + (t3 - t2)
          end if
-c 
+c
          if (bmat .eq. 'G') then
             rnorm_buf = ddot (n, resid, 1, workd, 1)
             call MPI_ALLREDUCE( rnorm_buf, rnorm, 1,
@@ -835,14 +835,14 @@ c
   130    continue
 c
          if (msglvl .gt. 2) then
-            call pdvout (comm, logfil, 1, [rnorm], ndigit, 
+            call pdvout (comm, logfil, 1, [rnorm], ndigit,
      &      '_saup2: B-norm of residual for NEV factorization')
             call pdvout (comm, logfil, nev, h(1,2), ndigit,
      &           '_saup2: main diagonal of compressed H matrix')
             call pdvout (comm, logfil, nev-1, h(2,1), ndigit,
      &           '_saup2: subdiagonal of compressed H matrix')
          end if
-c 
+c
       go to 1000
 c
 c     %---------------------------------------------------------------%
@@ -850,12 +850,12 @@ c     |                                                               |
 c     |  E N D     O F     M A I N     I T E R A T I O N     L O O P  |
 c     |                                                               |
 c     %---------------------------------------------------------------%
-c 
+c
  1100 continue
 c
       mxiter = iter
       nev = nconv
-c 
+c
  1200 continue
       ido = 99
 c
@@ -865,7 +865,7 @@ c     %------------%
 c
       call second (t1)
       tsaup2 = t1 - t0
-c 
+c
  9000 continue
       return
 c

--- a/mathlibs/src/parpack/pdsaup2.f
+++ b/mathlibs/src/parpack/pdsaup2.f
@@ -424,13 +424,13 @@ c
          iter = iter + 1
 c
          if (msglvl .gt. 0) then
-            call pivout (comm, logfil, 1, iter, ndigit, 
+            call pivout (comm, logfil, 1, [iter], ndigit, 
      &           '_saup2: **** Start of major iteration number ****')
          end if
          if (msglvl .gt. 1) then
-            call pivout (comm, logfil, 1, nev, ndigit, 
+            call pivout (comm, logfil, 1, [nev], ndigit, 
      &     '_saup2: The length of the current Lanczos factorization')
-            call pivout (comm, logfil, 1, np, ndigit, 
+            call pivout (comm, logfil, 1, [np], ndigit, 
      &           '_saup2: Extend the Lanczos factorization by')
          end if
 c 
@@ -469,7 +469,7 @@ c
          update = .false.
 c
          if (msglvl .gt. 1) then
-            call pdvout (comm, logfil, 1, rnorm, ndigit, 
+            call pdvout (comm, logfil, 1, [rnorm], ndigit, 
      &           '_saup2: Current B-norm of residual for factorization')
          end if
 c 
@@ -719,7 +719,7 @@ c
          end if
 c
          if (msglvl .gt. 0) then
-            call pivout (comm, logfil, 1, nconv, ndigit,
+            call pivout (comm, logfil, 1, [nconv], ndigit,
      &           '_saup2: no. of "converged" Ritz values at this iter.')
             if (msglvl .gt. 1) then
                kp(1) = nev
@@ -766,7 +766,7 @@ c
          if (ishift .eq. 0) call dcopy (np, workl, 1, ritz, 1)
 c
          if (msglvl .gt. 2) then
-            call pivout (comm, logfil, 1, np, ndigit,
+            call pivout (comm, logfil, 1, [np], ndigit,
      &                  '_saup2: The number of shifts to apply ')
             call pdvout (comm, logfil, np, workl, ndigit,
      &                  '_saup2: shifts selected')
@@ -835,7 +835,7 @@ c
   130    continue
 c
          if (msglvl .gt. 2) then
-            call pdvout (comm, logfil, 1, rnorm, ndigit, 
+            call pdvout (comm, logfil, 1, [rnorm], ndigit, 
      &      '_saup2: B-norm of residual for NEV factorization')
             call pdvout (comm, logfil, nev, h(1,2), ndigit,
      &           '_saup2: main diagonal of compressed H matrix')

--- a/mathlibs/src/parpack/pdsaupd.f
+++ b/mathlibs/src/parpack/pdsaupd.f
@@ -1,35 +1,35 @@
 c-----------------------------------------------------------------------
 c\BeginDoc
 c
-c\Name: pdsaupd 
+c\Name: pdsaupd
 c
-c Message Passing Layer: MPI 
+c Message Passing Layer: MPI
 c
-c\Description: 
+c\Description:
 c
-c  Reverse communication interface for the Implicitly Restarted Arnoldi 
-c  Iteration.  For symmetric problems this reduces to a variant of the Lanczos 
-c  method.  This method has been designed to compute approximations to a 
-c  few eigenpairs of a linear operator OP that is real and symmetric 
-c  with respect to a real positive semi-definite symmetric matrix B, 
+c  Reverse communication interface for the Implicitly Restarted Arnoldi
+c  Iteration.  For symmetric problems this reduces to a variant of the Lanczos
+c  method.  This method has been designed to compute approximations to a
+c  few eigenpairs of a linear operator OP that is real and symmetric
+c  with respect to a real positive semi-definite symmetric matrix B,
 c  i.e.
-c                   
-c       B*OP = (OP`)*B.  
 c
-c  Another way to express this condition is 
+c       B*OP = (OP`)*B.
+c
+c  Another way to express this condition is
 c
 c       < x,OPy > = < OPx,y >  where < z,w > = z`Bw  .
-c  
-c  In the standard eigenproblem B is the identity matrix.  
+c
+c  In the standard eigenproblem B is the identity matrix.
 c  ( A` denotes transpose of A)
 c
 c  The computed approximate eigenvalues are called Ritz values and
 c  the corresponding approximate eigenvectors are called Ritz vectors.
 c
-c  pdsaupd  is usually called iteratively to solve one of the 
+c  pdsaupd  is usually called iteratively to solve one of the
 c  following problems:
 c
-c  Mode 1:  A*x = lambda*x, A symmetric 
+c  Mode 1:  A*x = lambda*x, A symmetric
 c           ===> OP = A  and  B = I.
 c
 c  Mode 2:  A*x = lambda*M*x, A symmetric, M symmetric positive definite
@@ -37,10 +37,10 @@ c           ===> OP = inv[M]*A  and  B = M.
 c           ===> (If M can be factored see remark 3 below)
 c
 c  Mode 3:  K*x = lambda*M*x, K symmetric, M symmetric positive semi-definite
-c           ===> OP = (inv[K - sigma*M])*M  and  B = M. 
+c           ===> OP = (inv[K - sigma*M])*M  and  B = M.
 c           ===> Shift-and-Invert mode
 c
-c  Mode 4:  K*x = lambda*KG*x, K symmetric positive semi-definite, 
+c  Mode 4:  K*x = lambda*KG*x, K symmetric positive semi-definite,
 c           KG symmetric indefinite
 c           ===> OP = (inv[K - sigma*KG])*K  and  B = K.
 c           ===> Buckling mode
@@ -62,7 +62,7 @@ c        the accuracy requirements for the eigenvalue
 c        approximations.
 c
 c\Usage:
-c  call pdsaupd  
+c  call pdsaupd
 c     ( COMM, IDO, BMAT, N, WHICH, NEV, TOL, RESID, NCV, V, LDV, IPARAM,
 c       IPNTR, WORKD, WORKL, LWORKL, INFO )
 c
@@ -70,7 +70,7 @@ c\Arguments
 c  COMM    MPI  Communicator for the processor grid.  (INPUT)
 c
 c  IDO     Integer.  (INPUT/OUTPUT)
-c          Reverse communication flag.  IDO must be zero on the first 
+c          Reverse communication flag.  IDO must be zero on the first
 c          call to pdsaupd .  IDO will be set internally to
 c          indicate the type of operation to be performed.  Control is
 c          then given back to the calling routine which has the
@@ -99,7 +99,7 @@ c                    IPNTR(11) is the pointer into WORKL for
 c                    placing the shifts. See remark 6 below.
 c          IDO = 99: done
 c          -------------------------------------------------------------
-c             
+c
 c  BMAT    Character*1.  (INPUT)
 c          BMAT specifies the type of the matrix B that defines the
 c          semi-inner product for the operator OP.
@@ -115,7 +115,7 @@ c
 c          'LA' - compute the NEV largest (algebraic) eigenvalues.
 c          'SA' - compute the NEV smallest (algebraic) eigenvalues.
 c          'LM' - compute the NEV largest (in magnitude) eigenvalues.
-c          'SM' - compute the NEV smallest (in magnitude) eigenvalues. 
+c          'SM' - compute the NEV smallest (in magnitude) eigenvalues.
 c          'BE' - compute NEV eigenvalues, half from each end of the
 c                 spectrum.  When NEV is odd, compute one more from the
 c                 high end than from the low end.
@@ -125,27 +125,27 @@ c  NEV     Integer.  (INPUT)
 c          Number of eigenvalues of OP to be computed. 0 < NEV < N.
 c
 c  TOL     Double precision  scalar.  (INPUT)
-c          Stopping criterion: the relative accuracy of the Ritz value 
+c          Stopping criterion: the relative accuracy of the Ritz value
 c          is considered acceptable if BOUNDS(I) .LE. TOL*ABS(RITZ(I)).
 c          If TOL .LE. 0. is passed a default is set:
 c          DEFAULT = DLAMCH ('EPS')  (machine precision as computed
 c                    by the LAPACK auxiliary subroutine DLAMCH ).
 c
 c  RESID   Double precision  array of length N.  (INPUT/OUTPUT)
-c          On INPUT: 
+c          On INPUT:
 c          If INFO .EQ. 0, a random initial residual vector is used.
 c          If INFO .NE. 0, RESID contains the initial residual vector,
 c                          possibly from a previous run.
 c          On OUTPUT:
-c          RESID contains the final residual vector. 
+c          RESID contains the final residual vector.
 c
 c  NCV     Integer.  (INPUT)
 c          Number of columns of the matrix V (less than or equal to N).
-c          This will indicate how many Lanczos vectors are generated 
-c          at each iteration.  After the startup phase in which NEV 
-c          Lanczos vectors are generated, the algorithm generates 
+c          This will indicate how many Lanczos vectors are generated
+c          at each iteration.  After the startup phase in which NEV
+c          Lanczos vectors are generated, the algorithm generates
 c          NCV-NEV Lanczos vectors at each subsequent update iteration.
-c          Most of the cost in generating each Lanczos vector is in the 
+c          Most of the cost in generating each Lanczos vector is in the
 c          matrix-vector product OP*x. (See remark 4 below).
 c
 c  V       Double precision  N by NCV array.  (OUTPUT)
@@ -165,10 +165,10 @@ c                      reverse communication.  The NCV eigenvalues of
 c                      the current tridiagonal matrix T are returned in
 c                      the part of WORKL array corresponding to RITZ.
 c                      See remark 6 below.
-c          ISHIFT = 1: exact shifts with respect to the reduced 
-c                      tridiagonal matrix T.  This is equivalent to 
-c                      restarting the iteration with a starting vector 
-c                      that is a linear combination of Ritz vectors 
+c          ISHIFT = 1: exact shifts with respect to the reduced
+c                      tridiagonal matrix T.  This is equivalent to
+c                      restarting the iteration with a starting vector
+c                      that is a linear combination of Ritz vectors
 c                      associated with the "wanted" Ritz values.
 c          -------------------------------------------------------------
 c
@@ -176,8 +176,8 @@ c          IPARAM(2) = LEVEC
 c          No longer referenced. See remark 2 below.
 c
 c          IPARAM(3) = MXITER
-c          On INPUT:  maximum number of Arnoldi update iterations allowed. 
-c          On OUTPUT: actual number of Arnoldi update iterations taken. 
+c          On INPUT:  maximum number of Arnoldi update iterations allowed.
+c          On OUTPUT: actual number of Arnoldi update iterations taken.
 c
 c          IPARAM(4) = NB: blocksize to be used in the recurrence.
 c          The code currently works only for NB = 1.
@@ -187,11 +187,11 @@ c          This represents the number of Ritz values that satisfy
 c          the convergence criterion.
 c
 c          IPARAM(6) = IUPD
-c          No longer referenced. Implicit restarting is ALWAYS used. 
+c          No longer referenced. Implicit restarting is ALWAYS used.
 c
 c          IPARAM(7) = MODE
 c          On INPUT determines what type of eigenproblem is being solved.
-c          Must be 1,2,3,4,5; See under \Description of pdsaupd  for the 
+c          Must be 1,2,3,4,5; See under \Description of pdsaupd  for the
 c          five modes available.
 c
 c          IPARAM(8) = NP
@@ -203,7 +203,7 @@ c
 c          IPARAM(9) = NUMOP, IPARAM(10) = NUMOPB, IPARAM(11) = NUMREO,
 c          OUTPUT: NUMOP  = total number of OP*x operations,
 c                  NUMOPB = total number of B*x operations if BMAT='G',
-c                  NUMREO = total number of steps of re-orthogonalization.        
+c                  NUMREO = total number of steps of re-orthogonalization.
 c
 c  IPNTR   Integer array of length 11.  (OUTPUT)
 c          Pointer to mark the starting locations in the WORKD and WORKL
@@ -211,7 +211,7 @@ c          arrays for matrices/vectors used by the Lanczos iteration.
 c          -------------------------------------------------------------
 c          IPNTR(1): pointer to the current operand vector X in WORKD.
 c          IPNTR(2): pointer to the current result vector Y in WORKD.
-c          IPNTR(3): pointer to the vector B * X in WORKD when used in 
+c          IPNTR(3): pointer to the vector B * X in WORKD when used in
 c                    the shift-and-invert mode.
 c          IPNTR(4): pointer to the next available location in WORKL
 c                    that is untouched by the program.
@@ -220,7 +220,7 @@ c          IPNTR(6): pointer to the NCV RITZ values array in WORKL.
 c          IPNTR(7): pointer to the Ritz estimates in array WORKL associated
 c                    with the Ritz values located in RITZ in WORKL.
 c          IPNTR(11): pointer to the NP shifts in WORKL. See Remark 6 below.
-c          
+c
 c          Note: IPNTR(8:10) is only referenced by pdseupd . See Remark 2.
 c          IPNTR(8): pointer to the NCV RITZ values of the original system.
 c          IPNTR(9): pointer to the NCV corresponding error bounds.
@@ -228,14 +228,14 @@ c          IPNTR(10): pointer to the NCV by NCV matrix of eigenvectors
 c                     of the tridiagonal matrix T. Only referenced by
 c                     pdseupd  if RVEC = .TRUE. See Remarks.
 c          -------------------------------------------------------------
-c          
+c
 c  WORKD   Double precision  work array of length 3*N.  (REVERSE COMMUNICATION)
 c          Distributed array to be used in the basic Arnoldi iteration
-c          for reverse communication.  The user should not use WORKD 
+c          for reverse communication.  The user should not use WORKD
 c          as temporary workspace during the iteration. Upon termination
 c          WORKD(1:N) contains B*RESID(1:N). If the Ritz vectors are desired
 c          subroutine pdseupd  uses this output.
-c          See Data Distribution Note below.  
+c          See Data Distribution Note below.
 c
 c  WORKL   Double precision  work array of length LWORKL.  (OUTPUT/WORKSPACE)
 c          Private (replicated) array on each PE or array allocated on
@@ -251,13 +251,13 @@ c                          possibly from a previous run.
 c          Error flag on output.
 c          =  0: Normal exit.
 c          =  1: Maximum number of iterations taken.
-c                All possible eigenvalues of OP has been found. IPARAM(5)  
+c                All possible eigenvalues of OP has been found. IPARAM(5)
 c                returns the number of wanted converged Ritz values.
 c          =  2: No longer an informational error. Deprecated starting
 c                with release 2 of ARPACK.
-c          =  3: No shifts could be applied during a cycle of the 
-c                Implicitly restarted Arnoldi iteration. One possibility 
-c                is to increase the size of NCV relative to NEV. 
+c          =  3: No shifts could be applied during a cycle of the
+c                Implicitly restarted Arnoldi iteration. One possibility
+c                is to increase the size of NCV relative to NEV.
 c                See remark 4 below.
 c          = -1: N must be positive.
 c          = -2: NEV must be positive.
@@ -281,12 +281,12 @@ c                   enough workspace and array storage has been allocated.
 c
 c
 c\Remarks
-c  1. The converged Ritz values are always returned in ascending 
+c  1. The converged Ritz values are always returned in ascending
 c     algebraic order.  The computed Ritz values are approximate
 c     eigenvalues of OP.  The selection of WHICH should be made
-c     with this in mind when Mode = 3,4,5.  After convergence, 
-c     approximate eigenvalues of the original problem may be obtained 
-c     with the ARPACK subroutine pdseupd . 
+c     with this in mind when Mode = 3,4,5.  After convergence,
+c     approximate eigenvalues of the original problem may be obtained
+c     with the ARPACK subroutine pdseupd .
 c
 c  2. If the Ritz vectors corresponding to the converged Ritz values
 c     are needed, the user must call pdseupd  immediately following completion
@@ -294,7 +294,7 @@ c     of pdsaupd . This is new starting with version 2.1 of ARPACK.
 c
 c  3. If M can be factored into a Cholesky factorization M = LL`
 c     then Mode = 2 should not be selected.  Instead one should use
-c     Mode = 1 with  OP = inv(L)*A*inv(L`).  Appropriate triangular 
+c     Mode = 1 with  OP = inv(L)*A*inv(L`).  Appropriate triangular
 c     linear systems should be solved with L and L` rather
 c     than computing inverses.  After convergence, an approximate
 c     eigenvector z of the original problem is recovered by solving
@@ -304,7 +304,7 @@ c  4. At present there is no a-priori analysis to guide the selection
 c     of NCV relative to NEV.  The only formal requrement is that NCV > NEV.
 c     However, it is recommended that NCV .ge. 2*NEV.  If many problems of
 c     the same type are to be solved, one should experiment with increasing
-c     NCV while keeping NEV fixed for a given test problem.  This will 
+c     NCV while keeping NEV fixed for a given test problem.  This will
 c     usually decrease the required number of OP*x operations but it
 c     also increases the work and storage required to maintain the orthogonal
 c     basis vectors.   The optimal "cross-over" with respect to CPU time
@@ -316,16 +316,16 @@ c     When IPARAM(7) = 2 OP = inv(B)*A. After computing A*X the user
 c     must overwrite X with A*X. Y is then the solution to the linear set
 c     of equations B*Y = A*X.
 c
-c  6. When IPARAM(1) = 0, and IDO = 3, the user needs to provide the 
-c     NP = IPARAM(8) shifts in locations: 
-c     1   WORKL(IPNTR(11))           
-c     2   WORKL(IPNTR(11)+1)         
-c                        .           
-c                        .           
-c                        .      
-c     NP  WORKL(IPNTR(11)+NP-1). 
+c  6. When IPARAM(1) = 0, and IDO = 3, the user needs to provide the
+c     NP = IPARAM(8) shifts in locations:
+c     1   WORKL(IPNTR(11))
+c     2   WORKL(IPNTR(11)+1)
+c                        .
+c                        .
+c                        .
+c     NP  WORKL(IPNTR(11)+NP-1).
 c
-c     The eigenvalues of the current tridiagonal matrix are located in 
+c     The eigenvalues of the current tridiagonal matrix are located in
 c     WORKL(IPNTR(6)) through WORKL(IPNTR(6)+NCV-1). They are in the
 c     order defined by WHICH. The associated Ritz estimates are located in
 c     WORKL(IPNTR(8)), WORKL(IPNTR(8)+1), ... , WORKL(IPNTR(8)+NCV-1).
@@ -351,7 +351,7 @@ c  ===============
 c  REAL       RESID(N), V(LDV,NCV), WORKD(N,3), WORKL(LWORKL)
 c  SHARED     RESID(BLOCK), V(BLOCK,:), WORKD(BLOCK,:)
 c  REPLICATED WORKL(LWORKL)
-c  
+c
 c
 c\BeginLib
 c
@@ -359,7 +359,7 @@ c\References:
 c  1. D.C. Sorensen, "Implicit Application of Polynomial Filters in
 c     a k-Step Arnoldi Method", SIAM J. Matr. Anal. Apps., 13 (1992),
 c     pp 357-385.
-c  2. R.B. Lehoucq, "Analysis and Implementation of an Implicitly 
+c  2. R.B. Lehoucq, "Analysis and Implementation of an Implicitly
 c     Restarted Arnoldi Iteration", Rice University Technical Report
 c     TR95-13, Department of Computational and Applied Mathematics.
 c  3. B.N. Parlett, "The Symmetric Eigenvalue Problem". Prentice-Hall,
@@ -369,8 +369,8 @@ c     Computer Physics Communications, 53 (1989), pp 169-179.
 c  5. B. Nour-Omid, B.N. Parlett, T. Ericson, P.S. Jensen, "How to
 c     Implement the Spectral Transformation", Math. Comp., 48 (1987),
 c     pp 663-673.
-c  6. R.G. Grimes, J.G. Lewis and H.D. Simon, "A Shifted Block Lanczos 
-c     Algorithm for Solving Sparse Symmetric Generalized Eigenproblems", 
+c  6. R.G. Grimes, J.G. Lewis and H.D. Simon, "A Shifted Block Lanczos
+c     Algorithm for Solving Sparse Symmetric Generalized Eigenproblems",
 c     SIAM J. Matr. Anal. Apps.,  January (1993).
 c  7. L. Reichel, W.B. Gragg, "Algorithm 686: FORTRAN Subroutines
 c     for Updating the QR decomposition", ACM TOMS, December 1990,
@@ -394,8 +394,8 @@ c     Danny Sorensen               Phuong Vu
 c     Richard Lehoucq              CRPC / Rice University
 c     Dept. of Computational &     Houston, Texas
 c     Applied Mathematics
-c     Rice University           
-c     Houston, Texas            
+c     Rice University
+c     Houston, Texas
 c
 c\Parallel Modifications
 c     Kristi Maschhoff
@@ -403,8 +403,8 @@ c
 c\Revision history:
 c     Starting Point: Serial Code FILE: saupd.F   SID: 2.4
 c
-c\SCCS Information: 
-c FILE: saupd.F   SID: 1.7   DATE OF SID: 04/10/01   
+c\SCCS Information:
+c FILE: saupd.F   SID: 1.7   DATE OF SID: 04/10/01
 c
 c\Remarks
 c     1. None
@@ -413,8 +413,8 @@ c\EndLib
 c
 c-----------------------------------------------------------------------
 c
-      subroutine pdsaupd 
-     &   ( comm, ido, bmat, n, which, nev, tol, resid, ncv, v, ldv, 
+      subroutine pdsaupd
+     &   ( comm, ido, bmat, n, which, nev, tol, resid, ncv, v, ldv,
      &     iparam, ipntr, workd, workl, lworkl, info )
 c
       include  'mpif.h'
@@ -438,7 +438,7 @@ c     %------------------%
 c
       character  bmat*1, which*2
       integer    ido, info, ldv, lworkl, n, ncv, nev
-      Double precision 
+      Double precision
      &           tol
 c
 c     %-----------------%
@@ -446,14 +446,14 @@ c     | Array Arguments |
 c     %-----------------%
 c
       integer    iparam(11), ipntr(11)
-      Double precision 
+      Double precision
      &           resid(n), v(ldv,ncv), workd(3*n), workl(lworkl)
 c
 c     %------------%
 c     | Parameters |
 c     %------------%
 c
-      Double precision 
+      Double precision
      &           one, zero
       parameter (one = 1.0 , zero = 0.0 )
 c
@@ -461,7 +461,7 @@ c     %---------------%
 c     | Local Scalars |
 c     %---------------%
 c
-      integer    bounds, ierr, ih, iq, ishift, iupd, iw, 
+      integer    bounds, ierr, ih, iq, ishift, iupd, iw,
      &           ldh, ldq, msglvl, mxiter, mode, nb,
      &           nev0, next, np, ritz, j
       save       bounds, ierr, ih, iq, ishift, iupd, iw,
@@ -472,20 +472,20 @@ c     %----------------------%
 c     | External Subroutines |
 c     %----------------------%
 c
-      external   pdsaup2 , pdvout , pivout, second, dstats 
+      external   pdsaup2 , pdvout , pivout, second, dstats
 c
 c     %--------------------%
 c     | External Functions |
 c     %--------------------%
 c
-      Double precision 
+      Double precision
      &           pdlamch10
       external   pdlamch10
 c
 c     %-----------------------%
 c     | Executable Statements |
 c     %-----------------------%
-c 
+c
       if (ido .eq. 0) then
 c
 c        %-------------------------------%
@@ -493,7 +493,7 @@ c        | Initialize timing statistics  |
 c        | & message level for debugging |
 c        %-------------------------------%
 c
-         call dstats 
+         call dstats
          call second (t0)
          msglvl = msaupd
 c
@@ -528,7 +528,7 @@ c        | extend the length NEV Lanczos factorization. |
 c        %----------------------------------------------%
 c
          np     = ncv - nev
-c 
+c
          if (mxiter .le. 0)                     ierr = -4
          if (which .ne. 'LM' .and.
      &       which .ne. 'SM' .and.
@@ -547,7 +547,7 @@ c
          else if (nev .eq. 1 .and. which .eq. 'BE') then
                                                 ierr = -13
          end if
-c 
+c
 c        %------------%
 c        | Error Exit |
 c        %------------%
@@ -557,7 +557,7 @@ c
             ido  = 99
             go to 9000
          end if
-c 
+c
 c        %------------------------%
 c        | Set default parameters |
 c        %------------------------%
@@ -573,8 +573,8 @@ c        | size of the invariant subspace desired.      |
 c        %----------------------------------------------%
 c
          np     = ncv - nev
-         nev0   = nev 
-c 
+         nev0   = nev
+c
 c        %-----------------------------%
 c        | Zero out internal workspace |
 c        %-----------------------------%
@@ -582,7 +582,7 @@ c
          do 10 j = 1, ncv**2 + 8*ncv
             workl(j) = zero
  10      continue
-c 
+c
 c        %-------------------------------------------------------%
 c        | Pointer into WORKL for address of H, RITZ, BOUNDS, Q  |
 c        | etc... and the remaining workspace.                   |
@@ -615,7 +615,7 @@ c     %-------------------------------------------------------%
 c     | Carry out the Implicitly restarted Lanczos Iteration. |
 c     %-------------------------------------------------------%
 c
-      call pdsaup2  
+      call pdsaup2
      &   ( comm, ido, bmat, n, which, nev0, np, tol, resid, mode, iupd,
      &     ishift, mxiter, v, ldv, workl(ih), ldh, workl(ritz),
      &     workl(bounds), workl(iq), ldq, workl(iw), ipntr, workd,
@@ -628,7 +628,7 @@ c     %--------------------------------------------------%
 c
       if (ido .eq. 3) iparam(8) = np
       if (ido .ne. 99) go to 9000
-c 
+c
       iparam(3) = mxiter
       iparam(5) = np
       iparam(9) = nopx
@@ -648,15 +648,15 @@ c
      &               '_saupd: number of update iterations taken')
          call pivout (comm, logfil, 1, [np], ndigit,
      &               '_saupd: number of "converged" Ritz values')
-         call pdvout  (comm, logfil, np, workl(Ritz), ndigit, 
+         call pdvout  (comm, logfil, np, workl(Ritz), ndigit,
      &               '_saupd: final Ritz values')
-         call pdvout  (comm, logfil, np, workl(Bounds), ndigit, 
+         call pdvout  (comm, logfil, np, workl(Bounds), ndigit,
      &               '_saupd: corresponding error bounds')
-      end if 
+      end if
 c
       call second (t1)
       tsaupd = t1 - t0
-c 
+c
       if (msglvl .gt. 0) then
          call MPI_COMM_RANK( comm, myid, ierr )
          if ( myid .eq. 0 ) then
@@ -697,9 +697,9 @@ c
      &      5x, 'Total time in convergence testing          = ', f12.6)
          end if
       end if
-c 
+c
  9000 continue
-c 
+c
       return
 c
 c     %----------------%

--- a/mathlibs/src/parpack/pdsaupd.f
+++ b/mathlibs/src/parpack/pdsaupd.f
@@ -644,9 +644,9 @@ c
       if (info .eq. 2) info = 3
 c
       if (msglvl .gt. 0) then
-         call pivout (comm, logfil, 1, mxiter, ndigit,
+         call pivout (comm, logfil, 1, [mxiter], ndigit,
      &               '_saupd: number of update iterations taken')
-         call pivout (comm, logfil, 1, np, ndigit,
+         call pivout (comm, logfil, 1, [np], ndigit,
      &               '_saupd: number of "converged" Ritz values')
          call pdvout  (comm, logfil, np, workl(Ritz), ndigit, 
      &               '_saupd: final Ritz values')

--- a/mathlibs/src/parpack/pdseupd.f
+++ b/mathlibs/src/parpack/pdseupd.f
@@ -523,9 +523,9 @@ c        | caused by incorrect passing of the _saupd data.           |
 c        %-----------------------------------------------------------%
 c
          if (msglvl .gt. 2) then
-             call pivout(comm, logfil, 1, numcnv, ndigit,
+             call pivout(comm, logfil, 1, [numcnv], ndigit,
      &            '_neupd: Number of specified eigenvalues')
-             call pivout(comm, logfil, 1, nconv, ndigit,
+             call pivout(comm, logfil, 1, [nconv], ndigit,
      &            '_neupd: Number of "converged" eigenvalues')
          end if
 c

--- a/mathlibs/src/parpack/pdseupd.f
+++ b/mathlibs/src/parpack/pdseupd.f
@@ -1,10 +1,10 @@
 c\BeginDoc
 c
-c\Name: pdseupd 
+c\Name: pdseupd
 c
-c Message Passing Layer: MPI 
+c Message Passing Layer: MPI
 c
-c\Description: 
+c\Description:
 c
 c  This subroutine returns the converged approximations to eigenvalues
 c  of A*z = lambda*B*z and (optionally):
@@ -17,22 +17,22 @@ c
 c      (3) Both.
 c
 c  There is negligible additional cost to obtain eigenvectors.  An orthonormal
-c  (Lanczos) basis is always computed.  There is an additional storage cost 
-c  of n*nev if both are requested (in this case a separate array Z must be 
+c  (Lanczos) basis is always computed.  There is an additional storage cost
+c  of n*nev if both are requested (in this case a separate array Z must be
 c  supplied).
 c
 c  These quantities are obtained from the Lanczos factorization computed
 c  by PSSAUPD for the linear operator OP prescribed by the MODE selection
 c  (see IPARAM(7) in PSSAUPD documentation.)  PSSAUPD must be called before
-c  this routine is called. These approximate eigenvalues and vectors are 
-c  commonly called Ritz values and Ritz vectors respectively.  They are 
-c  referred to as such in the comments that follow.   The computed orthonormal 
-c  basis for the invariant subspace corresponding to these Ritz values is 
+c  this routine is called. These approximate eigenvalues and vectors are
+c  commonly called Ritz values and Ritz vectors respectively.  They are
+c  referred to as such in the comments that follow.   The computed orthonormal
+c  basis for the invariant subspace corresponding to these Ritz values is
 c  referred to as a Lanczos basis.
 c
-c  See documentation in the header of the subroutine PSSAUPD for a definition 
-c  of OP as well as other terms and the relation of computed Ritz values 
-c  and vectors of OP with respect to the given problem  A*z = lambda*B*z.  
+c  See documentation in the header of the subroutine PSSAUPD for a definition
+c  of OP as well as other terms and the relation of computed Ritz values
+c  and vectors of OP with respect to the given problem  A*z = lambda*B*z.
 c
 c  The approximate eigenvalues of the original problem are returned in
 c  ascending algebraic order.  The user may elect to call this routine
@@ -41,22 +41,22 @@ c  There is also the option of computing a selected set of these vectors
 c  with a single call.
 c
 c\Usage:
-c  call pdseupd  
+c  call pdseupd
 c     ( COMM, RVEC, HOWMNY, SELECT, D, Z, LDZ, SIGMA, BMAT, N, WHICH, NEV, TOL,
 c       RESID, NCV, V, LDV, IPARAM, IPNTR, WORKD, WORKL, LWORKL, INFO )
 c
 c\Arguments
 c  COMM    MPI  Communicator for the processor grid.  (INPUT)
 c
-c  RVEC    LOGICAL  (INPUT) 
-c          Specifies whether Ritz vectors corresponding to the Ritz value 
+c  RVEC    LOGICAL  (INPUT)
+c          Specifies whether Ritz vectors corresponding to the Ritz value
 c          approximations to the eigenproblem A*z = lambda*B*z are computed.
 c
 c             RVEC = .FALSE.     Compute Ritz values only.
 c
 c             RVEC = .TRUE.      Compute Ritz vectors.
 c
-c  HOWMNY  Character*1  (INPUT) 
+c  HOWMNY  Character*1  (INPUT)
 c          Specifies how many Ritz vectors are wanted and the form of Z
 c          the matrix of Ritz vectors. See remark 1 below.
 c          = 'A': compute NEV Ritz vectors;
@@ -66,7 +66,7 @@ c
 c  SELECT  Logical array of dimension NCV.  (INPUT/WORKSPACE)
 c          If HOWMNY = 'S', SELECT specifies the Ritz vectors to be
 c          computed. To select the Ritz vector corresponding to a
-c          Ritz value D(j), SELECT(j) must be set to .TRUE.. 
+c          Ritz value D(j), SELECT(j) must be set to .TRUE..
 c          If HOWMNY = 'A' , SELECT is used as workspace.
 c
 c  D       Double precision  array of dimension NEV.  (OUTPUT)
@@ -74,8 +74,8 @@ c          On exit, D contains the Ritz value approximations to the
 c          eigenvalues of A*z = lambda*B*z. The values are returned
 c          in ascending order. If IPARAM(7) = 3,4,5 then D represents
 c          the Ritz values of OP computed by pdsaupd  transformed to
-c          those of the original eigensystem A*z = lambda*B*z. If 
-c          IPARAM(7) = 1,2 then the Ritz values of OP are the same 
+c          those of the original eigensystem A*z = lambda*B*z. If
+c          IPARAM(7) = 1,2 then the Ritz values of OP are the same
 c          as the those of A*z = lambda*B*z.
 c
 c  Z       Double precision  N by NEV array if HOWMNY = 'A'.  (OUTPUT)
@@ -83,7 +83,7 @@ c          On exit, Z contains the B-orthonormal Ritz vectors of the
 c          eigensystem A*z = lambda*B*z corresponding to the Ritz
 c          value approximations.
 c          If  RVEC = .FALSE. then Z is not referenced.
-c          NOTE: The array Z may be set equal to first NEV columns of the 
+c          NOTE: The array Z may be set equal to first NEV columns of the
 c          Arnoldi/Lanczos basis array V computed by PSSAUPD.
 c
 c  LDZ     Integer.  (INPUT)
@@ -157,7 +157,7 @@ c\References:
 c  1. D.C. Sorensen, "Implicit Application of Polynomial Filters in
 c     a k-Step Arnoldi Method", SIAM J. Matr. Anal. Apps., 13 (1992),
 c     pp 357-385.
-c  2. R.B. Lehoucq, "Analysis and Implementation of an Implicitly 
+c  2. R.B. Lehoucq, "Analysis and Implementation of an Implicitly
 c     Restarted Arnoldi Iteration", Rice University Technical Report
 c     TR95-13, Department of Computational and Applied Mathematics.
 c  3. B.N. Parlett, "The Symmetric Eigenvalue Problem". Prentice-Hall,
@@ -167,19 +167,19 @@ c     Computer Physics Communications, 53 (1989), pp 169-179.
 c  5. B. Nour-Omid, B.N. Parlett, T. Ericson, P.S. Jensen, "How to
 c     Implement the Spectral Transformation", Math. Comp., 48 (1987),
 c     pp 663-673.
-c  6. R.G. Grimes, J.G. Lewis and H.D. Simon, "A Shifted Block Lanczos 
-c     Algorithm for Solving Sparse Symmetric Generalized Eigenproblems", 
+c  6. R.G. Grimes, J.G. Lewis and H.D. Simon, "A Shifted Block Lanczos
+c     Algorithm for Solving Sparse Symmetric Generalized Eigenproblems",
 c     SIAM J. Matr. Anal. Apps.,  January (1993).
 c  7. L. Reichel, W.B. Gragg, "Algorithm 686: FORTRAN Subroutines
 c     for Updating the QR decomposition", ACM TOMS, December 1990,
 c     Volume 16 Number 4, pp 369-377.
 c
 c\Remarks
-c  1. The converged Ritz values are always returned in increasing 
+c  1. The converged Ritz values are always returned in increasing
 c     (algebraic) order.
 c
 c  2. Currently only HOWMNY = 'A' is implemented. It is included at this
-c     stage for the user who wants to incorporate it. 
+c     stage for the user who wants to incorporate it.
 c
 c\Routines called:
 c     dsesrt   ARPACK routine that sorts an array X, and applies the
@@ -204,10 +204,10 @@ c\Authors
 c     Danny Sorensen               Phuong Vu
 c     Richard Lehoucq              CRPC / Rice University
 c     Chao Yang                    Houston, Texas
-c     Dept. of Computational & 
+c     Dept. of Computational &
 c     Applied Mathematics
-c     Rice University           
-c     Houston, Texas            
+c     Rice University
+c     Houston, Texas
 c
 c\Parallel Modifications
 c     Kristi Maschhoff
@@ -221,7 +221,7 @@ c
 c\EndLib
 c
 c-----------------------------------------------------------------------
-      subroutine pdseupd  
+      subroutine pdseupd
      &    (comm  , rvec  , howmny, select, d    ,
      &     z     , ldz   , sigma , bmat  , n    ,
      &     which , nev   , tol   , resid , ncv  ,
@@ -248,7 +248,7 @@ c
       character  bmat, howmny, which*2
       logical    rvec
       integer    info, ldz, ldv, lworkl, n, ncv, nev
-      Double precision      
+      Double precision
      &           sigma, tol
 c
 c     %-----------------%
@@ -257,15 +257,15 @@ c     %-----------------%
 c
       integer    iparam(7), ipntr(11)
       logical    select(ncv)
-      Double precision 
-     &           d(nev), resid(n), v(ldv,ncv), z(ldz, nev), 
+      Double precision
+     &           d(nev), resid(n), v(ldv,ncv), z(ldz, nev),
      &           workd(2*n), workl(lworkl)
 c
 c     %------------%
 c     | Parameters |
 c     %------------%
 c
-      Double precision 
+      Double precision
      &           one, zero
       parameter (one = 1.0 , zero = 0.0 )
 c
@@ -279,7 +279,7 @@ c
      &           ldq    , mode   , msglvl, nconv , next  ,
      &           ritz   , irz    , ibd   , np    , ishift,
      &           leftptr, rghtptr, numcnv, jj
-      Double precision 
+      Double precision
      &           bnorm2, rnorm, temp, temp1, eps23
       logical    reord
 c
@@ -287,14 +287,14 @@ c     %----------------------%
 c     | External Subroutines |
 c     %----------------------%
 c
-      external   dcopy  , dger   , dgeqr2 , dlacpy , dorm2r , dscal , 
-     &           dsesrt , dsteqr , dswap  , pdvout , pivout, dsortr 
+      external   dcopy  , dger   , dgeqr2 , dlacpy , dorm2r , dscal ,
+     &           dsesrt , dsteqr , dswap  , pdvout , pivout, dsortr
 c
 c     %--------------------%
 c     | External Functions |
 c     %--------------------%
 c
-      Double precision 
+      Double precision
      &           pdnorm2 , pdlamch10
       external   pdnorm2 , pdlamch10
 c
@@ -307,7 +307,7 @@ c
 c     %-----------------------%
 c     | Executable Statements |
 c     %-----------------------%
-c 
+c
 c     %------------------------%
 c     | Set default parameters |
 c     %------------------------%
@@ -324,7 +324,7 @@ c
       if (nconv .eq. 0) go to 9000
       ierr = 0
 c
-      if (nconv .le. 0)                        ierr = -14 
+      if (nconv .le. 0)                        ierr = -14
       if (n .le. 0)                            ierr = -1
       if (nev .le. 0)                          ierr = -2
       if (ncv .le. nev)                        ierr = -3
@@ -336,12 +336,12 @@ c
       if (bmat .ne. 'I' .and. bmat .ne. 'G')   ierr = -6
       if ( (howmny .ne. 'A' .and.
      &           howmny .ne. 'P' .and.
-     &           howmny .ne. 'S') .and. rvec ) 
+     &           howmny .ne. 'S') .and. rvec )
      &                                         ierr = -15
       if (rvec .and. howmny .eq. 'S')           ierr = -16
 c
       if (rvec .and. lworkl .lt. ncv**2+8*ncv) ierr = -7
-c     
+c
       if (mode .eq. 1 .or. mode .eq. 2) then
          type = 'REGULR'
       else if (mode .eq. 3 ) then
@@ -350,7 +350,7 @@ c
          type = 'BUCKLE'
       else if (mode .eq. 5 ) then
          type = 'CAYLEY'
-      else 
+      else
                                                ierr = -10
       end if
       if (mode .eq. 1 .and. bmat .eq. 'G')     ierr = -11
@@ -364,7 +364,7 @@ c
          info = ierr
          go to 9000
       end if
-c     
+c
 c     %-------------------------------------------------------%
 c     | Pointer into WORKL for address of H, RITZ, BOUNDS, Q  |
 c     | etc... and the remaining workspace.                   |
@@ -439,7 +439,7 @@ c     %---------------------------------%
 c     | Set machine dependent constant. |
 c     %---------------------------------%
 c
-      eps23 = pdlamch10(comm, 'Epsilon-Machine') 
+      eps23 = pdlamch10(comm, 'Epsilon-Machine')
       eps23 = eps23**(2.0  / 3.0 )
 c
 c     %---------------------------------------%
@@ -487,7 +487,7 @@ c        %-------------------------------------%
 c
          np     = ncv - nev
          ishift = 0
-         call pdsgets (comm         , ishift, which     , 
+         call pdsgets (comm         , ishift, which     ,
      &                nev          , np    , workl(irz),
      &                workl(bounds), workl , workl(np+1))
 c
@@ -663,8 +663,8 @@ c
             call dcopy (ncv, workl(bounds), 1, workl(ihb), 1)
          end if
 c
-      else 
-c 
+      else
+c
 c        %-------------------------------------------------------------%
 c        | *  Make a copy of all the Ritz values.                      |
 c        | *  Transform the Ritz values back to the original system.   |
@@ -681,13 +681,13 @@ c        |  They are only reordered.                                   |
 c        %-------------------------------------------------------------%
 c
          call dcopy  (ncv, workl(ihd), 1, workl(iw), 1)
-         if (type .eq. 'SHIFTI') then 
+         if (type .eq. 'SHIFTI') then
             do 40 k=1, ncv
                workl(ihd+k-1) = one / workl(ihd+k-1) + sigma
   40        continue
          else if (type .eq. 'BUCKLE') then
             do 50 k=1, ncv
-               workl(ihd+k-1) = sigma * workl(ihd+k-1) / 
+               workl(ihd+k-1) = sigma * workl(ihd+k-1) /
      &                          (workl(ihd+k-1) - one)
   50        continue
          else if (type .eq. 'CAYLEY') then
@@ -696,7 +696,7 @@ c
      &                          (workl(ihd+k-1) - one)
   60        continue
          end if
-c 
+c
 c        %-------------------------------------------------------------%
 c        | *  Store the wanted NCONV lambda values into D.             |
 c        | *  Sort the NCONV wanted lambda in WORKL(IHD:IHD+NCONV-1)   |
@@ -722,8 +722,8 @@ c
             call dsortr ('LA', .true., nconv, d, workl(ihb))
          end if
 c
-      end if 
-c 
+      end if
+c
 c     %------------------------------------------------%
 c     | Compute the Ritz vectors. Transform the wanted |
 c     | eigenvectors of the symmetric tridiagonal H by |
@@ -731,25 +731,25 @@ c     | the Lanczos basis matrix V.                    |
 c     %------------------------------------------------%
 c
       if (rvec .and. howmny .eq. 'A') then
-c    
+c
 c        %----------------------------------------------------------%
 c        | Compute the QR factorization of the matrix representing  |
 c        | the wanted invariant subspace located in the first NCONV |
 c        | columns of workl(iq,ldq).                                |
 c        %----------------------------------------------------------%
-c     
+c
          call dgeqr2 (ncv, nconv        , workl(iq) ,
      &               ldq, workl(iw+ncv), workl(ihb),
      &               ierr)
-c     
+c
 c        %--------------------------------------------------------%
-c        | * Postmultiply V by Q.                                 |   
+c        | * Postmultiply V by Q.                                 |
 c        | * Copy the first NCONV columns of VQ into Z.           |
 c        | The N by NCONV matrix Z is now a matrix representation |
 c        | of the approximate invariant subspace associated with  |
 c        | the Ritz values in workl(ihd).                         |
 c        %--------------------------------------------------------%
-c     
+c
          call dorm2r ('Right'      , 'Notranspose', n        ,
      &                ncv          , nconv        , workl(iq),
      &                ldq          , workl(iw+ncv), v        ,
@@ -795,10 +795,10 @@ c        | *  Determine Ritz estimates of the lambda.      |
 c        %-------------------------------------------------%
 c
          call dscal  (ncv, bnorm2, workl(ihb), 1)
-         if (type .eq. 'SHIFTI') then 
+         if (type .eq. 'SHIFTI') then
 c
             do 80 k=1, ncv
-               workl(ihb+k-1) = abs( workl(ihb+k-1) ) 
+               workl(ihb+k-1) = abs( workl(ihb+k-1) )
      &                        / workl(iw+k-1)**2
  80         continue
 c
@@ -823,15 +823,15 @@ c
       if (type .ne. 'REGULR' .and. msglvl .gt. 1) then
          call pdvout  (comm, logfil, nconv, d, ndigit,
      &          '_seupd: Untransformed converged Ritz values')
-         call pdvout  (comm, logfil, nconv, workl(ihb), ndigit, 
+         call pdvout  (comm, logfil, nconv, workl(ihb), ndigit,
      &     '_seupd: Ritz estimates of the untransformed Ritz values')
       else if (msglvl .gt. 1) then
          call pdvout  (comm, logfil, nconv, d, ndigit,
      &          '_seupd: Converged Ritz values')
-         call pdvout  (comm, logfil, nconv, workl(ihb), ndigit, 
+         call pdvout  (comm, logfil, nconv, workl(ihb), ndigit,
      &     '_seupd: Associated Ritz estimates')
       end if
-c 
+c
 c     %-------------------------------------------------%
 c     | Ritz vector purification step. Formally perform |
 c     | one of inverse subspace iteration. Only used    |
@@ -841,7 +841,7 @@ c
       if (rvec .and. (type .eq. 'SHIFTI' .or. type .eq. 'CAYLEY')) then
 c
          do 110 k=0, nconv-1
-            workl(iw+k) = workl(iq+k*ldq+ncv-1) 
+            workl(iw+k) = workl(iq+k*ldq+ncv-1)
      &                  / workl(iw+k)
  110     continue
 c
@@ -852,7 +852,7 @@ c
      &                  / (workl(iw+k)-one)
  120     continue
 c
-      end if 
+      end if
 c
       if (type .ne. 'REGULR')
      &   call dger (n, nconv, one, resid, 1, workl(iw), 1, z, ldz)

--- a/mathlibs/src/parpack/pdsgets.f
+++ b/mathlibs/src/parpack/pdsgets.f
@@ -216,8 +216,8 @@ c
       tsgets = tsgets + (t1 - t0)
 c
       if (msglvl .gt. 0) then
-         call pivout (comm, logfil, 1, kev, ndigit, '_sgets: KEV is')
-         call pivout (comm, logfil, 1, np, ndigit, '_sgets: NP is')
+         call pivout (comm, logfil, 1, [kev], ndigit, '_sgets: KEV is')
+         call pivout (comm, logfil, 1, [np], ndigit, '_sgets: NP is')
          call pdvout (comm, logfil, kev+np, ritz, ndigit,
      &        '_sgets: Eigenvalues of current H matrix')
          call pdvout (comm, logfil, kev+np, bounds, ndigit, 

--- a/mathlibs/src/parpack/pdsgets.f
+++ b/mathlibs/src/parpack/pdsgets.f
@@ -5,13 +5,13 @@ c\Name: pdsgets
 c
 c Message Passing Layer: MPI
 c
-c\Description: 
+c\Description:
 c  Given the eigenvalues of the symmetric tridiagonal matrix H,
-c  computes the NP shifts AMU that are zeros of the polynomial of 
-c  degree NP which filters out components of the unwanted eigenvectors 
+c  computes the NP shifts AMU that are zeros of the polynomial of
+c  degree NP which filters out components of the unwanted eigenvectors
 c  corresponding to the AMU's based on some given criteria.
 c
-c  NOTE: This is called even in the case of user specified shifts in 
+c  NOTE: This is called even in the case of user specified shifts in
 c  order to sort the eigenvalues, and error bounds of H for later use.
 c
 c\Usage:
@@ -43,8 +43,8 @@ c          Number of implicit shifts to be computed.
 c
 c  RITZ    Double precision array of length KEV+NP.  (INPUT/OUTPUT)
 c          On INPUT, RITZ contains the eigenvalues of H.
-c          On OUTPUT, RITZ are sorted so that the unwanted eigenvalues 
-c          are in the first NP locations and the wanted part is in 
+c          On OUTPUT, RITZ are sorted so that the unwanted eigenvalues
+c          are in the first NP locations and the wanted part is in
 c          the last KEV locations.  When exact shifts are selected, the
 c          unwanted part corresponds to the shifts to be applied.
 c
@@ -53,7 +53,7 @@ c          Error bounds corresponding to the ordering in RITZ.
 c
 c  SHIFTS  Double precision array of length NP.  (INPUT/OUTPUT)
 c          On INPUT:  contains the user specified shifts if ISHIFT = 0.
-c          On OUTPUT: contains the shifts sorted into decreasing order 
+c          On OUTPUT: contains the shifts sorted into decreasing order
 c          of magnitude with respect to the Ritz estimates contained in
 c          BOUNDS. If ISHIFT = 0, SHIFTS is not modified on exit.
 c
@@ -79,8 +79,8 @@ c     Danny Sorensen               Phuong Vu
 c     Richard Lehoucq              CRPC / Rice University
 c     Dept. of Computational &     Houston, Texas
 c     Applied Mathematics
-c     Rice University           
-c     Houston, Texas            
+c     Rice University
+c     Houston, Texas
 c
 c\Parallel Modifications
 c     Kristi Maschhoff
@@ -88,8 +88,8 @@ c
 c\Revision history:
 c     Starting Point: Serial Code FILE: sgets.F   SID: 2.3
 c
-c\SCCS Information: 
-c FILE: sgets.F   SID: 1.2   DATE OF SID: 2/22/96   
+c\SCCS Information:
+c FILE: sgets.F   SID: 1.2   DATE OF SID: 2/22/96
 c
 c\Remarks
 c
@@ -97,7 +97,7 @@ c\EndLib
 c
 c-----------------------------------------------------------------------
 c
-      subroutine pdsgets 
+      subroutine pdsgets
      &      ( comm, ishift, which, kev, np, ritz, bounds, shifts )
 c
 c     %--------------------%
@@ -156,7 +156,7 @@ c
 c     %-----------------------%
 c     | Executable Statements |
 c     %-----------------------%
-c 
+c
 c     %-------------------------------%
 c     | Initialize timing statistics  |
 c     | & message level for debugging |
@@ -164,7 +164,7 @@ c     %-------------------------------%
 c
       call second (t0)
       msglvl = msgets
-c 
+c
       if (which .eq. 'BE') then
 c
 c        %-----------------------------------------------------%
@@ -177,11 +177,11 @@ c        | overlapping locations.                              |
 c        %-----------------------------------------------------%
 c
          call dsortr ('LA', .true., kev+np, ritz, bounds)
-         kevd2 = kev / 2 
+         kevd2 = kev / 2
          if ( kev .gt. 1 ) then
-            call dswap ( min(kevd2,np), ritz, 1, 
+            call dswap ( min(kevd2,np), ritz, 1,
      &                   ritz( max(kevd2,np)+1 ), 1)
-            call dswap ( min(kevd2,np), bounds, 1, 
+            call dswap ( min(kevd2,np), bounds, 1,
      &                   bounds( max(kevd2,np)+1 ), 1)
          end if
 c
@@ -199,7 +199,7 @@ c
       end if
 c
       if (ishift .eq. 1 .and. np .gt. 0) then
-c     
+c
 c        %-------------------------------------------------------%
 c        | Sort the unwanted Ritz values used as shifts so that  |
 c        | the ones with largest Ritz estimates are first.       |
@@ -207,11 +207,11 @@ c        | This will tend to minimize the effects of the         |
 c        | forward instability of the iteration when the shifts  |
 c        | are applied in subroutine pdsapps.                    |
 c        %-------------------------------------------------------%
-c     
+c
          call dsortr ('SM', .true., np, bounds, ritz)
          call dcopy (np, ritz, 1, shifts, 1)
       end if
-c 
+c
       call second (t1)
       tsgets = tsgets + (t1 - t0)
 c
@@ -220,10 +220,10 @@ c
          call pivout (comm, logfil, 1, [np], ndigit, '_sgets: NP is')
          call pdvout (comm, logfil, kev+np, ritz, ndigit,
      &        '_sgets: Eigenvalues of current H matrix')
-         call pdvout (comm, logfil, kev+np, bounds, ndigit, 
+         call pdvout (comm, logfil, kev+np, bounds, ndigit,
      &        '_sgets: Associated Ritz estimates')
       end if
-c 
+c
       return
 c
 c     %----------------%

--- a/mathlibs/src/parpack/psgetv0.f
+++ b/mathlibs/src/parpack/psgetv0.f
@@ -391,9 +391,9 @@ c     | Check for further orthogonalization. |
 c     %--------------------------------------%
 c
       if (msglvl .gt. 2) then
-          call psvout (comm, logfil, 1, rnorm0, ndigit, 
+          call psvout (comm, logfil, 1, [rnorm0], ndigit, 
      &                '_getv0: re-orthonalization ; rnorm0 is')
-          call psvout (comm, logfil, 1, rnorm, ndigit, 
+          call psvout (comm, logfil, 1, [rnorm], ndigit, 
      &                '_getv0: re-orthonalization ; rnorm is')
       end if
 c
@@ -424,7 +424,7 @@ c
    50 continue
 c
       if (msglvl .gt. 0) then
-         call psvout (comm, logfil, 1, rnorm, ndigit,
+         call psvout (comm, logfil, 1, [rnorm], ndigit,
      &        '_getv0: B-norm of initial / restarted starting vector')
       end if
       if (msglvl .gt. 2) then

--- a/mathlibs/src/parpack/psgetv0.f
+++ b/mathlibs/src/parpack/psgetv0.f
@@ -5,13 +5,13 @@ c\Name: psgetv0
 c
 c Message Passing Layer: MPI
 c
-c\Description: 
+c\Description:
 c  Generate a random initial residual vector for the Arnoldi process.
-c  Force the residual vector to be in the range of the operator OP.  
+c  Force the residual vector to be in the range of the operator OP.
 c
 c\Usage:
 c  call psgetv0
-c     ( COMM, IDO, BMAT, ITRY, INITV, N, J, V, LDV, RESID, RNORM, 
+c     ( COMM, IDO, BMAT, ITRY, INITV, N, J, V, LDV, RESID, RNORM,
 c       IPNTR, WORKD, WORKL, IERR )
 c
 c\Arguments
@@ -40,7 +40,7 @@ c          B = 'I' -> standard eigenvalue problem A*x = lambda*x
 c          B = 'G' -> generalized eigenvalue problem A*x = lambda*B*x
 c
 c  ITRY    Integer.  (INPUT)
-c          ITRY counts the number of times that psgetv0 is called.  
+c          ITRY counts the number of times that psgetv0 is called.
 c          It should be set to 1 on the initial call to psgetv0.
 c
 c  INITV   Logical variable.  (INPUT)
@@ -59,11 +59,11 @@ c          The first J-1 columns of V contain the current Arnoldi basis
 c          if this is a "restart".
 c
 c  LDV     Integer.  (INPUT)
-c          Leading dimension of V exactly as declared in the calling 
+c          Leading dimension of V exactly as declared in the calling
 c          program.
 c
 c  RESID   Real array of length N.  (INPUT/OUTPUT)
-c          Initial residual vector to be generated.  If RESID is 
+c          Initial residual vector to be generated.  If RESID is
 c          provided, force RESID into the range of the operator OP.
 c
 c  RNORM   Real scalar.  (OUTPUT)
@@ -94,7 +94,7 @@ c\References:
 c  1. D.C. Sorensen, "Implicit Application of Polynomial Filters in
 c     a k-Step Arnoldi Method", SIAM J. Matr. Anal. Apps., 13 (1992),
 c     pp 357-385.
-c  2. R.B. Lehoucq, "Analysis and Implementation of an Implicitly 
+c  2. R.B. Lehoucq, "Analysis and Implementation of an Implicitly
 c     Restarted Arnoldi Iteration", Rice University Technical Report
 c     TR95-13, Department of Computational and Applied Mathematics.
 c
@@ -112,8 +112,8 @@ c     Danny Sorensen               Phuong Vu
 c     Richard Lehoucq              Cray Research, Inc. &
 c     Dept. of Computational &     CRPC / Rice University
 c     Applied Mathematics          Houston, Texas
-c     Rice University           
-c     Houston, Texas            
+c     Rice University
+c     Houston, Texas
 c
 c\Parallel Modifications
 c     Kristi Maschhoff
@@ -121,15 +121,15 @@ c
 c\Revision history:
 c     Starting Point: Serial Code FILE: getv0.F   SID: 2.3
 c
-c\SCCS Information: 
-c FILE: getv0.F   SID: 1.4   DATE OF SID: 3/19/97   
+c\SCCS Information:
+c FILE: getv0.F   SID: 1.4   DATE OF SID: 3/19/97
 c
 c\EndLib
 c
 c-----------------------------------------------------------------------
 c
-      subroutine psgetv0 
-     &   ( comm, ido, bmat, itry, initv, n, j, v, ldv, resid, rnorm, 
+      subroutine psgetv0
+     &   ( comm, ido, bmat, itry, initv, n, j, v, ldv, resid, rnorm,
      &     ipntr, workd, workl, ierr )
 c
       include   'mpif.h'
@@ -183,7 +183,7 @@ c
      &           rnorm0
       save       first, iseed, inits, iter, msglvl, orth, rnorm0
 c
-      Real     
+      Real
      &           rnorm_buf
 c
 c     %----------------------%
@@ -231,7 +231,7 @@ c
       end if
 c
       if (ido .eq.  0) then
-c 
+c
 c        %-------------------------------%
 c        | Initialize timing statistics  |
 c        | & message level for debugging |
@@ -239,7 +239,7 @@ c        %-------------------------------%
 c
          call second (t0)
          msglvl = mgetv0
-c 
+c
          ierr   = 0
          iter   = 0
          first  = .FALSE.
@@ -258,7 +258,7 @@ c
             idist = 2
             call pslarnv (comm, idist, iseed, n, resid)
          end if
-c 
+c
 c        %----------------------------------------------------------%
 c        | Force the starting vector into the range of OP to handle |
 c        | the generalized problem when B is possibly (singular).   |
@@ -274,7 +274,7 @@ c
             go to 9000
          end if
       end if
-c 
+c
 c     %-----------------------------------------%
 c     | Back from computing OP*(initial-vector) |
 c     %-----------------------------------------%
@@ -286,10 +286,10 @@ c     | Back from computing B*(orthogonalized-vector) |
 c     %-----------------------------------------------%
 c
       if (orth)  go to 40
-c 
+c
       call second (t3)
       tmvopx = tmvopx + (t3 - t2)
-c 
+c
 c     %------------------------------------------------------%
 c     | Starting vector is now in the range of OP; r = OP*r; |
 c     | Compute B-norm of starting vector.                   |
@@ -307,14 +307,14 @@ c
       else if (bmat .eq. 'I') then
          call scopy (n, resid, 1, workd, 1)
       end if
-c 
+c
    20 continue
 c
       if (bmat .eq. 'G') then
          call second (t3)
          tmvbx = tmvbx + (t3 - t2)
       endif
-c 
+c
       first = .FALSE.
       if (bmat .eq. 'G') then
           rnorm_buf = sdot (n, resid, 1, workd, 1)
@@ -331,7 +331,7 @@ c     | Exit if this is the very first Arnoldi step |
 c     %---------------------------------------------%
 c
       if (j .eq. 1) go to 50
-c 
+c
 c     %----------------------------------------------------------------
 c     | Otherwise need to B-orthogonalize the starting vector against |
 c     | the current Arnoldi basis using Gram-Schmidt with iter. ref.  |
@@ -353,7 +353,7 @@ c
      &                    MPI_REAL, MPI_SUM, comm, ierr)
       call sgemv ('N', n, j-1, -one, v, ldv, workl, 1,
      &            one, resid, 1)
-c 
+c
 c     %----------------------------------------------------------%
 c     | Compute the B-norm of the orthogonalized starting vector |
 c     %----------------------------------------------------------%
@@ -369,7 +369,7 @@ c
       else if (bmat .eq. 'I') then
          call scopy (n, resid, 1, workd, 1)
       end if
-c 
+c
    40 continue
 c
       if (bmat .eq. 'G') then
@@ -391,14 +391,14 @@ c     | Check for further orthogonalization. |
 c     %--------------------------------------%
 c
       if (msglvl .gt. 2) then
-          call psvout (comm, logfil, 1, [rnorm0], ndigit, 
+          call psvout (comm, logfil, 1, [rnorm0], ndigit,
      &                '_getv0: re-orthonalization ; rnorm0 is')
-          call psvout (comm, logfil, 1, [rnorm], ndigit, 
+          call psvout (comm, logfil, 1, [rnorm], ndigit,
      &                '_getv0: re-orthonalization ; rnorm is')
       end if
 c
       if (rnorm .gt. 0.717*rnorm0) go to 50
-c 
+c
       iter = iter + 1
       if (iter .le. 1) then
 c
@@ -420,7 +420,7 @@ c
          rnorm = zero
          ierr = -1
       end if
-c 
+c
    50 continue
 c
       if (msglvl .gt. 0) then
@@ -432,10 +432,10 @@ c
      &        '_getv0: initial / restarted starting vector')
       end if
       ido = 99
-c 
+c
       call second (t1)
       tgetv0 = tgetv0 + (t1 - t0)
-c 
+c
  9000 continue
       return
 c

--- a/mathlibs/src/parpack/psnaitr.f
+++ b/mathlibs/src/parpack/psnaitr.f
@@ -5,8 +5,8 @@ c\Name: psnaitr
 c
 c Message Passing Layer: MPI
 c
-c\Description: 
-c  Reverse communication interface for applying NP additional steps to 
+c\Description:
+c  Reverse communication interface for applying NP additional steps to
 c  a K step nonsymmetric Arnoldi factorization.
 c
 c  Input:  OP*V_{k}  -  V_{k}*H = r_{k}*e_{k}^T
@@ -22,7 +22,7 @@ c  computed and returned.
 c
 c\Usage:
 c  call psnaitr
-c     ( COMM, IDO, BMAT, N, K, NP, NB, RESID, RNORM, V, LDV, H, LDH, 
+c     ( COMM, IDO, BMAT, N, K, NP, NB, RESID, RNORM, V, LDV, H, LDH,
 c       IPNTR, WORKD, WORKL, INFO )
 c
 c\Arguments
@@ -66,8 +66,8 @@ c  NP      Integer.  (INPUT)
 c          Number of additional Arnoldi steps to take.
 c
 c  NB      Integer.  (INPUT)
-c          Blocksize to be used in the recurrence.          
-c          Only work for NB = 1 right now.  The goal is to have a 
+c          Blocksize to be used in the recurrence.
+c          Only work for NB = 1 right now.  The goal is to have a
 c          program that implement both the block and non-block method.
 c
 c  RESID   Real array of length N.  (INPUT/OUTPUT)
@@ -79,37 +79,37 @@ c          B-norm of the starting residual on input.
 c          B-norm of the updated residual r_{k+p} on output.
 c
 c  V       Real N by K+NP array.  (INPUT/OUTPUT)
-c          On INPUT:  V contains the Arnoldi vectors in the first K 
+c          On INPUT:  V contains the Arnoldi vectors in the first K
 c          columns.
 c          On OUTPUT: V contains the new NP Arnoldi vectors in the next
 c          NP columns.  The first K columns are unchanged.
 c
 c  LDV     Integer.  (INPUT)
-c          Leading dimension of V exactly as declared in the calling 
+c          Leading dimension of V exactly as declared in the calling
 c          program.
 c
 c  H       Real (K+NP) by (K+NP) array.  (INPUT/OUTPUT)
 c          H is used to store the generated upper Hessenberg matrix.
 c
 c  LDH     Integer.  (INPUT)
-c          Leading dimension of H exactly as declared in the calling 
+c          Leading dimension of H exactly as declared in the calling
 c          program.
 c
 c  IPNTR   Integer array of length 3.  (OUTPUT)
-c          Pointer to mark the starting locations in the WORK for 
+c          Pointer to mark the starting locations in the WORK for
 c          vectors used by the Arnoldi iteration.
 c          -------------------------------------------------------------
 c          IPNTR(1): pointer to the current operand vector X.
 c          IPNTR(2): pointer to the current result vector Y.
-c          IPNTR(3): pointer to the vector B * X when used in the 
+c          IPNTR(3): pointer to the vector B * X when used in the
 c                    shift-and-invert mode.  X is the current operand.
 c          -------------------------------------------------------------
-c          
+c
 c  WORKD   Real work array of length 3*N.  (REVERSE COMMUNICATION)
 c          Distributed array to be used in the basic Arnoldi iteration
-c          for reverse communication.  The calling program should not 
+c          for reverse communication.  The calling program should not
 c          use WORKD as temporary workspace during the iteration !!!!!!
-c          On input, WORKD(1:N) = B*RESID and is used to save some 
+c          On input, WORKD(1:N) = B*RESID and is used to save some
 c          computation at the first step.
 c
 c  WORKL   Real work space used for Gram Schmidt orthogonalization
@@ -131,7 +131,7 @@ c\References:
 c  1. D.C. Sorensen, "Implicit Application of Polynomial Filters in
 c     a k-Step Arnoldi Method", SIAM J. Matr. Anal. Apps., 13 (1992),
 c     pp 357-385.
-c  2. R.B. Lehoucq, "Analysis and Implementation of an Implicitly 
+c  2. R.B. Lehoucq, "Analysis and Implementation of an Implicitly
 c     Restarted Arnoldi Iteration", Rice University Technical Report
 c     TR95-13, Department of Computational and Applied Mathematics.
 c
@@ -149,7 +149,7 @@ c     sgemv    Level 2 BLAS routine for matrix vector multiplication.
 c     saxpy    Level 1 BLAS that computes a vector triad.
 c     sscal    Level 1 BLAS that scales a vector.
 c     scopy    Level 1 BLAS that copies one vector to another .
-c     sdot     Level 1 BLAS that computes the scalar product of two vectors. 
+c     sdot     Level 1 BLAS that computes the scalar product of two vectors.
 c     psnorm2  Parallel version of Level 1 BLAS that computes the norm of a vector.
 c
 c\Author
@@ -157,25 +157,25 @@ c     Danny Sorensen               Phuong Vu
 c     Richard Lehoucq              CRPC / Rice University
 c     Dept. of Computational &     Houston, Texas
 c     Applied Mathematics
-c     Rice University           
-c     Houston, Texas    
-c 
+c     Rice University
+c     Houston, Texas
+c
 c\Parallel Modifications
 c     Kristi Maschhoff
 c
 c\Revision history:
 c     Starting Point: Serial Code FILE: naitr.F   SID: 2.2
 c
-c\SCCS Information: 
-c FILE: naitr.F   SID: 1.3   DATE OF SID: 3/19/97   
+c\SCCS Information:
+c FILE: naitr.F   SID: 1.3   DATE OF SID: 3/19/97
 c
 c\Remarks
 c  The algorithm implemented is:
-c  
+c
 c  restart = .false.
-c  Given V_{k} = [v_{1}, ..., v_{k}], r_{k}; 
+c  Given V_{k} = [v_{1}, ..., v_{k}], r_{k};
 c  r_{k} contains the initial residual vector even for k = 0;
-c  Also assume that rnorm = || B*r_{k} || and B*r_{k} are already 
+c  Also assume that rnorm = || B*r_{k} || and B*r_{k} are already
 c  computed by the calling program.
 c
 c  betaj = rnorm ; p_{k+1} = B*r_{k} ;
@@ -183,7 +183,7 @@ c  For  j = k+1, ..., k+np  Do
 c     1) if ( betaj < tol ) stop or restart depending on j.
 c        ( At present tol is zero )
 c        if ( restart ) generate a new starting vector.
-c     2) v_{j} = r(j-1)/betaj;  V_{j} = [V_{j-1}, v_{j}];  
+c     2) v_{j} = r(j-1)/betaj;  V_{j} = [V_{j-1}, v_{j}];
 c        p_{j} = p_{j}/betaj
 c     3) r_{j} = OP*v_{j} where OP is defined as in psnaupd
 c        For shift-invert mode p_{j} = B*v_{j} is already available.
@@ -198,7 +198,7 @@ c        If (rnorm > 0.717*wnorm) accept step and go back to 1)
 c     5) Re-orthogonalization step:
 c        s = V_{j}'*B*r_{j}
 c        r_{j} = r_{j} - V_{j}*s;  rnorm1 = || r_{j} ||
-c        alphaj = alphaj + s_{j};   
+c        alphaj = alphaj + s_{j};
 c     6) Iterative refinement step:
 c        If (rnorm1 > 0.717*rnorm) then
 c           rnorm = rnorm1
@@ -208,7 +208,7 @@ c           rnorm = rnorm1
 c           If this is the first time in step 6), go to 5)
 c           Else r_{j} lies in the span of V_{j} numerically.
 c              Set r_{j} = 0 and rnorm = 0; go to 1)
-c        EndIf 
+c        EndIf
 c  End Do
 c
 c\EndLib
@@ -216,7 +216,7 @@ c
 c-----------------------------------------------------------------------
 c
       subroutine psnaitr
-     &   (comm, ido, bmat, n, k, np, nb, resid, rnorm, v, ldv, h, ldh, 
+     &   (comm, ido, bmat, n, k, np, nb, resid, rnorm, v, ldv, h, ldh,
      &    ipntr, workd, workl, info)
 c
       include   'mpif.h'
@@ -268,7 +268,7 @@ c
       integer    ierr, i, infol, ipj, irj, ivj, iter, itry, j, msglvl,
      &           jj
       Real
-     &           betaj, ovfl, temp1, rnorm1, smlnum, tst1, ulp, unfl, 
+     &           betaj, ovfl, temp1, rnorm1, smlnum, tst1, ulp, unfl,
      &           wnorm
       save       first, orth1, orth2, rstart, step3, step4,
      &           ierr, ipj, irj, ivj, iter, itry, j, msglvl, ovfl,
@@ -279,7 +279,7 @@ c
 c
 c
 c     %-----------------------%
-c     | Local Array Arguments | 
+c     | Local Array Arguments |
 c     %-----------------------%
 c
       Real
@@ -289,7 +289,7 @@ c     %----------------------%
 c     | External Subroutines |
 c     %----------------------%
 c
-      external   saxpy, scopy, sscal, sgemv, psgetv0, slabad, 
+      external   saxpy, scopy, sscal, sgemv, psgetv0, slabad,
      &           psvout, psmout, pivout, second
 c
 c     %--------------------%
@@ -335,7 +335,7 @@ c
       end if
 c
       if (ido .eq. 0) then
-c 
+c
 c        %-------------------------------%
 c        | Initialize timing statistics  |
 c        | & message level for debugging |
@@ -343,7 +343,7 @@ c        %-------------------------------%
 c
          call second (t0)
          msglvl = mnaitr
-c 
+c
 c        %------------------------------%
 c        | Initial call to this routine |
 c        %------------------------------%
@@ -359,7 +359,7 @@ c
          irj    = ipj   + n
          ivj    = irj   + n
       end if
-c 
+c
 c     %-------------------------------------------------%
 c     | When in reverse communication mode one of:      |
 c     | STEP3, STEP4, ORTH1, ORTH2, RSTART              |
@@ -389,16 +389,16 @@ c     |        A R N O L D I     I T E R A T I O N     L O O P       |
 c     |                                                              |
 c     | Note:  B*r_{j-1} is already in WORKD(1:N)=WORKD(IPJ:IPJ+N-1) |
 c     %--------------------------------------------------------------%
- 
+
  1000 continue
 c
          if (msglvl .gt. 1) then
-            call pivout (comm, logfil, 1, [j], ndigit, 
+            call pivout (comm, logfil, 1, [j], ndigit,
      &                  '_naitr: generating Arnoldi vector number')
-            call psvout (comm, logfil, 1, [rnorm], ndigit, 
+            call psvout (comm, logfil, 1, [rnorm], ndigit,
      &                  '_naitr: B-norm of the current residual is')
          end if
-c 
+c
 c        %---------------------------------------------------%
 c        | STEP 1: Check if the B norm of j-th residual      |
 c        | vector is zero. Equivalent to determing whether   |
@@ -418,13 +418,13 @@ c
                call pivout (comm, logfil, 1, [j], ndigit,
      &                     '_naitr: ****** RESTART AT STEP ******')
             end if
-c 
+c
 c           %---------------------------------------------%
 c           | ITRY is the loop variable that controls the |
 c           | maximum amount of times that a restart is   |
 c           | attempted. NRSTRT is used by stat.h         |
 c           %---------------------------------------------%
-c 
+c
             betaj  = zero
             nrstrt = nrstrt + 1
             itry   = 1
@@ -438,7 +438,7 @@ c           | If in reverse communication mode and |
 c           | RSTART = .true. flow returns here.   |
 c           %--------------------------------------%
 c
-            call psgetv0 ( comm, ido, bmat, itry, .false., n, j, v, ldv, 
+            call psgetv0 ( comm, ido, bmat, itry, .false., n, j, v, ldv,
      &                     resid, rnorm, ipntr, workd, workl, ierr)
             if (ido .ne. 99) go to 9000
             if (ierr .lt. 0) then
@@ -457,7 +457,7 @@ c
                ido = 99
                go to 9000
             end if
-c 
+c
    40    continue
 c
 c        %---------------------------------------------------------%
@@ -479,9 +479,9 @@ c            | To scale both v_{j} and p_{j} carefully |
 c            | use LAPACK routine SLASCL               |
 c            %-----------------------------------------%
 c
-             call slascl ('General', i, i, rnorm, one, n, 1, 
+             call slascl ('General', i, i, rnorm, one, n, 1,
      &                    v(1,j), n, infol)
-             call slascl ('General', i, i, rnorm, one, n, 1, 
+             call slascl ('General', i, i, rnorm, one, n, 1,
      &                    workd(ipj), n, infol)
          end if
 c
@@ -498,14 +498,14 @@ c
          ipntr(2) = irj
          ipntr(3) = ipj
          ido = 1
-c 
+c
 c        %-----------------------------------%
 c        | Exit in order to compute OP*v_{j} |
 c        %-----------------------------------%
-c 
-         go to 9000 
+c
+         go to 9000
    50    continue
-c 
+c
 c        %----------------------------------%
 c        | Back from reverse communication; |
 c        | WORKD(IRJ:IRJ+N-1) := OP*v_{j}   |
@@ -514,7 +514,7 @@ c        %----------------------------------%
 c
          call second (t3)
          tmvopx = tmvopx + (t3 - t2)
- 
+
          step3 = .false.
 c
 c        %------------------------------------------%
@@ -522,7 +522,7 @@ c        | Put another copy of OP*v_{j} into RESID. |
 c        %------------------------------------------%
 c
          call scopy (n, workd(irj), 1, resid, 1)
-c 
+c
 c        %---------------------------------------%
 c        | STEP 4:  Finish extending the Arnoldi |
 c        |          factorization to length j.   |
@@ -535,17 +535,17 @@ c
             ipntr(1) = irj
             ipntr(2) = ipj
             ido = 2
-c 
+c
 c           %-------------------------------------%
 c           | Exit in order to compute B*OP*v_{j} |
 c           %-------------------------------------%
-c 
+c
             go to 9000
          else if (bmat .eq. 'I') then
             call scopy (n, resid, 1, workd(ipj), 1)
          end if
    60    continue
-c 
+c
 c        %----------------------------------%
 c        | Back from reverse communication; |
 c        | WORKD(IPJ:IPJ+N-1) := B*OP*v_{j} |
@@ -556,7 +556,7 @@ c
             call second (t3)
             tmvbx = tmvbx + (t3 - t2)
          end if
-c 
+c
          step4 = .false.
 c
 c        %-------------------------------------%
@@ -594,7 +594,7 @@ c
 c
 c        %--------------------------------------%
 c        | Orthogonalize r_{j} against V_{j}.   |
-c        | RESID contains OP*v_{j}. See STEP 3. | 
+c        | RESID contains OP*v_{j}. See STEP 3. |
 c        %--------------------------------------%
 c
          call sgemv ('N', n, j, -one, v, ldv, h(1,j), 1,
@@ -603,7 +603,7 @@ c
          if (j .gt. 1) h(j,j-1) = betaj
 c
          call second (t4)
-c 
+c
          orth1 = .true.
 c
          call second (t2)
@@ -613,17 +613,17 @@ c
             ipntr(1) = irj
             ipntr(2) = ipj
             ido = 2
-c 
+c
 c           %----------------------------------%
 c           | Exit in order to compute B*r_{j} |
 c           %----------------------------------%
-c 
+c
             go to 9000
          else if (bmat .eq. 'I') then
             call scopy (n, resid, 1, workd(ipj), 1)
-         end if 
+         end if
    70    continue
-c 
+c
 c        %---------------------------------------------------%
 c        | Back from reverse communication if ORTH1 = .true. |
 c        | WORKD(IPJ:IPJ+N-1) := B*r_{j}.                    |
@@ -633,7 +633,7 @@ c
             call second (t3)
             tmvbx = tmvbx + (t3 - t2)
          end if
-c 
+c
          orth1 = .false.
 c
 c        %------------------------------%
@@ -648,7 +648,7 @@ c
          else if (bmat .eq. 'I') then
             rnorm = psnorm2( comm, n, resid, 1 )
          end if
-c 
+c
 c        %-----------------------------------------------------------%
 c        | STEP 5: Re-orthogonalization / Iterative refinement phase |
 c        | Maximum NITER_ITREF tries.                                |
@@ -670,20 +670,20 @@ c
          if (rnorm .gt. 0.717*wnorm) go to 100
          iter  = 0
          nrorth = nrorth + 1
-c 
+c
 c        %---------------------------------------------------%
 c        | Enter the Iterative refinement phase. If further  |
 c        | refinement is necessary, loop back here. The loop |
 c        | variable is ITER. Perform a step of Classical     |
 c        | Gram-Schmidt using all the Arnoldi vectors V_{j}  |
 c        %---------------------------------------------------%
-c 
+c
    80    continue
 c
          if (msglvl .gt. 2) then
             xtemp(1) = wnorm
             xtemp(2) = rnorm
-            call psvout (comm, logfil, 2, xtemp, ndigit, 
+            call psvout (comm, logfil, 2, xtemp, ndigit,
      &           '_naitr: re-orthonalization; wnorm and rnorm are')
             call psvout (comm, logfil, j, h(1,j), ndigit,
      &                  '_naitr: j-th column of H')
@@ -706,10 +706,10 @@ c        | The correction to H is v(:,1:J)*H(1:J,1:J)  |
 c        | + v(:,1:J)*WORKD(IRJ:IRJ+J-1)*e'_j.         |
 c        %---------------------------------------------%
 c
-         call sgemv ('N', n, j, -one, v, ldv, workl(1), 1, 
+         call sgemv ('N', n, j, -one, v, ldv, workl(1), 1,
      &               one, resid, 1)
          call saxpy (j, one, workl(1), 1, h(1,j), 1)
-c 
+c
          orth2 = .true.
          call second (t2)
          if (bmat .eq. 'G') then
@@ -718,16 +718,16 @@ c
             ipntr(1) = irj
             ipntr(2) = ipj
             ido = 2
-c 
+c
 c           %-----------------------------------%
 c           | Exit in order to compute B*r_{j}. |
 c           | r_{j} is the corrected residual.  |
 c           %-----------------------------------%
-c 
+c
             go to 9000
          else if (bmat .eq. 'I') then
             call scopy (n, resid, 1, workd(ipj), 1)
-         end if 
+         end if
    90    continue
 c
 c        %---------------------------------------------------%
@@ -742,7 +742,7 @@ c
 c        %-----------------------------------------------------%
 c        | Compute the B-norm of the corrected residual r_{j}. |
 c        %-----------------------------------------------------%
-c 
+c
          if (bmat .eq. 'G') then
            rnorm_buf = sdot (n, resid, 1, workd(ipj), 1)
            call MPI_ALLREDUCE( rnorm_buf, rnorm1, 1,
@@ -751,14 +751,14 @@ c
          else if (bmat .eq. 'I') then
            rnorm1 = psnorm2( comm, n, resid, 1 )
          end if
-c 
+c
          if (msglvl .gt. 0 .and. iter .gt. 0) then
             call pivout (comm, logfil, 1, [j], ndigit,
      &           '_naitr: Iterative refinement for Arnoldi residual')
             if (msglvl .gt. 2) then
                 xtemp(1) = rnorm
                 xtemp(2) = rnorm1
-                call psvout (comm, logfil, 2, xtemp, ndigit, 
+                call psvout (comm, logfil, 2, xtemp, ndigit,
      &           '_naitr: iterative refinement ; rnorm and rnorm1 are')
             end if
          end if
@@ -781,7 +781,7 @@ c           | angle of less than arcCOS(0.717)      |
 c           %---------------------------------------%
 c
             rnorm = rnorm1
-c 
+c
          else
 c
 c           %-------------------------------------------%
@@ -803,21 +803,21 @@ c
   95        continue
             rnorm = zero
          end if
-c 
+c
 c        %----------------------------------------------%
 c        | Branch here directly if iterative refinement |
 c        | wasn't necessary or after at most NITER_REF  |
 c        | steps of iterative refinement.               |
 c        %----------------------------------------------%
-c 
+c
   100    continue
-c 
+c
          rstart = .false.
          orth2  = .false.
-c 
+c
          call second (t5)
          titref = titref + (t5 - t4)
-c 
+c
 c        %------------------------------------%
 c        | STEP 6: Update  j = j+1;  Continue |
 c        %------------------------------------%
@@ -828,25 +828,25 @@ c
             tnaitr = tnaitr + (t1 - t0)
             ido = 99
             do 110 i = max(1,k), k+np-1
-c     
+c
 c              %--------------------------------------------%
 c              | Check for splitting and deflation.         |
 c              | Use a standard test as in the QR algorithm |
 c              | REFERENCE: LAPACK subroutine slahqr        |
 c              %--------------------------------------------%
-c     
+c
                tst1 = abs( h( i, i ) ) + abs( h( i+1, i+1 ) )
                if( tst1.eq.zero )
      &              tst1 = slanhs( '1', k+np, h, ldh, workd(n+1) )
-               if( abs( h( i+1,i ) ).le.max( ulp*tst1, smlnum ) ) 
+               if( abs( h( i+1,i ) ).le.max( ulp*tst1, smlnum ) )
      &              h(i+1,i) = zero
  110        continue
-c     
+c
             if (msglvl .gt. 2) then
-               call psmout (comm, logfil, k+np, k+np, h, ldh, ndigit, 
+               call psmout (comm, logfil, k+np, k+np, h, ldh, ndigit,
      &          '_naitr: Final upper Hessenberg matrix H of order K+NP')
             end if
-c     
+c
             go to 9000
          end if
 c
@@ -855,7 +855,7 @@ c        | Loop back to extend the factorization by another step. |
 c        %--------------------------------------------------------%
 c
       go to 1000
-c 
+c
 c     %---------------------------------------------------------------%
 c     |                                                               |
 c     |  E N D     O F     M A I N     I T E R A T I O N     L O O P  |

--- a/mathlibs/src/parpack/psnaitr.f
+++ b/mathlibs/src/parpack/psnaitr.f
@@ -393,9 +393,9 @@ c     %--------------------------------------------------------------%
  1000 continue
 c
          if (msglvl .gt. 1) then
-            call pivout (comm, logfil, 1, j, ndigit, 
+            call pivout (comm, logfil, 1, [j], ndigit, 
      &                  '_naitr: generating Arnoldi vector number')
-            call psvout (comm, logfil, 1, rnorm, ndigit, 
+            call psvout (comm, logfil, 1, [rnorm], ndigit, 
      &                  '_naitr: B-norm of the current residual is')
          end if
 c 
@@ -415,7 +415,7 @@ c           | basis and continue the iteration.                 |
 c           %---------------------------------------------------%
 c
             if (msglvl .gt. 0) then
-               call pivout (comm, logfil, 1, j, ndigit,
+               call pivout (comm, logfil, 1, [j], ndigit,
      &                     '_naitr: ****** RESTART AT STEP ******')
             end if
 c 
@@ -753,7 +753,7 @@ c
          end if
 c 
          if (msglvl .gt. 0 .and. iter .gt. 0) then
-            call pivout (comm, logfil, 1, j, ndigit,
+            call pivout (comm, logfil, 1, [j], ndigit,
      &           '_naitr: Iterative refinement for Arnoldi residual')
             if (msglvl .gt. 2) then
                 xtemp(1) = rnorm

--- a/mathlibs/src/parpack/psnapps.f
+++ b/mathlibs/src/parpack/psnapps.f
@@ -276,11 +276,11 @@ c
          sigmai = shifti(jj)
 c
          if (msglvl .gt. 2 ) then
-            call pivout (comm, logfil, 1, jj, ndigit, 
+            call pivout (comm, logfil, 1, [jj], ndigit, 
      &               '_napps: shift number.')
-            call psvout (comm, logfil, 1, sigmar, ndigit, 
+            call psvout (comm, logfil, 1, [sigmar], ndigit, 
      &               '_napps: The real part of the shift ')
-            call psvout (comm, logfil, 1, sigmai, ndigit, 
+            call psvout (comm, logfil, 1, [sigmai], ndigit, 
      &               '_napps: The imaginary part of the shift ')
          end if
 c
@@ -345,9 +345,9 @@ c
      &         tst1 = slanhs( '1', kplusp-jj+1, h, ldh, workl )
             if( abs( h( i+1,i ) ).le.max( ulp*tst1, smlnum ) ) then
                if (msglvl .gt. 0) then
-                  call pivout (comm, logfil, 1, i, ndigit, 
+                  call pivout (comm, logfil, 1, [i], ndigit, 
      &                 '_napps: matrix splitting at row/column no.')
-                  call pivout (comm, logfil, 1, jj, ndigit, 
+                  call pivout (comm, logfil, 1, [jj], ndigit, 
      &                 '_napps: matrix splitting with shift number.')
                   call psvout (comm, logfil, 1, h(i+1,i), ndigit, 
      &                 '_napps: off diagonal element.')
@@ -361,9 +361,9 @@ c
    40    continue
 c
          if (msglvl .gt. 2) then
-             call pivout (comm, logfil, 1, istart, ndigit, 
+             call pivout (comm, logfil, 1, [istart], ndigit, 
      &                   '_napps: Start of current block ')
-             call pivout (comm, logfil, 1, iend, ndigit, 
+             call pivout (comm, logfil, 1, [iend], ndigit, 
      &                   '_napps: End of current block ')
          end if
 c
@@ -635,7 +635,7 @@ c
      &        '_napps: sigmak = (e_{kev+p}^T*Q)*e_{kev}')
          call psvout (comm, logfil, 1, h(kev+1,kev), ndigit,
      &        '_napps: betak = e_{kev+1}^T*H*e_{kev}')
-         call pivout (comm, logfil, 1, kev, ndigit, 
+         call pivout (comm, logfil, 1, [kev], ndigit, 
      &               '_napps: Order of the final Hessenberg matrix ')
          if (msglvl .gt. 2) then
             call psmout (comm, logfil, kev, kev, h, ldh, ndigit,

--- a/mathlibs/src/parpack/psnapps.f
+++ b/mathlibs/src/parpack/psnapps.f
@@ -22,7 +22,7 @@ c     A*VNEW_{k} - VNEW_{k}*HNEW_{k} = rnew_{k}*e_{k}^T.
 c
 c\Usage:
 c  call psnapps
-c     ( COMM, N, KEV, NP, SHIFTR, SHIFTI, V, LDV, H, LDH, RESID, Q, LDQ, 
+c     ( COMM, N, KEV, NP, SHIFTR, SHIFTI, V, LDV, H, LDH, RESID, Q, LDQ,
 c       WORKL, WORKD )
 c
 c\Arguments
@@ -33,7 +33,7 @@ c          Problem size, i.e. size of matrix A.
 c
 c  KEV     Integer.  (INPUT/OUTPUT)
 c          KEV+NP is the size of the input matrix H.
-c          KEV is the size of the updated matrix HNEW.  KEV is only 
+c          KEV is the size of the updated matrix HNEW.  KEV is only
 c          updated on ouput when fewer than NP shifts are applied in
 c          order to keep the conjugate pair together.
 c
@@ -42,7 +42,7 @@ c          Number of implicit shifts to be applied.
 c
 c  SHIFTR, Real array of length NP.  (INPUT)
 c  SHIFTI  Real and imaginary part of the shifts to be applied.
-c          Upon, entry to psnapps, the shifts must be sorted so that the 
+c          Upon, entry to psnapps, the shifts must be sorted so that the
 c          conjugate pairs are in consecutive locations.
 c
 c  V       Real N by (KEV+NP) array.  (INPUT/OUTPUT)
@@ -55,7 +55,7 @@ c          Leading dimension of V exactly as declared in the calling
 c          program.
 c
 c  H       Real (KEV+NP) by (KEV+NP) array.  (INPUT/OUTPUT)
-c          On INPUT, H contains the current KEV+NP by KEV+NP upper 
+c          On INPUT, H contains the current KEV+NP by KEV+NP upper
 c          Hessenber matrix of the Arnoldi factorization.
 c          On OUTPUT, H contains the updated KEV by KEV upper Hessenberg
 c          matrix in the KEV leading submatrix.
@@ -66,7 +66,7 @@ c          program.
 c
 c  RESID   Real array of length N.  (INPUT/OUTPUT)
 c          On INPUT, RESID contains the the residual vector r_{k+p}.
-c          On OUTPUT, RESID is the update residual vector rnew_{k} 
+c          On OUTPUT, RESID is the update residual vector rnew_{k}
 c          in the first KEV locations.
 c
 c  Q       Real KEV+NP by KEV+NP work array.  (WORKSPACE)
@@ -120,8 +120,8 @@ c     Danny Sorensen               Phuong Vu
 c     Richard Lehoucq              CRPC / Rice University
 c     Dept. of Computational &     Houston, Texas
 c     Applied Mathematics
-c     Rice University           
-c     Houston, Texas    
+c     Rice University
+c     Houston, Texas
 c
 c\Parallel Modifications
 c     Kristi Maschhoff
@@ -129,8 +129,8 @@ c
 c\Revision history:
 c     Starting Point: Serial Code FILE: napps.F   SID: 2.2
 c
-c\SCCS Information: 
-c FILE: napps.F   SID: 1.5   DATE OF SID: 03/19/97   
+c\SCCS Information:
+c FILE: napps.F   SID: 1.5   DATE OF SID: 03/19/97
 c
 c\Remarks
 c  1. In this version, each shift is applied to all the sublocks of
@@ -144,7 +144,7 @@ c
 c-----------------------------------------------------------------------
 c
       subroutine psnapps
-     &   ( comm, n, kev, np, shiftr, shifti, v, ldv, h, ldh, resid, 
+     &   ( comm, n, kev, np, shiftr, shifti, v, ldv, h, ldh, resid,
      &     q, ldq, workl, workd )
 c
 c     %--------------------%
@@ -171,7 +171,7 @@ c     | Array Arguments |
 c     %-----------------%
 c
       Real
-     &           h(ldh,kev+np), resid(n), shifti(np), shiftr(np), 
+     &           h(ldh,kev+np), resid(n), shifti(np), shiftr(np),
      &           v(ldv,kev+np), q(ldq,kev+np), workd(2*n), workl(kev+np)
 c
 c     %------------%
@@ -189,15 +189,15 @@ c
       integer    i, iend, ir, istart, j, jj, kplusp, msglvl, nr
       logical    cconj, first
       Real
-     &           c, f, g, h11, h12, h21, h22, h32, ovfl, r, s, sigmai, 
+     &           c, f, g, h11, h12, h21, h22, h32, ovfl, r, s, sigmai,
      &           sigmar, smlnum, ulp, unfl, u(3), t, tau, tst1
-      save       first, ovfl, smlnum, ulp, unfl 
+      save       first, ovfl, smlnum, ulp, unfl
 c
 c     %----------------------%
 c     | External Subroutines |
 c     %----------------------%
 c
-      external   saxpy, scopy, sscal, slacpy, slarf, slarfg, slartg, 
+      external   saxpy, scopy, sscal, slacpy, slarf, slarfg, slartg,
      &           slaset, slabad, second, pivout, psvout, psmout
 c
 c     %--------------------%
@@ -248,9 +248,9 @@ c     %-------------------------------%
 c
       call second (t0)
       msglvl = mnapps
-c 
-      kplusp = kev + np 
-c 
+c
+      kplusp = kev + np
+c
 c     %--------------------------------------------%
 c     | Initialize Q to the identity to accumulate |
 c     | the rotations and reflections              |
@@ -276,11 +276,11 @@ c
          sigmai = shifti(jj)
 c
          if (msglvl .gt. 2 ) then
-            call pivout (comm, logfil, 1, [jj], ndigit, 
+            call pivout (comm, logfil, 1, [jj], ndigit,
      &               '_napps: shift number.')
-            call psvout (comm, logfil, 1, [sigmar], ndigit, 
+            call psvout (comm, logfil, 1, [sigmar], ndigit,
      &               '_napps: The real part of the shift ')
-            call psvout (comm, logfil, 1, [sigmai], ndigit, 
+            call psvout (comm, logfil, 1, [sigmai], ndigit,
      &               '_napps: The imaginary part of the shift ')
          end if
 c
@@ -345,11 +345,11 @@ c
      &         tst1 = slanhs( '1', kplusp-jj+1, h, ldh, workl )
             if( abs( h( i+1,i ) ).le.max( ulp*tst1, smlnum ) ) then
                if (msglvl .gt. 0) then
-                  call pivout (comm, logfil, 1, [i], ndigit, 
+                  call pivout (comm, logfil, 1, [i], ndigit,
      &                 '_napps: matrix splitting at row/column no.')
-                  call pivout (comm, logfil, 1, [jj], ndigit, 
+                  call pivout (comm, logfil, 1, [jj], ndigit,
      &                 '_napps: matrix splitting with shift number.')
-                  call psvout (comm, logfil, 1, h(i+1,i), ndigit, 
+                  call psvout (comm, logfil, 1, h(i+1,i), ndigit,
      &                 '_napps: off diagonal element.')
                end if
                iend = i
@@ -361,9 +361,9 @@ c
    40    continue
 c
          if (msglvl .gt. 2) then
-             call pivout (comm, logfil, 1, [istart], ndigit, 
+             call pivout (comm, logfil, 1, [istart], ndigit,
      &                   '_napps: Start of current block ')
-             call pivout (comm, logfil, 1, [iend], ndigit, 
+             call pivout (comm, logfil, 1, [iend], ndigit,
      &                   '_napps: End of current block ')
          end if
 c
@@ -378,7 +378,7 @@ c        | If istart + 1 = iend then no reason to apply a       |
 c        | complex conjugate pair of shifts on a 2 by 2 matrix. |
 c        %------------------------------------------------------%
 c
-         if ( istart + 1 .eq. iend .and. abs( sigmai ) .gt. zero ) 
+         if ( istart + 1 .eq. iend .and. abs( sigmai ) .gt. zero )
      &      go to 100
 c
          h11 = h(istart,istart)
@@ -391,7 +391,7 @@ c           %---------------------------------------------%
 c
             f = h11 - sigmar
             g = h21
-c 
+c
             do 80 i = istart, iend-1
 c
 c              %-----------------------------------------------------%
@@ -423,7 +423,7 @@ c
                do 50 j = i, kplusp
                   t        =  c*h(i,j) + s*h(i+1,j)
                   h(i+1,j) = -s*h(i,j) + c*h(i+1,j)
-                  h(i,j)   = t   
+                  h(i,j)   = t
    50          continue
 c
 c              %---------------------------------------------%
@@ -433,7 +433,7 @@ c
                do 60 j = 1, min(i+2,iend)
                   t        =  c*h(j,i) + s*h(j,i+1)
                   h(j,i+1) = -s*h(j,i) + c*h(j,i+1)
-                  h(j,i)   = t   
+                  h(j,i)   = t
    60          continue
 c
 c              %----------------------------------------------------%
@@ -443,7 +443,7 @@ c
                do 70 j = 1, min( i+jj, kplusp )
                   t        =   c*q(j,i) + s*q(j,i+1)
                   q(j,i+1) = - s*q(j,i) + c*q(j,i+1)
-                  q(j,i)   = t   
+                  q(j,i)   = t
    70          continue
 c
 c              %---------------------------%
@@ -459,7 +459,7 @@ c
 c           %-----------------------------------%
 c           | Finished applying the real shift. |
 c           %-----------------------------------%
-c 
+c
          else
 c
 c           %----------------------------------------------------%
@@ -475,9 +475,9 @@ c           | Compute 1st column of (H - shift*I)*(H - conj(shift)*I) |
 c           %---------------------------------------------------------%
 c
             s    = 2.0*sigmar
-            t = slapy2 ( sigmar, sigmai ) 
+            t = slapy2 ( sigmar, sigmai )
             u(1) = ( h11 * (h11 - s) + t * t ) / h21 + h12
-            u(2) = h11 + h22 - s 
+            u(2) = h11 + h22 - s
             u(3) = h32
 c
             do 90 i = istart, iend-1
@@ -517,7 +517,7 @@ c              %-----------------------------------------------------%
 c              | Accumulate the reflector in the matrix Q;  Q <- Q*G |
 c              %-----------------------------------------------------%
 c
-               call slarf ('Right', kplusp, nr, u, 1, tau, 
+               call slarf ('Right', kplusp, nr, u, 1, tau,
      &                     q(1,i), ldq, workl)
 c
 c              %----------------------------%
@@ -536,7 +536,7 @@ c           %--------------------------------------------%
 c           | Finished applying a complex pair of shifts |
 c           | to the current block                       |
 c           %--------------------------------------------%
-c 
+c
          end if
 c
   100    continue
@@ -593,7 +593,7 @@ c
       if (h(kev+1,kev) .gt. zero)
      &    call sgemv ('N', n, kplusp, one, v, ldv, q(1,kev+1), 1, zero,
      &                workd(n+1), 1)
-c 
+c
 c     %----------------------------------------------------------%
 c     | Compute column 1 to kev of (V*Q) in backward order       |
 c     | taking advantage of the upper Hessenberg structure of Q. |
@@ -610,7 +610,7 @@ c     |  Move v(:,kplusp-kev+1:kplusp) into v(:,1:kev). |
 c     %-------------------------------------------------%
 c
       call slacpy ('A', n, kev, v(1,kplusp-kev+1), ldv, v, ldv)
-c 
+c
 c     %--------------------------------------------------------------%
 c     | Copy the (kev+1)-st column of (V*Q) in the appropriate place |
 c     %--------------------------------------------------------------%
@@ -635,19 +635,19 @@ c
      &        '_napps: sigmak = (e_{kev+p}^T*Q)*e_{kev}')
          call psvout (comm, logfil, 1, h(kev+1,kev), ndigit,
      &        '_napps: betak = e_{kev+1}^T*H*e_{kev}')
-         call pivout (comm, logfil, 1, [kev], ndigit, 
+         call pivout (comm, logfil, 1, [kev], ndigit,
      &               '_napps: Order of the final Hessenberg matrix ')
          if (msglvl .gt. 2) then
             call psmout (comm, logfil, kev, kev, h, ldh, ndigit,
      &      '_napps: updated Hessenberg matrix H for next iteration')
          end if
-c 
+c
       end if
-c 
+c
  9000 continue
       call second (t1)
       tnapps = tnapps + (t1 - t0)
-c 
+c
       return
 c
 c     %----------------%

--- a/mathlibs/src/parpack/psnaup2.f
+++ b/mathlibs/src/parpack/psnaup2.f
@@ -408,7 +408,7 @@ c
          iter = iter + 1
 c
          if (msglvl .gt. 0) then
-            call pivout (comm, logfil, 1, iter, ndigit, 
+            call pivout (comm, logfil, 1, [iter], ndigit, 
      &           '_naup2: **** Start of major iteration number ****')
          end if
 c 
@@ -421,9 +421,9 @@ c
          np  = kplusp - nev
 c
          if (msglvl .gt. 1) then
-            call pivout (comm, logfil, 1, nev, ndigit, 
+            call pivout (comm, logfil, 1, [nev], ndigit, 
      &     '_naup2: The length of the current Arnoldi factorization')
-            call pivout (comm, logfil, 1, np, ndigit, 
+            call pivout (comm, logfil, 1, [np], ndigit, 
      &           '_naup2: Extend the Arnoldi factorization by')
          end if
 c
@@ -455,7 +455,7 @@ c
          update = .false.
 c
          if (msglvl .gt. 1) then
-            call psvout (comm, logfil, 1, rnorm, ndigit, 
+            call psvout (comm, logfil, 1, [rnorm], ndigit, 
      &           '_naup2: Corresponding B-norm of the residual')
          end if
 c 
@@ -699,7 +699,7 @@ c
          end if              
 c     
          if (msglvl .gt. 0) then
-            call pivout (comm, logfil, 1, nconv, ndigit, 
+            call pivout (comm, logfil, 1, [nconv], ndigit, 
      &           '_naup2: no. of "converged" Ritz values at this iter.')
             if (msglvl .gt. 1) then
                kp(1) = nev
@@ -751,7 +751,7 @@ c
          end if
 c
          if (msglvl .gt. 2) then 
-            call pivout (comm, logfil, 1, np, ndigit, 
+            call pivout (comm, logfil, 1, [np], ndigit, 
      &                  '_naup2: The number of shifts to apply ')
             call psvout (comm, logfil, np, ritzr, ndigit,
      &                  '_naup2: Real part of the shifts')
@@ -819,7 +819,7 @@ c
          cnorm = .false.
 c
          if (msglvl .gt. 2) then
-            call psvout (comm, logfil, 1, rnorm, ndigit, 
+            call psvout (comm, logfil, 1, [rnorm], ndigit, 
      &      '_naup2: B-norm of residual for compressed factorization')
             call psmout (comm, logfil, nev, nev, h, ldh, ndigit,
      &        '_naup2: Compressed upper Hessenberg matrix H')

--- a/mathlibs/src/parpack/psnaup2.f
+++ b/mathlibs/src/parpack/psnaup2.f
@@ -2,15 +2,15 @@ c\BeginDoc
 c
 c\Name: psnaup2
 c
-c Message Passing Layer: MPI 
+c Message Passing Layer: MPI
 c
-c\Description: 
+c\Description:
 c  Intermediate level interface called by psnaupd.
 c
 c\Usage:
 c  call psnaup2
 c     ( COMM, IDO, BMAT, N, WHICH, NEV, NP, TOL, RESID, MODE, IUPD,
-c       ISHIFT, MXITER, V, LDV, H, LDH, RITZR, RITZI, BOUNDS, 
+c       ISHIFT, MXITER, V, LDV, H, LDH, RITZR, RITZI, BOUNDS,
 c       Q, LDQ, WORKL, IPNTR, WORKD, INFO )
 c
 c\Arguments
@@ -19,22 +19,22 @@ c  COMM, IDO, BMAT, N, WHICH, NEV, TOL, RESID: same as defined in psnaupd.
 c  MODE, ISHIFT, MXITER: see the definition of IPARAM in psnaupd.
 c
 c  NP      Integer.  (INPUT/OUTPUT)
-c          Contains the number of implicit shifts to apply during 
-c          each Arnoldi iteration.  
-c          If ISHIFT=1, NP is adjusted dynamically at each iteration 
+c          Contains the number of implicit shifts to apply during
+c          each Arnoldi iteration.
+c          If ISHIFT=1, NP is adjusted dynamically at each iteration
 c          to accelerate convergence and prevent stagnation.
-c          This is also roughly equal to the number of matrix-vector 
+c          This is also roughly equal to the number of matrix-vector
 c          products (involving the operator OP) per Arnoldi iteration.
 c          The logic for adjusting is contained within the current
 c          subroutine.
 c          If ISHIFT=0, NP is the number of shifts the user needs
 c          to provide via reverse comunication. 0 < NP < NCV-NEV.
 c          NP may be less than NCV-NEV for two reasons. The first, is
-c          to keep complex conjugate pairs of "wanted" Ritz values 
+c          to keep complex conjugate pairs of "wanted" Ritz values
 c          together. The second, is that a leading block of the current
 c          upper Hessenberg matrix has split off and contains "unwanted"
 c          Ritz values.
-c          Upon termination of the IRA iteration, NP contains the number 
+c          Upon termination of the IRA iteration, NP contains the number
 c          of "converged" wanted Ritz values.
 c
 c  IUPD    Integer.  (INPUT)
@@ -42,18 +42,18 @@ c          IUPD .EQ. 0: use explicit restart instead implicit update.
 c          IUPD .NE. 0: use implicit update.
 c
 c  V       Real  N by (NEV+NP) array.  (INPUT/OUTPUT)
-c          The Arnoldi basis vectors are returned in the first NEV 
+c          The Arnoldi basis vectors are returned in the first NEV
 c          columns of V.
 c
 c  LDV     Integer.  (INPUT)
-c          Leading dimension of V exactly as declared in the calling 
+c          Leading dimension of V exactly as declared in the calling
 c          program.
 c
 c  H       Real  (NEV+NP) by (NEV+NP) array.  (OUTPUT)
 c          H is used to store the generated upper Hessenberg matrix
 c
 c  LDH     Integer.  (INPUT)
-c          Leading dimension of H exactly as declared in the calling 
+c          Leading dimension of H exactly as declared in the calling
 c          program.
 c
 c  RITZR,  Real  arrays of length NEV+NP.  (OUTPUT)
@@ -61,9 +61,9 @@ c  RITZI   RITZR(1:NEV) (resp. RITZI(1:NEV)) contains the real (resp.
 c          imaginary) part of the computed Ritz values of OP.
 c
 c  BOUNDS  Real  array of length NEV+NP.  (OUTPUT)
-c          BOUNDS(1:NEV) contain the error bounds corresponding to 
+c          BOUNDS(1:NEV) contain the error bounds corresponding to
 c          the computed Ritz values.
-c          
+c
 c  Q       Real  (NEV+NP) by (NEV+NP) array.  (WORKSPACE)
 c          Private (replicated) work array used to accumulate the
 c          rotation in the shift application step.
@@ -72,7 +72,7 @@ c  LDQ     Integer.  (INPUT)
 c          Leading dimension of Q exactly as declared in the calling
 c          program.
 c
-c  WORKL   Real  work array of length at least 
+c  WORKL   Real  work array of length at least
 c          (NEV+NP)**2 + 3*(NEV+NP).  (INPUT/WORKSPACE)
 c          Private (replicated) array on each PE or array allocated on
 c          the front end.  It is used in shifts calculation, shifts
@@ -84,19 +84,19 @@ c          estimates of the current Hessenberg matrix.  They are
 c          listed in the same order as returned from sneigh.
 c
 c          If ISHIFT .EQ. O and IDO .EQ. 3, the first 2*NP locations
-c          of WORKL are used in reverse communication to hold the user 
+c          of WORKL are used in reverse communication to hold the user
 c          supplied shifts.
 c
 c  IPNTR   Integer array of length 3.  (OUTPUT)
-c          Pointer to mark the starting locations in the WORKD for 
+c          Pointer to mark the starting locations in the WORKD for
 c          vectors used by the Arnoldi iteration.
 c          -------------------------------------------------------------
 c          IPNTR(1): pointer to the current operand vector X.
 c          IPNTR(2): pointer to the current result vector Y.
-c          IPNTR(3): pointer to the vector B * X when used in the 
+c          IPNTR(3): pointer to the vector B * X when used in the
 c                    shift-and-invert mode.  X is the current operand.
 c          -------------------------------------------------------------
-c          
+c
 c  WORKD   Real  work array of length 3*N.  (WORKSPACE)
 c          Distributed array to be used in the basic Arnoldi iteration
 c          for reverse communication.  The user should not use WORKD
@@ -110,7 +110,7 @@ c                          possibly from a previous run.
 c          Error flag on output.
 c          =     0: Normal return.
 c          =     1: Maximum number of iterations taken.
-c                   All possible eigenvalues of OP has been found.  
+c                   All possible eigenvalues of OP has been found.
 c                   NP returns the number of converged Ritz values.
 c          =     2: No shifts could be applied.
 c          =    -8: Error return from LAPACK eigenvalue calculation;
@@ -132,12 +132,12 @@ c\References:
 c  1. D.C. Sorensen, "Implicit Application of Polynomial Filters in
 c     a k-Step Arnoldi Method", SIAM J. Matr. Anal. Apps., 13 (1992),
 c     pp 357-385.
-c  2. R.B. Lehoucq, "Analysis and Implementation of an Implicitly 
+c  2. R.B. Lehoucq, "Analysis and Implementation of an Implicitly
 c     Restarted Arnoldi Iteration", Rice University Technical Report
 c     TR95-13, Department of Computational and Applied Mathematics.
 c
 c\Routines called:
-c     psgetv0  Parallel ARPACK initial vector generation routine. 
+c     psgetv0  Parallel ARPACK initial vector generation routine.
 c     psnaitr  Parallel ARPACK Arnoldi factorization routine.
 c     psnapps  Parallel ARPACK application of implicit shifts routine.
 c     snconv   ARPACK convergence of Ritz values routine.
@@ -151,7 +151,7 @@ c     psvout   ARPACK utility routine that prints vectors.
 c     pslamch  ScaLAPACK routine that determines machine constants.
 c     slapy2   LAPACK routine to compute sqrt(x**2+y**2) carefully.
 c     scopy    Level 1 BLAS that copies one vector to another .
-c     sdot     Level 1 BLAS that computes the scalar product of two vectors. 
+c     sdot     Level 1 BLAS that computes the scalar product of two vectors.
 c     psnorm2  Parallel version of Level 1 BLAS that computes the norm of a vector.
 c     sswap    Level 1 BLAS that swaps two vectors.
 c
@@ -160,14 +160,14 @@ c     Danny Sorensen               Phuong Vu
 c     Richard Lehoucq              Cray Research, Inc. &
 c     Dept. of Computational &     CRPC / Rice University
 c     Applied Mathematics          Houston, Texas
-c     Rice University           
-c     Houston, Texas    
-c 
+c     Rice University
+c     Houston, Texas
+c
 c\Revision history:
 c     Starting Point: Serial Code FILE: naup2.F   SID: 2.2
 c
-c\SCCS Information: 
-c FILE: naup2.F   SID: 1.5   DATE OF SID: 06/01/00   
+c\SCCS Information:
+c FILE: naup2.F   SID: 1.5   DATE OF SID: 06/01/00
 c
 c\Remarks
 c     1. None
@@ -177,8 +177,8 @@ c
 c-----------------------------------------------------------------------
 c
       subroutine psnaup2
-     &   ( comm, ido, bmat, n, which, nev, np, tol, resid, mode, iupd, 
-     &     ishift, mxiter, v, ldv, h, ldh, ritzr, ritzi, bounds, 
+     &   ( comm, ido, bmat, n, which, nev, np, tol, resid, mode, iupd,
+     &     ishift, mxiter, v, ldv, h, ldh, ritzr, ritzi, bounds,
      &     q, ldq, workl, ipntr, workd, info )
 c
       include   'mpif.h'
@@ -203,7 +203,7 @@ c
       character  bmat*1, which*2
       integer    ido, info, ishift, iupd, mode, ldh, ldq, ldv, mxiter,
      &           n, nev, np
-      Real 
+      Real
      &           tol
 c
 c     %-----------------%
@@ -211,16 +211,16 @@ c     | Array Arguments |
 c     %-----------------%
 c
       integer    ipntr(13)
-      Real 
+      Real
      &           bounds(nev+np), h(ldh,nev+np), q(ldq,nev+np), resid(n),
-     &           ritzi(nev+np), ritzr(nev+np), v(ldv,nev+np), 
+     &           ritzi(nev+np), ritzr(nev+np), v(ldv,nev+np),
      &           workd(3*n), workl( (nev+np)*(nev+np+3) )
 c
 c     %------------%
 c     | Parameters |
 c     %------------%
 c
-      Real 
+      Real
      &           one, zero
       parameter (one = 1.0 , zero = 0.0 )
 c
@@ -230,17 +230,17 @@ c     %---------------%
 c
       character  wprime*2
       logical    cnorm , getv0, initv , update, ushift
-      integer    ierr  , iter , kplusp, msglvl, nconv, 
+      integer    ierr  , iter , kplusp, msglvl, nconv,
      &           nevbef, nev0 , np0   , nptemp, numcnv,
      &           j
-      Real 
+      Real
      &           rnorm , temp , eps23
       save       cnorm , getv0, initv , update, ushift,
-     &           rnorm , iter , kplusp, msglvl, nconv, 
+     &           rnorm , iter , kplusp, msglvl, nconv,
      &           nevbef, nev0 , np0   , eps23 , numcnv
 c
- 
-      Real 
+
+      Real
      &           rnorm_buf
 c
 c     %-----------------------%
@@ -253,7 +253,7 @@ c     %----------------------%
 c     | External Subroutines |
 c     %----------------------%
 c
-      external   scopy, psgetv0, psnaitr, snconv, 
+      external   scopy, psgetv0, psnaitr, snconv,
      &           psneigh, psngets, psnapps,
      &           psvout, pivout, second
 c
@@ -261,7 +261,7 @@ c     %--------------------%
 c     | External Functions |
 c     %--------------------%
 c
-      Real 
+      Real
      &           sdot, psnorm2, slapy2, pslamch10
       external   sdot, psnorm2, slapy2, pslamch10
 c
@@ -276,11 +276,11 @@ c     | Executable Statements |
 c     %-----------------------%
 c
       if (ido .eq. 0) then
-c 
+c
          call second (t0)
-c 
+c
          msglvl = mnaup2
-c 
+c
 c        %-------------------------------------%
 c        | Get the machine dependent constant. |
 c        %-------------------------------------%
@@ -303,7 +303,7 @@ c
          kplusp = nev + np
          nconv  = 0
          iter   = 0
-c 
+c
 c        %---------------------------------------%
 c        | Set flags for computing the first NEV |
 c        | steps of the Arnoldi factorization.   |
@@ -326,7 +326,7 @@ c
             initv = .false.
          end if
       end if
-c 
+c
 c     %---------------------------------------------%
 c     | Get a possibly random starting vector and   |
 c     | force it into the range of the operator OP. |
@@ -335,7 +335,7 @@ c
    10 continue
 c
       if (getv0) then
-         call psgetv0 (comm, ido, bmat, 1, initv, n, 1, v, ldv, 
+         call psgetv0 (comm, ido, bmat, 1, initv, n, 1, v, ldv,
      &                resid, rnorm, ipntr, workd, workl, info)
 c
          if (ido .ne. 99) go to 9000
@@ -343,7 +343,7 @@ c
          if (rnorm .eq. zero) then
 c
 c           %-----------------------------------------%
-c           | The initial vector is zero. Error exit. | 
+c           | The initial vector is zero. Error exit. |
 c           %-----------------------------------------%
 c
             info = -9
@@ -352,7 +352,7 @@ c
          getv0 = .false.
          ido  = 0
       end if
-c 
+c
 c     %-----------------------------------%
 c     | Back from reverse communication : |
 c     | continue with update step         |
@@ -372,15 +372,15 @@ c     | at the end of the current iteration |
 c     %-------------------------------------%
 c
       if (cnorm)  go to 100
-c 
+c
 c     %----------------------------------------------------------%
 c     | Compute the first NEV steps of the Arnoldi factorization |
 c     %----------------------------------------------------------%
 c
-      call psnaitr (comm, ido, bmat, n, 0, nev, mode, 
-     &             resid, rnorm, v, ldv, h, ldh, ipntr, 
+      call psnaitr (comm, ido, bmat, n, 0, nev, mode,
+     &             resid, rnorm, v, ldv, h, ldh, ipntr,
      &             workd, workl, info)
-c 
+c
 c     %---------------------------------------------------%
 c     | ido .ne. 99 implies use of reverse communication  |
 c     | to compute operations involving OP and possibly B |
@@ -394,7 +394,7 @@ c
          info = -9999
          go to 1200
       end if
-c 
+c
 c     %--------------------------------------------------------------%
 c     |                                                              |
 c     |           M A I N  ARNOLDI  I T E R A T I O N  L O O P       |
@@ -402,16 +402,16 @@ c     |           Each iteration implicitly restarts the Arnoldi     |
 c     |           factorization in place.                            |
 c     |                                                              |
 c     %--------------------------------------------------------------%
-c 
+c
  1000 continue
 c
          iter = iter + 1
 c
          if (msglvl .gt. 0) then
-            call pivout (comm, logfil, 1, [iter], ndigit, 
+            call pivout (comm, logfil, 1, [iter], ndigit,
      &           '_naup2: **** Start of major iteration number ****')
          end if
-c 
+c
 c        %-----------------------------------------------------------%
 c        | Compute NP additional steps of the Arnoldi factorization. |
 c        | Adjust NP since NEV might have been updated by last call  |
@@ -421,9 +421,9 @@ c
          np  = kplusp - nev
 c
          if (msglvl .gt. 1) then
-            call pivout (comm, logfil, 1, [nev], ndigit, 
+            call pivout (comm, logfil, 1, [nev], ndigit,
      &     '_naup2: The length of the current Arnoldi factorization')
-            call pivout (comm, logfil, 1, [np], ndigit, 
+            call pivout (comm, logfil, 1, [np], ndigit,
      &           '_naup2: Extend the Arnoldi factorization by')
          end if
 c
@@ -435,10 +435,10 @@ c
    20    continue
          update = .true.
 c
-         call psnaitr (comm, ido, bmat, n, nev, np, mode, 
+         call psnaitr (comm, ido, bmat, n, nev, np, mode,
      &                resid, rnorm, v, ldv,
      &                h, ldh, ipntr, workd, workl, info)
-c 
+c
 c        %---------------------------------------------------%
 c        | ido .ne. 99 implies use of reverse communication  |
 c        | to compute operations involving OP and possibly B |
@@ -455,16 +455,16 @@ c
          update = .false.
 c
          if (msglvl .gt. 1) then
-            call psvout (comm, logfil, 1, [rnorm], ndigit, 
+            call psvout (comm, logfil, 1, [rnorm], ndigit,
      &           '_naup2: Corresponding B-norm of the residual')
          end if
-c 
+c
 c        %--------------------------------------------------------%
 c        | Compute the eigenvalues and corresponding error bounds |
 c        | of the current upper Hessenberg matrix.                |
 c        %--------------------------------------------------------%
 c
-         call psneigh ( comm, rnorm, kplusp, h, ldh, ritzr, ritzi, 
+         call psneigh ( comm, rnorm, kplusp, h, ldh, ritzr, ritzi,
      &                  bounds, q, ldq, workl, ierr)
 c
          if (ierr .ne. 0) then
@@ -497,30 +497,30 @@ c
          nev = nev0
          np = np0
          numcnv = nev
-         call psngets ( comm, ishift, which, nev, np, ritzr, ritzi, 
+         call psngets ( comm, ishift, which, nev, np, ritzr, ritzi,
      &                  bounds, workl, workl(np+1))
          if (nev .eq. nev0+1) numcnv = nev0+1
-c 
+c
 c        %-------------------%
 c        | Convergence test. |
 c        %-------------------%
 c
          call scopy (nev, bounds(np+1), 1, workl(2*np+1), 1)
-         call snconv (nev, ritzr(np+1), ritzi(np+1), workl(2*np+1), 
+         call snconv (nev, ritzr(np+1), ritzi(np+1), workl(2*np+1),
      &        tol, nconv)
-c 
+c
          if (msglvl .gt. 2) then
             kp(1) = nev
             kp(2) = np
             kp(3) = numcnv
             kp(4) = nconv
-            call pivout (comm, logfil, 4, kp, ndigit, 
+            call pivout (comm, logfil, 4, kp, ndigit,
      &                  '_naup2: NEV, NP, NUMCNV, NCONV are')
             call psvout (comm, logfil, kplusp, ritzr, ndigit,
      &           '_naup2: Real part of the eigenvalues of H')
             call psvout (comm, logfil, kplusp, ritzi, ndigit,
      &           '_naup2: Imaginary part of the eigenvalues of H')
-            call psvout (comm, logfil, kplusp, bounds, ndigit, 
+            call psvout (comm, logfil, kplusp, bounds, ndigit,
      &          '_naup2: Ritz estimates of the current NCV Ritz values')
          end if
 c
@@ -541,11 +541,11 @@ c
                nev = nev + 1
             end if
  30      continue
-c     
-         if ( (nconv .ge. numcnv) .or. 
+c
+         if ( (nconv .ge. numcnv) .or.
      &        (iter .gt. mxiter) .or.
      &        (np .eq. 0) ) then
-c     
+c
             if (msglvl .gt. 4) then
                call svout(logfil, kplusp, workl(kplusp**2+1), ndigit,
      &             '_naup2: Real part of the eig computed by _neigh:')
@@ -556,7 +556,7 @@ c
      &                     ndigit,
      &             '_naup2: Ritz estimates computed by _neigh:')
             end if
-c     
+c
 c           %------------------------------------------------%
 c           | Prepare to exit. Put the converged Ritz values |
 c           | and corresponding bounds in RITZ(1:NCONV) and  |
@@ -568,7 +568,7 @@ c           %------------------------------------------%
 c           |  Use h( 3,1 ) as storage to communicate  |
 c           |  rnorm to _neupd if needed               |
 c           %------------------------------------------%
- 
+
             h(3,1) = rnorm
 c
 c           %----------------------------------------------%
@@ -656,13 +656,13 @@ c
             end if
 c
 c           %------------------------------------%
-c           | Max iterations have been exceeded. | 
+c           | Max iterations have been exceeded. |
 c           %------------------------------------%
 c
             if (iter .gt. mxiter .and. nconv .lt. numcnv) info = 1
 c
 c           %---------------------%
-c           | No shifts to apply. | 
+c           | No shifts to apply. |
 c           %---------------------%
 c
             if (np .eq. 0 .and. nconv .lt. numcnv) info = 2
@@ -671,7 +671,7 @@ c
             go to 1100
 c
          else if ( (nconv .lt. numcnv) .and. (ishift .eq. 1) ) then
-c     
+c
 c           %-------------------------------------------------%
 c           | Do not have all the requested eigenvalues yet.  |
 c           | To prevent possible stagnation, adjust the size |
@@ -686,25 +686,25 @@ c
                nev = 2
             end if
             np = kplusp - nev
-c     
+c
 c           %---------------------------------------%
 c           | If the size of NEV was just increased |
 c           | resort the eigenvalues.               |
 c           %---------------------------------------%
-c     
-            if (nevbef .lt. nev) 
-     &         call psngets(comm, ishift, which, nev, np, ritzr, ritzi, 
+c
+            if (nevbef .lt. nev)
+     &         call psngets(comm, ishift, which, nev, np, ritzr, ritzi,
      &                      bounds, workl, workl(np+1))
 c
-         end if              
-c     
+         end if
+c
          if (msglvl .gt. 0) then
-            call pivout (comm, logfil, 1, [nconv], ndigit, 
+            call pivout (comm, logfil, 1, [nconv], ndigit,
      &           '_naup2: no. of "converged" Ritz values at this iter.')
             if (msglvl .gt. 1) then
                kp(1) = nev
                kp(2) = np
-               call pivout (comm, logfil, 2, kp, ndigit, 
+               call pivout (comm, logfil, 2, kp, ndigit,
      &              '_naup2: NEV and NP are')
                call psvout (comm, logfil, nev, ritzr(np+1), ndigit,
      &              '_naup2: "wanted" Ritz values -- real part')
@@ -727,7 +727,7 @@ c
             ido = 3
             go to 9000
          end if
-c 
+c
    50    continue
 c
 c        %------------------------------------%
@@ -739,7 +739,7 @@ c
          ushift = .false.
 c
          if ( ishift .eq. 0 ) then
-c 
+c
 c            %----------------------------------%
 c            | Move the NP shifts from WORKL to |
 c            | RITZR, RITZI to free up WORKL    |
@@ -750,14 +750,14 @@ c
              call scopy (np, workl(np+1), 1, ritzi, 1)
          end if
 c
-         if (msglvl .gt. 2) then 
-            call pivout (comm, logfil, 1, [np], ndigit, 
+         if (msglvl .gt. 2) then
+            call pivout (comm, logfil, 1, [np], ndigit,
      &                  '_naup2: The number of shifts to apply ')
             call psvout (comm, logfil, np, ritzr, ndigit,
      &                  '_naup2: Real part of the shifts')
             call psvout (comm, logfil, np, ritzi, ndigit,
      &                  '_naup2: Imaginary part of the shifts')
-            if ( ishift .eq. 1 ) 
+            if ( ishift .eq. 1 )
      &          call psvout (comm, logfil, np, bounds, ndigit,
      &                  '_naup2: Ritz estimates of the shifts')
          end if
@@ -769,7 +769,7 @@ c        | matrix H.                                               |
 c        | The first 2*N locations of WORKD are used as workspace. |
 c        %---------------------------------------------------------%
 c
-         call psnapps (comm, n, nev, np, ritzr, ritzi, v, ldv, 
+         call psnapps (comm, n, nev, np, ritzr, ritzi, v, ldv,
      &                 h, ldh, resid, q, ldq, workl, workd)
 c
 c        %---------------------------------------------%
@@ -786,18 +786,18 @@ c
             ipntr(1) = n + 1
             ipntr(2) = 1
             ido = 2
-c 
+c
 c           %----------------------------------%
 c           | Exit in order to compute B*RESID |
 c           %----------------------------------%
-c 
+c
             go to 9000
          else if (bmat .eq. 'I') then
             call scopy (n, resid, 1, workd, 1)
          end if
-c 
+c
   100    continue
-c 
+c
 c        %----------------------------------%
 c        | Back from reverse communication; |
 c        | WORKD(1:N) := B*RESID            |
@@ -819,12 +819,12 @@ c
          cnorm = .false.
 c
          if (msglvl .gt. 2) then
-            call psvout (comm, logfil, 1, [rnorm], ndigit, 
+            call psvout (comm, logfil, 1, [rnorm], ndigit,
      &      '_naup2: B-norm of residual for compressed factorization')
             call psmout (comm, logfil, nev, nev, h, ldh, ndigit,
      &        '_naup2: Compressed upper Hessenberg matrix H')
          end if
-c 
+c
       go to 1000
 c
 c     %---------------------------------------------------------------%
@@ -837,7 +837,7 @@ c
 c
       mxiter = iter
       nev = numcnv
-c     
+c
  1200 continue
       ido = 99
 c
@@ -847,7 +847,7 @@ c     %------------%
 c
       call second (t1)
       tnaup2 = t1 - t0
-c     
+c
  9000 continue
 c
 c     %----------------%

--- a/mathlibs/src/parpack/psnaupd.f
+++ b/mathlibs/src/parpack/psnaupd.f
@@ -2,21 +2,21 @@ c\BeginDoc
 c
 c\Name: psnaupd
 c
-c Message Passing Layer: MPI 
+c Message Passing Layer: MPI
 c
-c\Description: 
+c\Description:
 c  Reverse communication interface for the Implicitly Restarted Arnoldi
-c  iteration. This subroutine computes approximations to a few eigenpairs 
-c  of a linear operator "OP" with respect to a semi-inner product defined by 
-c  a symmetric positive semi-definite real matrix B. B may be the identity 
-c  matrix. NOTE: If the linear operator "OP" is real and symmetric 
-c  with respect to the real positive semi-definite symmetric matrix B, 
+c  iteration. This subroutine computes approximations to a few eigenpairs
+c  of a linear operator "OP" with respect to a semi-inner product defined by
+c  a symmetric positive semi-definite real matrix B. B may be the identity
+c  matrix. NOTE: If the linear operator "OP" is real and symmetric
+c  with respect to the real positive semi-definite symmetric matrix B,
 c  i.e. B*OP = (OP`)*B, then subroutine ssaupd should be used instead.
 c
 c  The computed approximate eigenvalues are called Ritz values and
 c  the corresponding approximate eigenvectors are called Ritz vectors.
 c
-c  psnaupd is usually called iteratively to solve one of the 
+c  psnaupd is usually called iteratively to solve one of the
 c  following problems:
 c
 c  Mode 1:  A*x = lambda*x.
@@ -27,18 +27,18 @@ c           ===> OP = inv[M]*A  and  B = M.
 c           ===> (If M can be factored see remark 3 below)
 c
 c  Mode 3:  A*x = lambda*M*x, M symmetric semi-definite
-c           ===> OP = Real_Part{ inv[A - sigma*M]*M }  and  B = M. 
+c           ===> OP = Real_Part{ inv[A - sigma*M]*M }  and  B = M.
 c           ===> shift-and-invert mode (in real arithmetic)
-c           If OP*x = amu*x, then 
+c           If OP*x = amu*x, then
 c           amu = 1/2 * [ 1/(lambda-sigma) + 1/(lambda-conjg(sigma)) ].
 c           Note: If sigma is real, i.e. imaginary part of sigma is zero;
-c                 Real_Part{ inv[A - sigma*M]*M } == inv[A - sigma*M]*M 
-c                 amu == 1/(lambda-sigma). 
-c  
+c                 Real_Part{ inv[A - sigma*M]*M } == inv[A - sigma*M]*M
+c                 amu == 1/(lambda-sigma).
+c
 c  Mode 4:  A*x = lambda*M*x, M symmetric semi-definite
-c           ===> OP = Imaginary_Part{ inv[A - sigma*M]*M }  and  B = M. 
+c           ===> OP = Imaginary_Part{ inv[A - sigma*M]*M }  and  B = M.
 c           ===> shift-and-invert mode (in real arithmetic)
-c           If OP*x = amu*x, then 
+c           If OP*x = amu*x, then
 c           amu = 1/2i * [ 1/(lambda-sigma) - 1/(lambda-conjg(sigma)) ].
 c
 c  Both mode 3 and 4 give the same enhancement to eigenvalues close to
@@ -67,7 +67,7 @@ c\Arguments
 c  COMM    MPI  Communicator for the processor grid.  (INPUT)
 c
 c  IDO     Integer.  (INPUT/OUTPUT)
-c          Reverse communication flag.  IDO must be zero on the first 
+c          Reverse communication flag.  IDO must be zero on the first
 c          call to psnaupd.  IDO will be set internally to
 c          indicate the type of operation to be performed.  Control is
 c          then given back to the calling routine which has the
@@ -90,13 +90,13 @@ c                    need to be recomputed in forming OP * X.
 c          IDO =  2: compute  Y = B * X  where
 c                    IPNTR(1) is the pointer into WORKD for X,
 c                    IPNTR(2) is the pointer into WORKD for Y.
-c          IDO =  3: compute the IPARAM(8) real and imaginary parts 
+c          IDO =  3: compute the IPARAM(8) real and imaginary parts
 c                    of the shifts where INPTR(14) is the pointer
 c                    into WORKL for placing the shifts. See Remark
 c                    5 below.
 c          IDO = 99: done
 c          -------------------------------------------------------------
-c             
+c
 c  BMAT    Character*1.  (INPUT)
 c          BMAT specifies the type of the matrix B that defines the
 c          semi-inner product for the operator OP.
@@ -118,14 +118,14 @@ c  NEV     Integer.  (INPUT)
 c          Number of eigenvalues of OP to be computed. 0 < NEV < N-1.
 c
 c  TOL     Real  scalar.  (INPUT)
-c          Stopping criterion: the relative accuracy of the Ritz value 
+c          Stopping criterion: the relative accuracy of the Ritz value
 c          is considered acceptable if BOUNDS(I) .LE. TOL*ABS(RITZ(I))
 c          where ABS(RITZ(I)) is the magnitude when RITZ(I) is complex.
 c          DEFAULT = SLAMCH('EPS')  (machine precision as computed
 c                    by the LAPACK auxiliary subroutine SLAMCH).
 c
 c  RESID   Real  array of length N.  (INPUT/OUTPUT)
-c          On INPUT: 
+c          On INPUT:
 c          If INFO .EQ. 0, a random initial residual vector is used.
 c          If INFO .NE. 0, RESID contains the initial residual vector,
 c                          possibly from a previous run.
@@ -135,17 +135,17 @@ c
 c  NCV     Integer.  (INPUT)
 c          Number of columns of the matrix V. NCV must satisfy the two
 c          inequalities 2 <= NCV-NEV and NCV <= N.
-c          This will indicate how many Arnoldi vectors are generated 
-c          at each iteration.  After the startup phase in which NEV 
-c          Arnoldi vectors are generated, the algorithm generates 
-c          approximately NCV-NEV Arnoldi vectors at each subsequent update 
-c          iteration. Most of the cost in generating each Arnoldi vector is 
-c          in the matrix-vector operation OP*x. 
-c          NOTE: 2 <= NCV-NEV in order that complex conjugate pairs of Ritz 
+c          This will indicate how many Arnoldi vectors are generated
+c          at each iteration.  After the startup phase in which NEV
+c          Arnoldi vectors are generated, the algorithm generates
+c          approximately NCV-NEV Arnoldi vectors at each subsequent update
+c          iteration. Most of the cost in generating each Arnoldi vector is
+c          in the matrix-vector operation OP*x.
+c          NOTE: 2 <= NCV-NEV in order that complex conjugate pairs of Ritz
 c          values are kept together. (See remark 4 below)
 c
 c  V       Real  array N by NCV.  (OUTPUT)
-c          Contains the final set of Arnoldi basis vectors. 
+c          Contains the final set of Arnoldi basis vectors.
 c
 c  LDV     Integer.  (INPUT)
 c          Leading dimension of V exactly as declared in the calling program.
@@ -158,11 +158,11 @@ c          -------------------------------------------------------------
 c          ISHIFT = 0: the shifts are provided by the user via
 c                      reverse communication.  The real and imaginary
 c                      parts of the NCV eigenvalues of the Hessenberg
-c                      matrix H are returned in the part of the WORKL 
-c                      array corresponding to RITZR and RITZI. See remark 
+c                      matrix H are returned in the part of the WORKL
+c                      array corresponding to RITZR and RITZI. See remark
 c                      5 below.
 c          ISHIFT = 1: exact shifts with respect to the current
-c                      Hessenberg matrix H.  This is equivalent to 
+c                      Hessenberg matrix H.  This is equivalent to
 c                      restarting the iteration with a starting vector
 c                      that is a linear combination of approximate Schur
 c                      vectors associated with the "wanted" Ritz values.
@@ -171,8 +171,8 @@ c
 c          IPARAM(2) = No longer referenced.
 c
 c          IPARAM(3) = MXITER
-c          On INPUT:  maximum number of Arnoldi update iterations allowed. 
-c          On OUTPUT: actual number of Arnoldi update iterations taken. 
+c          On INPUT:  maximum number of Arnoldi update iterations allowed.
+c          On OUTPUT: actual number of Arnoldi update iterations taken.
 c
 c          IPARAM(4) = NB: blocksize to be used in the recurrence.
 c          The code currently works only for NB = 1.
@@ -182,11 +182,11 @@ c          This represents the number of Ritz values that satisfy
 c          the convergence criterion.
 c
 c          IPARAM(6) = IUPD
-c          No longer referenced. Implicit restarting is ALWAYS used.  
+c          No longer referenced. Implicit restarting is ALWAYS used.
 c
 c          IPARAM(7) = MODE
 c          On INPUT determines what type of eigenproblem is being solved.
-c          Must be 1,2,3,4; See under \Description of psnaupd for the 
+c          Must be 1,2,3,4; See under \Description of psnaupd for the
 c          four modes available.
 c
 c          IPARAM(8) = NP
@@ -206,13 +206,13 @@ c          arrays for matrices/vectors used by the Arnoldi iteration.
 c          -------------------------------------------------------------
 c          IPNTR(1): pointer to the current operand vector X in WORKD.
 c          IPNTR(2): pointer to the current result vector Y in WORKD.
-c          IPNTR(3): pointer to the vector B * X in WORKD when used in 
+c          IPNTR(3): pointer to the vector B * X in WORKD when used in
 c                    the shift-and-invert mode.
 c          IPNTR(4): pointer to the next available location in WORKL
 c                    that is untouched by the program.
 c          IPNTR(5): pointer to the NCV by NCV upper Hessenberg matrix
 c                    H in WORKL.
-c          IPNTR(6): pointer to the real part of the ritz value array 
+c          IPNTR(6): pointer to the real part of the ritz value array
 c                    RITZR in WORKL.
 c          IPNTR(7): pointer to the imaginary part of the ritz value array
 c                    RITZI in WORKL.
@@ -222,9 +222,9 @@ c          IPNTR(14): pointer to the NP shifts in WORKL. See Remark 5 below.
 c
 c          Note: IPNTR(9:13) is only referenced by sneupd. See Remark 2 below.
 c
-c          IPNTR(9):  pointer to the real part of the NCV RITZ values of the 
+c          IPNTR(9):  pointer to the real part of the NCV RITZ values of the
 c                     original system.
-c          IPNTR(10): pointer to the imaginary part of the NCV RITZ values of 
+c          IPNTR(10): pointer to the imaginary part of the NCV RITZ values of
 c                     the original system.
 c          IPNTR(11): pointer to the NCV corresponding error bounds.
 c          IPNTR(12): pointer to the NCV by NCV upper quasi-triangular
@@ -233,15 +233,15 @@ c          IPNTR(13): pointer to the NCV by NCV matrix of eigenvectors
 c                     of the upper Hessenberg matrix H. Only referenced by
 c                     psneupd if RVEC = .TRUE. See Remark 2 below.
 c          -------------------------------------------------------------
-c          
+c
 c  WORKD   Real  work array of length 3*N.  (REVERSE COMMUNICATION)
 c          Distributed array to be used in the basic Arnoldi iteration
-c          for reverse communication.  The user should not use WORKD 
+c          for reverse communication.  The user should not use WORKD
 c          as temporary workspace during the iteration. Upon termination
 c          WORKD(1:N) contains B*RESID(1:N). If an invariant subspace
 c          associated with the converged Ritz values is desired, see remark
 c          2 below, subroutine sneupd uses this output.
-c          See Data Distribution Note below.  
+c          See Data Distribution Note below.
 c
 c  WORKL   Real  work array of length LWORKL.  (OUTPUT/WORKSPACE)
 c          Private (replicated) array on each PE or array allocated on
@@ -257,18 +257,18 @@ c                          possibly from a previous run.
 c          Error flag on output.
 c          =  0: Normal exit.
 c          =  1: Maximum number of iterations taken.
-c                All possible eigenvalues of OP has been found. IPARAM(5)  
+c                All possible eigenvalues of OP has been found. IPARAM(5)
 c                returns the number of wanted converged Ritz values.
 c          =  2: No longer an informational error. Deprecated starting
 c                with release 2 of ARPACK.
-c          =  3: No shifts could be applied during a cycle of the 
-c                Implicitly restarted Arnoldi iteration. One possibility 
-c                is to increase the size of NCV relative to NEV. 
+c          =  3: No shifts could be applied during a cycle of the
+c                Implicitly restarted Arnoldi iteration. One possibility
+c                is to increase the size of NCV relative to NEV.
 c                See remark 4 below.
 c          = -1: N must be positive.
 c          = -2: NEV must be positive.
 c          = -3: NCV-NEV >= 2 and less than or equal to N.
-c          = -4: The maximum number of Arnoldi update iteration 
+c          = -4: The maximum number of Arnoldi update iteration
 c                must be greater than zero.
 c          = -5: WHICH must be one of 'LM', 'SM', 'LR', 'SR', 'LI', 'SI'
 c          = -6: BMAT must be one of 'I' or 'G'.
@@ -288,13 +288,13 @@ c     selection of WHICH should be made with this in mind when
 c     Mode = 3 and 4.  After convergence, approximate eigenvalues of the
 c     original problem may be obtained with the ARPACK subroutine sneupd.
 c
-c  2. If a basis for the invariant subspace corresponding to the converged Ritz 
-c     values is needed, the user must call sneupd immediately following 
+c  2. If a basis for the invariant subspace corresponding to the converged Ritz
+c     values is needed, the user must call sneupd immediately following
 c     completion of psnaupd. This is new starting with release 2 of ARPACK.
 c
 c  3. If M can be factored into a Cholesky factorization M = LL`
 c     then Mode = 2 should not be selected.  Instead one should use
-c     Mode = 1 with  OP = inv(L)*A*inv(L`).  Appropriate triangular 
+c     Mode = 1 with  OP = inv(L)*A*inv(L`).  Appropriate triangular
 c     linear systems should be solved with L and L` rather
 c     than computing inverses.  After convergence, an approximate
 c     eigenvector z of the original problem is recovered by solving
@@ -304,15 +304,15 @@ c  4. At present there is no a-priori analysis to guide the selection
 c     of NCV relative to NEV.  The only formal requrement is that NCV > NEV + 2.
 c     However, it is recommended that NCV .ge. 2*NEV+1.  If many problems of
 c     the same type are to be solved, one should experiment with increasing
-c     NCV while keeping NEV fixed for a given test problem.  This will 
+c     NCV while keeping NEV fixed for a given test problem.  This will
 c     usually decrease the required number of OP*x operations but it
 c     also increases the work and storage required to maintain the orthogonal
 c     basis vectors.  The optimal "cross-over" with respect to CPU time
-c     is problem dependent and must be determined empirically. 
+c     is problem dependent and must be determined empirically.
 c     See Chapter 8 of Reference 2 for further information.
 c
-c  5. When IPARAM(1) = 0, and IDO = 3, the user needs to provide the 
-c     NP = IPARAM(8) real and imaginary parts of the shifts in locations 
+c  5. When IPARAM(1) = 0, and IDO = 3, the user needs to provide the
+c     NP = IPARAM(8) real and imaginary parts of the shifts in locations
 c         real part                  imaginary part
 c         -----------------------    --------------
 c     1   WORKL(IPNTR(14))           WORKL(IPNTR(14)+NP)
@@ -322,10 +322,10 @@ c                        .                          .
 c                        .                          .
 c     NP  WORKL(IPNTR(14)+NP-1)      WORKL(IPNTR(14)+2*NP-1).
 c
-c     Only complex conjugate pairs of shifts may be applied and the pairs 
-c     must be placed in consecutive locations. The real part of the 
-c     eigenvalues of the current upper Hessenberg matrix are located in 
-c     WORKL(IPNTR(6)) through WORKL(IPNTR(6)+NCV-1) and the imaginary part 
+c     Only complex conjugate pairs of shifts may be applied and the pairs
+c     must be placed in consecutive locations. The real part of the
+c     eigenvalues of the current upper Hessenberg matrix are located in
+c     WORKL(IPNTR(6)) through WORKL(IPNTR(6)+NCV-1) and the imaginary part
 c     in WORKL(IPNTR(7)) through WORKL(IPNTR(7)+NCV-1). They are ordered
 c     according to the order defined by WHICH. The complex conjugate
 c     pairs are kept together and the associated Ritz estimates are located in
@@ -333,7 +333,7 @@ c     WORKL(IPNTR(8)), WORKL(IPNTR(8)+1), ... , WORKL(IPNTR(8)+NCV-1).
 c
 c-----------------------------------------------------------------------
 c
-c\Data Distribution Note: 
+c\Data Distribution Note:
 c
 c  Fortran-D syntax:
 c  ================
@@ -352,10 +352,10 @@ c  ===============
 c  Real   resid(n), v(ldv,ncv), workd(n,3), workl(lworkl)
 c  shared     resid(block), v(block,:), workd(block,:)
 c  replicated workl(lworkl)
-c  
+c
 c  CM2/CM5 syntax:
 c  ==============
-c  
+c
 c-----------------------------------------------------------------------
 c
 c     include   'ex-nonsym.doc'
@@ -371,7 +371,7 @@ c\References:
 c  1. D.C. Sorensen, "Implicit Application of Polynomial Filters in
 c     a k-Step Arnoldi Method", SIAM J. Matr. Anal. Apps., 13 (1992),
 c     pp 357-385.
-c  2. R.B. Lehoucq, "Analysis and Implementation of an Implicitly 
+c  2. R.B. Lehoucq, "Analysis and Implementation of an Implicitly
 c     Restarted Arnoldi Iteration", Rice University Technical Report
 c     TR95-13, Department of Computational and Applied Mathematics.
 c  3. B.N. Parlett & Y. Saad, "Complex Shift and Invert Strategies for
@@ -391,8 +391,8 @@ c     Danny Sorensen               Phuong Vu
 c     Richard Lehoucq              Cray Research, Inc. &
 c     Dept. of Computational &     CRPC / Rice University
 c     Applied Mathematics          Houston, Texas
-c     Rice University           
-c     Houston, Texas            
+c     Rice University
+c     Houston, Texas
 c
 c\Parallel Modifications
 c     Kristi Maschhoff
@@ -400,8 +400,8 @@ c
 c\Revision history:
 c     Starting Point: Serial Code FILE: naupd.F   SID: 2.2
 c
-c\SCCS Information: 
-c FILE: naupd.F   SID: 1.9   DATE OF SID: 04/10/01   
+c\SCCS Information:
+c FILE: naupd.F   SID: 1.9   DATE OF SID: 04/10/01
 c
 c\Remarks
 c
@@ -410,7 +410,7 @@ c
 c-----------------------------------------------------------------------
 c
       subroutine psnaupd
-     &   ( comm, ido, bmat, n, which, nev, tol, resid, ncv, v, ldv, 
+     &   ( comm, ido, bmat, n, which, nev, tol, resid, ncv, v, ldv,
      &     iparam, ipntr, workd, workl, lworkl, info )
 c
       include  'mpif.h'
@@ -419,7 +419,7 @@ c     %------------------%
 c     | MPI Variables    |
 c     %------------------%
 c
-      integer    comm, myid 
+      integer    comm, myid
 c
 c     %----------------------------------------------------%
 c     | Include files for debugging and timing information |
@@ -434,7 +434,7 @@ c     %------------------%
 c
       character  bmat*1, which*2
       integer    ido, info, ldv, lworkl, n, ncv, nev
-      Real 
+      Real
      &           tol
 c
 c     %-----------------%
@@ -442,14 +442,14 @@ c     | Array Arguments |
 c     %-----------------%
 c
       integer    iparam(11), ipntr(14)
-      Real 
+      Real
      &           resid(n), v(ldv,ncv), workd(3*n), workl(lworkl)
 c
 c     %------------%
 c     | Parameters |
 c     %------------%
 c
-      Real 
+      Real
      &           one, zero
       parameter (one = 1.0 , zero = 0.0 )
 c
@@ -457,7 +457,7 @@ c     %---------------%
 c     | Local Scalars |
 c     %---------------%
 c
-      integer    bounds, ierr, ih, iq, ishift, iupd, iw, 
+      integer    bounds, ierr, ih, iq, ishift, iupd, iw,
      &           ldh, ldq, levec, mode, msglvl, mxiter, nb,
      &           nev0, next, np, ritzi, ritzr, j
       save       bounds, ih, iq, ishift, iupd, iw, ldh, ldq,
@@ -474,16 +474,16 @@ c     %--------------------%
 c     | External Functions |
 c     %--------------------%
 c
-      Real 
+      Real
      &           pslamch10
       external   pslamch10
 c
 c     %-----------------------%
 c     | Executable Statements |
 c     %-----------------------%
-c 
+c
       if (ido .eq. 0) then
-c 
+c
 c        %-------------------------------%
 c        | Initialize timing statistics  |
 c        | & message level for debugging |
@@ -537,7 +537,7 @@ c
          else if (ishift .lt. 0 .or. ishift .gt. 1) then
                                                 ierr = -12
          end if
-c 
+c
 c        %------------%
 c        | Error Exit |
 c        %------------%
@@ -547,7 +547,7 @@ c
             ido  = 99
             go to 9000
          end if
-c 
+c
 c        %------------------------%
 c        | Set default parameters |
 c        %------------------------%
@@ -563,8 +563,8 @@ c        | size of the invariant subspace desired.      |
 c        %----------------------------------------------%
 c
          np     = ncv - nev
-         nev0   = nev 
-c 
+         nev0   = nev
+c
 c        %-----------------------------%
 c        | Zero out internal workspace |
 c        %-----------------------------%
@@ -572,7 +572,7 @@ c
          do 10 j = 1, 3*ncv**2 + 6*ncv
             workl(j) = zero
  10      continue
-c 
+c
 c        %-------------------------------------------------------------%
 c        | Pointer into WORKL for address of H, RITZ, BOUNDS, Q        |
 c        | etc... and the remaining workspace.                         |
@@ -605,7 +605,7 @@ c
          ipntr(6) = ritzr
          ipntr(7) = ritzi
          ipntr(8) = bounds
-         ipntr(14) = iw 
+         ipntr(14) = iw
 c
       end if
 c
@@ -613,12 +613,12 @@ c     %-------------------------------------------------------%
 c     | Carry out the Implicitly restarted Arnoldi Iteration. |
 c     %-------------------------------------------------------%
 c
-      call psnaup2 
+      call psnaup2
      &   ( comm, ido, bmat, n, which, nev0, np, tol, resid, mode, iupd,
-     &     ishift, mxiter, v, ldv, workl(ih), ldh, workl(ritzr), 
-     &     workl(ritzi), workl(bounds), workl(iq), ldq, workl(iw), 
+     &     ishift, mxiter, v, ldv, workl(ih), ldh, workl(ritzr),
+     &     workl(ritzi), workl(bounds), workl(iq), ldq, workl(iw),
      &     ipntr, workd, info )
-c 
+c
 c     %--------------------------------------------------%
 c     | ido .ne. 99 implies use of reverse communication |
 c     | to compute operations involving OP or shifts.    |
@@ -626,7 +626,7 @@ c     %--------------------------------------------------%
 c
       if (ido .eq. 3) iparam(8) = np
       if (ido .ne. 99) go to 9000
-c 
+c
       iparam(3) = mxiter
       iparam(5) = np
       iparam(9) = nopx
@@ -646,11 +646,11 @@ c
      &               '_naupd: Number of update iterations taken')
          call pivout (comm, logfil, 1, [np], ndigit,
      &               '_naupd: Number of wanted "converged" Ritz values')
-         call psvout (comm, logfil, np, workl(ritzr), ndigit, 
+         call psvout (comm, logfil, np, workl(ritzr), ndigit,
      &               '_naupd: Real part of the final Ritz values')
-         call psvout (comm, logfil, np, workl(ritzi), ndigit, 
+         call psvout (comm, logfil, np, workl(ritzi), ndigit,
      &               '_naupd: Imaginary part of the final Ritz values')
-         call psvout (comm, logfil, np, workl(bounds), ndigit, 
+         call psvout (comm, logfil, np, workl(bounds), ndigit,
      &               '_naupd: Associated Ritz estimates')
       end if
 c

--- a/mathlibs/src/parpack/psnaupd.f
+++ b/mathlibs/src/parpack/psnaupd.f
@@ -642,9 +642,9 @@ c
       if (info .eq. 2) info = 3
 c
       if (msglvl .gt. 0) then
-         call pivout (comm, logfil, 1, mxiter, ndigit,
+         call pivout (comm, logfil, 1, [mxiter], ndigit,
      &               '_naupd: Number of update iterations taken')
-         call pivout (comm, logfil, 1, np, ndigit,
+         call pivout (comm, logfil, 1, [np], ndigit,
      &               '_naupd: Number of wanted "converged" Ritz values')
          call psvout (comm, logfil, np, workl(ritzr), ndigit, 
      &               '_naupd: Real part of the final Ritz values')

--- a/mathlibs/src/parpack/psneupd.f
+++ b/mathlibs/src/parpack/psneupd.f
@@ -617,9 +617,9 @@ c        | caused by incorrect passing of the dnaupd data.           |
 c        %-----------------------------------------------------------%
 c
          if (msglvl .gt. 2) then
-             call pivout(comm, logfil, 1, numcnv, ndigit,
+             call pivout(comm, logfil, 1, [numcnv], ndigit,
      &            '_neupd: Number of specified eigenvalues')
-             call pivout(comm, logfil, 1, nconv, ndigit,
+             call pivout(comm, logfil, 1, [nconv], ndigit,
      &            '_neupd: Number of "converged" eigenvalues')
          end if
 c

--- a/mathlibs/src/parpack/psneupd.f
+++ b/mathlibs/src/parpack/psneupd.f
@@ -2,9 +2,9 @@ c\BeginDoc
 c
 c\Name: psneupd
 c
-c Message Passing Layer: MPI 
+c Message Passing Layer: MPI
 c
-c\Description: 
+c\Description:
 c
 c  This subroutine returns the converged approximations to eigenvalues
 c  of A*z = lambda*B*z and (optionally):
@@ -30,36 +30,36 @@ c  in the comments that follow.  The computed orthonormal basis for the
 c  invariant subspace corresponding to these Ritz values is referred to as a
 c  Schur basis.
 c
-c  See documentation in the header of the subroutine PSNAUPD for 
+c  See documentation in the header of the subroutine PSNAUPD for
 c  definition of OP as well as other terms and the relation of computed
 c  Ritz values and Ritz vectors of OP with respect to the given problem
-c  A*z = lambda*B*z.  For a brief description, see definitions of 
+c  A*z = lambda*B*z.  For a brief description, see definitions of
 c  IPARAM(7), MODE and WHICH in the documentation of PSNAUPD.
 c
 c\Usage:
-c  call psneupd 
-c     ( COMM, RVEC, HOWMNY, SELECT, DR, DI, Z, LDZ, SIGMAR, SIGMAI, 
-c       WORKEV, BMAT, N, WHICH, NEV, TOL, RESID, NCV, V, LDV, IPARAM, 
+c  call psneupd
+c     ( COMM, RVEC, HOWMNY, SELECT, DR, DI, Z, LDZ, SIGMAR, SIGMAI,
+c       WORKEV, BMAT, N, WHICH, NEV, TOL, RESID, NCV, V, LDV, IPARAM,
 c       IPNTR, WORKD, WORKL, LWORKL, INFO )
 c
 c\Arguments
 c  COMM    MPI  Communicator for the processor grid.  (INPUT)
 c
-c  RVEC    LOGICAL  (INPUT) 
-c          Specifies whether a basis for the invariant subspace corresponding 
-c          to the converged Ritz value approximations for the eigenproblem 
+c  RVEC    LOGICAL  (INPUT)
+c          Specifies whether a basis for the invariant subspace corresponding
+c          to the converged Ritz value approximations for the eigenproblem
 c          A*z = lambda*B*z is computed.
 c
 c             RVEC = .FALSE.     Compute Ritz values only.
 c
 c             RVEC = .TRUE.      Compute the Ritz vectors or Schur vectors.
-c                                See Remarks below. 
-c 
-c  HOWMNY  Character*1  (INPUT) 
-c          Specifies the form of the basis for the invariant subspace 
+c                                See Remarks below.
+c
+c  HOWMNY  Character*1  (INPUT)
+c          Specifies the form of the basis for the invariant subspace
 c          corresponding to the converged Ritz values that is to be computed.
 c
-c          = 'A': Compute NEV Ritz vectors; 
+c          = 'A': Compute NEV Ritz vectors;
 c          = 'P': Compute NEV Schur vectors;
 c          = 'S': compute some of the Ritz vectors, specified
 c                 by the logical array SELECT.
@@ -67,43 +67,43 @@ c
 c  SELECT  Logical array of dimension NCV.  (INPUT)
 c          If HOWMNY = 'S', SELECT specifies the Ritz vectors to be
 c          computed. To select the Ritz vector corresponding to a
-c          Ritz value (DR(j), DI(j)), SELECT(j) must be set to .TRUE.. 
+c          Ritz value (DR(j), DI(j)), SELECT(j) must be set to .TRUE..
 c          If HOWMNY = 'A' or 'P', SELECT is used as internal workspace.
 c
 c  DR      Real  array of dimension NEV+1.  (OUTPUT)
-c          If IPARAM(7) = 1,2 or 3 and SIGMAI=0.0  then on exit: DR contains 
-c          the real part of the Ritz  approximations to the eigenvalues of 
-c          A*z = lambda*B*z. 
+c          If IPARAM(7) = 1,2 or 3 and SIGMAI=0.0  then on exit: DR contains
+c          the real part of the Ritz  approximations to the eigenvalues of
+c          A*z = lambda*B*z.
 c          If IPARAM(7) = 3, 4 and SIGMAI is not equal to zero, then on exit:
-c          DR contains the real part of the Ritz values of OP computed by 
+c          DR contains the real part of the Ritz values of OP computed by
 c          PSNAUPD. A further computation must be performed by the user
 c          to transform the Ritz values computed for OP by PSNAUPD to those
 c          of the original system A*z = lambda*B*z. See remark 3 below.
 c
 c  DI      Real  array of dimension NEV+1.  (OUTPUT)
-c          On exit, DI contains the imaginary part of the Ritz value 
+c          On exit, DI contains the imaginary part of the Ritz value
 c          approximations to the eigenvalues of A*z = lambda*B*z associated
 c          with DR.
 c
-c          NOTE: When Ritz values are complex, they will come in complex 
-c                conjugate pairs.  If eigenvectors are requested, the 
-c                corresponding Ritz vectors will also come in conjugate 
-c                pairs and the real and imaginary parts of these are 
-c                represented in two consecutive columns of the array Z 
+c          NOTE: When Ritz values are complex, they will come in complex
+c                conjugate pairs.  If eigenvectors are requested, the
+c                corresponding Ritz vectors will also come in conjugate
+c                pairs and the real and imaginary parts of these are
+c                represented in two consecutive columns of the array Z
 c                (see below).
 c
 c  Z       Real  N by NEV+1 array if RVEC = .TRUE. and HOWMNY = 'A'. (OUTPUT)
-c          On exit, if RVEC = .TRUE. and HOWMNY = 'A', then the columns of 
-c          Z represent approximate eigenvectors (Ritz vectors) corresponding 
-c          to the NCONV=IPARAM(5) Ritz values for eigensystem 
-c          A*z = lambda*B*z. 
-c 
-c          The complex Ritz vector associated with the Ritz value 
-c          with positive imaginary part is stored in two consecutive 
-c          columns.  The first column holds the real part of the Ritz 
-c          vector and the second column holds the imaginary part.  The 
-c          Ritz vector associated with the Ritz value with negative 
-c          imaginary part is simply the complex conjugate of the Ritz vector 
+c          On exit, if RVEC = .TRUE. and HOWMNY = 'A', then the columns of
+c          Z represent approximate eigenvectors (Ritz vectors) corresponding
+c          to the NCONV=IPARAM(5) Ritz values for eigensystem
+c          A*z = lambda*B*z.
+c
+c          The complex Ritz vector associated with the Ritz value
+c          with positive imaginary part is stored in two consecutive
+c          columns.  The first column holds the real part of the Ritz
+c          vector and the second column holds the imaginary part.  The
+c          Ritz vector associated with the Ritz value with negative
+c          imaginary part is simply the complex conjugate of the Ritz vector
 c          associated with the positive imaginary part.
 c
 c          If  RVEC = .FALSE. or HOWMNY = 'P', then Z is not referenced.
@@ -118,11 +118,11 @@ c          The leading dimension of the array Z.  If Ritz vectors are
 c          desired, then  LDZ >= max( 1, N ).  In any case,  LDZ >= 1.
 c
 c  SIGMAR  Real   (INPUT)
-c          If IPARAM(7) = 3 or 4, represents the real part of the shift. 
+c          If IPARAM(7) = 3 or 4, represents the real part of the shift.
 c          Not referenced if IPARAM(7) = 1 or 2.
 c
 c  SIGMAI  Real   (INPUT)
-c          If IPARAM(7) = 3 or 4, represents the imaginary part of the shift. 
+c          If IPARAM(7) = 3 or 4, represents the imaginary part of the shift.
 c          Not referenced if IPARAM(7) = 1 or 2. See remark 3 below.
 c
 c  WORKEV  Real  work array of dimension 3*NCV.  (WORKSPACE)
@@ -187,10 +187,10 @@ c          =  0: Normal exit.
 c
 c          =  1: The Schur form computed by LAPACK routine slahqr
 c                could not be reordered by LAPACK routine strsen.
-c                Re-enter subroutine psneupd with IPARAM(5)=NCV and 
-c                increase the size of the arrays DR and DI to have 
-c                dimension at least dimension NCV and allocate at least NCV 
-c                columns for Z. NOTE: Not necessary if Z and V share 
+c                Re-enter subroutine psneupd with IPARAM(5)=NCV and
+c                increase the size of the arrays DR and DI to have
+c                dimension at least dimension NCV and allocate at least NCV
+c                columns for Z. NOTE: Not necessary if Z and V share
 c                the same space. Please notify the authors if this error
 c                occurs.
 c
@@ -222,7 +222,7 @@ c\References:
 c  1. D.C. Sorensen, "Implicit Application of Polynomial Filters in
 c     a k-Step Arnoldi Method", SIAM J. Matr. Anal. Apps., 13 (1992),
 c     pp 357-385.
-c  2. R.B. Lehoucq, "Analysis and Implementation of an Implicitly 
+c  2. R.B. Lehoucq, "Analysis and Implementation of an Implicitly
 c     Restarted Arnoldi Iteration", Rice University Technical Report
 c     TR95-13, Department of Computational and Applied Mathematics.
 c  3. B.N. Parlett & Y. Saad, "Complex Shift and Invert Strategies for
@@ -233,7 +233,7 @@ c\Routines called:
 c     pivout  Parallel ARPACK utility routine that prints integers.
 c     psmout  Parallel ARPACK utility routine that prints matrices
 c     psvout  Parallel ARPACK utility routine that prints vectors.
-c     sgeqr2  LAPACK routine that computes the QR factorization of 
+c     sgeqr2  LAPACK routine that computes the QR factorization of
 c             a matrix.
 c     slacpy  LAPACK matrix copy routine.
 c     slahqr  LAPACK routine to compute the real Schur form of an
@@ -241,7 +241,7 @@ c             upper Hessenberg matrix.
 c     pslamch ScaLAPACK routine that determines machine constants.
 c     slapy2  LAPACK routine to compute sqrt(x**2+y**2) carefully.
 c     slaset  LAPACK matrix initialization routine.
-c     sorm2r  LAPACK routine that applies an orthogonal matrix in 
+c     sorm2r  LAPACK routine that applies an orthogonal matrix in
 c             factored form.
 c     strevc  LAPACK routine to compute the eigenvectors of a matrix
 c             in upper quasi-triangular form.
@@ -263,9 +263,9 @@ c     Ritz vectors. Thus, their numerical properties are often superior.
 c     If RVEC = .TRUE. then the relationship
 c             A * V(:,1:IPARAM(5)) = V(:,1:IPARAM(5)) * T, and
 c     V(:,1:IPARAM(5))` * V(:,1:IPARAM(5)) = I are approximately satisfied.
-c     Here T is the leading submatrix of order IPARAM(5) of the real 
+c     Here T is the leading submatrix of order IPARAM(5) of the real
 c     upper quasi-triangular matrix stored workl(ipntr(12)). That is,
-c     T is block upper triangular with 1-by-1 and 2-by-2 diagonal blocks; 
+c     T is block upper triangular with 1-by-1 and 2-by-2 diagonal blocks;
 c     each 2-by-2 diagonal block has its diagonal elements equal and its
 c     off-diagonal elements of opposite sign.  Corresponding to each 2-by-2
 c     diagonal block is a complex conjugate pair of Ritz values. The real
@@ -273,11 +273,11 @@ c     Ritz values are stored on the diagonal of T.
 c
 c  3. If IPARAM(7) = 3 or 4 and SIGMAI is not equal zero, then the user must
 c     form the IPARAM(5) Rayleigh quotients in order to transform the Ritz
-c     values computed by PSNAUPD for OP to those of A*z = lambda*B*z. 
+c     values computed by PSNAUPD for OP to those of A*z = lambda*B*z.
 c     Set RVEC = .true. and HOWMNY = 'A', and
-c     compute 
+c     compute
 c           Z(:,I)` * A * Z(:,I) if DI(I) = 0.
-c     If DI(I) is not equal to zero and DI(I+1) = - D(I), 
+c     If DI(I) is not equal to zero and DI(I+1) = - D(I),
 c     then the desired real and imaginary parts of the Ritz value are
 c           Z(:,I)` * A * Z(:,I) +  Z(:,I+1)` * A * Z(:,I+1),
 c           Z(:,I)` * A * Z(:,I+1) -  Z(:,I+1)` * A * Z(:,I), respectively.
@@ -288,12 +288,12 @@ c     2 above.
 c
 c\Authors
 c     Danny Sorensen               Phuong Vu
-c     Richard Lehoucq              CRPC / Rice University 
+c     Richard Lehoucq              CRPC / Rice University
 c     Chao Yang                    Houston, Texas
 c     Dept. of Computational &
-c     Applied Mathematics          
-c     Rice University           
-c     Houston, Texas            
+c     Applied Mathematics
+c     Rice University
+c     Houston, Texas
 c
 c\Parallel Modifications
 c     Kristi Maschhoff
@@ -307,7 +307,7 @@ c
 c\EndLib
 c
 c-----------------------------------------------------------------------
-      subroutine psneupd 
+      subroutine psneupd
      &         (comm , rvec , howmny, select, dr    , di  ,
      &          z    , ldz  , sigmar, sigmai, workev, bmat,
      &          n    , which, nev   , tol   , resid ,
@@ -334,7 +334,7 @@ c
       character  bmat, howmny, which*2
       logical    rvec
       integer    info, ldz, ldv, lworkl, n, ncv, nev
-      Real      
+      Real
      &           sigmar, sigmai, tol
 c
 c     %-----------------%
@@ -343,7 +343,7 @@ c     %-----------------%
 c
       integer    iparam(11), ipntr(14)
       logical    select(ncv)
-      Real 
+      Real
      &           dr(nev+1)    , di(nev+1)    , resid(n)  ,
      &           v(ldv,ncv)   , z(ldz,*)     , workd(3*n),
      &           workl(lworkl), workev(3*ncv)
@@ -352,7 +352,7 @@ c     %------------%
 c     | Parameters |
 c     %------------%
 c
-      Real 
+      Real
      &           one, zero
       parameter (one = 1.0 , zero = 0.0 )
 c
@@ -362,7 +362,7 @@ c     %---------------%
 c
       character  type*6
       integer    bounds, ierr, ih, ihbds,
-     &           iheigr, iheigi, iconj , nconv   , 
+     &           iheigr, iheigi, iconj , nconv   ,
      &           invsub, iuptri, iwev  , iwork(1),
      &           j     , k     , ldh   , ldq     ,
      &           mode  , msglvl, outncv, ritzr   ,
@@ -370,7 +370,7 @@ c
      &           iri   , ibd   , ishift, numcnv  ,
      &           np    , jj
       logical    reord
-      Real 
+      Real
      &           conds  , rnorm, sep  , temp,
      &           vl(1,1), temp1, eps23
 c
@@ -387,7 +387,7 @@ c     %--------------------%
 c     | External Functions |
 c     %--------------------%
 c
-      Real 
+      Real
      &           slapy2, snrm2, pslamch10
       external   slapy2, snrm2, pslamch10
 c
@@ -400,7 +400,7 @@ c
 c     %-----------------------%
 c     | Executable Statements |
 c     %-----------------------%
-c 
+c
 c     %------------------------%
 c     | Set default parameters |
 c     %------------------------%
@@ -449,7 +449,7 @@ c
       else if (howmny .eq. 'S' ) then
          ierr = -12
       end if
-c     
+c
       if (mode .eq. 1 .or. mode .eq. 2) then
          type = 'REGULR'
       else if (mode .eq. 3 .and. sigmai .eq. zero) then
@@ -458,7 +458,7 @@ c
          type = 'REALPT'
       else if (mode .eq. 4 ) then
          type = 'IMAGPT'
-      else 
+      else
                                               ierr = -10
       end if
       if (mode .eq. 1 .and. bmat .eq. 'G')    ierr = -11
@@ -471,7 +471,7 @@ c
          info = ierr
          go to 9000
       end if
-c 
+c
 c     %--------------------------------------------------------%
 c     | Pointer into WORKL for address of H, RITZ, BOUNDS, Q   |
 c     | etc... and the remaining workspace.                    |
@@ -498,7 +498,7 @@ c     |       associated matrix representation of the invariant   |
 c     |       subspace for H.                                     |
 c     | GRAND total of NCV * ( 3 * NCV + 6 ) locations.           |
 c     %-----------------------------------------------------------%
-c     
+c
       ih     = ipntr(5)
       ritzr  = ipntr(6)
       ritzi  = ipntr(7)
@@ -634,7 +634,7 @@ c        | of the upper Hessenberg matrix returned by PSNAUPD.       |
 c        | Make a copy of the upper Hessenberg matrix.               |
 c        | Initialize the Schur vector matrix Q to the identity.     |
 c        %-----------------------------------------------------------%
-c     
+c
          call scopy(ldh*ncv, workl(ih), 1, workl(iuptri), 1)
          call slaset('All', ncv, ncv, zero, one, workl(invsub), ldq)
          call slahqr(.true.       , .true.       , ncv, 1            ,
@@ -642,12 +642,12 @@ c
      &               workl(iheigi), 1            , ncv, workl(invsub),
      &               ldq          , ierr)
          call scopy (ncv, workl(invsub+ncv-1), ldq, workl(ihbds), 1)
-c     
+c
          if (ierr .ne. 0) then
             info = -8
             go to 9000
          end if
-c     
+c
          if (msglvl .gt. 1) then
             call psvout (comm, logfil, ncv, workl(iheigr), ndigit,
      &           '_neupd: Real part of the eigenvalues of H')
@@ -656,18 +656,18 @@ c
             call psvout (comm, logfil, ncv, workl(ihbds), ndigit,
      &           '_neupd: Last row of the Schur vector matrix')
             if (msglvl .gt. 3) then
-               call psmout (comm, logfil, ncv, ncv, 
-     &              workl(iuptri), ldh, ndigit, 
+               call psmout (comm, logfil, ncv, ncv,
+     &              workl(iuptri), ldh, ndigit,
      &              '_neupd: The upper quasi-triangular matrix ')
             end if
-         end if 
+         end if
 c
          if (reord) then
-c     
+c
 c           %-----------------------------------------------------%
-c           | Reorder the computed upper quasi-triangular matrix. | 
+c           | Reorder the computed upper quasi-triangular matrix. |
 c           %-----------------------------------------------------%
-c     
+c
             call strsen('None'       , 'V'          , select       ,
      &                   ncv          , workl(iuptri), ldh          ,
      &                   workl(invsub), ldq          , workl(iheigr),
@@ -686,7 +686,7 @@ c
                 call psvout(comm, logfil, ncv, workl(iheigi), ndigit,
      &           '_neupd: Imag part of the eigenvalues of H--reordered')
                 if (msglvl .gt. 3) then
-                   call psmout(comm, logfil, ncv, ncv, 
+                   call psmout(comm, logfil, ncv, ncv,
      &             workl(iuptri), ldq, ndigit,
      &             '_neupd: Quasi-triangular matrix after re-ordering')
                 end if
@@ -707,23 +707,23 @@ c        | Place the computed eigenvalues of H into DR and DI |
 c        | if a spectral transformation was not used.         |
 c        %----------------------------------------------------%
 c
-         if (type .eq. 'REGULR') then 
+         if (type .eq. 'REGULR') then
             call scopy(nconv, workl(iheigr), 1, dr, 1)
             call scopy(nconv, workl(iheigi), 1, di, 1)
          end if
-c     
+c
 c        %----------------------------------------------------------%
 c        | Compute the QR factorization of the matrix representing  |
 c        | the wanted invariant subspace located in the first NCONV |
 c        | columns of workl(invsub,ldq).                            |
 c        %----------------------------------------------------------%
-c     
+c
          call sgeqr2(ncv, nconv , workl(invsub),
      &               ldq, workev, workev(ncv+1),
      &               ierr)
 c
 c        %---------------------------------------------------------%
-c        | * Postmultiply V by Q using sorm2r.                     |   
+c        | * Postmultiply V by Q using sorm2r.                     |
 c        | * Copy the first NCONV columns of VQ into Z.            |
 c        | * Postmultiply Z by R.                                  |
 c        | The N by NCONV matrix Z is now a matrix representation  |
@@ -733,7 +733,7 @@ c        | The first NCONV columns of V are now approximate Schur  |
 c        | vectors associated with the real upper quasi-triangular |
 c        | matrix of order NCONV in workl(iuptri)                  |
 c        %---------------------------------------------------------%
-c     
+c
          call sorm2r('Right', 'Notranspose', n            ,
      &                ncv    , nconv        , workl(invsub),
      &                ldq    , workev       , v            ,
@@ -741,7 +741,7 @@ c
          call slacpy('All', n, nconv, v, ldv, z, ldz)
 c
          do 20 j=1, nconv
-c     
+c
 c           %---------------------------------------------------%
 c           | Perform both a column and row scaling if the      |
 c           | diagonal element of workl(invsub,ldq) is negative |
@@ -750,21 +750,21 @@ c           | quasi-triangular form of workl(iuptri,ldq)        |
 c           | Note that since Q is orthogonal, R is a diagonal  |
 c           | matrix consisting of plus or minus ones           |
 c           %---------------------------------------------------%
-c     
+c
             if (workl(invsub+(j-1)*ldq+j-1) .lt. zero) then
                call sscal(nconv, -one, workl(iuptri+j-1), ldq)
                call sscal(nconv, -one, workl(iuptri+(j-1)*ldq), 1)
             end if
-c     
+c
  20      continue
-c     
+c
          if (howmny .eq. 'A') then
-c     
+c
 c           %--------------------------------------------%
-c           | Compute the NCONV wanted eigenvectors of T | 
+c           | Compute the NCONV wanted eigenvectors of T |
 c           | located in workl(iuptri,ldq).              |
 c           %--------------------------------------------%
-c     
+c
             do 30 j=1, ncv
                if (j .le. nconv) then
                   select(j) = .true.
@@ -783,7 +783,7 @@ c
                 info = -9
                 go to 9000
             end if
-c     
+c
 c           %------------------------------------------------%
 c           | Scale the returning eigenvectors so that their |
 c           | Euclidean norms are all one. LAPACK subroutine |
@@ -791,21 +791,21 @@ c           | strevc returns each eigenvector normalized so  |
 c           | that the element of largest magnitude has      |
 c           | magnitude 1;                                   |
 c           %------------------------------------------------%
-c     
+c
             iconj = 0
             do 40 j=1, nconv
 c
                if ( workl(iheigi+j-1) .eq. zero ) then
-c     
+c
 c                 %----------------------%
 c                 | real eigenvalue case |
 c                 %----------------------%
-c     
+c
                   temp = snrm2( ncv, workl(invsub+(j-1)*ldq), 1 )
-                  call sscal ( ncv, one / temp, 
+                  call sscal ( ncv, one / temp,
      &                 workl(invsub+(j-1)*ldq), 1 )
                else
-c     
+c
 c                 %-------------------------------------------%
 c                 | Complex conjugate pair case. Note that    |
 c                 | since the real and imaginary part of      |
@@ -813,18 +813,18 @@ c                 | the eigenvector are stored in consecutive |
 c                 | columns, we further normalize by the      |
 c                 | square root of two.                       |
 c                 %-------------------------------------------%
-c     
+c
                   if (iconj .eq. 0) then
                      temp = slapy2(snrm2(ncv,
      &                                   workl(invsub+(j-1)*ldq),
-     &                                   1 ), 
+     &                                   1 ),
      &                             snrm2(ncv,
      &                                   workl(invsub+j*ldq),
      &                                   1)
-     &                             )  
-                     call sscal(ncv, one/temp, 
+     &                             )
+                     call sscal(ncv, one/temp,
      &                          workl(invsub+(j-1)*ldq), 1)
-                     call sscal(ncv, one/temp, 
+                     call sscal(ncv, one/temp,
      &                          workl(invsub+j*ldq), 1)
                      iconj = 1
                   else
@@ -864,12 +864,12 @@ c
                call psvout(comm, logfil, ncv, workl(ihbds), ndigit,
      &              '_neupd: Last row of the eigenvector matrix for T')
                if (msglvl .gt. 3) then
-                  call psmout(comm, logfil, ncv, ncv, 
-     &               workl(invsub), ldq, ndigit, 
+                  call psmout(comm, logfil, ncv, ncv,
+     &               workl(invsub), ldq, ndigit,
      &               '_neupd: The eigenvector matrix for T')
                end if
             end if
-c     
+c
 c
 c           %---------------------------------------%
 c           | Copy Ritz estimates into workl(ihbds) |
@@ -882,32 +882,32 @@ c           | Compute the QR factorization of the eigenvector matrix  |
 c           | associated with leading portion of T in the first NCONV |
 c           | columns of workl(invsub,ldq).                           |
 c           %---------------------------------------------------------%
-c     
+c
             call sgeqr2(ncv, nconv , workl(invsub),
      &                   ldq, workev, workev(ncv+1),
      &                   ierr)
-c     
+c
 c           %----------------------------------------------%
-c           | * Postmultiply Z by Q.                       |   
+c           | * Postmultiply Z by Q.                       |
 c           | * Postmultiply Z by R.                       |
-c           | The N by NCONV matrix Z is now contains the  | 
+c           | The N by NCONV matrix Z is now contains the  |
 c           | Ritz vectors associated with the Ritz values |
 c           | in workl(iheigr) and workl(iheigi).          |
 c           %----------------------------------------------%
-c     
+c
             call sorm2r('Right', 'Notranspose', n            ,
      &                   ncv    , nconv        , workl(invsub),
      &                   ldq    , workev       , z            ,
      &                   ldz    , workd(n+1)   , ierr)
-c     
+c
             call strmm('Right'   , 'Upper'      , 'No transpose',
      &                  'Non-unit', n            , nconv         ,
      &                  one       , workl(invsub), ldq           ,
      &                  z         , ldz)
-c     
+c
          end if
-c     
-      else 
+c
+      else
 c
 c        %------------------------------------------------------%
 c        | An approximate invariant subspace is not needed.     |
@@ -920,7 +920,7 @@ c
          call scopy(nconv, workl(ritzi), 1, workl(iheigi), 1)
          call scopy(nconv, workl(bounds), 1, workl(ihbds), 1)
       end if
-c 
+c
 c     %------------------------------------------------%
 c     | Transform the Ritz values and possibly vectors |
 c     | and corresponding error bounds of OP to those  |
@@ -931,23 +931,23 @@ c
 c
          if (rvec)
      &      call sscal(ncv, rnorm, workl(ihbds), 1)
-c    
-      else 
-c     
+c
+      else
+c
 c        %---------------------------------------%
 c        |   A spectral transformation was used. |
 c        | * Determine the Ritz estimates of the |
 c        |   Ritz values in the original system. |
 c        %---------------------------------------%
-c     
+c
          if (type .eq. 'SHIFTI') then
 c
             if (rvec)
      &         call sscal(ncv, rnorm, workl(ihbds), 1)
             do 50 k=1, ncv
-               temp = slapy2(workl(iheigr+k-1), 
+               temp = slapy2(workl(iheigr+k-1),
      &                       workl(iheigi+k-1) )
-               workl(ihbds+k-1) = abs( workl(ihbds+k-1) ) 
+               workl(ihbds+k-1) = abs( workl(ihbds+k-1) )
      &                          / temp / temp
  50         continue
 c
@@ -962,26 +962,26 @@ c
  70         continue
 c
          end if
-c     
+c
 c        %-----------------------------------------------------------%
 c        | *  Transform the Ritz values back to the original system. |
 c        |    For TYPE = 'SHIFTI' the transformation is              |
 c        |             lambda = 1/theta + sigma                      |
 c        |    For TYPE = 'REALPT' or 'IMAGPT' the user must from     |
-c        |    Rayleigh quotients or a projection. See remark 3 above.| 
+c        |    Rayleigh quotients or a projection. See remark 3 above.|
 c        | NOTES:                                                    |
 c        | *The Ritz vectors are not affected by the transformation. |
 c        %-----------------------------------------------------------%
-c     
-         if (type .eq. 'SHIFTI') then 
+c
+         if (type .eq. 'SHIFTI') then
 c
             do 80 k=1, ncv
-               temp = slapy2(workl(iheigr+k-1), 
+               temp = slapy2(workl(iheigr+k-1),
      &                       workl(iheigi+k-1) )
-               workl(iheigr+k-1) = workl(iheigr+k-1) / temp / temp 
-     &                           + sigmar   
+               workl(iheigr+k-1) = workl(iheigr+k-1) / temp / temp
+     &                           + sigmar
                workl(iheigi+k-1) = -workl(iheigi+k-1) / temp / temp
-     &                           + sigmai   
+     &                           + sigmai
  80         continue
 c
             call scopy(nconv, workl(iheigr), 1, dr, 1)
@@ -1011,7 +1011,7 @@ c
       end if
 c
       end if
-c 
+c
 c     %-------------------------------------------------%
 c     | Eigenvector Purification step. Formally perform |
 c     | one of inverse subspace iteration. Only used    |
@@ -1038,13 +1038,13 @@ c
      &                   /  workl(iheigr+j-1)
             else if (iconj .eq. 0) then
                temp = slapy2( workl(iheigr+j-1), workl(iheigi+j-1) )
-               workev(j) = ( workl(invsub+(j-1)*ldq+ncv-1) * 
+               workev(j) = ( workl(invsub+(j-1)*ldq+ncv-1) *
      &                       workl(iheigr+j-1) +
-     &                       workl(invsub+j*ldq+ncv-1) * 
+     &                       workl(invsub+j*ldq+ncv-1) *
      &                       workl(iheigi+j-1) ) / temp / temp
-               workev(j+1) = ( workl(invsub+j*ldq+ncv-1) * 
+               workev(j+1) = ( workl(invsub+j*ldq+ncv-1) *
      &                         workl(iheigr+j-1) -
-     &                         workl(invsub+(j-1)*ldq+ncv-1) * 
+     &                         workl(invsub+(j-1)*ldq+ncv-1) *
      &                         workl(iheigi+j-1) ) / temp / temp
                iconj = 1
             else
@@ -1064,7 +1064,7 @@ c
  9000 continue
 c
       return
-c     
+c
 c     %----------------%
 c     | End of PSNEUPD |
 c     %----------------%

--- a/mathlibs/src/parpack/psngets.f
+++ b/mathlibs/src/parpack/psngets.f
@@ -226,8 +226,8 @@ c
       tngets = tngets + (t1 - t0)
 c
       if (msglvl .gt. 0) then
-         call pivout (comm, logfil, 1, kev, ndigit, '_ngets: KEV is')
-         call pivout (comm, logfil, 1, np, ndigit, '_ngets: NP is')
+         call pivout (comm, logfil, 1, [kev], ndigit, '_ngets: KEV is')
+         call pivout (comm, logfil, 1, [np], ndigit, '_ngets: NP is')
          call psvout (comm, logfil, kev+np, ritzr, ndigit,
      &        '_ngets: Eigenvalues of current H matrix -- real part')
          call psvout (comm, logfil, kev+np, ritzi, ndigit,

--- a/mathlibs/src/parpack/psngets.f
+++ b/mathlibs/src/parpack/psngets.f
@@ -5,9 +5,9 @@ c\Name: psngets
 c
 c Message Passing Layer: MPI
 c
-c\Description: 
+c\Description:
 c  Given the eigenvalues of the upper Hessenberg matrix H,
-c  computes the NP shifts AMU that are zeros of the polynomial of 
+c  computes the NP shifts AMU that are zeros of the polynomial of
 c  degree NP which filters out components of the unwanted eigenvectors
 c  corresponding to the AMU's based on some given criteria.
 c
@@ -46,12 +46,12 @@ c           OUTPUT: Possibly decreases NP by one to keep complex conjugate
 c           pairs together.
 c
 c  RITZR,  Real array of length KEV+NP.  (INPUT/OUTPUT)
-c  RITZI   On INPUT, RITZR and RITZI contain the real and imaginary 
+c  RITZI   On INPUT, RITZR and RITZI contain the real and imaginary
 c          parts of the eigenvalues of H.
 c          On OUTPUT, RITZR and RITZI are sorted so that the unwanted
 c          eigenvalues are in the first NP locations and the wanted
-c          portion is in the last KEV locations.  When exact shifts are 
-c          selected, the unwanted part corresponds to the shifts to 
+c          portion is in the last KEV locations.  When exact shifts are
+c          selected, the unwanted part corresponds to the shifts to
 c          be applied. Also, if ISHIFT .eq. 1, the unwanted eigenvalues
 c          are further sorted so that the ones with largest Ritz values
 c          are first.
@@ -60,7 +60,7 @@ c  BOUNDS  Real array of length KEV+NP.  (INPUT/OUTPUT)
 c          Error bounds corresponding to the ordering in RITZ.
 c
 c  SHIFTR, SHIFTI  *** USE deprecated as of version 2.1. ***
-c  
+c
 c
 c\EndDoc
 c
@@ -80,8 +80,8 @@ c     Danny Sorensen               Phuong Vu
 c     Richard Lehoucq              CRPC / Rice University
 c     Dept. of Computational &     Houston, Texas
 c     Applied Mathematics
-c     Rice University           
-c     Houston, Texas    
+c     Rice University
+c     Houston, Texas
 c
 c\Parallel Modifications
 c     Kristi Maschhoff
@@ -89,8 +89,8 @@ c
 c\Revision history:
 c     Starting Point: Serial Code FILE: ngets.F   SID: 2.2
 c
-c\SCCS Information: 
-c FILE: ngets.F   SID: 1.2   DATE OF SID: 2/22/96   
+c\SCCS Information:
+c FILE: ngets.F   SID: 1.2   DATE OF SID: 2/22/96
 c
 c\Remarks
 c     1. xxxx
@@ -99,8 +99,8 @@ c\EndLib
 c
 c-----------------------------------------------------------------------
 c
-      subroutine psngets 
-     &                 ( comm, ishift, which, kev, np, ritzr, ritzi, 
+      subroutine psngets
+     &                 ( comm, ishift, which, kev, np, ritzr, ritzi,
      &                   bounds, shiftr, shifti )
 c
 c     %--------------------%
@@ -128,7 +128,7 @@ c     | Array Arguments |
 c     %-----------------%
 c
       Real
-     &           bounds(kev+np), ritzr(kev+np), ritzi(kev+np), 
+     &           bounds(kev+np), ritzr(kev+np), ritzi(kev+np),
      &           shiftr(1), shifti(1)
 c
 c     %------------%
@@ -165,10 +165,10 @@ c     %-------------------------------%
 c     | Initialize timing statistics  |
 c     | & message level for debugging |
 c     %-------------------------------%
-c 
+c
       call second (t0)
       msglvl = mngets
-c 
+c
 c     %----------------------------------------------------%
 c     | LM, SM, LR, SR, LI, SI case.                       |
 c     | Sort the eigenvalues of H into the desired order   |
@@ -192,16 +192,16 @@ c
       else if (which .eq. 'SI') then
          call ssortc ('SM', .true., kev+np, ritzr, ritzi, bounds)
       end if
-c      
+c
       call ssortc (which, .true., kev+np, ritzr, ritzi, bounds)
-c     
+c
 c     %-------------------------------------------------------%
 c     | Increase KEV by one if the ( ritzr(np),ritzi(np) )    |
 c     | = ( ritzr(np+1),-ritzi(np+1) ) and ritz(np) .ne. zero |
 c     | Accordingly decrease NP by one. In other words keep   |
 c     | complex conjugate pairs together.                     |
 c     %-------------------------------------------------------%
-c     
+c
       if (       ( ritzr(np+1) - ritzr(np) ) .eq. zero
      &     .and. ( ritzi(np+1) + ritzi(np) ) .eq. zero ) then
          np = np - 1
@@ -209,7 +209,7 @@ c
       end if
 c
       if ( ishift .eq. 1 ) then
-c     
+c
 c        %-------------------------------------------------------%
 c        | Sort the unwanted Ritz values used as shifts so that  |
 c        | the ones with largest Ritz estimates are first        |
@@ -218,10 +218,10 @@ c        | forward instability of the iteration when they shifts |
 c        | are applied in subroutine psnapps.                    |
 c        | Be careful and use 'SR' since we want to sort BOUNDS! |
 c        %-------------------------------------------------------%
-c     
+c
          call ssortc ( 'SR', .true., np, bounds, ritzr, ritzi )
       end if
-c     
+c
       call second (t1)
       tngets = tngets + (t1 - t0)
 c
@@ -232,14 +232,14 @@ c
      &        '_ngets: Eigenvalues of current H matrix -- real part')
          call psvout (comm, logfil, kev+np, ritzi, ndigit,
      &        '_ngets: Eigenvalues of current H matrix -- imag part')
-         call psvout (comm, logfil, kev+np, bounds, ndigit, 
+         call psvout (comm, logfil, kev+np, bounds, ndigit,
      &      '_ngets: Ritz estimates of the current KEV+NP Ritz values')
       end if
-c     
+c
       return
-c     
+c
 c     %----------------%
 c     | End of psngets |
 c     %----------------%
-c     
+c
       end

--- a/mathlibs/src/parpack/pssaitr.f
+++ b/mathlibs/src/parpack/pssaitr.f
@@ -5,8 +5,8 @@ c\Name: pssaitr
 c
 c Message Passing Layer: MPI
 c
-c\Description: 
-c  Reverse communication interface for applying NP additional steps to 
+c\Description:
+c  Reverse communication interface for applying NP additional steps to
 c  a K step symmetric Arnoldi factorization.
 c
 c  Input:  OP*V_{k}  -  V_{k}*H = r_{k}*e_{k}^T
@@ -22,7 +22,7 @@ c  computed and returned.
 c
 c\Usage:
 c  call pssaitr
-c     ( COMM, IDO, BMAT, N, K, NP, MODE, RESID, RNORM, V, LDV, H, LDH, 
+c     ( COMM, IDO, BMAT, N, K, NP, MODE, RESID, RNORM, V, LDV, H, LDH,
 c       IPNTR, WORKD, WORKL, INFO )
 c
 c\Arguments
@@ -80,13 +80,13 @@ c          On INPUT the B-norm of r_{k}.
 c          On OUTPUT the B-norm of the updated residual r_{k+p}.
 c
 c  V       Real N by K+NP array.  (INPUT/OUTPUT)
-c          On INPUT:  V contains the Arnoldi vectors in the first K 
+c          On INPUT:  V contains the Arnoldi vectors in the first K
 c          columns.
 c          On OUTPUT: V contains the new NP Arnoldi vectors in the next
 c          NP columns.  The first K columns are unchanged.
 c
 c  LDV     Integer.  (INPUT)
-c          Leading dimension of V exactly as declared in the calling 
+c          Leading dimension of V exactly as declared in the calling
 c          program.
 c
 c  H       Real (K+NP) by 2 array.  (INPUT/OUTPUT)
@@ -95,26 +95,26 @@ c          with the subdiagonal in the first column starting at H(2,1)
 c          and the main diagonal in the second column.
 c
 c  LDH     Integer.  (INPUT)
-c          Leading dimension of H exactly as declared in the calling 
+c          Leading dimension of H exactly as declared in the calling
 c          program.
 c
 c  IPNTR   Integer array of length 3.  (OUTPUT)
-c          Pointer to mark the starting locations in the WORK for 
+c          Pointer to mark the starting locations in the WORK for
 c          vectors used by the Arnoldi iteration.
 c          -------------------------------------------------------------
 c          IPNTR(1): pointer to the current operand vector X.
 c          IPNTR(2): pointer to the current result vector Y.
-c          IPNTR(3): pointer to the vector B * X when used in the 
+c          IPNTR(3): pointer to the vector B * X when used in the
 c                    shift-and-invert mode.  X is the current operand.
 c          -------------------------------------------------------------
-c          
+c
 c  WORKD   Real work array of length 3*N.  (REVERSE COMMUNICATION)
 c          Distributed array to be used in the basic Arnoldi iteration
-c          for reverse communication.  The calling program should not 
+c          for reverse communication.  The calling program should not
 c          use WORKD as temporary workspace during the iteration !!!!!!
 c          On INPUT, WORKD(1:N) = B*RESID where RESID is associated
-c          with the K step Arnoldi factorization. Used to save some 
-c          computation at the first step. 
+c          with the K step Arnoldi factorization. Used to save some
+c          computation at the first step.
 c          On OUTPUT, WORKD(1:N) = B*RESID where RESID is associated
 c          with the K+NP step Arnoldi factorization.
 c
@@ -145,7 +145,7 @@ c     sgemv    Level 2 BLAS routine for matrix vector multiplication.
 c     saxpy    Level 1 BLAS that computes a vector triad.
 c     sscal    Level 1 BLAS that scales a vector.
 c     scopy    Level 1 BLAS that copies one vector to another .
-c     sdot     Level 1 BLAS that computes the scalar product of two vectors. 
+c     sdot     Level 1 BLAS that computes the scalar product of two vectors.
 c     psnorm2  Parallel version of Level 1 BLAS that computes the norm of a vector.
 c
 c\Author
@@ -153,32 +153,32 @@ c     Danny Sorensen               Phuong Vu
 c     Richard Lehoucq              CRPC / Rice University
 c     Dept. of Computational &     Houston, Texas
 c     Applied Mathematics
-c     Rice University           
-c     Houston, Texas            
-c 
+c     Rice University
+c     Houston, Texas
+c
 c\Parallel Modifications
 c     Kristi Maschhoff
 c
 c\Revision history:
 c     Starting Point: Serial Code FILE: saitr.F   SID: 2.3
 c
-c\SCCS Information: 
-c FILE: saitr.F   SID: 1.3   DATE OF SID: 3/19/97   
+c\SCCS Information:
+c FILE: saitr.F   SID: 1.3   DATE OF SID: 3/19/97
 c
 c\Remarks
 c  The algorithm implemented is:
-c  
+c
 c  restart = .false.
-c  Given V_{k} = [v_{1}, ..., v_{k}], r_{k}; 
+c  Given V_{k} = [v_{1}, ..., v_{k}], r_{k};
 c  r_{k} contains the initial residual vector even for k = 0;
-c  Also assume that rnorm = || B*r_{k} || and B*r_{k} are already 
+c  Also assume that rnorm = || B*r_{k} || and B*r_{k} are already
 c  computed by the calling program.
 c
 c  betaj = rnorm ; p_{k+1} = B*r_{k} ;
 c  For  j = k+1, ..., k+np  Do
 c     1) if ( betaj < tol ) stop or restart depending on j.
 c        if ( restart ) generate a new starting vector.
-c     2) v_{j} = r(j-1)/betaj;  V_{j} = [V_{j-1}, v_{j}];  
+c     2) v_{j} = r(j-1)/betaj;  V_{j} = [V_{j-1}, v_{j}];
 c        p_{j} = p_{j}/betaj
 c     3) r_{j} = OP*v_{j} where OP is defined as in pssaupd
 c        For shift-invert mode p_{j} = B*v_{j} is already available.
@@ -193,7 +193,7 @@ c        If (rnorm > 0.717*wnorm) accept step and go back to 1)
 c     5) Re-orthogonalization step:
 c        s = V_{j}'*B*r_{j}
 c        r_{j} = r_{j} - V_{j}*s;  rnorm1 = || r_{j} ||
-c        alphaj = alphaj + s_{j};   
+c        alphaj = alphaj + s_{j};
 c     6) Iterative refinement step:
 c        If (rnorm1 > 0.717*rnorm) then
 c           rnorm = rnorm1
@@ -203,7 +203,7 @@ c           rnorm = rnorm1
 c           If this is the first time in step 6), go to 5)
 c           Else r_{j} lies in the span of V_{j} numerically.
 c              Set r_{j} = 0 and rnorm = 0; go to 1)
-c        EndIf 
+c        EndIf
 c  End Do
 c
 c\EndLib
@@ -211,7 +211,7 @@ c
 c-----------------------------------------------------------------------
 c
       subroutine pssaitr
-     &   (comm, ido, bmat, n, k, np, mode, resid, rnorm, v, ldv, h, ldh, 
+     &   (comm, ido, bmat, n, k, np, mode, resid, rnorm, v, ldv, h, ldh,
      &    ipntr, workd, workl, info)
 c
       include   'mpif.h'
@@ -272,7 +272,7 @@ c
      &           rnorm_buf
 c
 c     %-----------------------%
-c     | Local Array Arguments | 
+c     | Local Array Arguments |
 c     %-----------------------%
 c
       Real
@@ -322,7 +322,7 @@ c
       end if
 c
       if (ido .eq. 0) then
-c 
+c
 c        %-------------------------------%
 c        | Initialize timing statistics  |
 c        | & message level for debugging |
@@ -330,7 +330,7 @@ c        %-------------------------------%
 c
          call second (t0)
          msglvl = msaitr
-c 
+c
 c        %------------------------------%
 c        | Initial call to this routine |
 c        %------------------------------%
@@ -341,14 +341,14 @@ c
          rstart = .false.
          orth1  = .false.
          orth2  = .false.
-c 
+c
 c        %--------------------------------%
 c        | Pointer to the current step of |
 c        | the factorization to build     |
 c        %--------------------------------%
 c
          j      = k + 1
-c 
+c
 c        %------------------------------------------%
 c        | Pointers used for reverse communication  |
 c        | when using WORKD.                        |
@@ -358,7 +358,7 @@ c
          irj    = ipj   + n
          ivj    = irj   + n
       end if
-c 
+c
 c     %-------------------------------------------------%
 c     | When in reverse communication mode one of:      |
 c     | STEP3, STEP4, ORTH1, ORTH2, RSTART              |
@@ -381,7 +381,7 @@ c
 c     %------------------------------%
 c     | Else this is the first step. |
 c     %------------------------------%
-c 
+c
 c     %--------------------------------------------------------------%
 c     |                                                              |
 c     |        A R N O L D I     I T E R A T I O N     L O O P       |
@@ -392,9 +392,9 @@ c
  1000 continue
 c
          if (msglvl .gt. 2) then
-            call pivout (comm, logfil, 1, [j], ndigit, 
+            call pivout (comm, logfil, 1, [j], ndigit,
      &                  '_saitr: generating Arnoldi vector no.')
-            call psvout (comm, logfil, 1, [rnorm], ndigit, 
+            call psvout (comm, logfil, 1, [rnorm], ndigit,
      &                  '_saitr: B-norm of the current residual =')
          end if
 c
@@ -415,7 +415,7 @@ c
                call pivout (comm, logfil, 1, [j], ndigit,
      &                     '_saitr: ****** restart at step ******')
             end if
-c 
+c
 c           %---------------------------------------------%
 c           | ITRY is the loop variable that controls the |
 c           | maximum amount of times that a restart is   |
@@ -434,7 +434,7 @@ c           | If in reverse communication mode and |
 c           | RSTART = .true. flow returns here.   |
 c           %--------------------------------------%
 c
-            call psgetv0 (comm, ido, bmat, itry, .false., n, j, v, ldv, 
+            call psgetv0 (comm, ido, bmat, itry, .false., n, j, v, ldv,
      &                   resid, rnorm, ipntr, workd, workl, ierr)
             if (ido .ne. 99) go to 9000
             if (ierr .lt. 0) then
@@ -453,7 +453,7 @@ c
                ido = 99
                go to 9000
             end if
-c 
+c
    40    continue
 c
 c        %---------------------------------------------------------%
@@ -475,12 +475,12 @@ c            | To scale both v_{j} and p_{j} carefully |
 c            | use LAPACK routine SLASCL               |
 c            %-----------------------------------------%
 c
-             call slascl ('General', i, i, rnorm, one, n, 1, 
+             call slascl ('General', i, i, rnorm, one, n, 1,
      &                    v(1,j), n, infol)
-             call slascl ('General', i, i, rnorm, one, n, 1, 
+             call slascl ('General', i, i, rnorm, one, n, 1,
      &                    workd(ipj), n, infol)
          end if
-c 
+c
 c        %------------------------------------------------------%
 c        | STEP 3:  r_{j} = OP*v_{j}; Note that p_{j} = B*v_{j} |
 c        | Note that this is not quite yet r_{j}. See STEP 4    |
@@ -494,14 +494,14 @@ c
          ipntr(2) = irj
          ipntr(3) = ipj
          ido = 1
-c 
+c
 c        %-----------------------------------%
 c        | Exit in order to compute OP*v_{j} |
 c        %-----------------------------------%
-c 
+c
          go to 9000
    50    continue
-c 
+c
 c        %-----------------------------------%
 c        | Back from reverse communication;  |
 c        | WORKD(IRJ:IRJ+N-1) := OP*v_{j}.   |
@@ -509,7 +509,7 @@ c        %-----------------------------------%
 c
          call second (t3)
          tmvopx = tmvopx + (t3 - t2)
-c 
+c
          step3 = .false.
 c
 c        %------------------------------------------%
@@ -517,7 +517,7 @@ c        | Put another copy of OP*v_{j} into RESID. |
 c        %------------------------------------------%
 c
          call scopy (n, workd(irj), 1, resid, 1)
-c 
+c
 c        %-------------------------------------------%
 c        | STEP 4:  Finish extending the symmetric   |
 c        |          Arnoldi to length j. If MODE = 2 |
@@ -535,17 +535,17 @@ c
             ipntr(1) = irj
             ipntr(2) = ipj
             ido = 2
-c 
+c
 c           %-------------------------------------%
 c           | Exit in order to compute B*OP*v_{j} |
 c           %-------------------------------------%
-c 
+c
             go to 9000
          else if (bmat .eq. 'I') then
               call scopy(n, resid, 1 , workd(ipj), 1)
          end if
    60    continue
-c 
+c
 c        %-----------------------------------%
 c        | Back from reverse communication;  |
 c        | WORKD(IPJ:IPJ+N-1) := B*OP*v_{j}. |
@@ -554,7 +554,7 @@ c
          if (bmat .eq. 'G') then
             call second (t3)
             tmvbx = tmvbx + (t3 - t2)
-         end if 
+         end if
 c
          step4 = .false.
 c
@@ -599,12 +599,12 @@ c        | WORKD(IPJ:IPJ+N-1) contains B*OP*v_{j}.  |
 c        %------------------------------------------%
 c
          if (mode .ne. 2 ) then
-            call sgemv('T', n, j, one, v, ldv, workd(ipj), 1, zero, 
+            call sgemv('T', n, j, one, v, ldv, workd(ipj), 1, zero,
      &                  workl(j+1), 1)
             call MPI_ALLREDUCE( workl(j+1), workl(1), j,
      &                  MPI_REAL, MPI_SUM, comm, ierr)
          else if (mode .eq. 2) then
-            call sgemv('T', n, j, one, v, ldv, workd(ivj), 1, zero, 
+            call sgemv('T', n, j, one, v, ldv, workd(ivj), 1, zero,
      &                  workl(j+1), 1)
             call MPI_ALLREDUCE( workl(j+1), workl(1), j,
      &                  MPI_REAL, MPI_SUM, comm, ierr)
@@ -612,10 +612,10 @@ c
 c
 c        %--------------------------------------%
 c        | Orthgonalize r_{j} against V_{j}.    |
-c        | RESID contains OP*v_{j}. See STEP 3. | 
+c        | RESID contains OP*v_{j}. See STEP 3. |
 c        %--------------------------------------%
 c
-         call sgemv('N', n, j, -one, v, ldv, workl(1), 1, one, 
+         call sgemv('N', n, j, -one, v, ldv, workl(1), 1, one,
      &               resid, 1)
 c
 c        %--------------------------------------%
@@ -629,10 +629,10 @@ c
             h(j,1) = rnorm
          end if
          call second (t4)
-c 
+c
          orth1 = .true.
          iter  = 0
-c 
+c
          call second (t2)
          if (bmat .eq. 'G') then
             nbx = nbx + 1
@@ -640,17 +640,17 @@ c
             ipntr(1) = irj
             ipntr(2) = ipj
             ido = 2
-c 
+c
 c           %----------------------------------%
 c           | Exit in order to compute B*r_{j} |
 c           %----------------------------------%
-c 
+c
             go to 9000
          else if (bmat .eq. 'I') then
             call scopy (n, resid, 1, workd(ipj), 1)
          end if
    70    continue
-c 
+c
 c        %---------------------------------------------------%
 c        | Back from reverse communication if ORTH1 = .true. |
 c        | WORKD(IPJ:IPJ+N-1) := B*r_{j}.                    |
@@ -660,7 +660,7 @@ c
             call second (t3)
             tmvbx = tmvbx + (t3 - t2)
          end if
-c 
+c
          orth1 = .false.
 c
 c        %------------------------------%
@@ -693,7 +693,7 @@ c        %-----------------------------------------------------------%
 c
          if (rnorm .gt. 0.717*wnorm) go to 100
          nrorth = nrorth + 1
-c 
+c
 c        %---------------------------------------------------%
 c        | Enter the Iterative refinement phase. If further  |
 c        | refinement is necessary, loop back here. The loop |
@@ -706,7 +706,7 @@ c
          if (msglvl .gt. 2) then
             xtemp(1) = wnorm
             xtemp(2) = rnorm
-            call psvout (comm, logfil, 2, xtemp, ndigit, 
+            call psvout (comm, logfil, 2, xtemp, ndigit,
      &           '_naitr: re-orthonalization ; wnorm and rnorm are')
          end if
 c
@@ -728,12 +728,12 @@ c        | v(:,1:J)*WORKD(IRJ:IRJ+J-1)*e'_j, but only   |
 c        | H(j,j) is updated.                           |
 c        %----------------------------------------------%
 c
-         call sgemv ('N', n, j, -one, v, ldv, workl(1), 1, 
+         call sgemv ('N', n, j, -one, v, ldv, workl(1), 1,
      &               one, resid, 1)
 c
          if (j .eq. 1  .or.  rstart) h(j,1) = zero
          h(j,2) = h(j,2) + workl(j)
-c 
+c
          orth2 = .true.
          call second (t2)
          if (bmat .eq. 'G') then
@@ -742,12 +742,12 @@ c
             ipntr(1) = irj
             ipntr(2) = ipj
             ido = 2
-c 
+c
 c           %-----------------------------------%
 c           | Exit in order to compute B*r_{j}. |
 c           | r_{j} is the corrected residual.  |
 c           %-----------------------------------%
-c 
+c
             go to 9000
          else if (bmat .eq. 'I') then
             call scopy (n, resid, 1, workd(ipj), 1)
@@ -766,7 +766,7 @@ c
 c        %-----------------------------------------------------%
 c        | Compute the B-norm of the corrected residual r_{j}. |
 c        %-----------------------------------------------------%
-c 
+c
          if (bmat .eq. 'G') then
            rnorm_buf = sdot (n, resid, 1, workd(ipj), 1)
            call MPI_ALLREDUCE( rnorm_buf, rnorm1, 1,
@@ -775,7 +775,7 @@ c
          else if (bmat .eq. 'I') then
            rnorm1 = psnorm2( comm, n, resid, 1 )
          end if
-c 
+c
          if (msglvl .gt. 0 .and. iter .gt. 0) then
             call pivout (comm, logfil, 1, [j], ndigit,
      &           '_naitr: Iterative refinement for Arnoldi residual')
@@ -799,7 +799,7 @@ c           | No need for further refinement |
 c           %--------------------------------%
 c
             rnorm = rnorm1
-c 
+c
          else
 c
 c           %-------------------------------------------%
@@ -821,7 +821,7 @@ c
   95        continue
             rnorm = zero
          end if
-c 
+c
 c        %----------------------------------------------%
 c        | Branch here directly if iterative refinement |
 c        | wasn't necessary or after at most NITER_REF  |
@@ -829,13 +829,13 @@ c        | steps of iterative refinement.               |
 c        %----------------------------------------------%
 c
   100    continue
-c 
+c
          rstart = .false.
          orth2  = .false.
-c 
+c
          call second (t5)
          titref = titref + (t5 - t4)
-c 
+c
 c        %----------------------------------------------------------%
 c        | Make sure the last off-diagonal element is non negative  |
 c        | If not perform a similarity transformation on H(1:j,1:j) |
@@ -850,7 +850,7 @@ c
                call sscal(n, -one, resid, 1)
             end if
          end if
-c 
+c
 c        %------------------------------------%
 c        | STEP 6: Update  j = j+1;  Continue |
 c        %------------------------------------%
@@ -862,10 +862,10 @@ c
             ido = 99
 c
             if (msglvl .gt. 1) then
-               call psvout (comm, logfil, k+np, h(1,2), ndigit, 
+               call psvout (comm, logfil, k+np, h(1,2), ndigit,
      &         '_saitr: main diagonal of matrix H of step K+NP.')
                if (k+np .gt. 1) then
-               call psvout (comm, logfil, k+np-1, h(2,1), ndigit, 
+               call psvout (comm, logfil, k+np-1, h(2,1), ndigit,
      &         '_saitr: sub diagonal of matrix H of step K+NP.')
                end if
             end if
@@ -878,7 +878,7 @@ c        | Loop back to extend the factorization by another step. |
 c        %--------------------------------------------------------%
 c
       go to 1000
-c 
+c
 c     %---------------------------------------------------------------%
 c     |                                                               |
 c     |  E N D     O F     M A I N     I T E R A T I O N     L O O P  |

--- a/mathlibs/src/parpack/pssaitr.f
+++ b/mathlibs/src/parpack/pssaitr.f
@@ -392,9 +392,9 @@ c
  1000 continue
 c
          if (msglvl .gt. 2) then
-            call pivout (comm, logfil, 1, j, ndigit, 
+            call pivout (comm, logfil, 1, [j], ndigit, 
      &                  '_saitr: generating Arnoldi vector no.')
-            call psvout (comm, logfil, 1, rnorm, ndigit, 
+            call psvout (comm, logfil, 1, [rnorm], ndigit, 
      &                  '_saitr: B-norm of the current residual =')
          end if
 c
@@ -412,7 +412,7 @@ c           | basis and continue the iteration.                 |
 c           %---------------------------------------------------%
 c
             if (msglvl .gt. 0) then
-               call pivout (comm, logfil, 1, j, ndigit,
+               call pivout (comm, logfil, 1, [j], ndigit,
      &                     '_saitr: ****** restart at step ******')
             end if
 c 
@@ -777,7 +777,7 @@ c
          end if
 c 
          if (msglvl .gt. 0 .and. iter .gt. 0) then
-            call pivout (comm, logfil, 1, j, ndigit,
+            call pivout (comm, logfil, 1, [j], ndigit,
      &           '_naitr: Iterative refinement for Arnoldi residual')
             if (msglvl .gt. 2) then
                 xtemp(1) = rnorm

--- a/mathlibs/src/parpack/pssapps.f
+++ b/mathlibs/src/parpack/pssapps.f
@@ -272,9 +272,9 @@ c
             big   = abs(h(i,2)) + abs(h(i+1,2))
             if (h(i+1,1) .le. epsmch*big) then
                if (msglvl .gt. 0) then
-                  call pivout (comm, logfil, 1, i, ndigit, 
+                  call pivout (comm, logfil, 1, [i], ndigit, 
      &                 '_sapps: deflation at row/column no.')
-                  call pivout (comm, logfil, 1, jj, ndigit, 
+                  call pivout (comm, logfil, 1, [jj], ndigit, 
      &                 '_sapps: occured before shift number.')
                   call psvout (comm, logfil, 1, h(i+1,1), ndigit, 
      &                 '_sapps: the corresponding off diagonal element')
@@ -443,7 +443,7 @@ c
          big   = abs(h(i,2)) + abs(h(i+1,2))
          if (h(i+1,1) .le. epsmch*big) then
             if (msglvl .gt. 0) then
-               call pivout (comm, logfil, 1, i, ndigit, 
+               call pivout (comm, logfil, 1, [i], ndigit, 
      &              '_sapps: deflation at row/column no.')
                call psvout (comm, logfil, 1, h(i+1,1), ndigit, 
      &              '_sapps: the corresponding off diagonal element')

--- a/mathlibs/src/parpack/pssapps.f
+++ b/mathlibs/src/parpack/pssapps.f
@@ -12,8 +12,8 @@ c  apply NP shifts implicitly resulting in
 c
 c     A*(V_{k}*Q) - (V_{k}*Q)*(Q^T* H_{k}*Q) = r_{k+p}*e_{k+p}^T * Q
 c
-c  where Q is an orthogonal matrix of order KEV+NP. Q is the product of 
-c  rotations resulting from the NP bulge chasing sweeps.  The updated Arnoldi 
+c  where Q is an orthogonal matrix of order KEV+NP. Q is the product of
+c  rotations resulting from the NP bulge chasing sweeps.  The updated Arnoldi
 c  factorization becomes:
 c
 c     A*VNEW_{k} - VNEW_{k}*HNEW_{k} = rnew_{k}*e_{k}^T.
@@ -51,7 +51,7 @@ c  H       Real (KEV+NP) by 2 array.  (INPUT/OUTPUT)
 c          INPUT: H contains the symmetric tridiagonal matrix of the
 c          Arnoldi factorization with the subdiagonal in the 1st column
 c          starting at H(2,1) and the main diagonal in the 2nd column.
-c          OUTPUT: H contains the updated tridiagonal matrix in the 
+c          OUTPUT: H contains the updated tridiagonal matrix in the
 c          KEV leading submatrix.
 c
 c  LDH     Integer.  (INPUT)
@@ -87,12 +87,12 @@ c\References:
 c  1. D.C. Sorensen, "Implicit Application of Polynomial Filters in
 c     a k-Step Arnoldi Method", SIAM J. Matr. Anal. Apps., 13 (1992),
 c     pp 357-385.
-c  2. R.B. Lehoucq, "Analysis and Implementation of an Implicitly 
+c  2. R.B. Lehoucq, "Analysis and Implementation of an Implicitly
 c     Restarted Arnoldi Iteration", Rice University Technical Report
 c     TR95-13, Department of Computational and Applied Mathematics.
 c
 c\Routines called:
-c     pivout  Parallel ARPACK utility routine that prints integers. 
+c     pivout  Parallel ARPACK utility routine that prints integers.
 c     second  ARPACK utility routine for timing.
 c     psvout  Parallel ARPACK utility routine that prints vectors.
 c     pslamch ScaLAPACK routine that determines machine constants.
@@ -109,8 +109,8 @@ c     Danny Sorensen               Phuong Vu
 c     Richard Lehoucq              CRPC / Rice University
 c     Dept. of Computational &     Houston, Texas
 c     Applied Mathematics
-c     Rice University           
-c     Houston, Texas            
+c     Rice University
+c     Houston, Texas
 c
 c\Parallel Modifications
 c     Kristi Maschhoff
@@ -123,8 +123,8 @@ c FILE: sapps.F   SID: 1.3   DATE OF SID: 3/19/97
 c
 c\Remarks
 c  1. In this version, each shift is applied to all the subblocks of
-c     the tridiagonal matrix H and not just to the submatrix that it 
-c     comes from. This routine assumes that the subdiagonal elements 
+c     the tridiagonal matrix H and not just to the submatrix that it
+c     comes from. This routine assumes that the subdiagonal elements
 c     of H that are stored in h(1:kev+np,1) are nonegative upon input
 c     and enforce this condition upon output. This version incorporates
 c     deflation. See code for documentation.
@@ -160,7 +160,7 @@ c     | Array Arguments |
 c     %-----------------%
 c
       Real
-     &           h(ldh,2), q(ldq,kev+np), resid(n), shift(np), 
+     &           h(ldh,2), q(ldq,kev+np), resid(n), shift(np),
      &           v(ldv,kev+np), workd(2*n)
 c
 c     %------------%
@@ -186,7 +186,7 @@ c     %----------------------%
 c     | External Subroutines |
 c     %----------------------%
 c
-      external   saxpy, scopy, sscal, slacpy, slartg, slaset, psvout, 
+      external   saxpy, scopy, sscal, slacpy, slartg, slaset, psvout,
      &           pivout, second, sgemv
 c
 c     %--------------------%
@@ -226,9 +226,9 @@ c     %-------------------------------%
 c
       call second (t0)
       msglvl = msapps
-c 
-      kplusp = kev + np 
-c 
+c
+      kplusp = kev + np
+c
 c     %----------------------------------------------%
 c     | Initialize Q to the identity matrix of order |
 c     | kplusp used to accumulate the rotations.     |
@@ -241,7 +241,7 @@ c     | Quick return if there are no shifts to apply |
 c     %----------------------------------------------%
 c
       if (np .eq. 0) go to 9000
-c 
+c
 c     %----------------------------------------------------------%
 c     | Apply the np shifts implicitly. Apply each shift to the  |
 c     | whole matrix and not just to the submatrix from which it |
@@ -249,7 +249,7 @@ c     | comes.                                                   |
 c     %----------------------------------------------------------%
 c
       do 90 jj = 1, np
-c 
+c
          istart = itop
 c
 c        %----------------------------------------------------------%
@@ -272,11 +272,11 @@ c
             big   = abs(h(i,2)) + abs(h(i+1,2))
             if (h(i+1,1) .le. epsmch*big) then
                if (msglvl .gt. 0) then
-                  call pivout (comm, logfil, 1, [i], ndigit, 
+                  call pivout (comm, logfil, 1, [i], ndigit,
      &                 '_sapps: deflation at row/column no.')
-                  call pivout (comm, logfil, 1, [jj], ndigit, 
+                  call pivout (comm, logfil, 1, [jj], ndigit,
      &                 '_sapps: occured before shift number.')
-                  call psvout (comm, logfil, 1, h(i+1,1), ndigit, 
+                  call psvout (comm, logfil, 1, h(i+1,1), ndigit,
      &                 '_sapps: the corresponding off diagonal element')
                end if
                h(i+1,1) = zero
@@ -288,7 +288,7 @@ c
    40    continue
 c
          if (istart .lt. iend) then
-c 
+c
 c           %--------------------------------------------------------%
 c           | Construct the plane rotation G'(istart,istart+1,theta) |
 c           | that attempts to drive h(istart+1,1) to zero.          |
@@ -297,7 +297,7 @@ c
              f = h(istart,2) - shift(jj)
              g = h(istart+1,1)
              call slartg (f, g, c, s, r)
-c 
+c
 c            %-------------------------------------------------------%
 c            | Apply rotation to the left and right of H;            |
 c            | H <- G' * H * G,  where G = G(istart,istart+1,theta). |
@@ -307,11 +307,11 @@ c
              a1 = c*h(istart,2)   + s*h(istart+1,1)
              a2 = c*h(istart+1,1) + s*h(istart+1,2)
              a4 = c*h(istart+1,2) - s*h(istart+1,1)
-             a3 = c*h(istart+1,1) - s*h(istart,2) 
+             a3 = c*h(istart+1,1) - s*h(istart,2)
              h(istart,2)   = c*a1 + s*a2
              h(istart+1,2) = c*a4 - s*a3
              h(istart+1,1) = c*a3 + s*a4
-c 
+c
 c            %----------------------------------------------------%
 c            | Accumulate the rotation in the matrix Q;  Q <- Q*G |
 c            %----------------------------------------------------%
@@ -334,7 +334,7 @@ c            | zero.                                        |
 c            %----------------------------------------------%
 c
              do 70 i = istart+1, iend-1
-c 
+c
 c               %----------------------------------------------%
 c               | Construct the plane rotation G'(i,i+1,theta) |
 c               | that zeros the i-th bulge that was created   |
@@ -362,28 +362,28 @@ c
                    c = -c
                    s = -s
                 end if
-c 
+c
 c               %--------------------------------------------%
 c               | Apply rotation to the left and right of H; |
 c               | H <- G * H * G',  where G = G(i,i+1,theta) |
 c               %--------------------------------------------%
 c
                 h(i,1) = r
-c 
+c
                 a1 = c*h(i,2)   + s*h(i+1,1)
                 a2 = c*h(i+1,1) + s*h(i+1,2)
                 a3 = c*h(i+1,1) - s*h(i,2)
                 a4 = c*h(i+1,2) - s*h(i+1,1)
-c 
+c
                 h(i,2)   = c*a1 + s*a2
                 h(i+1,2) = c*a4 - s*a3
                 h(i+1,1) = c*a3 + s*a4
-c 
+c
 c               %----------------------------------------------------%
 c               | Accumulate the rotation in the matrix Q;  Q <- Q*G |
 c               %----------------------------------------------------%
 c
-                do 50 j = 1, min( i+jj, kplusp ) 
+                do 50 j = 1, min( i+jj, kplusp )
                    a1       =   c*q(j,i) + s*q(j,i+1)
                    q(j,i+1) = - s*q(j,i) + c*q(j,i+1)
                    q(j,i)   = a1
@@ -436,16 +436,16 @@ c
 c     %------------------------------------------%
 c     | All shifts have been applied. Check for  |
 c     | more possible deflation that might occur |
-c     | after the last shift is applied.         |                               
+c     | after the last shift is applied.         |
 c     %------------------------------------------%
 c
       do 100 i = itop, kplusp-1
          big   = abs(h(i,2)) + abs(h(i+1,2))
          if (h(i+1,1) .le. epsmch*big) then
             if (msglvl .gt. 0) then
-               call pivout (comm, logfil, 1, [i], ndigit, 
+               call pivout (comm, logfil, 1, [i], ndigit,
      &              '_sapps: deflation at row/column no.')
-               call psvout (comm, logfil, 1, h(i+1,1), ndigit, 
+               call psvout (comm, logfil, 1, h(i+1,1), ndigit,
      &              '_sapps: the corresponding off diagonal element')
             end if
             h(i+1,1) = zero
@@ -458,13 +458,13 @@ c     | temporarily store the result in WORKD(N+1:2*N). |
 c     | This is not necessary if h(kev+1,1) = 0.         |
 c     %-------------------------------------------------%
 c
-      if ( h(kev+1,1) .gt. zero ) 
+      if ( h(kev+1,1) .gt. zero )
      &   call sgemv ('N', n, kplusp, one, v, ldv,
      &                q(1,kev+1), 1, zero, workd(n+1), 1)
-c 
+c
 c     %-------------------------------------------------------%
 c     | Compute column 1 to kev of (V*Q) in backward order    |
-c     | taking advantage that Q is an upper triangular matrix |    
+c     | taking advantage that Q is an upper triangular matrix |
 c     | with lower bandwidth np.                              |
 c     | Place results in v(:,kplusp-kev:kplusp) temporarily.  |
 c     %-------------------------------------------------------%
@@ -480,15 +480,15 @@ c     |  Move v(:,kplusp-kev+1:kplusp) into v(:,1:kev). |
 c     %-------------------------------------------------%
 c
       call slacpy ('All', n, kev, v(1,np+1), ldv, v, ldv)
-c 
+c
 c     %--------------------------------------------%
 c     | Copy the (kev+1)-st column of (V*Q) in the |
 c     | appropriate place if h(kev+1,1) .ne. zero. |
 c     %--------------------------------------------%
 c
-      if ( h(kev+1,1) .gt. zero ) 
+      if ( h(kev+1,1) .gt. zero )
      &     call scopy (n, workd(n+1), 1, v(1,kev+1), 1)
-c 
+c
 c     %-------------------------------------%
 c     | Update the residual vector:         |
 c     |    r <- sigmak*r + betak*v(:,kev+1) |
@@ -498,26 +498,26 @@ c     |    betak = e_{kev+1}'*H*e_{kev}     |
 c     %-------------------------------------%
 c
       call sscal (n, q(kplusp,kev), resid, 1)
-      if (h(kev+1,1) .gt. zero) 
+      if (h(kev+1,1) .gt. zero)
      &   call saxpy (n, h(kev+1,1), v(1,kev+1), 1, resid, 1)
 c
       if (msglvl .gt. 1) then
-         call psvout (comm, logfil, 1, q(kplusp,kev), ndigit, 
+         call psvout (comm, logfil, 1, q(kplusp,kev), ndigit,
      &      '_sapps: sigmak of the updated residual vector')
-         call psvout (comm, logfil, 1, h(kev+1,1), ndigit, 
+         call psvout (comm, logfil, 1, h(kev+1,1), ndigit,
      &      '_sapps: betak of the updated residual vector')
-         call psvout (comm, logfil, kev, h(1,2), ndigit, 
+         call psvout (comm, logfil, kev, h(1,2), ndigit,
      &      '_sapps: updated main diagonal of H for next iteration')
          if (kev .gt. 1) then
-         call psvout (comm, logfil, kev-1, h(2,1), ndigit, 
+         call psvout (comm, logfil, kev-1, h(2,1), ndigit,
      &      '_sapps: updated sub diagonal of H for next iteration')
          end if
       end if
 c
       call second (t1)
       tsapps = tsapps + (t1 - t0)
-c 
- 9000 continue 
+c
+ 9000 continue
       return
 c
 c     %----------------%

--- a/mathlibs/src/parpack/pssaup2.f
+++ b/mathlibs/src/parpack/pssaup2.f
@@ -424,13 +424,13 @@ c
          iter = iter + 1
 c
          if (msglvl .gt. 0) then
-            call pivout (comm, logfil, 1, iter, ndigit, 
+            call pivout (comm, logfil, 1, [iter], ndigit, 
      &           '_saup2: **** Start of major iteration number ****')
          end if
          if (msglvl .gt. 1) then
-            call pivout (comm, logfil, 1, nev, ndigit, 
+            call pivout (comm, logfil, 1, [nev], ndigit, 
      &     '_saup2: The length of the current Lanczos factorization')
-            call pivout (comm, logfil, 1, np, ndigit, 
+            call pivout (comm, logfil, 1, [np], ndigit, 
      &           '_saup2: Extend the Lanczos factorization by')
          end if
 c 
@@ -469,7 +469,7 @@ c
          update = .false.
 c
          if (msglvl .gt. 1) then
-            call psvout (comm, logfil, 1, rnorm, ndigit, 
+            call psvout (comm, logfil, 1, [rnorm], ndigit, 
      &           '_saup2: Current B-norm of residual for factorization')
          end if
 c 
@@ -719,7 +719,7 @@ c
          end if
 c
          if (msglvl .gt. 0) then
-            call pivout (comm, logfil, 1, nconv, ndigit,
+            call pivout (comm, logfil, 1, [nconv], ndigit,
      &           '_saup2: no. of "converged" Ritz values at this iter.')
             if (msglvl .gt. 1) then
                kp(1) = nev
@@ -766,7 +766,7 @@ c
          if (ishift .eq. 0) call scopy (np, workl, 1, ritz, 1)
 c
          if (msglvl .gt. 2) then
-            call pivout (comm, logfil, 1, np, ndigit,
+            call pivout (comm, logfil, 1, [np], ndigit,
      &                  '_saup2: The number of shifts to apply ')
             call psvout (comm, logfil, np, workl, ndigit,
      &                  '_saup2: shifts selected')
@@ -835,7 +835,7 @@ c
   130    continue
 c
          if (msglvl .gt. 2) then
-            call psvout (comm, logfil, 1, rnorm, ndigit, 
+            call psvout (comm, logfil, 1, [rnorm], ndigit, 
      &      '_saup2: B-norm of residual for NEV factorization')
             call psvout (comm, logfil, nev, h(1,2), ndigit,
      &           '_saup2: main diagonal of compressed H matrix')

--- a/mathlibs/src/parpack/pssaup2.f
+++ b/mathlibs/src/parpack/pssaup2.f
@@ -5,26 +5,26 @@ c\Name: pssaup2
 c
 c Message Passing Layer: MPI
 c
-c\Description: 
+c\Description:
 c  Intermediate level interface called by pssaupd.
 c
 c\Usage:
-c  call pssaup2 
+c  call pssaup2
 c     ( COMM, IDO, BMAT, N, WHICH, NEV, NP, TOL, RESID, MODE, IUPD,
-c       ISHIFT, MXITER, V, LDV, H, LDH, RITZ, BOUNDS, Q, LDQ, WORKL, 
+c       ISHIFT, MXITER, V, LDV, H, LDH, RITZ, BOUNDS, Q, LDQ, WORKL,
 c       IPNTR, WORKD, INFO )
 c
 c\Arguments
 c
 c  COMM, IDO, BMAT, N, WHICH, NEV, TOL, RESID: same as defined in pssaupd.
 c  MODE, ISHIFT, MXITER: see the definition of IPARAM in pssaupd.
-c  
+c
 c  NP      Integer.  (INPUT/OUTPUT)
-c          Contains the number of implicit shifts to apply during 
-c          each Arnoldi/Lanczos iteration.  
-c          If ISHIFT=1, NP is adjusted dynamically at each iteration 
+c          Contains the number of implicit shifts to apply during
+c          each Arnoldi/Lanczos iteration.
+c          If ISHIFT=1, NP is adjusted dynamically at each iteration
 c          to accelerate convergence and prevent stagnation.
-c          This is also roughly equal to the number of matrix-vector 
+c          This is also roughly equal to the number of matrix-vector
 c          products (involving the operator OP) per Arnoldi iteration.
 c          The logic for adjusting is contained within the current
 c          subroutine.
@@ -33,7 +33,7 @@ c          to provide via reverse comunication. 0 < NP < NCV-NEV.
 c          NP may be less than NCV-NEV since a leading block of the current
 c          upper Tridiagonal matrix has split off and contains "unwanted"
 c          Ritz values.
-c          Upon termination of the IRA iteration, NP contains the number 
+c          Upon termination of the IRA iteration, NP contains the number
 c          of "converged" wanted Ritz values.
 c
 c  IUPD    Integer.  (INPUT)
@@ -44,18 +44,18 @@ c  V       Real N by (NEV+NP) array.  (INPUT/OUTPUT)
 c          The Lanczos basis vectors.
 c
 c  LDV     Integer.  (INPUT)
-c          Leading dimension of V exactly as declared in the calling 
+c          Leading dimension of V exactly as declared in the calling
 c          program.
 c
 c  H       Real (NEV+NP) by 2 array.  (OUTPUT)
 c          H is used to store the generated symmetric tridiagonal matrix
-c          The subdiagonal is stored in the first column of H starting 
+c          The subdiagonal is stored in the first column of H starting
 c          at H(2,1).  The main diagonal is stored in the second column
-c          of H starting at H(1,2). If pssaup2 converges store the 
+c          of H starting at H(1,2). If pssaup2 converges store the
 c          B-norm of the final residual vector in H(1,1).
 c
 c  LDH     Integer.  (INPUT)
-c          Leading dimension of H exactly as declared in the calling 
+c          Leading dimension of H exactly as declared in the calling
 c          program.
 c
 c  RITZ    Real array of length NEV+NP.  (OUTPUT)
@@ -65,33 +65,33 @@ c  BOUNDS  Real array of length NEV+NP.  (OUTPUT)
 c          BOUNDS(1:NEV) contain the error bounds corresponding to RITZ.
 c
 c  Q       Real (NEV+NP) by (NEV+NP) array.  (WORKSPACE)
-c          Private (replicated) work array used to accumulate the 
+c          Private (replicated) work array used to accumulate the
 c          rotation in the shift application step.
 c
 c  LDQ     Integer.  (INPUT)
 c          Leading dimension of Q exactly as declared in the calling
 c          program.
-c          
+c
 c  WORKL   Real array of length at least 3*(NEV+NP).  (INPUT/WORKSPACE)
 c          Private (replicated) array on each PE or array allocated on
-c          the front end.  It is used in the computation of the 
+c          the front end.  It is used in the computation of the
 c          tridiagonal eigenvalue problem, the calculation and
 c          application of the shifts and convergence checking.
 c          If ISHIFT .EQ. O and IDO .EQ. 3, the first NP locations
-c          of WORKL are used in reverse communication to hold the user 
+c          of WORKL are used in reverse communication to hold the user
 c          supplied shifts.
 c
 c  IPNTR   Integer array of length 3.  (OUTPUT)
-c          Pointer to mark the starting locations in the WORKD for 
+c          Pointer to mark the starting locations in the WORKD for
 c          vectors used by the Lanczos iteration.
 c          -------------------------------------------------------------
 c          IPNTR(1): pointer to the current operand vector X.
 c          IPNTR(2): pointer to the current result vector Y.
-c          IPNTR(3): pointer to the vector B * X when used in one of  
+c          IPNTR(3): pointer to the vector B * X when used in one of
 c                    the spectral transformation modes.  X is the current
 c                    operand.
 c          -------------------------------------------------------------
-c          
+c
 c  WORKD   Real work array of length 3*N.  (REVERSE COMMUNICATION)
 c          Distributed array to be used in the basic Lanczos iteration
 c          for reverse communication.  The user should not use WORKD
@@ -104,9 +104,9 @@ c          If INFO .NE. 0, RESID contains the initial residual vector,
 c                          possibly from a previous run.
 c          Error flag on output.
 c          =     0: Normal return.
-c          =     1: All possible eigenvalues of OP has been found.  
+c          =     1: All possible eigenvalues of OP has been found.
 c                   NP returns the size of the invariant subspace
-c                   spanning the operator OP. 
+c                   spanning the operator OP.
 c          =     2: No shifts could be applied.
 c          =    -8: Error return from trid. eigenvalue calculation;
 c                   This should never happen.
@@ -124,7 +124,7 @@ c\References:
 c  1. D.C. Sorensen, "Implicit Application of Polynomial Filters in
 c     a k-Step Arnoldi Method", SIAM J. Matr. Anal. Apps., 13 (1992),
 c     pp 357-385.
-c  2. R.B. Lehoucq, "Analysis and Implementation of an Implicitly 
+c  2. R.B. Lehoucq, "Analysis and Implementation of an Implicitly
 c     Restarted Arnoldi Iteration", Rice University Technical Report
 c     TR95-13, Department of Computational and Applied Mathematics.
 c  3. B.N. Parlett, "The Symmetric Eigenvalue Problem". Prentice-Hall,
@@ -134,15 +134,15 @@ c     Computer Physics Communications, 53 (1989), pp 169-179.
 c  5. B. Nour-Omid, B.N. Parlett, T. Ericson, P.S. Jensen, "How to
 c     Implement the Spectral Transformation", Math. Comp., 48 (1987),
 c     pp 663-673.
-c  6. R.G. Grimes, J.G. Lewis and H.D. Simon, "A Shifted Block Lanczos 
-c     Algorithm for Solving Sparse Symmetric Generalized Eigenproblems", 
+c  6. R.G. Grimes, J.G. Lewis and H.D. Simon, "A Shifted Block Lanczos
+c     Algorithm for Solving Sparse Symmetric Generalized Eigenproblems",
 c     SIAM J. Matr. Anal. Apps.,  January (1993).
 c  7. L. Reichel, W.B. Gragg, "Algorithm 686: FORTRAN Subroutines
 c     for Updating the QR decomposition", ACM TOMS, December 1990,
 c     Volume 16 Number 4, pp 369-377.
 c
 c\Routines called:
-c     psgetv0  Parallel ARPACK initial vector generation routine. 
+c     psgetv0  Parallel ARPACK initial vector generation routine.
 c     pssaitr  Parallel ARPACK Lanczos factorization routine.
 c     pssapps  Parallel ARPACK application of implicit shifts routine.
 c     ssconv   ARPACK convergence of Ritz values routine.
@@ -167,25 +167,25 @@ c     Danny Sorensen               Phuong Vu
 c     Richard Lehoucq              CRPC / Rice University
 c     Dept. of Computational &     Houston, Texas
 c     Applied Mathematics
-c     Rice University           
-c     Houston, Texas            
+c     Rice University
+c     Houston, Texas
 c
 c\Parallel Modifications
 c     Kristi Maschhoff
 c
 c\Revision history:
 c     Starting Point: Serial Code FILE: saup2.F   SID: 2.4
-c 
-c\SCCS Information: 
-c FILE: saup2.F   SID: 1.5   DATE OF SID: 05/20/98   
+c
+c\SCCS Information:
+c FILE: saup2.F   SID: 1.5   DATE OF SID: 05/20/98
 c
 c\EndLib
 c
 c-----------------------------------------------------------------------
 c
       subroutine pssaup2
-     &   ( comm, ido, bmat, n, which, nev, np, tol, resid, mode, iupd, 
-     &     ishift, mxiter, v, ldv, h, ldh, ritz, bounds, 
+     &   ( comm, ido, bmat, n, which, nev, np, tol, resid, mode, iupd,
+     &     ishift, mxiter, v, ldv, h, ldh, ritz, bounds,
      &     q, ldq, workl, ipntr, workd, info )
 c
       include   'mpif.h'
@@ -220,8 +220,8 @@ c     %-----------------%
 c
       integer    ipntr(3)
       Real
-     &           bounds(nev+np), h(ldh,2), q(ldq,nev+np), resid(n), 
-     &           ritz(nev+np), v(ldv,nev+np), workd(3*n), 
+     &           bounds(nev+np), h(ldh,2), q(ldq,nev+np), resid(n),
+     &           ritz(nev+np), v(ldv,nev+np), workd(3*n),
      &           workl(3*(nev+np))
 c
 c     %------------%
@@ -238,8 +238,8 @@ c     %---------------%
 c
       character  wprime*2
       logical    cnorm, getv0, initv, update, ushift
-      integer    ierr, iter, j, kplusp, msglvl, nconv, nevbef, nev0, 
-     &           np0, nptemp, nevd2, nevm2, kp(3) 
+      integer    ierr, iter, j, kplusp, msglvl, nconv, nevbef, nev0,
+     &           np0, nptemp, nevd2, nevm2, kp(3)
       Real
      &           rnorm, temp, eps23
       save       cnorm, getv0, initv, update, ushift,
@@ -254,7 +254,7 @@ c     %----------------------%
 c     | External Subroutines |
 c     %----------------------%
 c
-      external   scopy, psgetv0, pssaitr, sscal, ssconv, 
+      external   scopy, psgetv0, pssaitr, sscal, ssconv,
      &           psseigt, pssgets, pssapps,
      &           ssortr, psvout, pivout, second
 c
@@ -277,7 +277,7 @@ c     | Executable Statements |
 c     %-----------------------%
 c
       if (ido .eq. 0) then
-c 
+c
 c        %-------------------------------%
 c        | Initialize timing statistics  |
 c        | & message level for debugging |
@@ -313,7 +313,7 @@ c
          kplusp = nev0 + np0
          nconv  = 0
          iter   = 0
-c 
+c
 c        %---------------------------------------------%
 c        | Set flags for computing the first NEV steps |
 c        | of the Lanczos factorization.               |
@@ -336,7 +336,7 @@ c
             initv = .false.
          end if
       end if
-c 
+c
 c     %---------------------------------------------%
 c     | Get a possibly random starting vector and   |
 c     | force it into the range of the operator OP. |
@@ -345,7 +345,7 @@ c
    10 continue
 c
       if (getv0) then
-         call psgetv0 ( comm, ido, bmat, 1, initv, n, 1, v, ldv, 
+         call psgetv0 ( comm, ido, bmat, 1, initv, n, 1, v, ldv,
      &                  resid, rnorm, ipntr, workd, workl, info)
 c
          if (ido .ne. 99) go to 9000
@@ -353,7 +353,7 @@ c
          if (rnorm .eq. zero) then
 c
 c           %-----------------------------------------%
-c           | The initial vector is zero. Error exit. | 
+c           | The initial vector is zero. Error exit. |
 c           %-----------------------------------------%
 c
             info = -9
@@ -362,7 +362,7 @@ c
          getv0 = .false.
          ido  = 0
       end if
-c 
+c
 c     %------------------------------------------------------------%
 c     | Back from reverse communication: continue with update step |
 c     %------------------------------------------------------------%
@@ -381,15 +381,15 @@ c     | at the end of the current iteration |
 c     %-------------------------------------%
 c
       if (cnorm)  go to 100
-c 
+c
 c     %----------------------------------------------------------%
 c     | Compute the first NEV steps of the Lanczos factorization |
 c     %----------------------------------------------------------%
 c
-      call pssaitr (comm, ido, bmat, n, 0, nev0, mode, 
+      call pssaitr (comm, ido, bmat, n, 0, nev0, mode,
      &              resid, rnorm, v, ldv, h, ldh, ipntr,
      &              workd, workl, info)
-c 
+c
 c     %---------------------------------------------------%
 c     | ido .ne. 99 implies use of reverse communication  |
 c     | to compute operations involving OP and possibly B |
@@ -410,7 +410,7 @@ c
          info = -9999
          go to 1200
       end if
-c 
+c
 c     %--------------------------------------------------------------%
 c     |                                                              |
 c     |           M A I N  LANCZOS  I T E R A T I O N  L O O P       |
@@ -418,22 +418,22 @@ c     |           Each iteration implicitly restarts the Lanczos     |
 c     |           factorization in place.                            |
 c     |                                                              |
 c     %--------------------------------------------------------------%
-c 
+c
  1000 continue
 c
          iter = iter + 1
 c
          if (msglvl .gt. 0) then
-            call pivout (comm, logfil, 1, [iter], ndigit, 
+            call pivout (comm, logfil, 1, [iter], ndigit,
      &           '_saup2: **** Start of major iteration number ****')
          end if
          if (msglvl .gt. 1) then
-            call pivout (comm, logfil, 1, [nev], ndigit, 
+            call pivout (comm, logfil, 1, [nev], ndigit,
      &     '_saup2: The length of the current Lanczos factorization')
-            call pivout (comm, logfil, 1, [np], ndigit, 
+            call pivout (comm, logfil, 1, [np], ndigit,
      &           '_saup2: Extend the Lanczos factorization by')
          end if
-c 
+c
 c        %------------------------------------------------------------%
 c        | Compute NP additional steps of the Lanczos factorization.  |
 c        %------------------------------------------------------------%
@@ -442,10 +442,10 @@ c
    20    continue
          update = .true.
 c
-         call pssaitr (comm, ido, bmat, n, nev, np, mode, 
+         call pssaitr (comm, ido, bmat, n, nev, np, mode,
      &                 resid, rnorm, v, ldv, h, ldh, ipntr,
      &                 workd, workl, info)
-c 
+c
 c        %---------------------------------------------------%
 c        | ido .ne. 99 implies use of reverse communication  |
 c        | to compute operations involving OP and possibly B |
@@ -457,7 +457,7 @@ c
 c
 c           %-----------------------------------------------------%
 c           | pssaitr was unable to build an Lanczos factorization|
-c           | of length NEV0+NP0. INFO is returned with the size  |  
+c           | of length NEV0+NP0. INFO is returned with the size  |
 c           | of the factorization built. Exit main loop.         |
 c           %-----------------------------------------------------%
 c
@@ -469,16 +469,16 @@ c
          update = .false.
 c
          if (msglvl .gt. 1) then
-            call psvout (comm, logfil, 1, [rnorm], ndigit, 
+            call psvout (comm, logfil, 1, [rnorm], ndigit,
      &           '_saup2: Current B-norm of residual for factorization')
          end if
-c 
+c
 c        %--------------------------------------------------------%
 c        | Compute the eigenvalues and corresponding error bounds |
 c        | of the current symmetric tridiagonal matrix.           |
 c        %--------------------------------------------------------%
 c
-         call psseigt ( comm, rnorm, kplusp, h, ldh, ritz, bounds, 
+         call psseigt ( comm, rnorm, kplusp, h, ldh, ritz, bounds,
      &                  workl, ierr)
 c
          if (ierr .ne. 0) then
@@ -506,7 +506,7 @@ c        %---------------------------------------------------%
 c
          nev = nev0
          np = np0
-         call pssgets ( comm, ishift, which, nev, np, ritz, 
+         call pssgets ( comm, ishift, which, nev, np, ritz,
      &                  bounds, workl)
 c
 c        %-------------------%
@@ -545,11 +545,11 @@ c
                nev = nev + 1
             end if
  30      continue
-c 
-         if ( (nconv .ge. nev0) .or. 
+c
+         if ( (nconv .ge. nev0) .or.
      &        (iter .gt. mxiter) .or.
      &        (np .eq. 0) ) then
-c     
+c
 c           %------------------------------------------------%
 c           | Prepare to exit. Put the converged Ritz values |
 c           | and corresponding bounds in RITZ(1:NCONV) and  |
@@ -656,7 +656,7 @@ c              | Ritz values according to WHICH so that the   |
 c              | "threshold" value appears at the front of    |
 c              | ritz.                                        |
 c              %----------------------------------------------%
- 
+
                call ssortr(which, .true., nconv, ritz, bounds)
 c
             end if
@@ -676,13 +676,13 @@ c
             end if
 c
 c           %------------------------------------%
-c           | Max iterations have been exceeded. | 
+c           | Max iterations have been exceeded. |
 c           %------------------------------------%
 c
             if (iter .gt. mxiter .and. nconv .lt. nev) info = 1
 c
 c           %---------------------%
-c           | No shifts to apply. | 
+c           | No shifts to apply. |
 c           %---------------------%
 c
             if (np .eq. 0 .and. nconv .lt. nev0) info = 2
@@ -706,14 +706,14 @@ c
                nev = 2
             end if
             np  = kplusp - nev
-c     
+c
 c           %---------------------------------------%
 c           | If the size of NEV was just increased |
 c           | resort the eigenvalues.               |
 c           %---------------------------------------%
-c     
-            if (nevbef .lt. nev) 
-     &         call pssgets ( comm, ishift, which, nev, np, 
+c
+            if (nevbef .lt. nev)
+     &         call pssgets ( comm, ishift, which, nev, np,
      &                        ritz, bounds, workl)
 c
          end if
@@ -724,7 +724,7 @@ c
             if (msglvl .gt. 1) then
                kp(1) = nev
                kp(2) = np
-               call pivout (comm, logfil, 2, kp, ndigit, 
+               call pivout (comm, logfil, 2, kp, ndigit,
      &              '_saup2: NEV and NP .')
                call psvout (comm, logfil, nev, ritz(np+1), ndigit,
      &              '_saup2: "wanted" Ritz values.')
@@ -732,7 +732,7 @@ c
      &              '_saup2: Ritz estimates of the "wanted" values ')
             end if
          end if
-c 
+c
          if (ishift .eq. 0) then
 c
 c           %-----------------------------------------------------%
@@ -755,8 +755,8 @@ c        | in WORKL(1:NP)                     |
 c        %------------------------------------%
 c
          ushift = .false.
-c 
-c 
+c
+c
 c        %---------------------------------------------------------%
 c        | Move the NP shifts to the first NP locations of RITZ to |
 c        | free up WORKL.  This is for the non-exact shift case;   |
@@ -784,7 +784,7 @@ c        | After pssapps is done, we have a Lanczos                |
 c        | factorization of length NEV.                            |
 c        %---------------------------------------------------------%
 c
-         call pssapps ( comm, n, nev, np, ritz, v, ldv, h, ldh, resid, 
+         call pssapps ( comm, n, nev, np, ritz, v, ldv, h, ldh, resid,
      &                  q, ldq, workd)
 c
 c        %---------------------------------------------%
@@ -801,18 +801,18 @@ c
             ipntr(1) = n + 1
             ipntr(2) = 1
             ido = 2
-c 
+c
 c           %----------------------------------%
 c           | Exit in order to compute B*RESID |
 c           %----------------------------------%
-c 
+c
             go to 9000
          else if (bmat .eq. 'I') then
             call scopy (n, resid, 1, workd, 1)
          end if
-c 
+c
   100    continue
-c 
+c
 c        %----------------------------------%
 c        | Back from reverse communication; |
 c        | WORKD(1:N) := B*RESID            |
@@ -822,7 +822,7 @@ c
             call second (t3)
             tmvbx = tmvbx + (t3 - t2)
          end if
-c 
+c
          if (bmat .eq. 'G') then
             rnorm_buf = sdot (n, resid, 1, workd, 1)
             call MPI_ALLREDUCE( rnorm_buf, rnorm, 1,
@@ -835,14 +835,14 @@ c
   130    continue
 c
          if (msglvl .gt. 2) then
-            call psvout (comm, logfil, 1, [rnorm], ndigit, 
+            call psvout (comm, logfil, 1, [rnorm], ndigit,
      &      '_saup2: B-norm of residual for NEV factorization')
             call psvout (comm, logfil, nev, h(1,2), ndigit,
      &           '_saup2: main diagonal of compressed H matrix')
             call psvout (comm, logfil, nev-1, h(2,1), ndigit,
      &           '_saup2: subdiagonal of compressed H matrix')
          end if
-c 
+c
       go to 1000
 c
 c     %---------------------------------------------------------------%
@@ -850,12 +850,12 @@ c     |                                                               |
 c     |  E N D     O F     M A I N     I T E R A T I O N     L O O P  |
 c     |                                                               |
 c     %---------------------------------------------------------------%
-c 
+c
  1100 continue
 c
       mxiter = iter
       nev = nconv
-c 
+c
  1200 continue
       ido = 99
 c
@@ -865,7 +865,7 @@ c     %------------%
 c
       call second (t1)
       tsaup2 = t1 - t0
-c 
+c
  9000 continue
       return
 c

--- a/mathlibs/src/parpack/pssaupd.f
+++ b/mathlibs/src/parpack/pssaupd.f
@@ -644,9 +644,9 @@ c
       if (info .eq. 2) info = 3
 c
       if (msglvl .gt. 0) then
-         call pivout (comm, logfil, 1, mxiter, ndigit,
+         call pivout (comm, logfil, 1, [mxiter], ndigit,
      &               '_saupd: number of update iterations taken')
-         call pivout (comm, logfil, 1, np, ndigit,
+         call pivout (comm, logfil, 1, [np], ndigit,
      &               '_saupd: number of "converged" Ritz values')
          call psvout (comm, logfil, np, workl(Ritz), ndigit, 
      &               '_saupd: final Ritz values')

--- a/mathlibs/src/parpack/pssaupd.f
+++ b/mathlibs/src/parpack/pssaupd.f
@@ -3,33 +3,33 @@ c\BeginDoc
 c
 c\Name: pssaupd
 c
-c Message Passing Layer: MPI 
+c Message Passing Layer: MPI
 c
-c\Description: 
+c\Description:
 c
-c  Reverse communication interface for the Implicitly Restarted Arnoldi 
-c  Iteration.  For symmetric problems this reduces to a variant of the Lanczos 
-c  method.  This method has been designed to compute approximations to a 
-c  few eigenpairs of a linear operator OP that is real and symmetric 
-c  with respect to a real positive semi-definite symmetric matrix B, 
+c  Reverse communication interface for the Implicitly Restarted Arnoldi
+c  Iteration.  For symmetric problems this reduces to a variant of the Lanczos
+c  method.  This method has been designed to compute approximations to a
+c  few eigenpairs of a linear operator OP that is real and symmetric
+c  with respect to a real positive semi-definite symmetric matrix B,
 c  i.e.
-c                   
-c       B*OP = (OP`)*B.  
 c
-c  Another way to express this condition is 
+c       B*OP = (OP`)*B.
+c
+c  Another way to express this condition is
 c
 c       < x,OPy > = < OPx,y >  where < z,w > = z`Bw  .
-c  
-c  In the standard eigenproblem B is the identity matrix.  
+c
+c  In the standard eigenproblem B is the identity matrix.
 c  ( A` denotes transpose of A)
 c
 c  The computed approximate eigenvalues are called Ritz values and
 c  the corresponding approximate eigenvectors are called Ritz vectors.
 c
-c  pssaupd is usually called iteratively to solve one of the 
+c  pssaupd is usually called iteratively to solve one of the
 c  following problems:
 c
-c  Mode 1:  A*x = lambda*x, A symmetric 
+c  Mode 1:  A*x = lambda*x, A symmetric
 c           ===> OP = A  and  B = I.
 c
 c  Mode 2:  A*x = lambda*M*x, A symmetric, M symmetric positive definite
@@ -37,10 +37,10 @@ c           ===> OP = inv[M]*A  and  B = M.
 c           ===> (If M can be factored see remark 3 below)
 c
 c  Mode 3:  K*x = lambda*M*x, K symmetric, M symmetric positive semi-definite
-c           ===> OP = (inv[K - sigma*M])*M  and  B = M. 
+c           ===> OP = (inv[K - sigma*M])*M  and  B = M.
 c           ===> Shift-and-Invert mode
 c
-c  Mode 4:  K*x = lambda*KG*x, K symmetric positive semi-definite, 
+c  Mode 4:  K*x = lambda*KG*x, K symmetric positive semi-definite,
 c           KG symmetric indefinite
 c           ===> OP = (inv[K - sigma*KG])*K  and  B = K.
 c           ===> Buckling mode
@@ -62,7 +62,7 @@ c        the accuracy requirements for the eigenvalue
 c        approximations.
 c
 c\Usage:
-c  call pssaupd 
+c  call pssaupd
 c     ( COMM, IDO, BMAT, N, WHICH, NEV, TOL, RESID, NCV, V, LDV, IPARAM,
 c       IPNTR, WORKD, WORKL, LWORKL, INFO )
 c
@@ -70,7 +70,7 @@ c\Arguments
 c  COMM    MPI  Communicator for the processor grid.  (INPUT)
 c
 c  IDO     Integer.  (INPUT/OUTPUT)
-c          Reverse communication flag.  IDO must be zero on the first 
+c          Reverse communication flag.  IDO must be zero on the first
 c          call to pssaupd.  IDO will be set internally to
 c          indicate the type of operation to be performed.  Control is
 c          then given back to the calling routine which has the
@@ -99,7 +99,7 @@ c                    IPNTR(11) is the pointer into WORKL for
 c                    placing the shifts. See remark 6 below.
 c          IDO = 99: done
 c          -------------------------------------------------------------
-c             
+c
 c  BMAT    Character*1.  (INPUT)
 c          BMAT specifies the type of the matrix B that defines the
 c          semi-inner product for the operator OP.
@@ -115,7 +115,7 @@ c
 c          'LA' - compute the NEV largest (algebraic) eigenvalues.
 c          'SA' - compute the NEV smallest (algebraic) eigenvalues.
 c          'LM' - compute the NEV largest (in magnitude) eigenvalues.
-c          'SM' - compute the NEV smallest (in magnitude) eigenvalues. 
+c          'SM' - compute the NEV smallest (in magnitude) eigenvalues.
 c          'BE' - compute NEV eigenvalues, half from each end of the
 c                 spectrum.  When NEV is odd, compute one more from the
 c                 high end than from the low end.
@@ -125,27 +125,27 @@ c  NEV     Integer.  (INPUT)
 c          Number of eigenvalues of OP to be computed. 0 < NEV < N.
 c
 c  TOL     Real  scalar.  (INPUT)
-c          Stopping criterion: the relative accuracy of the Ritz value 
+c          Stopping criterion: the relative accuracy of the Ritz value
 c          is considered acceptable if BOUNDS(I) .LE. TOL*ABS(RITZ(I)).
 c          If TOL .LE. 0. is passed a default is set:
 c          DEFAULT = SLAMCH('EPS')  (machine precision as computed
 c                    by the LAPACK auxiliary subroutine SLAMCH).
 c
 c  RESID   Real  array of length N.  (INPUT/OUTPUT)
-c          On INPUT: 
+c          On INPUT:
 c          If INFO .EQ. 0, a random initial residual vector is used.
 c          If INFO .NE. 0, RESID contains the initial residual vector,
 c                          possibly from a previous run.
 c          On OUTPUT:
-c          RESID contains the final residual vector. 
+c          RESID contains the final residual vector.
 c
 c  NCV     Integer.  (INPUT)
 c          Number of columns of the matrix V (less than or equal to N).
-c          This will indicate how many Lanczos vectors are generated 
-c          at each iteration.  After the startup phase in which NEV 
-c          Lanczos vectors are generated, the algorithm generates 
+c          This will indicate how many Lanczos vectors are generated
+c          at each iteration.  After the startup phase in which NEV
+c          Lanczos vectors are generated, the algorithm generates
 c          NCV-NEV Lanczos vectors at each subsequent update iteration.
-c          Most of the cost in generating each Lanczos vector is in the 
+c          Most of the cost in generating each Lanczos vector is in the
 c          matrix-vector product OP*x. (See remark 4 below).
 c
 c  V       Real  N by NCV array.  (OUTPUT)
@@ -165,10 +165,10 @@ c                      reverse communication.  The NCV eigenvalues of
 c                      the current tridiagonal matrix T are returned in
 c                      the part of WORKL array corresponding to RITZ.
 c                      See remark 6 below.
-c          ISHIFT = 1: exact shifts with respect to the reduced 
-c                      tridiagonal matrix T.  This is equivalent to 
-c                      restarting the iteration with a starting vector 
-c                      that is a linear combination of Ritz vectors 
+c          ISHIFT = 1: exact shifts with respect to the reduced
+c                      tridiagonal matrix T.  This is equivalent to
+c                      restarting the iteration with a starting vector
+c                      that is a linear combination of Ritz vectors
 c                      associated with the "wanted" Ritz values.
 c          -------------------------------------------------------------
 c
@@ -176,8 +176,8 @@ c          IPARAM(2) = LEVEC
 c          No longer referenced. See remark 2 below.
 c
 c          IPARAM(3) = MXITER
-c          On INPUT:  maximum number of Arnoldi update iterations allowed. 
-c          On OUTPUT: actual number of Arnoldi update iterations taken. 
+c          On INPUT:  maximum number of Arnoldi update iterations allowed.
+c          On OUTPUT: actual number of Arnoldi update iterations taken.
 c
 c          IPARAM(4) = NB: blocksize to be used in the recurrence.
 c          The code currently works only for NB = 1.
@@ -187,11 +187,11 @@ c          This represents the number of Ritz values that satisfy
 c          the convergence criterion.
 c
 c          IPARAM(6) = IUPD
-c          No longer referenced. Implicit restarting is ALWAYS used. 
+c          No longer referenced. Implicit restarting is ALWAYS used.
 c
 c          IPARAM(7) = MODE
 c          On INPUT determines what type of eigenproblem is being solved.
-c          Must be 1,2,3,4,5; See under \Description of pssaupd for the 
+c          Must be 1,2,3,4,5; See under \Description of pssaupd for the
 c          five modes available.
 c
 c          IPARAM(8) = NP
@@ -203,7 +203,7 @@ c
 c          IPARAM(9) = NUMOP, IPARAM(10) = NUMOPB, IPARAM(11) = NUMREO,
 c          OUTPUT: NUMOP  = total number of OP*x operations,
 c                  NUMOPB = total number of B*x operations if BMAT='G',
-c                  NUMREO = total number of steps of re-orthogonalization.        
+c                  NUMREO = total number of steps of re-orthogonalization.
 c
 c  IPNTR   Integer array of length 11.  (OUTPUT)
 c          Pointer to mark the starting locations in the WORKD and WORKL
@@ -211,7 +211,7 @@ c          arrays for matrices/vectors used by the Lanczos iteration.
 c          -------------------------------------------------------------
 c          IPNTR(1): pointer to the current operand vector X in WORKD.
 c          IPNTR(2): pointer to the current result vector Y in WORKD.
-c          IPNTR(3): pointer to the vector B * X in WORKD when used in 
+c          IPNTR(3): pointer to the vector B * X in WORKD when used in
 c                    the shift-and-invert mode.
 c          IPNTR(4): pointer to the next available location in WORKL
 c                    that is untouched by the program.
@@ -220,7 +220,7 @@ c          IPNTR(6): pointer to the NCV RITZ values array in WORKL.
 c          IPNTR(7): pointer to the Ritz estimates in array WORKL associated
 c                    with the Ritz values located in RITZ in WORKL.
 c          IPNTR(11): pointer to the NP shifts in WORKL. See Remark 6 below.
-c          
+c
 c          Note: IPNTR(8:10) is only referenced by psseupd. See Remark 2.
 c          IPNTR(8): pointer to the NCV RITZ values of the original system.
 c          IPNTR(9): pointer to the NCV corresponding error bounds.
@@ -228,14 +228,14 @@ c          IPNTR(10): pointer to the NCV by NCV matrix of eigenvectors
 c                     of the tridiagonal matrix T. Only referenced by
 c                     psseupd if RVEC = .TRUE. See Remarks.
 c          -------------------------------------------------------------
-c          
+c
 c  WORKD   Real  work array of length 3*N.  (REVERSE COMMUNICATION)
 c          Distributed array to be used in the basic Arnoldi iteration
-c          for reverse communication.  The user should not use WORKD 
+c          for reverse communication.  The user should not use WORKD
 c          as temporary workspace during the iteration. Upon termination
 c          WORKD(1:N) contains B*RESID(1:N). If the Ritz vectors are desired
 c          subroutine psseupd uses this output.
-c          See Data Distribution Note below.  
+c          See Data Distribution Note below.
 c
 c  WORKL   Real  work array of length LWORKL.  (OUTPUT/WORKSPACE)
 c          Private (replicated) array on each PE or array allocated on
@@ -251,13 +251,13 @@ c                          possibly from a previous run.
 c          Error flag on output.
 c          =  0: Normal exit.
 c          =  1: Maximum number of iterations taken.
-c                All possible eigenvalues of OP has been found. IPARAM(5)  
+c                All possible eigenvalues of OP has been found. IPARAM(5)
 c                returns the number of wanted converged Ritz values.
 c          =  2: No longer an informational error. Deprecated starting
 c                with release 2 of ARPACK.
-c          =  3: No shifts could be applied during a cycle of the 
-c                Implicitly restarted Arnoldi iteration. One possibility 
-c                is to increase the size of NCV relative to NEV. 
+c          =  3: No shifts could be applied during a cycle of the
+c                Implicitly restarted Arnoldi iteration. One possibility
+c                is to increase the size of NCV relative to NEV.
 c                See remark 4 below.
 c          = -1: N must be positive.
 c          = -2: NEV must be positive.
@@ -281,12 +281,12 @@ c                   enough workspace and array storage has been allocated.
 c
 c
 c\Remarks
-c  1. The converged Ritz values are always returned in ascending 
+c  1. The converged Ritz values are always returned in ascending
 c     algebraic order.  The computed Ritz values are approximate
 c     eigenvalues of OP.  The selection of WHICH should be made
-c     with this in mind when Mode = 3,4,5.  After convergence, 
-c     approximate eigenvalues of the original problem may be obtained 
-c     with the ARPACK subroutine psseupd. 
+c     with this in mind when Mode = 3,4,5.  After convergence,
+c     approximate eigenvalues of the original problem may be obtained
+c     with the ARPACK subroutine psseupd.
 c
 c  2. If the Ritz vectors corresponding to the converged Ritz values
 c     are needed, the user must call psseupd immediately following completion
@@ -294,7 +294,7 @@ c     of pssaupd. This is new starting with version 2.1 of ARPACK.
 c
 c  3. If M can be factored into a Cholesky factorization M = LL`
 c     then Mode = 2 should not be selected.  Instead one should use
-c     Mode = 1 with  OP = inv(L)*A*inv(L`).  Appropriate triangular 
+c     Mode = 1 with  OP = inv(L)*A*inv(L`).  Appropriate triangular
 c     linear systems should be solved with L and L` rather
 c     than computing inverses.  After convergence, an approximate
 c     eigenvector z of the original problem is recovered by solving
@@ -304,7 +304,7 @@ c  4. At present there is no a-priori analysis to guide the selection
 c     of NCV relative to NEV.  The only formal requrement is that NCV > NEV.
 c     However, it is recommended that NCV .ge. 2*NEV.  If many problems of
 c     the same type are to be solved, one should experiment with increasing
-c     NCV while keeping NEV fixed for a given test problem.  This will 
+c     NCV while keeping NEV fixed for a given test problem.  This will
 c     usually decrease the required number of OP*x operations but it
 c     also increases the work and storage required to maintain the orthogonal
 c     basis vectors.   The optimal "cross-over" with respect to CPU time
@@ -316,16 +316,16 @@ c     When IPARAM(7) = 2 OP = inv(B)*A. After computing A*X the user
 c     must overwrite X with A*X. Y is then the solution to the linear set
 c     of equations B*Y = A*X.
 c
-c  6. When IPARAM(1) = 0, and IDO = 3, the user needs to provide the 
-c     NP = IPARAM(8) shifts in locations: 
-c     1   WORKL(IPNTR(11))           
-c     2   WORKL(IPNTR(11)+1)         
-c                        .           
-c                        .           
-c                        .      
-c     NP  WORKL(IPNTR(11)+NP-1). 
+c  6. When IPARAM(1) = 0, and IDO = 3, the user needs to provide the
+c     NP = IPARAM(8) shifts in locations:
+c     1   WORKL(IPNTR(11))
+c     2   WORKL(IPNTR(11)+1)
+c                        .
+c                        .
+c                        .
+c     NP  WORKL(IPNTR(11)+NP-1).
 c
-c     The eigenvalues of the current tridiagonal matrix are located in 
+c     The eigenvalues of the current tridiagonal matrix are located in
 c     WORKL(IPNTR(6)) through WORKL(IPNTR(6)+NCV-1). They are in the
 c     order defined by WHICH. The associated Ritz estimates are located in
 c     WORKL(IPNTR(8)), WORKL(IPNTR(8)+1), ... , WORKL(IPNTR(8)+NCV-1).
@@ -351,7 +351,7 @@ c  ===============
 c  REAL       RESID(N), V(LDV,NCV), WORKD(N,3), WORKL(LWORKL)
 c  SHARED     RESID(BLOCK), V(BLOCK,:), WORKD(BLOCK,:)
 c  REPLICATED WORKL(LWORKL)
-c  
+c
 c
 c\BeginLib
 c
@@ -359,7 +359,7 @@ c\References:
 c  1. D.C. Sorensen, "Implicit Application of Polynomial Filters in
 c     a k-Step Arnoldi Method", SIAM J. Matr. Anal. Apps., 13 (1992),
 c     pp 357-385.
-c  2. R.B. Lehoucq, "Analysis and Implementation of an Implicitly 
+c  2. R.B. Lehoucq, "Analysis and Implementation of an Implicitly
 c     Restarted Arnoldi Iteration", Rice University Technical Report
 c     TR95-13, Department of Computational and Applied Mathematics.
 c  3. B.N. Parlett, "The Symmetric Eigenvalue Problem". Prentice-Hall,
@@ -369,8 +369,8 @@ c     Computer Physics Communications, 53 (1989), pp 169-179.
 c  5. B. Nour-Omid, B.N. Parlett, T. Ericson, P.S. Jensen, "How to
 c     Implement the Spectral Transformation", Math. Comp., 48 (1987),
 c     pp 663-673.
-c  6. R.G. Grimes, J.G. Lewis and H.D. Simon, "A Shifted Block Lanczos 
-c     Algorithm for Solving Sparse Symmetric Generalized Eigenproblems", 
+c  6. R.G. Grimes, J.G. Lewis and H.D. Simon, "A Shifted Block Lanczos
+c     Algorithm for Solving Sparse Symmetric Generalized Eigenproblems",
 c     SIAM J. Matr. Anal. Apps.,  January (1993).
 c  7. L. Reichel, W.B. Gragg, "Algorithm 686: FORTRAN Subroutines
 c     for Updating the QR decomposition", ACM TOMS, December 1990,
@@ -394,8 +394,8 @@ c     Danny Sorensen               Phuong Vu
 c     Richard Lehoucq              CRPC / Rice University
 c     Dept. of Computational &     Houston, Texas
 c     Applied Mathematics
-c     Rice University           
-c     Houston, Texas            
+c     Rice University
+c     Houston, Texas
 c
 c\Parallel Modifications
 c     Kristi Maschhoff
@@ -403,8 +403,8 @@ c
 c\Revision history:
 c     Starting Point: Serial Code FILE: saupd.F   SID: 2.4
 c
-c\SCCS Information: 
-c FILE: saupd.F   SID: 1.7   DATE OF SID: 04/10/01   
+c\SCCS Information:
+c FILE: saupd.F   SID: 1.7   DATE OF SID: 04/10/01
 c
 c\Remarks
 c     1. None
@@ -414,7 +414,7 @@ c
 c-----------------------------------------------------------------------
 c
       subroutine pssaupd
-     &   ( comm, ido, bmat, n, which, nev, tol, resid, ncv, v, ldv, 
+     &   ( comm, ido, bmat, n, which, nev, tol, resid, ncv, v, ldv,
      &     iparam, ipntr, workd, workl, lworkl, info )
 c
       include  'mpif.h'
@@ -438,7 +438,7 @@ c     %------------------%
 c
       character  bmat*1, which*2
       integer    ido, info, ldv, lworkl, n, ncv, nev
-      Real 
+      Real
      &           tol
 c
 c     %-----------------%
@@ -446,14 +446,14 @@ c     | Array Arguments |
 c     %-----------------%
 c
       integer    iparam(11), ipntr(11)
-      Real 
+      Real
      &           resid(n), v(ldv,ncv), workd(3*n), workl(lworkl)
 c
 c     %------------%
 c     | Parameters |
 c     %------------%
 c
-      Real 
+      Real
      &           one, zero
       parameter (one = 1.0 , zero = 0.0 )
 c
@@ -461,7 +461,7 @@ c     %---------------%
 c     | Local Scalars |
 c     %---------------%
 c
-      integer    bounds, ierr, ih, iq, ishift, iupd, iw, 
+      integer    bounds, ierr, ih, iq, ishift, iupd, iw,
      &           ldh, ldq, msglvl, mxiter, mode, nb,
      &           nev0, next, np, ritz, j
       save       bounds, ierr, ih, iq, ishift, iupd, iw,
@@ -478,14 +478,14 @@ c     %--------------------%
 c     | External Functions |
 c     %--------------------%
 c
-      Real 
+      Real
      &           pslamch10
       external   pslamch10
 c
 c     %-----------------------%
 c     | Executable Statements |
 c     %-----------------------%
-c 
+c
       if (ido .eq. 0) then
 c
 c        %-------------------------------%
@@ -528,7 +528,7 @@ c        | extend the length NEV Lanczos factorization. |
 c        %----------------------------------------------%
 c
          np     = ncv - nev
-c 
+c
          if (mxiter .le. 0)                     ierr = -4
          if (which .ne. 'LM' .and.
      &       which .ne. 'SM' .and.
@@ -547,7 +547,7 @@ c
          else if (nev .eq. 1 .and. which .eq. 'BE') then
                                                 ierr = -13
          end if
-c 
+c
 c        %------------%
 c        | Error Exit |
 c        %------------%
@@ -557,7 +557,7 @@ c
             ido  = 99
             go to 9000
          end if
-c 
+c
 c        %------------------------%
 c        | Set default parameters |
 c        %------------------------%
@@ -573,8 +573,8 @@ c        | size of the invariant subspace desired.      |
 c        %----------------------------------------------%
 c
          np     = ncv - nev
-         nev0   = nev 
-c 
+         nev0   = nev
+c
 c        %-----------------------------%
 c        | Zero out internal workspace |
 c        %-----------------------------%
@@ -582,7 +582,7 @@ c
          do 10 j = 1, ncv**2 + 8*ncv
             workl(j) = zero
  10      continue
-c 
+c
 c        %-------------------------------------------------------%
 c        | Pointer into WORKL for address of H, RITZ, BOUNDS, Q  |
 c        | etc... and the remaining workspace.                   |
@@ -615,7 +615,7 @@ c     %-------------------------------------------------------%
 c     | Carry out the Implicitly restarted Lanczos Iteration. |
 c     %-------------------------------------------------------%
 c
-      call pssaup2 
+      call pssaup2
      &   ( comm, ido, bmat, n, which, nev0, np, tol, resid, mode, iupd,
      &     ishift, mxiter, v, ldv, workl(ih), ldh, workl(ritz),
      &     workl(bounds), workl(iq), ldq, workl(iw), ipntr, workd,
@@ -628,7 +628,7 @@ c     %--------------------------------------------------%
 c
       if (ido .eq. 3) iparam(8) = np
       if (ido .ne. 99) go to 9000
-c 
+c
       iparam(3) = mxiter
       iparam(5) = np
       iparam(9) = nopx
@@ -648,15 +648,15 @@ c
      &               '_saupd: number of update iterations taken')
          call pivout (comm, logfil, 1, [np], ndigit,
      &               '_saupd: number of "converged" Ritz values')
-         call psvout (comm, logfil, np, workl(Ritz), ndigit, 
+         call psvout (comm, logfil, np, workl(Ritz), ndigit,
      &               '_saupd: final Ritz values')
-         call psvout (comm, logfil, np, workl(Bounds), ndigit, 
+         call psvout (comm, logfil, np, workl(Bounds), ndigit,
      &               '_saupd: corresponding error bounds')
-      end if 
+      end if
 c
       call second (t1)
       tsaupd = t1 - t0
-c 
+c
       if (msglvl .gt. 0) then
          call MPI_COMM_RANK( comm, myid, ierr )
          if ( myid .eq. 0 ) then
@@ -697,9 +697,9 @@ c
      &      5x, 'Total time in convergence testing          = ', f12.6)
          end if
       end if
-c 
+c
  9000 continue
-c 
+c
       return
 c
 c     %----------------%

--- a/mathlibs/src/parpack/psseupd.f
+++ b/mathlibs/src/parpack/psseupd.f
@@ -523,9 +523,9 @@ c        | caused by incorrect passing of the _saupd data.           |
 c        %-----------------------------------------------------------%
 c
          if (msglvl .gt. 2) then
-             call pivout(comm, logfil, 1, numcnv, ndigit,
+             call pivout(comm, logfil, 1, [numcnv], ndigit,
      &            '_neupd: Number of specified eigenvalues')
-             call pivout(comm, logfil, 1, nconv, ndigit,
+             call pivout(comm, logfil, 1, [nconv], ndigit,
      &            '_neupd: Number of "converged" eigenvalues')
          end if
 c

--- a/mathlibs/src/parpack/psseupd.f
+++ b/mathlibs/src/parpack/psseupd.f
@@ -2,9 +2,9 @@ c\BeginDoc
 c
 c\Name: psseupd
 c
-c Message Passing Layer: MPI 
+c Message Passing Layer: MPI
 c
-c\Description: 
+c\Description:
 c
 c  This subroutine returns the converged approximations to eigenvalues
 c  of A*z = lambda*B*z and (optionally):
@@ -17,22 +17,22 @@ c
 c      (3) Both.
 c
 c  There is negligible additional cost to obtain eigenvectors.  An orthonormal
-c  (Lanczos) basis is always computed.  There is an additional storage cost 
-c  of n*nev if both are requested (in this case a separate array Z must be 
+c  (Lanczos) basis is always computed.  There is an additional storage cost
+c  of n*nev if both are requested (in this case a separate array Z must be
 c  supplied).
 c
 c  These quantities are obtained from the Lanczos factorization computed
 c  by PSSAUPD for the linear operator OP prescribed by the MODE selection
 c  (see IPARAM(7) in PSSAUPD documentation.)  PSSAUPD must be called before
-c  this routine is called. These approximate eigenvalues and vectors are 
-c  commonly called Ritz values and Ritz vectors respectively.  They are 
-c  referred to as such in the comments that follow.   The computed orthonormal 
-c  basis for the invariant subspace corresponding to these Ritz values is 
+c  this routine is called. These approximate eigenvalues and vectors are
+c  commonly called Ritz values and Ritz vectors respectively.  They are
+c  referred to as such in the comments that follow.   The computed orthonormal
+c  basis for the invariant subspace corresponding to these Ritz values is
 c  referred to as a Lanczos basis.
 c
-c  See documentation in the header of the subroutine PSSAUPD for a definition 
-c  of OP as well as other terms and the relation of computed Ritz values 
-c  and vectors of OP with respect to the given problem  A*z = lambda*B*z.  
+c  See documentation in the header of the subroutine PSSAUPD for a definition
+c  of OP as well as other terms and the relation of computed Ritz values
+c  and vectors of OP with respect to the given problem  A*z = lambda*B*z.
 c
 c  The approximate eigenvalues of the original problem are returned in
 c  ascending algebraic order.  The user may elect to call this routine
@@ -41,22 +41,22 @@ c  There is also the option of computing a selected set of these vectors
 c  with a single call.
 c
 c\Usage:
-c  call psseupd 
+c  call psseupd
 c     ( COMM, RVEC, HOWMNY, SELECT, D, Z, LDZ, SIGMA, BMAT, N, WHICH, NEV, TOL,
 c       RESID, NCV, V, LDV, IPARAM, IPNTR, WORKD, WORKL, LWORKL, INFO )
 c
 c\Arguments
 c  COMM    MPI  Communicator for the processor grid.  (INPUT)
 c
-c  RVEC    LOGICAL  (INPUT) 
-c          Specifies whether Ritz vectors corresponding to the Ritz value 
+c  RVEC    LOGICAL  (INPUT)
+c          Specifies whether Ritz vectors corresponding to the Ritz value
 c          approximations to the eigenproblem A*z = lambda*B*z are computed.
 c
 c             RVEC = .FALSE.     Compute Ritz values only.
 c
 c             RVEC = .TRUE.      Compute Ritz vectors.
 c
-c  HOWMNY  Character*1  (INPUT) 
+c  HOWMNY  Character*1  (INPUT)
 c          Specifies how many Ritz vectors are wanted and the form of Z
 c          the matrix of Ritz vectors. See remark 1 below.
 c          = 'A': compute NEV Ritz vectors;
@@ -66,7 +66,7 @@ c
 c  SELECT  Logical array of dimension NCV.  (INPUT/WORKSPACE)
 c          If HOWMNY = 'S', SELECT specifies the Ritz vectors to be
 c          computed. To select the Ritz vector corresponding to a
-c          Ritz value D(j), SELECT(j) must be set to .TRUE.. 
+c          Ritz value D(j), SELECT(j) must be set to .TRUE..
 c          If HOWMNY = 'A' , SELECT is used as workspace.
 c
 c  D       Real  array of dimension NEV.  (OUTPUT)
@@ -74,8 +74,8 @@ c          On exit, D contains the Ritz value approximations to the
 c          eigenvalues of A*z = lambda*B*z. The values are returned
 c          in ascending order. If IPARAM(7) = 3,4,5 then D represents
 c          the Ritz values of OP computed by pssaupd transformed to
-c          those of the original eigensystem A*z = lambda*B*z. If 
-c          IPARAM(7) = 1,2 then the Ritz values of OP are the same 
+c          those of the original eigensystem A*z = lambda*B*z. If
+c          IPARAM(7) = 1,2 then the Ritz values of OP are the same
 c          as the those of A*z = lambda*B*z.
 c
 c  Z       Real  N by NEV array if HOWMNY = 'A'.  (OUTPUT)
@@ -83,7 +83,7 @@ c          On exit, Z contains the B-orthonormal Ritz vectors of the
 c          eigensystem A*z = lambda*B*z corresponding to the Ritz
 c          value approximations.
 c          If  RVEC = .FALSE. then Z is not referenced.
-c          NOTE: The array Z may be set equal to first NEV columns of the 
+c          NOTE: The array Z may be set equal to first NEV columns of the
 c          Arnoldi/Lanczos basis array V computed by PSSAUPD.
 c
 c  LDZ     Integer.  (INPUT)
@@ -157,7 +157,7 @@ c\References:
 c  1. D.C. Sorensen, "Implicit Application of Polynomial Filters in
 c     a k-Step Arnoldi Method", SIAM J. Matr. Anal. Apps., 13 (1992),
 c     pp 357-385.
-c  2. R.B. Lehoucq, "Analysis and Implementation of an Implicitly 
+c  2. R.B. Lehoucq, "Analysis and Implementation of an Implicitly
 c     Restarted Arnoldi Iteration", Rice University Technical Report
 c     TR95-13, Department of Computational and Applied Mathematics.
 c  3. B.N. Parlett, "The Symmetric Eigenvalue Problem". Prentice-Hall,
@@ -167,19 +167,19 @@ c     Computer Physics Communications, 53 (1989), pp 169-179.
 c  5. B. Nour-Omid, B.N. Parlett, T. Ericson, P.S. Jensen, "How to
 c     Implement the Spectral Transformation", Math. Comp., 48 (1987),
 c     pp 663-673.
-c  6. R.G. Grimes, J.G. Lewis and H.D. Simon, "A Shifted Block Lanczos 
-c     Algorithm for Solving Sparse Symmetric Generalized Eigenproblems", 
+c  6. R.G. Grimes, J.G. Lewis and H.D. Simon, "A Shifted Block Lanczos
+c     Algorithm for Solving Sparse Symmetric Generalized Eigenproblems",
 c     SIAM J. Matr. Anal. Apps.,  January (1993).
 c  7. L. Reichel, W.B. Gragg, "Algorithm 686: FORTRAN Subroutines
 c     for Updating the QR decomposition", ACM TOMS, December 1990,
 c     Volume 16 Number 4, pp 369-377.
 c
 c\Remarks
-c  1. The converged Ritz values are always returned in increasing 
+c  1. The converged Ritz values are always returned in increasing
 c     (algebraic) order.
 c
 c  2. Currently only HOWMNY = 'A' is implemented. It is included at this
-c     stage for the user who wants to incorporate it. 
+c     stage for the user who wants to incorporate it.
 c
 c\Routines called:
 c     ssesrt  ARPACK routine that sorts an array X, and applies the
@@ -204,10 +204,10 @@ c\Authors
 c     Danny Sorensen               Phuong Vu
 c     Richard Lehoucq              CRPC / Rice University
 c     Chao Yang                    Houston, Texas
-c     Dept. of Computational & 
+c     Dept. of Computational &
 c     Applied Mathematics
-c     Rice University           
-c     Houston, Texas            
+c     Rice University
+c     Houston, Texas
 c
 c\Parallel Modifications
 c     Kristi Maschhoff
@@ -221,7 +221,7 @@ c
 c\EndLib
 c
 c-----------------------------------------------------------------------
-      subroutine psseupd 
+      subroutine psseupd
      &    (comm  , rvec  , howmny, select, d    ,
      &     z     , ldz   , sigma , bmat  , n    ,
      &     which , nev   , tol   , resid , ncv  ,
@@ -248,7 +248,7 @@ c
       character  bmat, howmny, which*2
       logical    rvec
       integer    info, ldz, ldv, lworkl, n, ncv, nev
-      Real      
+      Real
      &           sigma, tol
 c
 c     %-----------------%
@@ -257,15 +257,15 @@ c     %-----------------%
 c
       integer    iparam(7), ipntr(11)
       logical    select(ncv)
-      Real 
-     &           d(nev), resid(n), v(ldv,ncv), z(ldz, nev), 
+      Real
+     &           d(nev), resid(n), v(ldv,ncv), z(ldz, nev),
      &           workd(2*n), workl(lworkl)
 c
 c     %------------%
 c     | Parameters |
 c     %------------%
 c
-      Real 
+      Real
      &           one, zero
       parameter (one = 1.0 , zero = 0.0 )
 c
@@ -279,7 +279,7 @@ c
      &           ldq    , mode   , msglvl, nconv , next  ,
      &           ritz   , irz    , ibd   , np    , ishift,
      &           leftptr, rghtptr, numcnv, jj
-      Real 
+      Real
      &           bnorm2, rnorm, temp, temp1, eps23
       logical    reord
 c
@@ -287,14 +287,14 @@ c     %----------------------%
 c     | External Subroutines |
 c     %----------------------%
 c
-      external   scopy , sger  , sgeqr2, slacpy, sorm2r, sscal, 
+      external   scopy , sger  , sgeqr2, slacpy, sorm2r, sscal,
      &           ssesrt, ssteqr, sswap , psvout, pivout, ssortr
 c
 c     %--------------------%
 c     | External Functions |
 c     %--------------------%
 c
-      Real 
+      Real
      &           psnorm2, pslamch10
       external   psnorm2, pslamch10
 c
@@ -307,7 +307,7 @@ c
 c     %-----------------------%
 c     | Executable Statements |
 c     %-----------------------%
-c 
+c
 c     %------------------------%
 c     | Set default parameters |
 c     %------------------------%
@@ -324,7 +324,7 @@ c
       if (nconv .eq. 0) go to 9000
       ierr = 0
 c
-      if (nconv .le. 0)                        ierr = -14 
+      if (nconv .le. 0)                        ierr = -14
       if (n .le. 0)                            ierr = -1
       if (nev .le. 0)                          ierr = -2
       if (ncv .le. nev)                        ierr = -3
@@ -336,12 +336,12 @@ c
       if (bmat .ne. 'I' .and. bmat .ne. 'G')   ierr = -6
       if ( (howmny .ne. 'A' .and.
      &           howmny .ne. 'P' .and.
-     &           howmny .ne. 'S') .and. rvec ) 
+     &           howmny .ne. 'S') .and. rvec )
      &                                         ierr = -15
       if (rvec .and. howmny .eq. 'S')           ierr = -16
 c
       if (rvec .and. lworkl .lt. ncv**2+8*ncv) ierr = -7
-c     
+c
       if (mode .eq. 1 .or. mode .eq. 2) then
          type = 'REGULR'
       else if (mode .eq. 3 ) then
@@ -350,7 +350,7 @@ c
          type = 'BUCKLE'
       else if (mode .eq. 5 ) then
          type = 'CAYLEY'
-      else 
+      else
                                                ierr = -10
       end if
       if (mode .eq. 1 .and. bmat .eq. 'G')     ierr = -11
@@ -364,7 +364,7 @@ c
          info = ierr
          go to 9000
       end if
-c     
+c
 c     %-------------------------------------------------------%
 c     | Pointer into WORKL for address of H, RITZ, BOUNDS, Q  |
 c     | etc... and the remaining workspace.                   |
@@ -439,7 +439,7 @@ c     %---------------------------------%
 c     | Set machine dependent constant. |
 c     %---------------------------------%
 c
-      eps23 = pslamch10(comm, 'Epsilon-Machine') 
+      eps23 = pslamch10(comm, 'Epsilon-Machine')
       eps23 = eps23**(2.0  / 3.0 )
 c
 c     %---------------------------------------%
@@ -487,7 +487,7 @@ c        %-------------------------------------%
 c
          np     = ncv - nev
          ishift = 0
-         call pssgets(comm         , ishift, which     , 
+         call pssgets(comm         , ishift, which     ,
      &                nev          , np    , workl(irz),
      &                workl(bounds), workl , workl(np+1))
 c
@@ -663,8 +663,8 @@ c
             call scopy(ncv, workl(bounds), 1, workl(ihb), 1)
          end if
 c
-      else 
-c 
+      else
+c
 c        %-------------------------------------------------------------%
 c        | *  Make a copy of all the Ritz values.                      |
 c        | *  Transform the Ritz values back to the original system.   |
@@ -681,13 +681,13 @@ c        |  They are only reordered.                                   |
 c        %-------------------------------------------------------------%
 c
          call scopy (ncv, workl(ihd), 1, workl(iw), 1)
-         if (type .eq. 'SHIFTI') then 
+         if (type .eq. 'SHIFTI') then
             do 40 k=1, ncv
                workl(ihd+k-1) = one / workl(ihd+k-1) + sigma
   40        continue
          else if (type .eq. 'BUCKLE') then
             do 50 k=1, ncv
-               workl(ihd+k-1) = sigma * workl(ihd+k-1) / 
+               workl(ihd+k-1) = sigma * workl(ihd+k-1) /
      &                          (workl(ihd+k-1) - one)
   50        continue
          else if (type .eq. 'CAYLEY') then
@@ -696,7 +696,7 @@ c
      &                          (workl(ihd+k-1) - one)
   60        continue
          end if
-c 
+c
 c        %-------------------------------------------------------------%
 c        | *  Store the wanted NCONV lambda values into D.             |
 c        | *  Sort the NCONV wanted lambda in WORKL(IHD:IHD+NCONV-1)   |
@@ -722,8 +722,8 @@ c
             call ssortr('LA', .true., nconv, d, workl(ihb))
          end if
 c
-      end if 
-c 
+      end if
+c
 c     %------------------------------------------------%
 c     | Compute the Ritz vectors. Transform the wanted |
 c     | eigenvectors of the symmetric tridiagonal H by |
@@ -731,25 +731,25 @@ c     | the Lanczos basis matrix V.                    |
 c     %------------------------------------------------%
 c
       if (rvec .and. howmny .eq. 'A') then
-c    
+c
 c        %----------------------------------------------------------%
 c        | Compute the QR factorization of the matrix representing  |
 c        | the wanted invariant subspace located in the first NCONV |
 c        | columns of workl(iq,ldq).                                |
 c        %----------------------------------------------------------%
-c     
+c
          call sgeqr2(ncv, nconv        , workl(iq) ,
      &               ldq, workl(iw+ncv), workl(ihb),
      &               ierr)
-c     
+c
 c        %--------------------------------------------------------%
-c        | * Postmultiply V by Q.                                 |   
+c        | * Postmultiply V by Q.                                 |
 c        | * Copy the first NCONV columns of VQ into Z.           |
 c        | The N by NCONV matrix Z is now a matrix representation |
 c        | of the approximate invariant subspace associated with  |
 c        | the Ritz values in workl(ihd).                         |
 c        %--------------------------------------------------------%
-c     
+c
          call sorm2r('Right'      , 'Notranspose', n        ,
      &                ncv          , nconv        , workl(iq),
      &                ldq          , workl(iw+ncv), v        ,
@@ -795,10 +795,10 @@ c        | *  Determine Ritz estimates of the lambda.      |
 c        %-------------------------------------------------%
 c
          call sscal (ncv, bnorm2, workl(ihb), 1)
-         if (type .eq. 'SHIFTI') then 
+         if (type .eq. 'SHIFTI') then
 c
             do 80 k=1, ncv
-               workl(ihb+k-1) = abs( workl(ihb+k-1) ) 
+               workl(ihb+k-1) = abs( workl(ihb+k-1) )
      &                        / workl(iw+k-1)**2
  80         continue
 c
@@ -823,15 +823,15 @@ c
       if (type .ne. 'REGULR' .and. msglvl .gt. 1) then
          call psvout (comm, logfil, nconv, d, ndigit,
      &          '_seupd: Untransformed converged Ritz values')
-         call psvout (comm, logfil, nconv, workl(ihb), ndigit, 
+         call psvout (comm, logfil, nconv, workl(ihb), ndigit,
      &     '_seupd: Ritz estimates of the untransformed Ritz values')
       else if (msglvl .gt. 1) then
          call psvout (comm, logfil, nconv, d, ndigit,
      &          '_seupd: Converged Ritz values')
-         call psvout (comm, logfil, nconv, workl(ihb), ndigit, 
+         call psvout (comm, logfil, nconv, workl(ihb), ndigit,
      &     '_seupd: Associated Ritz estimates')
       end if
-c 
+c
 c     %-------------------------------------------------%
 c     | Ritz vector purification step. Formally perform |
 c     | one of inverse subspace iteration. Only used    |
@@ -841,7 +841,7 @@ c
       if (rvec .and. (type .eq. 'SHIFTI' .or. type .eq. 'CAYLEY')) then
 c
          do 110 k=0, nconv-1
-            workl(iw+k) = workl(iq+k*ldq+ncv-1) 
+            workl(iw+k) = workl(iq+k*ldq+ncv-1)
      &                  / workl(iw+k)
  110     continue
 c
@@ -852,7 +852,7 @@ c
      &                  / (workl(iw+k)-one)
  120     continue
 c
-      end if 
+      end if
 c
       if (type .ne. 'REGULR')
      &   call sger(n, nconv, one, resid, 1, workl(iw), 1, z, ldz)

--- a/mathlibs/src/parpack/pssgets.f
+++ b/mathlibs/src/parpack/pssgets.f
@@ -5,13 +5,13 @@ c\Name: pssgets
 c
 c Message Passing Layer: MPI
 c
-c\Description: 
+c\Description:
 c  Given the eigenvalues of the symmetric tridiagonal matrix H,
-c  computes the NP shifts AMU that are zeros of the polynomial of 
-c  degree NP which filters out components of the unwanted eigenvectors 
+c  computes the NP shifts AMU that are zeros of the polynomial of
+c  degree NP which filters out components of the unwanted eigenvectors
 c  corresponding to the AMU's based on some given criteria.
 c
-c  NOTE: This is called even in the case of user specified shifts in 
+c  NOTE: This is called even in the case of user specified shifts in
 c  order to sort the eigenvalues, and error bounds of H for later use.
 c
 c\Usage:
@@ -43,8 +43,8 @@ c          Number of implicit shifts to be computed.
 c
 c  RITZ    Real array of length KEV+NP.  (INPUT/OUTPUT)
 c          On INPUT, RITZ contains the eigenvalues of H.
-c          On OUTPUT, RITZ are sorted so that the unwanted eigenvalues 
-c          are in the first NP locations and the wanted part is in 
+c          On OUTPUT, RITZ are sorted so that the unwanted eigenvalues
+c          are in the first NP locations and the wanted part is in
 c          the last KEV locations.  When exact shifts are selected, the
 c          unwanted part corresponds to the shifts to be applied.
 c
@@ -53,7 +53,7 @@ c          Error bounds corresponding to the ordering in RITZ.
 c
 c  SHIFTS  Real array of length NP.  (INPUT/OUTPUT)
 c          On INPUT:  contains the user specified shifts if ISHIFT = 0.
-c          On OUTPUT: contains the shifts sorted into decreasing order 
+c          On OUTPUT: contains the shifts sorted into decreasing order
 c          of magnitude with respect to the Ritz estimates contained in
 c          BOUNDS. If ISHIFT = 0, SHIFTS is not modified on exit.
 c
@@ -79,8 +79,8 @@ c     Danny Sorensen               Phuong Vu
 c     Richard Lehoucq              CRPC / Rice University
 c     Dept. of Computational &     Houston, Texas
 c     Applied Mathematics
-c     Rice University           
-c     Houston, Texas            
+c     Rice University
+c     Houston, Texas
 c
 c\Parallel Modifications
 c     Kristi Maschhoff
@@ -88,8 +88,8 @@ c
 c\Revision history:
 c     Starting Point: Serial Code FILE: sgets.F   SID: 2.3
 c
-c\SCCS Information: 
-c FILE: sgets.F   SID: 1.2   DATE OF SID: 2/22/96   
+c\SCCS Information:
+c FILE: sgets.F   SID: 1.2   DATE OF SID: 2/22/96
 c
 c\Remarks
 c
@@ -97,7 +97,7 @@ c\EndLib
 c
 c-----------------------------------------------------------------------
 c
-      subroutine pssgets 
+      subroutine pssgets
      &      ( comm, ishift, which, kev, np, ritz, bounds, shifts )
 c
 c     %--------------------%
@@ -156,7 +156,7 @@ c
 c     %-----------------------%
 c     | Executable Statements |
 c     %-----------------------%
-c 
+c
 c     %-------------------------------%
 c     | Initialize timing statistics  |
 c     | & message level for debugging |
@@ -164,7 +164,7 @@ c     %-------------------------------%
 c
       call second (t0)
       msglvl = msgets
-c 
+c
       if (which .eq. 'BE') then
 c
 c        %-----------------------------------------------------%
@@ -177,11 +177,11 @@ c        | overlapping locations.                              |
 c        %-----------------------------------------------------%
 c
          call ssortr ('LA', .true., kev+np, ritz, bounds)
-         kevd2 = kev / 2 
+         kevd2 = kev / 2
          if ( kev .gt. 1 ) then
-            call sswap ( min(kevd2,np), ritz, 1, 
+            call sswap ( min(kevd2,np), ritz, 1,
      &                   ritz( max(kevd2,np)+1 ), 1)
-            call sswap ( min(kevd2,np), bounds, 1, 
+            call sswap ( min(kevd2,np), bounds, 1,
      &                   bounds( max(kevd2,np)+1 ), 1)
          end if
 c
@@ -199,7 +199,7 @@ c
       end if
 c
       if (ishift .eq. 1 .and. np .gt. 0) then
-c     
+c
 c        %-------------------------------------------------------%
 c        | Sort the unwanted Ritz values used as shifts so that  |
 c        | the ones with largest Ritz estimates are first.       |
@@ -207,11 +207,11 @@ c        | This will tend to minimize the effects of the         |
 c        | forward instability of the iteration when the shifts  |
 c        | are applied in subroutine pssapps.                    |
 c        %-------------------------------------------------------%
-c     
+c
          call ssortr ('SM', .true., np, bounds, ritz)
          call scopy (np, ritz, 1, shifts, 1)
       end if
-c 
+c
       call second (t1)
       tsgets = tsgets + (t1 - t0)
 c
@@ -220,10 +220,10 @@ c
          call pivout (comm, logfil, 1, [np], ndigit, '_sgets: NP is')
          call psvout (comm, logfil, kev+np, ritz, ndigit,
      &        '_sgets: Eigenvalues of current H matrix')
-         call psvout (comm, logfil, kev+np, bounds, ndigit, 
+         call psvout (comm, logfil, kev+np, bounds, ndigit,
      &        '_sgets: Associated Ritz estimates')
       end if
-c 
+c
       return
 c
 c     %----------------%

--- a/mathlibs/src/parpack/pssgets.f
+++ b/mathlibs/src/parpack/pssgets.f
@@ -216,8 +216,8 @@ c
       tsgets = tsgets + (t1 - t0)
 c
       if (msglvl .gt. 0) then
-         call pivout (comm, logfil, 1, kev, ndigit, '_sgets: KEV is')
-         call pivout (comm, logfil, 1, np, ndigit, '_sgets: NP is')
+         call pivout (comm, logfil, 1, [kev], ndigit, '_sgets: KEV is')
+         call pivout (comm, logfil, 1, [np], ndigit, '_sgets: NP is')
          call psvout (comm, logfil, kev+np, ritz, ndigit,
      &        '_sgets: Eigenvalues of current H matrix')
          call psvout (comm, logfil, kev+np, bounds, ndigit, 

--- a/mathlibs/src/parpack/pzgetv0.f
+++ b/mathlibs/src/parpack/pzgetv0.f
@@ -1,16 +1,16 @@
 c\BeginDoc
 c
-c\Name: pzgetv0 
+c\Name: pzgetv0
 c
-c Message Passing Layer: MPI 
+c Message Passing Layer: MPI
 c
-c\Description: 
+c\Description:
 c  Generate a random initial residual vector for the Arnoldi process.
-c  Force the residual vector to be in the range of the operator OP.  
+c  Force the residual vector to be in the range of the operator OP.
 c
 c\Usage:
-c  call pzgetv0 
-c     ( COMM, IDO, BMAT, ITRY, INITV, N, J, V, LDV, RESID, RNORM, 
+c  call pzgetv0
+c     ( COMM, IDO, BMAT, ITRY, INITV, N, J, V, LDV, RESID, RNORM,
 c       IPNTR, WORKD, WORKL, IERR )
 c
 c\Arguments
@@ -39,7 +39,7 @@ c          B = 'I' -> standard eigenvalue problem A*x = lambda*x
 c          B = 'G' -> generalized eigenvalue problem A*x = lambda*B*x
 c
 c  ITRY    Integer.  (INPUT)
-c          ITRY counts the number of times that pzgetv0  is called.  
+c          ITRY counts the number of times that pzgetv0  is called.
 c          It should be set to 1 on the initial call to pzgetv0 .
 c
 c  INITV   Logical variable.  (INPUT)
@@ -58,11 +58,11 @@ c          The first J-1 columns of V contain the current Arnoldi basis
 c          if this is a "restart".
 c
 c  LDV     Integer.  (INPUT)
-c          Leading dimension of V exactly as declared in the calling 
+c          Leading dimension of V exactly as declared in the calling
 c          program.
 c
 c  RESID   Complex*16  array of length N.  (INPUT/OUTPUT)
-c          Initial residual vector to be generated.  If RESID is 
+c          Initial residual vector to be generated.  If RESID is
 c          provided, force RESID into the range of the operator OP.
 c
 c  RNORM   Double precision  scalar.  (OUTPUT)
@@ -87,7 +87,7 @@ c
 c\BeginLib
 c
 c\Local variables:
-c     xxxxxx  Complex*16 
+c     xxxxxx  Complex*16
 c
 c\References:
 c  1. D.C. Sorensen, "Implicit Application of Polynomial Filters in
@@ -97,19 +97,19 @@ c
 c\Routines called:
 c     second   ARPACK utility routine for timing.
 c     pzvout    Parallel ARPACK utility routine that prints vectors.
-c     pzlarnv   Parallel wrapper for LAPACK routine zlarnv  (generates a random vector). 
+c     pzlarnv   Parallel wrapper for LAPACK routine zlarnv  (generates a random vector).
 c     zgemv     Level 2 BLAS routine for matrix vector multiplication.
 c     zcopy     Level 1 BLAS that copies one vector to another.
 c     zdotc     Level 1 BLAS that computes the scalar product of two vectors.
-c     pdznorm2  Parallel version of Level 1 BLAS that computes the norm of a vector. 
+c     pdznorm2  Parallel version of Level 1 BLAS that computes the norm of a vector.
 c
 c\Author
 c     Danny Sorensen               Phuong Vu
 c     Richard Lehoucq              CRPC / Rice University
 c     Dept. of Computational &     Houston, Texas
-c     Applied Mathematics 
-c     Rice University           
-c     Houston, Texas            
+c     Applied Mathematics
+c     Rice University
+c     Houston, Texas
 c
 c\Parallel Modifications
 c     Kristi Maschhoff
@@ -124,10 +124,10 @@ c\EndLib
 c
 c-----------------------------------------------------------------------
 c
-      subroutine pzgetv0  
-     &   ( comm, ido, bmat, itry, initv, n, j, v, ldv, resid, rnorm, 
+      subroutine pzgetv0
+     &   ( comm, ido, bmat, itry, initv, n, j, v, ldv, resid, rnorm,
      &     ipntr, workd, workl, ierr )
-c 
+c
       include   'mpif.h'
 c
 c     %---------------%
@@ -150,7 +150,7 @@ c
       character  bmat*1
       logical    initv
       integer    ido, ierr, itry, j, ldv, n
-      Double precision 
+      Double precision
      &           rnorm
 c
 c     %-----------------%
@@ -158,16 +158,16 @@ c     | Array Arguments |
 c     %-----------------%
 c
       integer    ipntr(3)
-      Complex*16 
+      Complex*16
      &           resid(n), v(ldv,j), workd(2*n), workl(2*j)
 c
 c     %------------%
 c     | Parameters |
 c     %------------%
 c
-      Complex*16 
+      Complex*16
      &           one, zero
-      Double precision 
+      Double precision
      &           rzero
       parameter  (one = (1.0, 0.0) , zero = (0.0, 0.0) ,
      &            rzero = 0.0 )
@@ -178,13 +178,13 @@ c     %------------------------%
 c
       logical    first, inits, orth
       integer    idist, iseed(4), iter, msglvl, jj, myid, igen
-      Double precision 
+      Double precision
      &           rnorm0
-      Complex*16 
+      Complex*16
      &           cnorm, cnorm2
       save       first, iseed, inits, iter, msglvl, orth, rnorm0
 c
-      Complex*16 
+      Complex*16
      &           cnorm_buf
 c
 c     %----------------------%
@@ -197,11 +197,11 @@ c     %--------------------%
 c     | External Functions |
 c     %--------------------%
 c
-      Double precision  
-     &           pdznorm2 , dlapy2 
-      Complex*16 
-     &           zdotc 
-      external   zdotc , pdznorm2 , dlapy2 
+      Double precision
+     &           pdznorm2 , dlapy2
+      Complex*16
+     &           zdotc
+      external   zdotc , pdznorm2 , dlapy2
 c
 c     %-----------------%
 c     | Data Statements |
@@ -245,7 +245,7 @@ c
       end if
 c
       if (ido .eq.  0) then
-c 
+c
 c        %-------------------------------%
 c        | Initialize timing statistics  |
 c        | & message level for debugging |
@@ -253,7 +253,7 @@ c        %-------------------------------%
 c
          call second (t0)
          msglvl = mgetv0
-c 
+c
          ierr   = 0
          iter   = 0
          first  = .FALSE.
@@ -272,7 +272,7 @@ c
             idist = 2
             call pzlarnv  (comm, idist, iseed, n, resid)
          end if
-c 
+c
 c        %----------------------------------------------------------%
 c        | Force the starting vector into the range of OP to handle |
 c        | the generalized problem when B is possibly (singular).   |
@@ -288,7 +288,7 @@ c
             go to 9000
          end if
       end if
-c 
+c
 c     %----------------------------------------%
 c     | Back from computing B*(initial-vector) |
 c     %----------------------------------------%
@@ -300,10 +300,10 @@ c     | Back from computing B*(orthogonalized-vector) |
 c     %-----------------------------------------------%
 c
       if (orth)  go to 40
-c 
+c
       call second (t3)
       tmvopx = tmvopx + (t3 - t2)
-c 
+c
 c     %------------------------------------------------------%
 c     | Starting vector is now in the range of OP; r = OP*r; |
 c     | Compute B-norm of starting vector.                   |
@@ -321,14 +321,14 @@ c
       else if (bmat .eq. 'I') then
          call zcopy  (n, resid, 1, workd, 1)
       end if
-c 
+c
    20 continue
 c
       if (bmat .eq. 'G') then
          call second (t3)
          tmvbx = tmvbx + (t3 - t2)
       end if
-c 
+c
       first = .FALSE.
       if (bmat .eq. 'G') then
           cnorm_buf = zdotc  (n, resid, 1, workd, 1)
@@ -345,7 +345,7 @@ c     | Exit if this is the very first Arnoldi step |
 c     %---------------------------------------------%
 c
       if (j .eq. 1) go to 50
-c 
+c
 c     %----------------------------------------------------------------
 c     | Otherwise need to B-orthogonalize the starting vector against |
 c     | the current Arnoldi basis using Gram-Schmidt with iter. ref.  |
@@ -361,13 +361,13 @@ c
       orth = .TRUE.
    30 continue
 c
-      call zgemv  ('C', n, j-1, one, v, ldv, workd, 1, 
+      call zgemv  ('C', n, j-1, one, v, ldv, workd, 1,
      &            zero, workl(j+1), 1)
       call MPI_ALLREDUCE( workl(j+1), workl, j-1,
      &                    MPI_DOUBLE_COMPLEX , MPI_SUM, comm, ierr)
-      call zgemv  ('N', n, j-1, -one, v, ldv, workl, 1, 
+      call zgemv  ('N', n, j-1, -one, v, ldv, workl, 1,
      &            one, resid, 1)
-c 
+c
 c     %----------------------------------------------------------%
 c     | Compute the B-norm of the orthogonalized starting vector |
 c     %----------------------------------------------------------%
@@ -383,14 +383,14 @@ c
       else if (bmat .eq. 'I') then
          call zcopy  (n, resid, 1, workd, 1)
       end if
-c 
+c
    40 continue
 c
       if (bmat .eq. 'G') then
          call second (t3)
          tmvbx = tmvbx + (t3 - t2)
       end if
-c 
+c
       if (bmat .eq. 'G') then
          cnorm_buf = zdotc  (n, resid, 1, workd, 1)
          call MPI_ALLREDUCE( cnorm_buf, cnorm, 1,
@@ -405,14 +405,14 @@ c     | Check for further orthogonalization. |
 c     %--------------------------------------%
 c
       if (msglvl .gt. 2) then
-          call pdvout  (comm, logfil, 1, [rnorm0], ndigit, 
+          call pdvout  (comm, logfil, 1, [rnorm0], ndigit,
      &                '_getv0: re-orthonalization ; rnorm0 is')
-          call pdvout  (comm, logfil, 1, [rnorm], ndigit, 
+          call pdvout  (comm, logfil, 1, [rnorm], ndigit,
      &                '_getv0: re-orthonalization ; rnorm is')
       end if
 c
       if (rnorm .gt. 0.717*rnorm0) go to 50
-c 
+c
       iter = iter + 1
       if (iter .le. 5 ) then
 c
@@ -434,7 +434,7 @@ c
          rnorm = rzero
          ierr = -1
       end if
-c 
+c
    50 continue
 c
       if (msglvl .gt. 0) then
@@ -447,10 +447,10 @@ c
      &        '_getv0: initial / restarted starting vector')
       end if
       ido = 99
-c 
+c
       call second (t1)
       tgetv0 = tgetv0 + (t1 - t0)
-c 
+c
  9000 continue
       return
 c

--- a/mathlibs/src/parpack/pzgetv0.f
+++ b/mathlibs/src/parpack/pzgetv0.f
@@ -405,9 +405,9 @@ c     | Check for further orthogonalization. |
 c     %--------------------------------------%
 c
       if (msglvl .gt. 2) then
-          call pdvout  (comm, logfil, 1, rnorm0, ndigit, 
+          call pdvout  (comm, logfil, 1, [rnorm0], ndigit, 
      &                '_getv0: re-orthonalization ; rnorm0 is')
-          call pdvout  (comm, logfil, 1, rnorm, ndigit, 
+          call pdvout  (comm, logfil, 1, [rnorm], ndigit, 
      &                '_getv0: re-orthonalization ; rnorm is')
       end if
 c
@@ -439,7 +439,7 @@ c
 c
       if (msglvl .gt. 0) then
          cnorm2 = dcmplx (rnorm,rzero)
-         call pzvout  (comm, logfil, 1, cnorm2, ndigit,
+         call pzvout  (comm, logfil, 1, [cnorm2], ndigit,
      &        '_getv0: B-norm of initial / restarted starting vector')
       end if
       if (msglvl .gt. 2) then

--- a/mathlibs/src/parpack/pznaitr.f
+++ b/mathlibs/src/parpack/pznaitr.f
@@ -4,8 +4,8 @@ c\Name: pznaitr
 c
 c Message Passing Layer: MPI
 c
-c\Description: 
-c  Reverse communication interface for applying NP additional steps to 
+c\Description:
+c  Reverse communication interface for applying NP additional steps to
 c  a K step nonsymmetric Arnoldi factorization.
 c
 c  Input:  OP*V_{k}  -  V_{k}*H = r_{k}*e_{k}^T
@@ -21,7 +21,7 @@ c  computed and returned.
 c
 c\Usage:
 c  call pznaitr
-c     ( COMM, IDO, BMAT, N, K, NP, NB, RESID, RNORM, V, LDV, H, LDH, 
+c     ( COMM, IDO, BMAT, N, K, NP, NB, RESID, RNORM, V, LDV, H, LDH,
 c       IPNTR, WORKD, WORKL, INFO )
 c
 c\Arguments
@@ -65,8 +65,8 @@ c  NP      Integer.  (INPUT)
 c          Number of additional Arnoldi steps to take.
 c
 c  NB      Integer.  (INPUT)
-c          Blocksize to be used in the recurrence.          
-c          Only work for NB = 1 right now.  The goal is to have a 
+c          Blocksize to be used in the recurrence.
+c          Only work for NB = 1 right now.  The goal is to have a
 c          program that implement both the block and non-block method.
 c
 c  RESID   Complex*16 array of length N.  (INPUT/OUTPUT)
@@ -78,37 +78,37 @@ c          B-norm of the starting residual on input.
 c          B-norm of the updated residual r_{k+p} on output.
 c
 c  V       Complex*16 N by K+NP array.  (INPUT/OUTPUT)
-c          On INPUT:  V contains the Arnoldi vectors in the first K 
+c          On INPUT:  V contains the Arnoldi vectors in the first K
 c          columns.
 c          On OUTPUT: V contains the new NP Arnoldi vectors in the next
 c          NP columns.  The first K columns are unchanged.
 c
 c  LDV     Integer.  (INPUT)
-c          Leading dimension of V exactly as declared in the calling 
+c          Leading dimension of V exactly as declared in the calling
 c          program.
 c
 c  H       Complex*16 (K+NP) by (K+NP) array.  (INPUT/OUTPUT)
 c          H is used to store the generated upper Hessenberg matrix.
 c
 c  LDH     Integer.  (INPUT)
-c          Leading dimension of H exactly as declared in the calling 
+c          Leading dimension of H exactly as declared in the calling
 c          program.
 c
 c  IPNTR   Integer array of length 3.  (OUTPUT)
-c          Pointer to mark the starting locations in the WORK for 
+c          Pointer to mark the starting locations in the WORK for
 c          vectors used by the Arnoldi iteration.
 c          -------------------------------------------------------------
 c          IPNTR(1): pointer to the current operand vector X.
 c          IPNTR(2): pointer to the current result vector Y.
-c          IPNTR(3): pointer to the vector B * X when used in the 
+c          IPNTR(3): pointer to the vector B * X when used in the
 c                    shift-and-invert mode.  X is the current operand.
 c          -------------------------------------------------------------
-c          
+c
 c  WORKD   Complex*16 work array of length 3*N.  (REVERSE COMMUNICATION)
 c          Distributed array to be used in the basic Arnoldi iteration
-c          for reverse communication.  The calling program should not 
+c          for reverse communication.  The calling program should not
 c          use WORKD as temporary workspace during the iteration !!!!!!
-c          On input, WORKD(1:N) = B*RESID and is used to save some 
+c          On input, WORKD(1:N) = B*RESID and is used to save some
 c          computation at the first step.
 c
 c  WORKL   Complex*16 work space used for Gram Schmidt orthogonalization
@@ -130,7 +130,7 @@ c\References:
 c  1. D.C. Sorensen, "Implicit Application of Polynomial Filters in
 c     a k-Step Arnoldi Method", SIAM J. Matr. Anal. Apps., 13 (1992),
 c     pp 357-385.
-c  2. R.B. Lehoucq, "Analysis and Implementation of an Implicitly 
+c  2. R.B. Lehoucq, "Analysis and Implementation of an Implicitly
 c     Restarted Arnoldi Iteration", Rice University Technical Report
 c     TR95-13, Department of Computational and Applied Mathematics.
 c
@@ -149,21 +149,21 @@ c     dlapy2    LAPACK routine to compute sqrt(x**2+y**2) carefully.
 c     zgemv     Level 2 BLAS routine for matrix vector multiplication.
 c     zaxpy     Level 1 BLAS that computes a vector triad.
 c     zcopy     Level 1 BLAS that copies one vector to another .
-c     zdotc     Level 1 BLAS that computes the scalar product of 
-c               two vectors. 
+c     zdotc     Level 1 BLAS that computes the scalar product of
+c               two vectors.
 c     zscal     Level 1 BLAS that scales a vector.
 c     zdscal    Level 1 BLAS that scales a complex vector by a real number.
-c     pdznorm2  Parallel version of Level 1 BLAS that computes the 
+c     pdznorm2  Parallel version of Level 1 BLAS that computes the
 c               norm of a vector.
 c
 c\Author
 c     Danny Sorensen               Phuong Vu
 c     Richard Lehoucq              CRPC / Rice University
-c     Dept. of Computational &     Houston, Texas 
-c     Applied Mathematics 
-c     Rice University           
-c     Houston, Texas 
-c 
+c     Dept. of Computational &     Houston, Texas
+c     Applied Mathematics
+c     Rice University
+c     Houston, Texas
+c
 c\Parallel Modifications
 c     Kristi Maschhoff
 c
@@ -175,11 +175,11 @@ c FILE: naitr.F   SID: 1.3   DATE OF SID: 3/19/97
 c
 c\Remarks
 c  The algorithm implemented is:
-c  
+c
 c  restart = .false.
-c  Given V_{k} = [v_{1}, ..., v_{k}], r_{k}; 
+c  Given V_{k} = [v_{1}, ..., v_{k}], r_{k};
 c  r_{k} contains the initial residual vector even for k = 0;
-c  Also assume that rnorm = || B*r_{k} || and B*r_{k} are already 
+c  Also assume that rnorm = || B*r_{k} || and B*r_{k} are already
 c  computed by the calling program.
 c
 c  betaj = rnorm ; p_{k+1} = B*r_{k} ;
@@ -187,7 +187,7 @@ c  For  j = k+1, ..., k+np  Do
 c     1) if ( betaj < tol ) stop or restart depending on j.
 c        ( At present tol is zero )
 c        if ( restart ) generate a new starting vector.
-c     2) v_{j} = r(j-1)/betaj;  V_{j} = [V_{j-1}, v_{j}];  
+c     2) v_{j} = r(j-1)/betaj;  V_{j} = [V_{j-1}, v_{j}];
 c        p_{j} = p_{j}/betaj
 c     3) r_{j} = OP*v_{j} where OP is defined as in pznaupd
 c        For shift-invert mode p_{j} = B*v_{j} is already available.
@@ -202,7 +202,7 @@ c        If (rnorm > 0.717*wnorm) accept step and go back to 1)
 c     5) Re-orthogonalization step:
 c        s = V_{j}'*B*r_{j}
 c        r_{j} = r_{j} - V_{j}*s;  rnorm1 = || r_{j} ||
-c        alphaj = alphaj + s_{j};   
+c        alphaj = alphaj + s_{j};
 c     6) Iterative refinement step:
 c        If (rnorm1 > 0.717*rnorm) then
 c           rnorm = rnorm1
@@ -212,7 +212,7 @@ c           rnorm = rnorm1
 c           If this is the first time in step 6), go to 5)
 c           Else r_{j} lies in the span of V_{j} numerically.
 c              Set r_{j} = 0 and rnorm = 0; go to 1)
-c        EndIf 
+c        EndIf
 c  End Do
 c
 c\EndLib
@@ -220,7 +220,7 @@ c
 c-----------------------------------------------------------------------
 c
       subroutine pznaitr
-     &   (comm, ido, bmat, n, k, np, nb, resid, rnorm, v, ldv, h, ldh, 
+     &   (comm, ido, bmat, n, k, np, nb, resid, rnorm, v, ldv, h, ldh,
      &    ipntr, workd, workl, info)
 c
       include   'mpif.h'
@@ -298,7 +298,7 @@ c     %----------------------%
 c     | External Subroutines |
 c     %----------------------%
 c
-      external   zaxpy, zcopy, zscal, zgemv, pzgetv0, dlabad, 
+      external   zaxpy, zcopy, zscal, zgemv, pzgetv0, dlabad,
      &           zdscal, pzvout, pzmout, pivout, second
 c
 c     %--------------------%
@@ -306,8 +306,8 @@ c     | External Functions |
 c     %--------------------%
 c
       Complex*16
-     &           zdotc 
-      Double precision            
+     &           zdotc
+      Double precision
      &           pdlamch10, pdznorm2, zlanhs, dlapy2
       external   zdotc, pdznorm2, zlanhs, pdlamch10, dlapy2
 c
@@ -315,7 +315,7 @@ c     %---------------------%
 c     | Intrinsic Functions |
 c     %---------------------%
 c
-      intrinsic  dimag, dble, max, sqrt 
+      intrinsic  dimag, dble, max, sqrt
 c
 c     %-----------------%
 c     | Data statements |
@@ -346,7 +346,7 @@ c
       end if
 c
       if (ido .eq. 0) then
-c 
+c
 c        %-------------------------------%
 c        | Initialize timing statistics  |
 c        | & message level for debugging |
@@ -354,7 +354,7 @@ c        %-------------------------------%
 c
          call second (t0)
          msglvl = mcaitr
-c 
+c
 c        %------------------------------%
 c        | Initial call to this routine |
 c        %------------------------------%
@@ -370,7 +370,7 @@ c
          irj    = ipj   + n
          ivj    = irj   + n
       end if
-c 
+c
 c     %-------------------------------------------------%
 c     | When in reverse communication mode one of:      |
 c     | STEP3, STEP4, ORTH1, ORTH2, RSTART              |
@@ -400,16 +400,16 @@ c     |        A R N O L D I     I T E R A T I O N     L O O P       |
 c     |                                                              |
 c     | Note:  B*r_{j-1} is already in WORKD(1:N)=WORKD(IPJ:IPJ+N-1) |
 c     %--------------------------------------------------------------%
- 
+
  1000 continue
 c
          if (msglvl .gt. 1) then
-            call pivout (comm, logfil, 1, [j], ndigit, 
+            call pivout (comm, logfil, 1, [j], ndigit,
      &                  '_naitr: generating Arnoldi vector number')
-            call pdvout (comm, logfil, 1, [rnorm], ndigit, 
+            call pdvout (comm, logfil, 1, [rnorm], ndigit,
      &                  '_naitr: B-norm of the current residual is')
          end if
-c 
+c
 c        %---------------------------------------------------%
 c        | STEP 1: Check if the B norm of j-th residual      |
 c        | vector is zero. Equivalent to determine whether   |
@@ -429,14 +429,14 @@ c
                call pivout (comm, logfil, 1, [j], ndigit,
      &                     '_naitr: ****** RESTART AT STEP ******')
             end if
-c 
+c
 c           %---------------------------------------------%
 c           | ITRY is the loop variable that controls the |
 c           | maximum amount of times that a restart is   |
 c           | attempted. NRSTRT is used by stat.h         |
 c           %---------------------------------------------%
 c
-            betaj  = rzero 
+            betaj  = rzero
             nrstrt = nrstrt + 1
             itry   = 1
    20       continue
@@ -449,7 +449,7 @@ c           | If in reverse communication mode and |
 c           | RSTART = .true. flow returns here.   |
 c           %--------------------------------------%
 c
-            call pzgetv0 (comm, ido, bmat, itry, .false., n, j, v, ldv, 
+            call pzgetv0 (comm, ido, bmat, itry, .false., n, j, v, ldv,
      &                   resid, rnorm, ipntr, workd, workl, ierr)
             if (ido .ne. 99) go to 9000
             if (ierr .lt. 0) then
@@ -468,7 +468,7 @@ c
                ido = 99
                go to 9000
             end if
-c 
+c
    40    continue
 c
 c        %---------------------------------------------------------%
@@ -509,14 +509,14 @@ c
          ipntr(2) = irj
          ipntr(3) = ipj
          ido = 1
-c 
+c
 c        %-----------------------------------%
 c        | Exit in order to compute OP*v_{j} |
 c        %-----------------------------------%
-c 
-         go to 9000 
+c
+         go to 9000
    50    continue
-c 
+c
 c        %----------------------------------%
 c        | Back from reverse communication; |
 c        | WORKD(IRJ:IRJ+N-1) := OP*v_{j}   |
@@ -525,7 +525,7 @@ c        %----------------------------------%
 c
          call second (t3)
          tmvopx = tmvopx + (t3 - t2)
- 
+
          step3 = .false.
 c
 c        %------------------------------------------%
@@ -533,7 +533,7 @@ c        | Put another copy of OP*v_{j} into RESID. |
 c        %------------------------------------------%
 c
          call zcopy (n, workd(irj), 1, resid, 1)
-c 
+c
 c        %---------------------------------------%
 c        | STEP 4:  Finish extending the Arnoldi |
 c        |          factorization to length j.   |
@@ -546,17 +546,17 @@ c
             ipntr(1) = irj
             ipntr(2) = ipj
             ido = 2
-c 
+c
 c           %-------------------------------------%
 c           | Exit in order to compute B*OP*v_{j} |
 c           %-------------------------------------%
-c 
+c
             go to 9000
          else if (bmat .eq. 'I') then
             call zcopy (n, resid, 1, workd(ipj), 1)
          end if
    60    continue
-c 
+c
 c        %----------------------------------%
 c        | Back from reverse communication; |
 c        | WORKD(IPJ:IPJ+N-1) := B*OP*v_{j} |
@@ -567,7 +567,7 @@ c
             call second (t3)
             tmvbx = tmvbx + (t3 - t2)
          end if
-c 
+c
          step4 = .false.
 c
 c        %-------------------------------------%
@@ -605,7 +605,7 @@ c
 c
 c        %--------------------------------------%
 c        | Orthogonalize r_{j} against V_{j}.   |
-c        | RESID contains OP*v_{j}. See STEP 3. | 
+c        | RESID contains OP*v_{j}. See STEP 3. |
 c        %--------------------------------------%
 c
          call zgemv ('N', n, j, -one, v, ldv, h(1,j), 1,
@@ -614,9 +614,9 @@ c
          if (j .gt. 1) h(j,j-1) = dcmplx(betaj, rzero)
 c
          call second (t4)
-c 
+c
          orth1 = .true.
-c 
+c
          call second (t2)
          if (bmat .eq. 'G') then
             nbx = nbx + 1
@@ -624,17 +624,17 @@ c
             ipntr(1) = irj
             ipntr(2) = ipj
             ido = 2
-c 
+c
 c           %----------------------------------%
 c           | Exit in order to compute B*r_{j} |
 c           %----------------------------------%
-c 
+c
             go to 9000
          else if (bmat .eq. 'I') then
             call zcopy (n, resid, 1, workd(ipj), 1)
-         end if 
+         end if
    70    continue
-c 
+c
 c        %---------------------------------------------------%
 c        | Back from reverse communication if ORTH1 = .true. |
 c        | WORKD(IPJ:IPJ+N-1) := B*r_{j}.                    |
@@ -644,7 +644,7 @@ c
             call second (t3)
             tmvbx = tmvbx + (t3 - t2)
          end if
-c 
+c
          orth1 = .false.
 c
 c        %------------------------------%
@@ -659,7 +659,7 @@ c
          else if (bmat .eq. 'I') then
             rnorm = pdznorm2(comm, n, resid, 1)
          end if
-c 
+c
 c        %-----------------------------------------------------------%
 c        | STEP 5: Re-orthogonalization / Iterative refinement phase |
 c        | Maximum NITER_ITREF tries.                                |
@@ -682,20 +682,20 @@ c
 c
          iter  = 0
          nrorth = nrorth + 1
-c 
+c
 c        %---------------------------------------------------%
 c        | Enter the Iterative refinement phase. If further  |
 c        | refinement is necessary, loop back here. The loop |
 c        | variable is ITER. Perform a step of Classical     |
 c        | Gram-Schmidt using all the Arnoldi vectors V_{j}  |
 c        %---------------------------------------------------%
-c 
+c
    80    continue
 c
          if (msglvl .gt. 2) then
             rtemp(1) = wnorm
             rtemp(2) = rnorm
-            call pdvout (comm, logfil, 2, rtemp, ndigit, 
+            call pdvout (comm, logfil, 2, rtemp, ndigit,
      &      '_naitr: re-orthogonalization; wnorm and rnorm are')
             call pzvout (comm, logfil, j, h(1,j), ndigit,
      &                  '_naitr: j-th column of H')
@@ -718,10 +718,10 @@ c        | The correction to H is v(:,1:J)*H(1:J,1:J)  |
 c        | + v(:,1:J)*WORKD(IRJ:IRJ+J-1)*e'_j.         |
 c        %---------------------------------------------%
 c
-         call zgemv ('N', n, j, -one, v, ldv, workl(1), 1, 
+         call zgemv ('N', n, j, -one, v, ldv, workl(1), 1,
      &               one, resid, 1)
          call zaxpy (j, one, workl(1), 1, h(1,j), 1)
-c 
+c
          orth2 = .true.
          call second (t2)
          if (bmat .eq. 'G') then
@@ -730,16 +730,16 @@ c
             ipntr(1) = irj
             ipntr(2) = ipj
             ido = 2
-c 
+c
 c           %-----------------------------------%
 c           | Exit in order to compute B*r_{j}. |
 c           | r_{j} is the corrected residual.  |
 c           %-----------------------------------%
-c 
+c
             go to 9000
          else if (bmat .eq. 'I') then
             call zcopy (n, resid, 1, workd(ipj), 1)
-         end if 
+         end if
    90    continue
 c
 c        %---------------------------------------------------%
@@ -749,12 +749,12 @@ c
          if (bmat .eq. 'G') then
             call second (t3)
             tmvbx = tmvbx + (t3 - t2)
-         end if 
+         end if
 c
 c        %-----------------------------------------------------%
 c        | Compute the B-norm of the corrected residual r_{j}. |
 c        %-----------------------------------------------------%
-c 
+c
          if (bmat .eq. 'G') then
              cnorm_buf = zdotc (n, resid, 1, workd(ipj), 1)
             call MPI_ALLREDUCE( cnorm_buf, cnorm, 1,
@@ -763,7 +763,7 @@ c
          else if (bmat .eq. 'I') then
              rnorm1 = pdznorm2(comm, n, resid, 1)
          end if
-c 
+c
          if (msglvl .gt. 0 .and. iter .gt. 0 ) then
             call pivout (comm, logfil, 1, [j], ndigit,
      &           '_naitr: Iterative refinement for Arnoldi residual')
@@ -793,7 +793,7 @@ c           | angle of less than arcCOS(0.717)      |
 c           %---------------------------------------%
 c
             rnorm = rnorm1
-c 
+c
          else
 c
 c           %-------------------------------------------%
@@ -815,21 +815,21 @@ c
   95        continue
             rnorm = rzero
          end if
-c 
+c
 c        %----------------------------------------------%
 c        | Branch here directly if iterative refinement |
 c        | wasn't necessary or after at most NITER_REF  |
 c        | steps of iterative refinement.               |
 c        %----------------------------------------------%
-c 
+c
   100    continue
-c 
+c
          rstart = .false.
          orth2  = .false.
-c 
+c
          call second (t5)
          titref = titref + (t5 - t4)
-c 
+c
 c        %------------------------------------%
 c        | STEP 6: Update  j = j+1;  Continue |
 c        %------------------------------------%
@@ -840,13 +840,13 @@ c
             tcaitr = tcaitr + (t1 - t0)
             ido = 99
             do 110 i = max(1,k), k+np-1
-c     
+c
 c              %--------------------------------------------%
 c              | Check for splitting and deflation.         |
 c              | Use a standard test as in the QR algorithm |
 c              | REFERENCE: LAPACK subroutine zlahqr        |
 c              %--------------------------------------------%
-c     
+c
                tst1 = dlapy2(dble(h(i,i)),dimag(h(i,i)))
      &              + dlapy2(dble(h(i+1,i+1)), dimag(h(i+1,i+1)))
                if( tst1.eq.dble(zero) )
@@ -855,12 +855,12 @@ c
      &                    max( ulp*tst1, smlnum ) )
      &             h(i+1,i) = zero
  110        continue
-c     
+c
             if (msglvl .gt. 2) then
-               call pzmout (comm, logfil, k+np, k+np, h, ldh, ndigit, 
+               call pzmout (comm, logfil, k+np, k+np, h, ldh, ndigit,
      &          '_naitr: Final upper Hessenberg matrix H of order K+NP')
             end if
-c     
+c
             go to 9000
          end if
 c
@@ -869,7 +869,7 @@ c        | Loop back to extend the factorization by another step. |
 c        %--------------------------------------------------------%
 c
       go to 1000
-c 
+c
 c     %---------------------------------------------------------------%
 c     |                                                               |
 c     |  E N D     O F     M A I N     I T E R A T I O N     L O O P  |

--- a/mathlibs/src/parpack/pznaitr.f
+++ b/mathlibs/src/parpack/pznaitr.f
@@ -404,9 +404,9 @@ c     %--------------------------------------------------------------%
  1000 continue
 c
          if (msglvl .gt. 1) then
-            call pivout (comm, logfil, 1, j, ndigit, 
+            call pivout (comm, logfil, 1, [j], ndigit, 
      &                  '_naitr: generating Arnoldi vector number')
-            call pzvout (comm, logfil, 1, rnorm, ndigit, 
+            call pdvout (comm, logfil, 1, [rnorm], ndigit, 
      &                  '_naitr: B-norm of the current residual is')
          end if
 c 
@@ -426,7 +426,7 @@ c           | basis and continue the iteration.                 |
 c           %---------------------------------------------------%
 c
             if (msglvl .gt. 0) then
-               call pivout (comm, logfil, 1, j, ndigit,
+               call pivout (comm, logfil, 1, [j], ndigit,
      &                     '_naitr: ****** RESTART AT STEP ******')
             end if
 c 
@@ -765,7 +765,7 @@ c
          end if
 c 
          if (msglvl .gt. 0 .and. iter .gt. 0 ) then
-            call pivout (comm, logfil, 1, j, ndigit,
+            call pivout (comm, logfil, 1, [j], ndigit,
      &           '_naitr: Iterative refinement for Arnoldi residual')
             if (msglvl .gt. 2) then
                 rtemp(1) = rnorm

--- a/mathlibs/src/parpack/pznapps.f
+++ b/mathlibs/src/parpack/pznapps.f
@@ -21,7 +21,7 @@ c     A*VNEW_{k} - VNEW_{k}*HNEW_{k} = rnew_{k}*e_{k}^T.
 c
 c\Usage:
 c  call pznapps
-c     ( COMM, N, KEV, NP, SHIFT, V, LDV, H, LDH, RESID, Q, LDQ, 
+c     ( COMM, N, KEV, NP, SHIFT, V, LDV, H, LDH, RESID, Q, LDQ,
 c       WORKL, WORKD )
 c
 c\Arguments
@@ -32,7 +32,7 @@ c          Problem size, i.e. size of matrix A.
 c
 c  KEV     Integer.  (INPUT/OUTPUT)
 c          KEV+NP is the size of the input matrix H.
-c          KEV is the size of the updated matrix HNEW. 
+c          KEV is the size of the updated matrix HNEW.
 c
 c  NP      Integer.  (INPUT)
 c          Number of implicit shifts to be applied.
@@ -50,7 +50,7 @@ c          Leading dimension of V exactly as declared in the calling
 c          program.
 c
 c  H       Complex*16 (KEV+NP) by (KEV+NP) array.  (INPUT/OUTPUT)
-c          On INPUT, H contains the current KEV+NP by KEV+NP upper 
+c          On INPUT, H contains the current KEV+NP by KEV+NP upper
 c          Hessenberg matrix of the Arnoldi factorization.
 c          On OUTPUT, H contains the updated KEV by KEV upper Hessenberg
 c          matrix in the KEV leading submatrix.
@@ -61,7 +61,7 @@ c          program.
 c
 c  RESID   Complex*16 array of length N.  (INPUT/OUTPUT)
 c          On INPUT, RESID contains the the residual vector r_{k+p}.
-c          On OUTPUT, RESID is the update residual vector rnew_{k} 
+c          On OUTPUT, RESID is the update residual vector rnew_{k}
 c          in the first KEV locations.
 c
 c  Q       Complex*16 KEV+NP by KEV+NP work array.  (WORKSPACE)
@@ -116,9 +116,9 @@ c\Author
 c     Danny Sorensen               Phuong Vu
 c     Richard Lehoucq              CRPC / Rice University
 c     Dept. of Computational &     Houston, Texas
-c     Applied Mathematics 
-c     Rice University           
-c     Houston, Texas 
+c     Applied Mathematics
+c     Rice University
+c     Houston, Texas
 c
 c\Parallel Modifications
 c     Kristi Maschhoff
@@ -142,7 +142,7 @@ c
 c-----------------------------------------------------------------------
 c
       subroutine pznapps
-     &   ( comm, n, kev, np, shift, v, ldv, h, ldh, resid, q, ldq, 
+     &   ( comm, n, kev, np, shift, v, ldv, h, ldh, resid, q, ldq,
      &     workl, workd )
 c
 c     %--------------------%
@@ -169,7 +169,7 @@ c     | Array Arguments |
 c     %-----------------%
 c
       Complex*16
-     &           h(ldh,kev+np), resid(n), shift(np), 
+     &           h(ldh,kev+np), resid(n), shift(np),
      &           v(ldv,kev+np), q(ldq,kev+np), workd(2*n), workl(kev+np)
 c
 c     %------------%
@@ -191,22 +191,22 @@ c
       logical    first
       Complex*16
      &           cdum, f, g, h11, h21, r, s, sigma, t
-      Double precision             
+      Double precision
      &           c,  ovfl, smlnum, ulp, unfl, tst1
-      save       first, ovfl, smlnum, ulp, unfl 
+      save       first, ovfl, smlnum, ulp, unfl
 c
 c     %----------------------%
 c     | External Subroutines |
 c     %----------------------%
 c
-      external   zaxpy, zcopy, zgemv, zscal, zlacpy, zlartg, 
+      external   zaxpy, zcopy, zgemv, zscal, zlacpy, zlartg,
      &           pzvout, zlaset, dlabad, pzmout, second, pivout
 c
 c     %--------------------%
 c     | External Functions |
 c     %--------------------%
 c
-      Double precision                 
+      Double precision
      &           zlanhs, dlapy2
       external   zlanhs, dlapy2
 c
@@ -220,7 +220,7 @@ c     %---------------------%
 c     | Statement Functions |
 c     %---------------------%
 c
-      Double precision     
+      Double precision
      &           cabs1
       cabs1( cdum ) = abs( dble( cdum ) ) + abs( dimag( cdum ) )
 c
@@ -258,9 +258,9 @@ c     %-------------------------------%
 c
       call second (t0)
       msglvl = mcapps
-c 
-      kplusp = kev + np 
-c 
+c
+      kplusp = kev + np
+c
 c     %--------------------------------------------%
 c     | Initialize Q to the identity to accumulate |
 c     | the rotations and reflections              |
@@ -284,9 +284,9 @@ c
          sigma = shift(jj)
 c
          if (msglvl .gt. 2 ) then
-            call pivout (comm, logfil, 1, [jj], ndigit, 
+            call pivout (comm, logfil, 1, [jj], ndigit,
      &               '_napps: shift number.')
-            call pzvout (comm, logfil, 1, [sigma], ndigit, 
+            call pzvout (comm, logfil, 1, [sigma], ndigit,
      &               '_napps: Value of the shift ')
          end if
 c
@@ -304,14 +304,14 @@ c
             tst1 = cabs1( h( i, i ) ) + cabs1( h( i+1, i+1 ) )
             if( tst1.eq.rzero )
      &         tst1 = zlanhs( '1', kplusp-jj+1, h, ldh, workl )
-            if ( abs(dble(h(i+1,i))) 
+            if ( abs(dble(h(i+1,i)))
      &           .le. max(ulp*tst1, smlnum) )  then
                if (msglvl .gt. 0) then
-                  call pivout (comm, logfil, 1, [i], ndigit, 
+                  call pivout (comm, logfil, 1, [i], ndigit,
      &                 '_napps: matrix splitting at row/column no.')
-                  call pivout (comm, logfil, 1, [jj], ndigit, 
+                  call pivout (comm, logfil, 1, [jj], ndigit,
      &                 '_napps: matrix splitting with shift number.')
-                  call pzvout (comm, logfil, 1, h(i+1,i), ndigit, 
+                  call pzvout (comm, logfil, 1, h(i+1,i), ndigit,
      &                 '_napps: off diagonal element.')
                end if
                iend = i
@@ -323,9 +323,9 @@ c
    40    continue
 c
          if (msglvl .gt. 2) then
-             call pivout (comm, logfil, 1, [istart], ndigit, 
+             call pivout (comm, logfil, 1, [istart], ndigit,
      &                   '_napps: Start of current block ')
-             call pivout (comm, logfil, 1, [iend], ndigit, 
+             call pivout (comm, logfil, 1, [iend], ndigit,
      &                   '_napps: End of current block ')
          end if
 c
@@ -341,7 +341,7 @@ c
          h21 = h(istart+1,istart)
          f = h11 - sigma
          g = h21
-c 
+c
          do 80 i = istart, iend-1
 c
 c           %------------------------------------------------------%
@@ -361,7 +361,7 @@ c
             do 50 j = i, kplusp
                t        =  c*h(i,j) + s*h(i+1,j)
                h(i+1,j) = -conjg(s)*h(i,j) + c*h(i+1,j)
-               h(i,j)   = t   
+               h(i,j)   = t
    50       continue
 c
 c           %---------------------------------------------%
@@ -371,7 +371,7 @@ c
             do 60 j = 1, min(i+2,iend)
                t        =  c*h(j,i) + conjg(s)*h(j,i+1)
                h(j,i+1) = -s*h(j,i) + c*h(j,i+1)
-               h(j,i)   = t   
+               h(j,i)   = t
    60       continue
 c
 c           %-----------------------------------------------------%
@@ -381,7 +381,7 @@ c
             do 70 j = 1, min(i+jj, kplusp)
                t        =   c*q(j,i) + conjg(s)*q(j,i+1)
                q(j,i+1) = - s*q(j,i) + c*q(j,i+1)
-               q(j,i)   = t   
+               q(j,i)   = t
    70       continue
 c
 c           %---------------------------%
@@ -397,7 +397,7 @@ c
 c        %-------------------------------%
 c        | Finished applying the shift.  |
 c        %-------------------------------%
-c 
+c
   100    continue
 c
 c        %---------------------------------------------------------%
@@ -444,7 +444,7 @@ c
          tst1 = cabs1( h( i, i ) ) + cabs1( h( i+1, i+1 ) )
          if( tst1 .eq. rzero )
      &       tst1 = zlanhs( '1', kev, h, ldh, workl )
-         if( dble( h( i+1,i ) ) .le. max( ulp*tst1, smlnum ) ) 
+         if( dble( h( i+1,i ) ) .le. max( ulp*tst1, smlnum ) )
      &       h(i+1,i) = zero
  130  continue
 c
@@ -457,9 +457,9 @@ c     | of H would be zero as in exact arithmetic.      |
 c     %-------------------------------------------------%
 c
       if ( dble( h(kev+1,kev) ) .gt. rzero )
-     &   call zgemv ('N', n, kplusp, one, v, ldv, q(1,kev+1), 1, zero, 
+     &   call zgemv ('N', n, kplusp, one, v, ldv, q(1,kev+1), 1, zero,
      &                workd(n+1), 1)
-c 
+c
 c     %----------------------------------------------------------%
 c     | Compute column 1 to kev of (V*Q) in backward order       |
 c     | taking advantage of the upper Hessenberg structure of Q. |
@@ -476,14 +476,14 @@ c     |  Move v(:,kplusp-kev+1:kplusp) into v(:,1:kev). |
 c     %-------------------------------------------------%
 c
       call zlacpy ('A', n, kev, v(1,kplusp-kev+1), ldv, v, ldv)
-c 
+c
 c     %--------------------------------------------------------------%
 c     | Copy the (kev+1)-st column of (V*Q) in the appropriate place |
 c     %--------------------------------------------------------------%
 c
       if ( dble( h(kev+1,kev) ) .gt. rzero )
      &   call zcopy (n, workd(n+1), 1, v(1,kev+1), 1)
-c 
+c
 c     %-------------------------------------%
 c     | Update the residual vector:         |
 c     |    r <- sigmak*r + betak*v(:,kev+1) |
@@ -501,7 +501,7 @@ c
      &        '_napps: sigmak = (e_{kev+p}^T*Q)*e_{kev}')
          call pzvout (comm, logfil, 1, h(kev+1,kev), ndigit,
      &        '_napps: betak = e_{kev+1}^T*H*e_{kev}')
-         call pivout (comm, logfil, 1, [kev], ndigit, 
+         call pivout (comm, logfil, 1, [kev], ndigit,
      &               '_napps: Order of the final Hessenberg matrix ')
          if (msglvl .gt. 2) then
             call pzmout (comm, logfil, kev, kev, h, ldh, ndigit,
@@ -513,7 +513,7 @@ c
  9000 continue
       call second (t1)
       tcapps = tcapps + (t1 - t0)
-c 
+c
       return
 c
 c     %----------------%

--- a/mathlibs/src/parpack/pznapps.f
+++ b/mathlibs/src/parpack/pznapps.f
@@ -284,9 +284,9 @@ c
          sigma = shift(jj)
 c
          if (msglvl .gt. 2 ) then
-            call pivout (comm, logfil, 1, jj, ndigit, 
+            call pivout (comm, logfil, 1, [jj], ndigit, 
      &               '_napps: shift number.')
-            call pzvout (comm, logfil, 1, sigma, ndigit, 
+            call pzvout (comm, logfil, 1, [sigma], ndigit, 
      &               '_napps: Value of the shift ')
          end if
 c
@@ -307,9 +307,9 @@ c
             if ( abs(dble(h(i+1,i))) 
      &           .le. max(ulp*tst1, smlnum) )  then
                if (msglvl .gt. 0) then
-                  call pivout (comm, logfil, 1, i, ndigit, 
+                  call pivout (comm, logfil, 1, [i], ndigit, 
      &                 '_napps: matrix splitting at row/column no.')
-                  call pivout (comm, logfil, 1, jj, ndigit, 
+                  call pivout (comm, logfil, 1, [jj], ndigit, 
      &                 '_napps: matrix splitting with shift number.')
                   call pzvout (comm, logfil, 1, h(i+1,i), ndigit, 
      &                 '_napps: off diagonal element.')
@@ -323,9 +323,9 @@ c
    40    continue
 c
          if (msglvl .gt. 2) then
-             call pivout (comm, logfil, 1, istart, ndigit, 
+             call pivout (comm, logfil, 1, [istart], ndigit, 
      &                   '_napps: Start of current block ')
-             call pivout (comm, logfil, 1, iend, ndigit, 
+             call pivout (comm, logfil, 1, [iend], ndigit, 
      &                   '_napps: End of current block ')
          end if
 c
@@ -501,7 +501,7 @@ c
      &        '_napps: sigmak = (e_{kev+p}^T*Q)*e_{kev}')
          call pzvout (comm, logfil, 1, h(kev+1,kev), ndigit,
      &        '_napps: betak = e_{kev+1}^T*H*e_{kev}')
-         call pivout (comm, logfil, 1, kev, ndigit, 
+         call pivout (comm, logfil, 1, [kev], ndigit, 
      &               '_napps: Order of the final Hessenberg matrix ')
          if (msglvl .gt. 2) then
             call pzmout (comm, logfil, kev, kev, h, ldh, ndigit,

--- a/mathlibs/src/parpack/pznaup2.f
+++ b/mathlibs/src/parpack/pznaup2.f
@@ -1,16 +1,16 @@
 c\BeginDoc
 c
-c\Name: pznaup2 
+c\Name: pznaup2
 c
-c Message Passing Layer: MPI 
+c Message Passing Layer: MPI
 c
-c\Description: 
+c\Description:
 c  Intermediate level interface called by pznaupd .
 c
 c\Usage:
-c  call pznaup2 
+c  call pznaup2
 c     ( COMM, IDO, BMAT, N, WHICH, NEV, NP, TOL, RESID, MODE, IUPD,
-c       ISHIFT, MXITER, V, LDV, H, LDH, RITZ, BOUNDS, 
+c       ISHIFT, MXITER, V, LDV, H, LDH, RITZ, BOUNDS,
 c       Q, LDQ, WORKL, IPNTR, WORKD, RWORK, INFO )
 c
 c\Arguments
@@ -40,27 +40,27 @@ c          IUPD .EQ. 0: use explicit restart instead implicit update.
 c          IUPD .NE. 0: use implicit update.
 c
 c  V       Complex*16  N by (NEV+NP) array.  (INPUT/OUTPUT)
-c          The Arnoldi basis vectors are returned in the first NEV 
+c          The Arnoldi basis vectors are returned in the first NEV
 c          columns of V.
 c
 c  LDV     Integer.  (INPUT)
-c          Leading dimension of V exactly as declared in the calling 
+c          Leading dimension of V exactly as declared in the calling
 c          program.
 c
 c  H       Complex*16  (NEV+NP) by (NEV+NP) array.  (OUTPUT)
 c          H is used to store the generated upper Hessenberg matrix
 c
 c  LDH     Integer.  (INPUT)
-c          Leading dimension of H exactly as declared in the calling 
+c          Leading dimension of H exactly as declared in the calling
 c          program.
 c
 c  RITZ    Complex*16  array of length NEV+NP.  (OUTPUT)
 c          RITZ(1:NEV)  contains the computed Ritz values of OP.
 c
 c  BOUNDS  Complex*16  array of length NEV+NP.  (OUTPUT)
-c          BOUNDS(1:NEV) contain the error bounds corresponding to 
+c          BOUNDS(1:NEV) contain the error bounds corresponding to
 c          the computed Ritz values.
-c          
+c
 c  Q       Complex*16  (NEV+NP) by (NEV+NP) array.  (WORKSPACE)
 c          Private (replicated) work array used to accumulate the
 c          rotation in the shift application step.
@@ -69,7 +69,7 @@ c  LDQ     Integer.  (INPUT)
 c          Leading dimension of Q exactly as declared in the calling
 c          program.
 c
-c  WORKL   Complex*16  work array of length at least 
+c  WORKL   Complex*16  work array of length at least
 c          (NEV+NP)**2 + 3*(NEV+NP).  (WORKSPACE)
 c          Private (replicated) array on each PE or array allocated on
 c          the front end.  It is used in shifts calculation, shifts
@@ -77,15 +77,15 @@ c          application and convergence checking.
 c
 c
 c  IPNTR   Integer array of length 3.  (OUTPUT)
-c          Pointer to mark the starting locations in the WORKD for 
+c          Pointer to mark the starting locations in the WORKD for
 c          vectors used by the Arnoldi iteration.
 c          -------------------------------------------------------------
 c          IPNTR(1): pointer to the current operand vector X.
 c          IPNTR(2): pointer to the current result vector Y.
-c          IPNTR(3): pointer to the vector B * X when used in the 
+c          IPNTR(3): pointer to the vector B * X when used in the
 c                    shift-and-invert mode.  X is the current operand.
 c          -------------------------------------------------------------
-c          
+c
 c  WORKD   Complex*16  work array of length 3*N.  (WORKSPACE)
 c          Distributed array to be used in the basic Arnoldi iteration
 c          for reverse communication.  The user should not use WORKD
@@ -103,7 +103,7 @@ c                          possibly from a previous run.
 c          Error flag on output.
 c          =     0: Normal return.
 c          =     1: Maximum number of iterations taken.
-c                   All possible eigenvalues of OP has been found.  
+c                   All possible eigenvalues of OP has been found.
 c                   NP returns the number of converged Ritz values.
 c          =     2: No shifts could be applied.
 c          =    -8: Error return from LAPACK eigenvalue calculation;
@@ -119,21 +119,21 @@ c
 c\BeginLib
 c
 c\Local variables:
-c     xxxxxx  Complex*16 
+c     xxxxxx  Complex*16
 c
 c\References:
 c  1. D.C. Sorensen, "Implicit Application of Polynomial Filters in
 c     a k-Step Arnoldi Method", SIAM J. Matr. Anal. Apps., 13 (1992),
 c     pp 357-385.
-c  2. R.B. Lehoucq, "Analysis and Implementation of an Implicitly 
+c  2. R.B. Lehoucq, "Analysis and Implementation of an Implicitly
 c     Restarted Arnoldi Iteration", Rice University Technical Report
 c     TR95-13, Department of Computational and Applied Mathematics.
 c
 c\Routines called:
-c     pzgetv0   Parallel ARPACK initial vector generation routine. 
+c     pzgetv0   Parallel ARPACK initial vector generation routine.
 c     pznaitr   Parallel ARPACK Arnoldi factorization routine.
 c     pznapps   Parallel ARPACK application of implicit shifts routine.
-c     pzneigh   Parallel ARPACK compute Ritz values and error bounds routine. 
+c     pzneigh   Parallel ARPACK compute Ritz values and error bounds routine.
 c     pzngets   Parallel ARPACK reorder Ritz values and error bounds routine.
 c     zsortc    ARPACK sorting routine.
 c     pivout   Parallel ARPACK utility routine that prints integers.
@@ -144,7 +144,7 @@ c     pdvout    ARPACK utility routine that prints vectors.
 c     pdlamch   ScaLAPACK routine that determines machine constants.
 c     dlapy2    LAPACK routine to compute sqrt(x**2+y**2) carefully.
 c     zcopy     Level 1 BLAS that copies one vector to another .
-c     zdotc     Level 1 BLAS that computes the scalar product of two vectors. 
+c     zdotc     Level 1 BLAS that computes the scalar product of two vectors.
 c     zswap     Level 1 BLAS that swaps two vectors.
 c     pdznorm2  Parallel version of Level 1 BLAS that computes the norm of a vector.
 c
@@ -152,10 +152,10 @@ c\Author
 c     Danny Sorensen               Phuong Vu
 c     Richard Lehoucq              CRPC / Rice University
 c     Dept. of Computational &     Houston, Texas
-c     Applied Mathematics 
-c     Rice University           
-c     Houston, Texas 
-c 
+c     Applied Mathematics
+c     Rice University
+c     Houston, Texas
+c
 c FILE: naup2.F   SID: 1.6   DATE OF SID: 06/01/00   RELEASE: 1
 c
 c\Remarks
@@ -165,9 +165,9 @@ c\EndLib
 c
 c-----------------------------------------------------------------------
 c
-      subroutine pznaup2 
-     &   ( comm, ido, bmat, n, which, nev, np, tol, resid, mode, iupd, 
-     &     ishift, mxiter, v, ldv, h, ldh, ritz, bounds, 
+      subroutine pznaup2
+     &   ( comm, ido, bmat, n, which, nev, np, tol, resid, mode, iupd,
+     &     ishift, mxiter, v, ldv, h, ldh, ritz, bounds,
      &     q, ldq, workl, ipntr, workd, rwork, info )
 c
       include   'mpif.h'
@@ -192,7 +192,7 @@ c
       character  bmat*1, which*2
       integer    ido, info, ishift, iupd, mode, ldh, ldq, ldv, mxiter,
      &           n, nev, np
-      Double precision   
+      Double precision
      &           tol
 c
 c     %-----------------%
@@ -200,20 +200,20 @@ c     | Array Arguments |
 c     %-----------------%
 c
       integer    ipntr(13)
-      Complex*16 
-     &           bounds(nev+np), h(ldh,nev+np), q(ldq,nev+np), 
-     &           resid(n), ritz(nev+np),  v(ldv,nev+np), 
+      Complex*16
+     &           bounds(nev+np), h(ldh,nev+np), q(ldq,nev+np),
+     &           resid(n), ritz(nev+np),  v(ldv,nev+np),
      &           workd(3*n), workl( (nev+np)*(nev+np+3) )
-       Double precision   
+       Double precision
      &           rwork(nev+np)
 c
 c     %------------%
 c     | Parameters |
 c     %------------%
 c
-      Complex*16 
+      Complex*16
      &           one, zero
-      Double precision 
+      Double precision
      &           rzero
       parameter (one = (1.0, 0.0) , zero = (0.0, 0.0) ,
      &           rzero = 0.0 )
@@ -226,18 +226,18 @@ c
       integer    ierr ,  iter , kplusp, msglvl, nconv,
      &           nevbef, nev0 , np0   , nptemp, i    ,
      &           j
-      Complex*16 
+      Complex*16
      &           cmpnorm
-      Double precision 
+      Double precision
      &           rnorm,  eps23, rtemp
       character  wprime*2
 c
       save       cnorm,  getv0, initv , update, ushift,
-     &           rnorm,  iter , kplusp, msglvl, nconv, 
+     &           rnorm,  iter , kplusp, msglvl, nconv,
      &           nevbef, nev0 , np0,    eps23
 c
- 
-      Double precision 
+
+      Double precision
      &           cmpnorm_buf
 c
 c     %-----------------------%
@@ -257,11 +257,11 @@ c     %--------------------%
 c     | External functions |
 c     %--------------------%
 c
-      Complex*16 
-     &           zdotc 
-      Double precision   
-     &           pdznorm2 , pdlamch10 , dlapy2 
-      external   zdotc , pdznorm2 , pdlamch10 , dlapy2 
+      Complex*16
+     &           zdotc
+      Double precision
+     &           pdznorm2 , pdlamch10 , dlapy2
+      external   zdotc , pdznorm2 , pdlamch10 , dlapy2
 c
 c     %---------------------%
 c     | Intrinsic Functions |
@@ -274,11 +274,11 @@ c     | Executable Statements |
 c     %-----------------------%
 c
       if (ido .eq. 0) then
-c 
+c
          call second (t0)
-c 
+c
          msglvl = mcaup2
-c 
+c
          nev0   = nev
          np0    = np
 c
@@ -294,7 +294,7 @@ c
          kplusp = nev + np
          nconv  = 0
          iter   = 0
-c 
+c
 c        %---------------------------------%
 c        | Get machine dependent constant. |
 c        %---------------------------------%
@@ -324,7 +324,7 @@ c
             initv = .false.
          end if
       end if
-c 
+c
 c     %---------------------------------------------%
 c     | Get a possibly random starting vector and   |
 c     | force it into the range of the operator OP. |
@@ -333,7 +333,7 @@ c
    10 continue
 c
       if (getv0) then
-         call pzgetv0  (comm, ido, bmat, 1, initv, n, 1, v, ldv, 
+         call pzgetv0  (comm, ido, bmat, 1, initv, n, 1, v, ldv,
      &                 resid, rnorm, ipntr, workd, workl, info)
 c
          if (ido .ne. 99) go to 9000
@@ -341,7 +341,7 @@ c
          if (rnorm .eq. rzero) then
 c
 c           %-----------------------------------------%
-c           | The initial vector is zero. Error exit. | 
+c           | The initial vector is zero. Error exit. |
 c           %-----------------------------------------%
 c
             info = -9
@@ -350,7 +350,7 @@ c
          getv0 = .false.
          ido  = 0
       end if
-c 
+c
 c     %-----------------------------------%
 c     | Back from reverse communication : |
 c     | continue with update step         |
@@ -370,13 +370,13 @@ c     | at the end of the current iteration |
 c     %-------------------------------------%
 c
       if (cnorm)  go to 100
-c 
+c
 c     %----------------------------------------------------------%
 c     | Compute the first NEV steps of the Arnoldi factorization |
 c     %----------------------------------------------------------%
 c
-      call pznaitr  (comm, ido, bmat, n, 0, nev, mode, 
-     &             resid, rnorm, v, ldv, 
+      call pznaitr  (comm, ido, bmat, n, 0, nev, mode,
+     &             resid, rnorm, v, ldv,
      &             h, ldh, ipntr, workd, workl, info)
 c
 c
@@ -388,7 +388,7 @@ c
          info = -9999
          go to 1200
       end if
-c 
+c
 c     %--------------------------------------------------------------%
 c     |                                                              |
 c     |           M A I N  ARNOLDI  I T E R A T I O N  L O O P       |
@@ -396,16 +396,16 @@ c     |           Each iteration implicitly restarts the Arnoldi     |
 c     |           factorization in place.                            |
 c     |                                                              |
 c     %--------------------------------------------------------------%
-c 
+c
  1000 continue
 c
          iter = iter + 1
 c
          if (msglvl .gt. 0) then
-            call pivout (comm, logfil, 1, [iter], ndigit, 
+            call pivout (comm, logfil, 1, [iter], ndigit,
      &           '_naup2: **** Start of major iteration number ****')
          end if
-c 
+c
 c        %-----------------------------------------------------------%
 c        | Compute NP additional steps of the Arnoldi factorization. |
 c        | Adjust NP since NEV might have been updated by last call  |
@@ -415,9 +415,9 @@ c
          np  = kplusp - nev
 c
          if (msglvl .gt. 1) then
-            call pivout (comm, logfil, 1, [nev], ndigit, 
+            call pivout (comm, logfil, 1, [nev], ndigit,
      &     '_naup2: The length of the current Arnoldi factorization')
-            call pivout (comm, logfil, 1, [np], ndigit, 
+            call pivout (comm, logfil, 1, [np], ndigit,
      &           '_naup2: Extend the Arnoldi factorization by')
          end if
 c
@@ -429,7 +429,7 @@ c
    20    continue
          update = .true.
 c
-         call pznaitr  (comm, ido, bmat, n, nev, np, mode, 
+         call pznaitr  (comm, ido, bmat, n, nev, np, mode,
      &                resid, rnorm, v, ldv,
      &                h, ldh, ipntr, workd, workl, info)
 c
@@ -444,10 +444,10 @@ c
          update = .false.
 c
          if (msglvl .gt. 1) then
-            call pdvout  (comm, logfil, 1, [rnorm], ndigit, 
+            call pdvout  (comm, logfil, 1, [rnorm], ndigit,
      &           '_naup2: Corresponding B-norm of the residual')
          end if
-c 
+c
 c        %--------------------------------------------------------%
 c        | Compute the eigenvalues and corresponding error bounds |
 c        | of the current upper Hessenberg matrix.                |
@@ -488,9 +488,9 @@ c        | bounds are in the last NEV loc. of RITZ           |
 c        | BOUNDS respectively.                              |
 c        %---------------------------------------------------%
 c
-         call pzngets  ( comm, ishift, which, nev, np, ritz, 
+         call pzngets  ( comm, ishift, which, nev, np, ritz,
      &                  bounds)
-c 
+c
 c        %------------------------------------------------------------%
 c        | Convergence test: currently we use the following criteria. |
 c        | The relative accuracy of a Ritz value is considered        |
@@ -510,16 +510,16 @@ c
                nconv = nconv + 1
             end if
    25    continue
-c 
+c
          if (msglvl .gt. 2) then
             kp(1) = nev
             kp(2) = np
             kp(3) = nconv
-            call pivout (comm, logfil, 3, kp, ndigit, 
+            call pivout (comm, logfil, 3, kp, ndigit,
      &                  '_naup2: NEV, NP, NCONV are')
             call pzvout  (comm, logfil, kplusp, ritz, ndigit,
      &           '_naup2: The eigenvalues of H')
-            call pzvout  (comm, logfil, kplusp, bounds, ndigit, 
+            call pzvout  (comm, logfil, kplusp, bounds, ndigit,
      &          '_naup2: Ritz estimates of the current NCV Ritz values')
          end if
 c
@@ -540,20 +540,20 @@ c
                nev = nev + 1
             end if
  30      continue
-c     
-         if ( (nconv .ge. nev0) .or. 
+c
+         if ( (nconv .ge. nev0) .or.
      &        (iter .gt. mxiter) .or.
      &        (np .eq. 0) ) then
 c
             if (msglvl .gt. 4) then
-               call pzvout (comm, logfil, kplusp, 
+               call pzvout (comm, logfil, kplusp,
      &             workl(kplusp**2+1), ndigit,
      &             '_naup2: Eigenvalues computed by _neigh:')
-               call pzvout (comm, logfil, kplusp, 
+               call pzvout (comm, logfil, kplusp,
      &             workl(kplusp**2+kplusp+1), ndigit,
      &             '_naup2: Ritz eistmates computed by _neigh:')
             end if
-c     
+c
 c           %------------------------------------------------%
 c           | Prepare to exit. Put the converged Ritz values |
 c           | and corresponding bounds in RITZ(1:NCONV) and  |
@@ -632,13 +632,13 @@ c
             end if
 c
 c           %------------------------------------%
-c           | Max iterations have been exceeded. | 
+c           | Max iterations have been exceeded. |
 c           %------------------------------------%
 c
             if (iter .gt. mxiter .and. nconv .lt. nev0) info = 1
 c
 c           %---------------------%
-c           | No shifts to apply. | 
+c           | No shifts to apply. |
 c           %---------------------%
 c
             if (np .eq. 0 .and. nconv .lt. nev0) info = 2
@@ -647,7 +647,7 @@ c
             go to 1100
 c
          else if ( (nconv .lt. nev0) .and. (ishift .eq. 1) ) then
-c     
+c
 c           %-------------------------------------------------%
 c           | Do not have all the requested eigenvalues yet.  |
 c           | To prevent possible stagnation, adjust the size |
@@ -662,25 +662,25 @@ c
                nev = 2
             end if
             np = kplusp - nev
-c     
+c
 c           %---------------------------------------%
 c           | If the size of NEV was just increased |
 c           | resort the eigenvalues.               |
 c           %---------------------------------------%
-c     
-            if (nevbef .lt. nev) 
-     &         call pzngets  (comm, ishift, which, nev, np, ritz, 
+c
+            if (nevbef .lt. nev)
+     &         call pzngets  (comm, ishift, which, nev, np, ritz,
      &                       bounds)
 c
-         end if              
-c     
+         end if
+c
          if (msglvl .gt. 0) then
-            call pivout (comm, logfil, 1, [nconv], ndigit, 
+            call pivout (comm, logfil, 1, [nconv], ndigit,
      &           '_naup2: no. of "converged" Ritz values at this iter.')
             if (msglvl .gt. 1) then
                kp(1) = nev
                kp(2) = np
-               call pivout (comm, logfil, 2, kp, ndigit, 
+               call pivout (comm, logfil, 2, kp, ndigit,
      &              '_naup2: NEV and NP are')
                call pzvout  (comm, logfil, nev, ritz(np+1), ndigit,
      &              '_naup2: "wanted" Ritz values ')
@@ -704,7 +704,7 @@ c
          ushift = .false.
 c
          if ( ishift .ne. 1 ) then
-c 
+c
 c            %----------------------------------%
 c            | Move the NP shifts from WORKL to |
 c            | RITZ, to free up WORKL           |
@@ -714,12 +714,12 @@ c
              call zcopy  (np, workl, 1, ritz, 1)
          end if
 c
-         if (msglvl .gt. 2) then 
-            call pivout (comm, logfil, 1, [np], ndigit, 
+         if (msglvl .gt. 2) then
+            call pivout (comm, logfil, 1, [np], ndigit,
      &                  '_naup2: The number of shifts to apply ')
             call pzvout  (comm, logfil, np, ritz, ndigit,
      &                  '_naup2: values of the shifts')
-            if ( ishift .eq. 1 ) 
+            if ( ishift .eq. 1 )
      &          call pzvout  (comm, logfil, np, bounds, ndigit,
      &                  '_naup2: Ritz estimates of the shifts')
          end if
@@ -731,7 +731,7 @@ c        | matrix H.                                               |
 c        | The first 2*N locations of WORKD are used as workspace. |
 c        %---------------------------------------------------------%
 c
-         call pznapps (comm, n, nev, np, ritz, v, ldv, 
+         call pznapps (comm, n, nev, np, ritz, v, ldv,
      &                h, ldh, resid, q, ldq, workl, workd)
 c
 c        %---------------------------------------------%
@@ -748,18 +748,18 @@ c
             ipntr(1) = n + 1
             ipntr(2) = 1
             ido = 2
-c 
+c
 c           %----------------------------------%
 c           | Exit in order to compute B*RESID |
 c           %----------------------------------%
-c 
+c
             go to 9000
          else if (bmat .eq. 'I') then
             call zcopy  (n, resid, 1, workd, 1)
          end if
-c 
+c
   100    continue
-c 
+c
 c        %----------------------------------%
 c        | Back from reverse communication; |
 c        | WORKD(1:N) := B*RESID            |
@@ -769,7 +769,7 @@ c
             call second (t3)
             tmvbx = tmvbx + (t3 - t2)
          end if
-c 
+c
          if (bmat .eq. 'G') then
             cmpnorm_buf = zdotc  (n, resid, 1, workd, 1)
             call MPI_ALLREDUCE( cmpnorm_buf, cmpnorm, 1,
@@ -781,12 +781,12 @@ c
          cnorm = .false.
 c
          if (msglvl .gt. 2) then
-            call pdvout  (comm, logfil, 1, [rnorm], ndigit, 
+            call pdvout  (comm, logfil, 1, [rnorm], ndigit,
      &      '_naup2: B-norm of residual for compressed factorization')
             call pzmout  (comm, logfil, nev, nev, h, ldh, ndigit,
      &        '_naup2: Compressed upper Hessenberg matrix H')
          end if
-c 
+c
       go to 1000
 c
 c     %---------------------------------------------------------------%
@@ -799,7 +799,7 @@ c
 c
       mxiter = iter
       nev = nconv
-c     
+c
  1200 continue
       ido = 99
 c
@@ -809,7 +809,7 @@ c     %------------%
 c
       call second (t1)
       tcaup2 = t1 - t0
-c     
+c
  9000 continue
 c
 c     %----------------%

--- a/mathlibs/src/parpack/pznaup2.f
+++ b/mathlibs/src/parpack/pznaup2.f
@@ -402,7 +402,7 @@ c
          iter = iter + 1
 c
          if (msglvl .gt. 0) then
-            call pivout (comm, logfil, 1, iter, ndigit, 
+            call pivout (comm, logfil, 1, [iter], ndigit, 
      &           '_naup2: **** Start of major iteration number ****')
          end if
 c 
@@ -415,9 +415,9 @@ c
          np  = kplusp - nev
 c
          if (msglvl .gt. 1) then
-            call pivout (comm, logfil, 1, nev, ndigit, 
+            call pivout (comm, logfil, 1, [nev], ndigit, 
      &     '_naup2: The length of the current Arnoldi factorization')
-            call pivout (comm, logfil, 1, np, ndigit, 
+            call pivout (comm, logfil, 1, [np], ndigit, 
      &           '_naup2: Extend the Arnoldi factorization by')
          end if
 c
@@ -444,7 +444,7 @@ c
          update = .false.
 c
          if (msglvl .gt. 1) then
-            call pdvout  (comm, logfil, 1, rnorm, ndigit, 
+            call pdvout  (comm, logfil, 1, [rnorm], ndigit, 
      &           '_naup2: Corresponding B-norm of the residual')
          end if
 c 
@@ -675,7 +675,7 @@ c
          end if              
 c     
          if (msglvl .gt. 0) then
-            call pivout (comm, logfil, 1, nconv, ndigit, 
+            call pivout (comm, logfil, 1, [nconv], ndigit, 
      &           '_naup2: no. of "converged" Ritz values at this iter.')
             if (msglvl .gt. 1) then
                kp(1) = nev
@@ -715,7 +715,7 @@ c
          end if
 c
          if (msglvl .gt. 2) then 
-            call pivout (comm, logfil, 1, np, ndigit, 
+            call pivout (comm, logfil, 1, [np], ndigit, 
      &                  '_naup2: The number of shifts to apply ')
             call pzvout  (comm, logfil, np, ritz, ndigit,
      &                  '_naup2: values of the shifts')
@@ -781,7 +781,7 @@ c
          cnorm = .false.
 c
          if (msglvl .gt. 2) then
-            call pdvout  (comm, logfil, 1, rnorm, ndigit, 
+            call pdvout  (comm, logfil, 1, [rnorm], ndigit, 
      &      '_naup2: B-norm of residual for compressed factorization')
             call pzmout  (comm, logfil, nev, nev, h, ldh, ndigit,
      &        '_naup2: Compressed upper Hessenberg matrix H')

--- a/mathlibs/src/parpack/pznaupd.f
+++ b/mathlibs/src/parpack/pznaupd.f
@@ -618,9 +618,9 @@ c
       if (info .eq. 2) info = 3
 c
       if (msglvl .gt. 0) then
-         call pivout (comm, logfil, 1, mxiter, ndigit,
+         call pivout (comm, logfil, 1, [mxiter], ndigit,
      &               '_naupd: Number of update iterations taken')
-         call pivout (comm, logfil, 1, np, ndigit,
+         call pivout (comm, logfil, 1, [np], ndigit,
      &               '_naupd: Number of wanted "converged" Ritz values')
          call pzvout  (comm, logfil, np, workl(ritz), ndigit, 
      &               '_naupd: The final Ritz values')

--- a/mathlibs/src/parpack/pznaupd.f
+++ b/mathlibs/src/parpack/pznaupd.f
@@ -1,14 +1,14 @@
 c\BeginDoc
 c
-c\Name: pznaupd 
+c\Name: pznaupd
 c
-c Message Passing Layer: MPI 
+c Message Passing Layer: MPI
 c
-c\Description: 
+c\Description:
 c  Reverse communication interface for the Implicitly Restarted Arnoldi
-c  iteration. This is intended to be used to find a few eigenpairs of a 
-c  complex linear operator OP with respect to a semi-inner product defined 
-c  by a hermitian positive semi-definite real matrix B. B may be the identity 
+c  iteration. This is intended to be used to find a few eigenpairs of a
+c  complex linear operator OP with respect to a semi-inner product defined
+c  by a hermitian positive semi-definite real matrix B. B may be the identity
 c  matrix.  NOTE: if both OP and B are real, then dsaupd  or dnaupd  should
 c  be used.
 c
@@ -16,7 +16,7 @@ c
 c  The computed approximate eigenvalues are called Ritz values and
 c  the corresponding approximate eigenvectors are called Ritz vectors.
 c
-c  pznaupd  is usually called iteratively to solve one of the 
+c  pznaupd  is usually called iteratively to solve one of the
 c  following problems:
 c
 c  Mode 1:  A*x = lambda*x.
@@ -27,10 +27,10 @@ c           ===> OP = inv[M]*A  and  B = M.
 c           ===> (If M can be factored see remark 3 below)
 c
 c  Mode 3:  A*x = lambda*M*x, M symmetric semi-definite
-c           ===> OP =  inv[A - sigma*M]*M   and  B = M. 
-c           ===> shift-and-invert mode 
+c           ===> OP =  inv[A - sigma*M]*M   and  B = M.
+c           ===> shift-and-invert mode
 c           If OP*x = amu*x, then lambda = sigma + 1/amu.
-c  
+c
 c
 c  NOTE: The action of w <- inv[A - sigma*M]*v or w <- inv[M]*v
 c        should be accomplished either by a direct method
@@ -45,7 +45,7 @@ c        the accuracy requirements for the eigenvalue
 c        approximations.
 c
 c\Usage:
-c  call pznaupd 
+c  call pznaupd
 c     ( COMM, IDO, BMAT, N, WHICH, NEV, TOL, RESID, NCV, V, LDV, IPARAM,
 c       IPNTR, WORKD, WORKL, LWORKL, RWORK, INFO )
 c
@@ -53,7 +53,7 @@ c\Arguments
 c  COMM    MPI  Communicator for the processor grid.  (INPUT)
 c
 c  IDO     Integer.  (INPUT/OUTPUT)
-c          Reverse communication flag.  IDO must be zero on the first 
+c          Reverse communication flag.  IDO must be zero on the first
 c          call to pznaupd .  IDO will be set internally to
 c          indicate the type of operation to be performed.  Control is
 c          then given back to the calling routine which has the
@@ -76,14 +76,14 @@ c                    need to be recomputed in forming OP * X.
 c          IDO =  2: compute  Y = M * X  where
 c                    IPNTR(1) is the pointer into WORKD for X,
 c                    IPNTR(2) is the pointer into WORKD for Y.
-c          IDO =  3: compute and return the shifts in the first 
+c          IDO =  3: compute and return the shifts in the first
 c                    NP locations of WORKL.
 c          IDO = 99: done
 c          -------------------------------------------------------------
-c          After the initialization phase, when the routine is used in 
-c          the "shift-and-invert" mode, the vector M * X is already 
+c          After the initialization phase, when the routine is used in
+c          the "shift-and-invert" mode, the vector M * X is already
 c          available and does not need to be recomputed in forming OP*X.
-c             
+c
 c  BMAT    Character*1.  (INPUT)
 c          BMAT specifies the type of the matrix B that defines the
 c          semi-inner product for the operator OP.
@@ -105,14 +105,14 @@ c  NEV     Integer.  (INPUT)
 c          Number of eigenvalues of OP to be computed. 0 < NEV < N-1.
 c
 c  TOL     Double precision   scalar.  (INPUT)
-c          Stopping criteria: the relative accuracy of the Ritz value 
+c          Stopping criteria: the relative accuracy of the Ritz value
 c          is considered acceptable if BOUNDS(I) .LE. TOL*ABS(RITZ(I))
 c          where ABS(RITZ(I)) is the magnitude when RITZ(I) is complex.
 c          DEFAULT = pdlamch (comm, 'EPS')  (machine precision as computed
 c                    by the ScaLAPACK auxiliary subroutine pdlamch ).
 c
 c  RESID   Complex*16  array of length N.  (INPUT/OUTPUT)
-c          On INPUT: 
+c          On INPUT:
 c          If INFO .EQ. 0, a random initial residual vector is used.
 c          If INFO .NE. 0, RESID contains the initial residual vector,
 c                          possibly from a previous run.
@@ -122,15 +122,15 @@ c
 c  NCV     Integer.  (INPUT)
 c          Number of columns of the matrix V. NCV must satisfy the two
 c          inequalities 1 <= NCV-NEV and NCV <= N.
-c          This will indicate how many Arnoldi vectors are generated 
-c          at each iteration.  After the startup phase in which NEV 
-c          Arnoldi vectors are generated, the algorithm generates 
-c          approximately NCV-NEV Arnoldi vectors at each subsequent update 
-c          iteration. Most of the cost in generating each Arnoldi vector is 
+c          This will indicate how many Arnoldi vectors are generated
+c          at each iteration.  After the startup phase in which NEV
+c          Arnoldi vectors are generated, the algorithm generates
+c          approximately NCV-NEV Arnoldi vectors at each subsequent update
+c          iteration. Most of the cost in generating each Arnoldi vector is
 c          in the matrix-vector operation OP*x. (See remark 4 below)
 c
 c  V       Complex*16  array N by NCV.  (OUTPUT)
-c          Contains the final set of Arnoldi basis vectors. 
+c          Contains the final set of Arnoldi basis vectors.
 c
 c  LDV     Integer.  (INPUT)
 c          Leading dimension of V exactly as declared in the calling program.
@@ -141,23 +141,23 @@ c          The shifts selected at each iteration are used to filter out
 c          the components of the unwanted eigenvector.
 c          -------------------------------------------------------------
 c          ISHIFT = 0: the shifts are to be provided by the user via
-c                      reverse communication.  The NCV eigenvalues of 
+c                      reverse communication.  The NCV eigenvalues of
 c                      the Hessenberg matrix H are returned in the part
 c                      of WORKL array corresponding to RITZ.
 c          ISHIFT = 1: exact shifts with respect to the current
-c                      Hessenberg matrix H.  This is equivalent to 
-c                      restarting the iteration from the beginning 
+c                      Hessenberg matrix H.  This is equivalent to
+c                      restarting the iteration from the beginning
 c                      after updating the starting vector with a linear
-c                      combination of Ritz vectors associated with the 
+c                      combination of Ritz vectors associated with the
 c                      "wanted" eigenvalues.
 c          ISHIFT = 2: other choice of internal shift to be defined.
 c          -------------------------------------------------------------
 c
-c          IPARAM(2) = No longer referenced 
+c          IPARAM(2) = No longer referenced
 c
 c          IPARAM(3) = MXITER
-c          On INPUT:  maximum number of Arnoldi update iterations allowed. 
-c          On OUTPUT: actual number of Arnoldi update iterations taken. 
+c          On INPUT:  maximum number of Arnoldi update iterations allowed.
+c          On OUTPUT: actual number of Arnoldi update iterations taken.
 c
 c          IPARAM(4) = NB: blocksize to be used in the recurrence.
 c          The code currently works only for NB = 1.
@@ -167,11 +167,11 @@ c          This represents the number of Ritz values that satisfy
 c          the convergence criterion.
 c
 c          IPARAM(6) = IUPD
-c          No longer referenced. Implicit restarting is ALWAYS used.  
+c          No longer referenced. Implicit restarting is ALWAYS used.
 c
 c          IPARAM(7) = MODE
 c          On INPUT determines what type of eigenproblem is being solved.
-c          Must be 1,2,3; See under \Description of pznaupd  for the 
+c          Must be 1,2,3; See under \Description of pznaupd  for the
 c          four modes available.
 c
 c          IPARAM(8) = NP
@@ -190,7 +190,7 @@ c          arrays for matrices/vectors used by the Arnoldi iteration.
 c          -------------------------------------------------------------
 c          IPNTR(1): pointer to the current operand vector X in WORKD.
 c          IPNTR(2): pointer to the current result vector Y in WORKD.
-c          IPNTR(3): pointer to the vector B * X in WORKD when used in 
+c          IPNTR(3): pointer to the vector B * X in WORKD when used in
 c                    the shift-and-invert mode.
 c          IPNTR(4): pointer to the next available location in WORKL
 c                    that is untouched by the program.
@@ -203,7 +203,7 @@ c          IPNTR(14): pointer to the NP shifts in WORKL. See Remark 5 below.
 c
 c          Note: IPNTR(9:13) is only referenced by pzneupd . See Remark 2 below.
 c
-c          IPNTR(9):  pointer to the NCV RITZ values of the 
+c          IPNTR(9):  pointer to the NCV RITZ values of the
 c                     original system.
 c          IPNTR(10): Not Used
 c          IPNTR(11): pointer to the NCV corresponding error bounds.
@@ -213,12 +213,12 @@ c          IPNTR(13): pointer to the NCV by NCV matrix of eigenvectors
 c                     of the upper Hessenberg matrix H. Only referenced by
 c                     zneupd  if RVEC = .TRUE. See Remark 2 below.
 c          -------------------------------------------------------------
-c          
+c
 c  WORKD   Complex*16  work array of length 3*N.  (REVERSE COMMUNICATION)
 c          Distributed array to be used in the basic Arnoldi iteration
-c          for reverse communication.  The user should not use WORKD 
+c          for reverse communication.  The user should not use WORKD
 c          as temporary workspace during the iteration !!!!!!!!!!
-c          See Data Distribution Note below.  
+c          See Data Distribution Note below.
 c
 c  WORKL   Complex*16  work array of length LWORKL.  (OUTPUT/WORKSPACE)
 c          Private (replicated) array on each PE or array allocated on
@@ -239,18 +239,18 @@ c                          possibly from a previous run.
 c          Error flag on output.
 c          =  0: Normal exit.
 c          =  1: Maximum number of iterations taken.
-c                All possible eigenvalues of OP has been found. IPARAM(5)  
+c                All possible eigenvalues of OP has been found. IPARAM(5)
 c                returns the number of wanted converged Ritz values.
 c          =  2: No longer an informational error. Deprecated starting
 c                with release 2 of ARPACK.
-c          =  3: No shifts could be applied during a cycle of the 
-c                Implicitly restarted Arnoldi iteration. One possibility 
-c                is to increase the size of NCV relative to NEV. 
+c          =  3: No shifts could be applied during a cycle of the
+c                Implicitly restarted Arnoldi iteration. One possibility
+c                is to increase the size of NCV relative to NEV.
 c                See remark 4 below.
 c          = -1: N must be positive.
 c          = -2: NEV must be positive.
 c          = -3: NCV-NEV >= 2 and less than or equal to N.
-c          = -4: The maximum number of Arnoldi update iteration 
+c          = -4: The maximum number of Arnoldi update iteration
 c                must be greater than zero.
 c          = -5: WHICH must be one of 'LM', 'SM', 'LR', 'SR', 'LI', 'SI'
 c          = -6: BMAT must be one of 'I' or 'G'.
@@ -271,16 +271,16 @@ c  1. The computed Ritz values are approximate eigenvalues of OP. The
 c     selection of WHICH should be made with this in mind when using
 c     Mode = 3.  When operating in Mode = 3 setting WHICH = 'LM' will
 c     compute the NEV eigenvalues of the original problem that are
-c     closest to the shift SIGMA . After convergence, approximate eigenvalues 
+c     closest to the shift SIGMA . After convergence, approximate eigenvalues
 c     of the original problem may be obtained with the ARPACK subroutine pzneupd .
 c
-c  2. If a basis for the invariant subspace corresponding to the converged Ritz 
-c     values is needed, the user must call pzneupd  immediately following 
+c  2. If a basis for the invariant subspace corresponding to the converged Ritz
+c     values is needed, the user must call pzneupd  immediately following
 c     completion of pznaupd . This is new starting with release 2 of ARPACK.
 c
 c  3. If M can be factored into a Cholesky factorization M = LL`
 c     then Mode = 2 should not be selected.  Instead one should use
-c     Mode = 1 with  OP = inv(L)*A*inv(L`).  Appropriate triangular 
+c     Mode = 1 with  OP = inv(L)*A*inv(L`).  Appropriate triangular
 c     linear systems should be solved with L and L` rather
 c     than computing inverses.  After convergence, an approximate
 c     eigenvector z of the original problem is recovered by solving
@@ -290,11 +290,11 @@ c  4. At present there is no a-priori analysis to guide the selection
 c     of NCV relative to NEV.  The only formal requrement is that NCV > NEV + 1.
 c     However, it is recommended that NCV .ge. 2*NEV.  If many problems of
 c     the same type are to be solved, one should experiment with increasing
-c     NCV while keeping NEV fixed for a given test problem.  This will 
+c     NCV while keeping NEV fixed for a given test problem.  This will
 c     usually decrease the required number of OP*x operations but it
 c     also increases the work and storage required to maintain the orthogonal
 c     basis vectors.  The optimal "cross-over" with respect to CPU time
-c     is problem dependent and must be determined empirically. 
+c     is problem dependent and must be determined empirically.
 c     See Chapter 8 of Reference 2 for further information.
 c
 c  5. When IPARAM(1) = 0, and IDO = 3, the user needs to provide the
@@ -308,7 +308,7 @@ c     WORKL(IPNTR(8)+NCV-1).
 c
 c-----------------------------------------------------------------------
 c
-c\Data Distribution Note: 
+c\Data Distribution Note:
 c
 c  Fortran-D syntax:
 c  ================
@@ -327,10 +327,10 @@ c  ===============
 c  Complex*16  resid(n), v(ldv,ncv), workd(n,3), workl(lworkl)
 c  shared     resid(block), v(block,:), workd(block,:)
 c  replicated workl(lworkl)
-c  
+c
 c  CM2/CM5 syntax:
 c  ==============
-c  
+c
 c-----------------------------------------------------------------------
 c
 c     include   'ex-nonsym.doc'
@@ -340,13 +340,13 @@ c
 c\BeginLib
 c
 c\Local variables:
-c     xxxxxx  Complex*16 
+c     xxxxxx  Complex*16
 c
 c\References:
 c  1. D.C. Sorensen, "Implicit Application of Polynomial Filters in
 c     a k-Step Arnoldi Method", SIAM J. Matr. Anal. Apps., 13 (1992),
 c     pp 357-385.
-c  2. R.B. Lehoucq, "Analysis and Implementation of an Implicitly 
+c  2. R.B. Lehoucq, "Analysis and Implementation of an Implicitly
 c     Restarted Arnoldi Iteration", Rice University Technical Report
 c     TR95-13, Department of Computational and Applied Mathematics.
 c  3. B.N. Parlett & Y. Saad, "_Complex_ Shift and Invert Strategies for
@@ -366,9 +366,9 @@ c\Author
 c     Danny Sorensen               Phuong Vu
 c     Richard Lehoucq              CRPC / Rice University
 c     Dept. of Computational &     Houston, Texas
-c     Applied Mathematics 
-c     Rice University           
-c     Houston, Texas 
+c     Applied Mathematics
+c     Rice University
+c     Houston, Texas
 c
 c\Parallel Modifications
 c     Kristi Maschhoff
@@ -385,8 +385,8 @@ c\EndLib
 c
 c-----------------------------------------------------------------------
 c
-      subroutine pznaupd 
-     &   ( comm, ido, bmat, n, which, nev, tol, resid, ncv, v, ldv, 
+      subroutine pznaupd
+     &   ( comm, ido, bmat, n, which, nev, tol, resid, ncv, v, ldv,
      &     iparam, ipntr, workd, workl, lworkl, rwork, info )
 c
       include  'mpif.h'
@@ -410,7 +410,7 @@ c     %------------------%
 c
       character  bmat*1, which*2
       integer    ido, info, ldv, lworkl, n, ncv, nev
-      Double precision  
+      Double precision
      &           tol
 c
 c     %-----------------%
@@ -418,16 +418,16 @@ c     | Array Arguments |
 c     %-----------------%
 c
       integer    iparam(11), ipntr(14)
-      Complex*16 
+      Complex*16
      &           resid(n), v(ldv,ncv), workd(3*n), workl(lworkl)
-      Double precision   
+      Double precision
      &           rwork(ncv)
 c
 c     %------------%
 c     | Parameters |
 c     %------------%
 c
-      Complex*16 
+      Complex*16
      &           one, zero
       parameter (one = (1.0, 0.0) , zero = (0.0, 0.0) )
 c
@@ -435,7 +435,7 @@ c     %---------------%
 c     | Local Scalars |
 c     %---------------%
 c
-      integer    bounds, ierr, ih, iq, ishift, iupd, iw, 
+      integer    bounds, ierr, ih, iq, ishift, iupd, iw,
      &           ldh, ldq, levec, mode, msglvl, mxiter, nb,
      &           nev0, next, np, ritz, j
       save       bounds, ih, iq, ishift, iupd, iw,
@@ -446,28 +446,28 @@ c     %----------------------%
 c     | External Subroutines |
 c     %----------------------%
 c
-      external   pznaup2 , pzvout , pivout, second, zstatn 
+      external   pznaup2 , pzvout , pivout, second, zstatn
 c
 c     %--------------------%
 c     | External Functions |
 c     %--------------------%
 c
-      Double precision  
+      Double precision
      &           pdlamch10
       external   pdlamch10
 c
 c     %-----------------------%
 c     | Executable Statements |
 c     %-----------------------%
-c 
+c
       if (ido .eq. 0) then
-c 
+c
 c        %-------------------------------%
 c        | Initialize timing statistics  |
 c        | & message level for debugging |
 c        %-------------------------------%
 c
-         call zstatn 
+         call zstatn
          call second (t0)
          msglvl = mcaupd
 c
@@ -513,7 +513,7 @@ c
          else if (mode .eq. 1 .and. bmat .eq. 'G') then
                                                 ierr = -11
          end if
-c 
+c
 c        %------------%
 c        | Error Exit |
 c        %------------%
@@ -523,14 +523,14 @@ c
             ido  = 99
             go to 9000
          end if
-c 
+c
 c        %------------------------%
 c        | Set default parameters |
 c        %------------------------%
 c
          if (nb .le. 0)	nb = 1
          if (tol .le. 0.0  ) tol = pdlamch10 (comm, 'EpsMach')
-         if (ishift .ne. 0  .and.  
+         if (ishift .ne. 0  .and.
      &       ishift .ne. 1  .and.
      &       ishift .ne. 2)	ishift = 1
 c
@@ -542,8 +542,8 @@ c        | size of the invariant subspace desired.      |
 c        %----------------------------------------------%
 c
          np     = ncv - nev
-         nev0   = nev 
-c 
+         nev0   = nev
+c
 c        %-----------------------------%
 c        | Zero out internal workspace |
 c        %-----------------------------%
@@ -551,7 +551,7 @@ c
          do 10 j = 1, 3*ncv**2 + 5*ncv
             workl(j) = zero
   10     continue
-c 
+c
 c        %-------------------------------------------------------------%
 c        | Pointer into WORKL for address of H, RITZ, BOUNDS, Q        |
 c        | etc... and the remaining workspace.                         |
@@ -589,12 +589,12 @@ c     %-------------------------------------------------------%
 c     | Carry out the Implicitly restarted Arnoldi Iteration. |
 c     %-------------------------------------------------------%
 c
-      call pznaup2  
+      call pznaup2
      &   ( comm, ido, bmat, n, which, nev0, np, tol, resid, mode, iupd,
-     &     ishift, mxiter, v, ldv, workl(ih), ldh, workl(ritz), 
-     &     workl(bounds), workl(iq), ldq, workl(iw), 
+     &     ishift, mxiter, v, ldv, workl(ih), ldh, workl(ritz),
+     &     workl(bounds), workl(iq), ldq, workl(iw),
      &     ipntr, workd, rwork, info )
-c 
+c
 c     %--------------------------------------------------%
 c     | ido .ne. 99 implies use of reverse communication |
 c     | to compute operations involving OP.              |
@@ -602,7 +602,7 @@ c     %--------------------------------------------------%
 c
       if (ido .eq. 3) iparam(8) = np
       if (ido .ne. 99) go to 9000
-c 
+c
       iparam(3) = mxiter
       iparam(5) = np
       iparam(9) = nopx
@@ -622,9 +622,9 @@ c
      &               '_naupd: Number of update iterations taken')
          call pivout (comm, logfil, 1, [np], ndigit,
      &               '_naupd: Number of wanted "converged" Ritz values')
-         call pzvout  (comm, logfil, np, workl(ritz), ndigit, 
+         call pzvout  (comm, logfil, np, workl(ritz), ndigit,
      &               '_naupd: The final Ritz values')
-         call pzvout  (comm, logfil, np, workl(bounds), ndigit, 
+         call pzvout  (comm, logfil, np, workl(bounds), ndigit,
      &               '_naupd: Associated Ritz estimates')
       end if
 c

--- a/mathlibs/src/parpack/pzneupd.f
+++ b/mathlibs/src/parpack/pzneupd.f
@@ -1,44 +1,44 @@
 c\BeginDoc
-c 
-c\Name: pzneupd 
+c
+c\Name: pzneupd
 c
 c Message Passing Layer: MPI
 c
-c\Description: 
-c  This subroutine returns the converged approximations to eigenvalues 
-c  of A*z = lambda*B*z and (optionally): 
-c 
-c      (1) The corresponding approximate eigenvectors; 
-c 
-c      (2) An orthonormal basis for the associated approximate 
-c          invariant subspace; 
-c 
-c      (3) Both.  
+c\Description:
+c  This subroutine returns the converged approximations to eigenvalues
+c  of A*z = lambda*B*z and (optionally):
 c
-c  There is negligible additional cost to obtain eigenvectors.  An orthonormal 
+c      (1) The corresponding approximate eigenvectors;
+c
+c      (2) An orthonormal basis for the associated approximate
+c          invariant subspace;
+c
+c      (3) Both.
+c
+c  There is negligible additional cost to obtain eigenvectors.  An orthonormal
 c  basis is always computed.  There is an additional storage cost of n*nev
-c  if both are requested (in this case a separate array Z must be supplied). 
+c  if both are requested (in this case a separate array Z must be supplied).
 c
 c  The approximate eigenvalues and eigenvectors of  A*z = lambda*B*z
 c  are derived from approximate eigenvalues and eigenvectors of
 c  of the linear operator OP prescribed by the MODE selection in the
 c  call to PZNAUPD.  PZNAUPD must be called before this routine is called.
 c  These approximate eigenvalues and vectors are commonly called Ritz
-c  values and Ritz vectors respectively.  They are referred to as such 
-c  in the comments that follow.   The computed orthonormal basis for the 
-c  invariant subspace corresponding to these Ritz values is referred to as a 
-c  Schur basis. 
-c 
+c  values and Ritz vectors respectively.  They are referred to as such
+c  in the comments that follow.   The computed orthonormal basis for the
+c  invariant subspace corresponding to these Ritz values is referred to as a
+c  Schur basis.
+c
 c  The definition of OP as well as other terms and the relation of computed
 c  Ritz values and vectors of OP with respect to the given problem
-c  A*z = lambda*B*z may be found in the header of PZNAUPD.  For a brief 
+c  A*z = lambda*B*z may be found in the header of PZNAUPD.  For a brief
 c  description, see definitions of IPARAM(7), MODE and WHICH in the
 c  documentation of PZNAUPD.
 c
 c\Usage:
-c  call pzneupd 
-c     ( COMM, RVEC, HOWMNY, SELECT, D, Z, LDZ, SIGMA, WORKEV, BMAT, 
-c       N, WHICH, NEV, TOL, RESID, NCV, V, LDV, IPARAM, IPNTR, WORKD, 
+c  call pzneupd
+c     ( COMM, RVEC, HOWMNY, SELECT, D, Z, LDZ, SIGMA, WORKEV, BMAT,
+c       N, WHICH, NEV, TOL, RESID, NCV, V, LDV, IPARAM, IPNTR, WORKD,
 c       WORKL, LWORKL, RWORK, INFO )
 c
 c\Arguments
@@ -46,7 +46,7 @@ c  COMM    MPI Communicator for the processor grid.  (INPUT)
 c
 c  RVEC    LOGICAL  (INPUT)
 c          Specifies whether a basis for the invariant subspace corresponding
-c          to the converged Ritz value approximations for the eigenproblem 
+c          to the converged Ritz value approximations for the eigenproblem
 c          A*z = lambda*B*z is computed.
 c
 c             RVEC = .FALSE.     Compute Ritz values only.
@@ -55,7 +55,7 @@ c             RVEC = .TRUE.      Compute Ritz vectors or Schur vectors.
 c                                See Remarks below.
 c
 c  HOWMNY  Character*1  (INPUT)
-c          Specifies the form of the basis for the invariant subspace 
+c          Specifies the form of the basis for the invariant subspace
 c          corresponding to the converged Ritz values that is to be computed.
 c
 c          = 'A': Compute NEV Ritz vectors;
@@ -66,34 +66,34 @@ c
 c  SELECT  Logical array of dimension NCV.  (INPUT)
 c          If HOWMNY = 'S', SELECT specifies the Ritz vectors to be
 c          computed. To select the  Ritz vector corresponding to a
-c          Ritz value D(j), SELECT(j) must be set to .TRUE.. 
-c          If HOWMNY = 'A' or 'P', SELECT need not be initialized 
+c          Ritz value D(j), SELECT(j) must be set to .TRUE..
+c          If HOWMNY = 'A' or 'P', SELECT need not be initialized
 c          but it is used as internal workspace.
 c
 c  D       Complex*16 array of dimension NEV+1.  (OUTPUT)
-c          On exit, D contains the  Ritz  approximations 
+c          On exit, D contains the  Ritz  approximations
 c          to the eigenvalues lambda for A*z = lambda*B*z.
 c
 c  Z       Complex*16 N by NEV array    (OUTPUT)
-c          On exit, if RVEC = .TRUE. and HOWMNY = 'A', then the columns of 
-c          Z represents approximate eigenvectors (Ritz vectors) corresponding 
+c          On exit, if RVEC = .TRUE. and HOWMNY = 'A', then the columns of
+c          Z represents approximate eigenvectors (Ritz vectors) corresponding
 c          to the NCONV=IPARAM(5) Ritz values for eigensystem
 c          A*z = lambda*B*z.
 c
 c          If RVEC = .FALSE. or HOWMNY = 'P', then Z is NOT REFERENCED.
 c
-c          NOTE: If if RVEC = .TRUE. and a Schur basis is not required, 
-c          the array Z may be set equal to first NEV+1 columns of the Arnoldi 
-c          basis array V computed by PZNAUPD.  In this case the Arnoldi basis 
+c          NOTE: If if RVEC = .TRUE. and a Schur basis is not required,
+c          the array Z may be set equal to first NEV+1 columns of the Arnoldi
+c          basis array V computed by PZNAUPD.  In this case the Arnoldi basis
 c          will be destroyed and overwritten with the eigenvector basis.
 c
 c  LDZ     Integer.  (INPUT)
 c          The leading dimension of the array Z.  If Ritz vectors are
-c          desired, then  LDZ .ge.  max( 1, N ) is required.  
+c          desired, then  LDZ .ge.  max( 1, N ) is required.
 c          In any case,  LDZ .ge. 1 is required.
 c
 c  SIGMA   Complex*16  (INPUT)
-c          If IPARAM(7) = 3 then SIGMA represents the shift. 
+c          If IPARAM(7) = 3 then SIGMA represents the shift.
 c          Not referenced if IPARAM(7) = 1 or 2.
 c
 c  WORKEV  Complex*16 work array of dimension 2*NCV.  (WORKSPACE)
@@ -101,12 +101,12 @@ c
 c  **** The remaining arguments MUST be the same as for the   ****
 c  **** call to PZNAUPD that was just completed.               ****
 c
-c  NOTE: The remaining arguments 
+c  NOTE: The remaining arguments
 c
-c           BMAT, N, WHICH, NEV, TOL, RESID, NCV, V, LDV, IPARAM, IPNTR, 
-c           WORKD, WORKL, LWORKL, RWORK, INFO 
+c           BMAT, N, WHICH, NEV, TOL, RESID, NCV, V, LDV, IPARAM, IPNTR,
+c           WORKD, WORKL, LWORKL, RWORK, INFO
 c
-c         must be passed directly to ZNEUPD following the last call 
+c         must be passed directly to ZNEUPD following the last call
 c         to PZNAUPD.  These arguments MUST NOT BE MODIFIED between
 c         the the last call to PZNAUPD and the call to ZNEUPD.
 c
@@ -186,18 +186,18 @@ c\References:
 c  1. D.C. Sorensen, "Implicit Application of Polynomial Filters in
 c     a k-Step Arnoldi Method", SIAM J. Matr. Anal. Apps., 13 (1992),
 c     pp 357-385.
-c  2. R.B. Lehoucq, "Analysis and Implementation of an Implicitly 
+c  2. R.B. Lehoucq, "Analysis and Implementation of an Implicitly
 c     Restarted Arnoldi Iteration", Rice University Technical Report
 c     TR95-13, Department of Computational and Applied Mathematics.
 c  3. B. Nour-Omid, B. N. Parlett, T. Ericsson and P. S. Jensen,
 c     "How to Implement the Spectral Transformation", Math Comp.,
-c     Vol. 48, No. 178, April, 1987 pp. 664-673. 
+c     Vol. 48, No. 178, April, 1987 pp. 664-673.
 c
 c\Routines called:
 c     pivout  Parallel ARPACK utility routine that prints integers.
 c     pzmout  Parallel ARPACK utility routine that prints matrices
 c     pzvout  Parallel ARPACK utility routine that prints vectors.
-c     zgeqr2  LAPACK routine that computes the QR factorization of 
+c     zgeqr2  LAPACK routine that computes the QR factorization of
 c             a matrix.
 c     zlacpy  LAPACK matrix copy routine.
 c     zlahqr  LAPACK routine that computes the Schur form of a
@@ -206,7 +206,7 @@ c     zlaset  LAPACK matrix initialization routine.
 c     ztrevc  LAPACK routine to compute the eigenvectors of a matrix
 c             in upper triangular form.
 c     ztrsen  LAPACK routine that re-orders the Schur form.
-c     zunm2r  LAPACK routine that applies an orthogonal matrix in 
+c     zunm2r  LAPACK routine that applies an orthogonal matrix in
 c             factored form.
 c     pdlamch ScaLAPACK routine that determines machine constants.
 c     ztrmm   Level 3 BLAS matrix times an upper triangular matrix.
@@ -218,23 +218,23 @@ c     dznrm2  Level 1 BLAS that computes the norm of a complex vector.
 c
 c\Remarks
 c
-c  1. Currently only HOWMNY = 'A' and 'P' are implemented. 
+c  1. Currently only HOWMNY = 'A' and 'P' are implemented.
 c
 c  2. Schur vectors are an orthogonal representation for the basis of
 c     Ritz vectors. Thus, their numerical properties are often superior.
 c     If RVEC = .true. then the relationship
 c             A * V(:,1:IPARAM(5)) = V(:,1:IPARAM(5)) * T, and
 c     V(:,1:IPARAM(5))' * V(:,1:IPARAM(5)) = I are approximately satisfied.
-c     Here T is the leading submatrix of order IPARAM(5) of the 
-c     upper triangular matrix stored workl(ipntr(12)). 
+c     Here T is the leading submatrix of order IPARAM(5) of the
+c     upper triangular matrix stored workl(ipntr(12)).
 c
 c\Authors
 c     Danny Sorensen               Phuong Vu
 c     Richard Lehoucq              CRPC / Rice University
-c     Chao Yang                    Houston, Texas 
-c     Dept. of Computational & 
-c     Applied Mathematics 
-c     Rice University 
+c     Chao Yang                    Houston, Texas
+c     Dept. of Computational &
+c     Applied Mathematics
+c     Rice University
 c     Houston, Texas
 c
 c\Parallel Modifications
@@ -249,10 +249,10 @@ c
 c\EndLib
 c
 c-----------------------------------------------------------------------
-      subroutine pzneupd 
-     &         ( comm, rvec, howmny, select, d, z, ldz, sigma, 
-     &           workev, bmat, n, which, nev, tol, 
-     &           resid, ncv, v, ldv, iparam, ipntr, workd, 
+      subroutine pzneupd
+     &         ( comm, rvec, howmny, select, d, z, ldz, sigma,
+     &           workev, bmat, n, which, nev, tol,
+     &           resid, ncv, v, ldv, iparam, ipntr, workd,
      &           workl, lworkl, rwork, info)
 c
 c     %--------------------%
@@ -275,9 +275,9 @@ c
       character  bmat, howmny, which*2
       logical    rvec
       integer    info, ldz, ldv, lworkl, n, ncv, nev
-      Complex*16     
+      Complex*16
      &           sigma
-      Double precision 
+      Double precision
      &           tol
 c
 c     %-----------------%
@@ -289,7 +289,7 @@ c
       Double precision
      &           rwork(ncv)
       Complex*16
-     &           d(nev), resid(n), v(ldv,ncv), z(ldz, nev), 
+     &           d(nev), resid(n), v(ldv,ncv), z(ldz, nev),
      &           workd(3*n), workl(lworkl), workev(2*ncv)
 c
 c     %------------%
@@ -305,8 +305,8 @@ c     | Local Scalars |
 c     %---------------%
 c
       character  type*6
-      integer    bounds, ierr, ih, ihbds, iheig, nconv, 
-     &           invsub, iuptri, iwev, j, 
+      integer    bounds, ierr, ih, ihbds, iheig, nconv,
+     &           invsub, iuptri, iwev, j,
      &           ldh, ldq, mode, msglvl, ritz, wr, k,
      &           irz, ibd, ktrord, outncv, iq
       Complex*16
@@ -322,7 +322,7 @@ c
       external   zcopy, zgeru, zgeqr2, zlacpy, pzmout,
      &           zunm2r, ztrmm, pzvout, pivout,
      &           zlahqr
-c  
+c
 c     %--------------------%
 c     | External Functions |
 c     %--------------------%
@@ -344,7 +344,7 @@ c
 c     %-----------------------%
 c     | Executable Statements |
 c     %-----------------------%
-c 
+c
 c     %------------------------%
 c     | Set default parameters |
 c     %------------------------%
@@ -395,12 +395,12 @@ c
       else if (howmny .eq. 'S' ) then
          ierr = -12
       end if
-c     
+c
       if (mode .eq. 1 .or. mode .eq. 2) then
          type = 'REGULR'
       else if (mode .eq. 3 ) then
          type = 'SHIFTI'
-      else 
+      else
                                               ierr = -10
       end if
       if (mode .eq. 1 .and. bmat .eq. 'G')    ierr = -11
@@ -413,7 +413,7 @@ c
          info = ierr
          go to 9000
       end if
-c 
+c
 c     %--------------------------------------------------------%
 c     | Pointer into WORKL for address of H, RITZ, WORKEV, Q   |
 c     | etc... and the remaining workspace.                    |
@@ -441,7 +441,7 @@ c     |                                      the invariant        |
 c     |                                      subspace for H.      |
 c     | GRAND total of NCV * ( 3 * NCV + 4 ) locations.           |
 c     %-----------------------------------------------------------%
-c     
+c
       ih     = ipntr(5)
       ritz   = ipntr(6)
       iq     = ipntr(7)
@@ -476,7 +476,7 @@ c     %------------------------------------%
 c
       rnorm = workl(ih+2)
       workl(ih+2) = zero
-c     
+c
       if (rvec) then
 c
 c        %-------------------------------------------%
@@ -502,13 +502,13 @@ c
 c
 c        %---------------------------------------------------------%
 c        | Check to see if all converged Ritz values appear at the |
-c        | at the top of the upper triangular matrix computed by   | 
-c        | _neigh in _naup2.  This is done in the following way:   | 
+c        | at the top of the upper triangular matrix computed by   |
+c        | _neigh in _naup2.  This is done in the following way:   |
 c        |                                                         |
 c        | 1) For each Ritz value from _neigh, compare it with the |
 c        |    threshold Ritz value computed above to determine     |
 c        |    whether it is a wanted one.                          |
-c        |                                                         | 
+c        |                                                         |
 c        | 2) If it is wanted, then check the corresponding Ritz   |
 c        |    estimate to see if it has converged.  If it has, set |
 c        |    correponding entry in the logical array SELECT to    |
@@ -584,7 +584,7 @@ c
      &            '_neupd: Number of specified eigenvalues')
              call pivout(comm, logfil, 1, [nconv], ndigit,
      &            '_neupd: Number of "converged" eigenvalues')
-         end if 
+         end if
 c
 c        if (ktrord .gt. nconv) then
 c
@@ -634,7 +634,7 @@ c           | Reorder the computed upper triangular matrix. |
 c           %-----------------------------------------------%
 c
             call ztrsen ('None', 'V', select, ncv, workl(iuptri), ldh,
-     &           workl(invsub), ldq, workl(iheig), nconv, conds, sep, 
+     &           workl(invsub), ldq, workl(iheig), nconv, conds, sep,
      &           workev, ncv, ierr)
 c
             if (ierr .eq. 1) then
@@ -662,7 +662,7 @@ c        | Ritz values.                                |
 c        %---------------------------------------------%
 c
          call zcopy (ncv, workl(invsub+ncv-1), ldq, workl(ihbds), 1)
-c 
+c
 c        %--------------------------------------------%
 c        | Place the computed eigenvalues of H into D |
 c        | if a spectral transformation was not used. |
@@ -687,14 +687,14 @@ c        | * Copy the first NCONV columns of VQ into Z.           |
 c        | * Postmultiply Z by R.                                 |
 c        | The N by NCONV matrix Z is now a matrix representation |
 c        | of the approximate invariant subspace associated with  |
-c        | the Ritz values in workl(iheig). The first NCONV       | 
+c        | the Ritz values in workl(iheig). The first NCONV       |
 c        | columns of V are now approximate Schur vectors         |
 c        | associated with the upper triangular matrix of order   |
 c        | NCONV in workl(iuptri).                                |
 c        %--------------------------------------------------------%
 c
-         call zunm2r ('Right', 'Notranspose', n, ncv, nconv, 
-     &        workl(invsub), ldq, workev, v, ldv, workd(n+1), 
+         call zunm2r ('Right', 'Notranspose', n, ncv, nconv,
+     &        workl(invsub), ldq, workev, v, ldv, workd(n+1),
      &        ierr)
          call zlacpy ('All', n, nconv, v, ldv, z, ldz)
 c
@@ -709,7 +709,7 @@ c           | Note that since Q is orthogonal, R is a diagonal  |
 c           | matrix consisting of plus or minus ones.          |
 c           %---------------------------------------------------%
 c
-            if ( dble( workl(invsub+(j-1)*ldq+j-1) ) .lt. 
+            if ( dble( workl(invsub+(j-1)*ldq+j-1) ) .lt.
      &                  dble(zero) ) then
                call zscal (nconv, -one, workl(iuptri+j-1), ldq)
                call zscal (nconv, -one, workl(iuptri+(j-1)*ldq), 1)
@@ -763,7 +763,7 @@ c                 | Note that the eigenvector matrix of T is |
 c                 | upper triangular, thus the length of the |
 c                 | inner product can be set to j.           |
 c                 %------------------------------------------%
-c 
+c
                   workev(j) = zdotc(j, workl(ihbds), 1,
      &                        workl(invsub+(j-1)*ldq), 1)
  40         continue
@@ -782,7 +782,7 @@ c
 c           %---------------------------------------%
 c           | Copy Ritz estimates into workl(ihbds) |
 c           %---------------------------------------%
-c 
+c
             call zcopy(nconv, workev, 1, workl(ihbds), 1)
 c
 c           %----------------------------------------------%
@@ -793,7 +793,7 @@ c
             call ztrmm ('Right', 'Upper', 'No transpose', 'Non-unit',
      &                  n, nconv, one, workl(invsub), ldq, z, ldz)
 c
-         end if 
+         end if
 c
       else
 c
@@ -816,25 +816,25 @@ c     %------------------------------------------------%
 c
       if (type .eq. 'REGULR') then
 c
-         if (rvec) 
+         if (rvec)
      &      call zscal(ncv, rnorm, workl(ihbds), 1)
-c      
+c
       else
-c     
+c
 c        %---------------------------------------%
 c        |   A spectral transformation was used. |
 c        | * Determine the Ritz estimates of the |
 c        |   Ritz values in the original system. |
 c        %---------------------------------------%
 c
-         if (rvec) 
+         if (rvec)
      &      call zscal(ncv, rnorm, workl(ihbds), 1)
-c    
+c
          do 50 k=1, ncv
             temp = workl(iheig+k-1)
             workl(ihbds+k-1) = workl(ihbds+k-1) / temp / temp
   50     continue
-c  
+c
       end if
 c
 c     %-----------------------------------------------------------%
@@ -844,7 +844,7 @@ c     |             lambda = 1/theta + sigma                      |
 c     | NOTES:                                                    |
 c     | *The Ritz vectors are not affected by the transformation. |
 c     %-----------------------------------------------------------%
-c    
+c
       if (type .eq. 'SHIFTI') then
          do 60 k=1, nconv
             d(k) = one / workl(iheig+k-1) + sigma
@@ -898,7 +898,7 @@ c
  9000 continue
 c
       return
-c     
+c
 c     %----------------%
 c     | End of pzneupd |
 c     %----------------%

--- a/mathlibs/src/parpack/pzneupd.f
+++ b/mathlibs/src/parpack/pzneupd.f
@@ -496,7 +496,7 @@ c
             thres = dimag(workl(ritz))
          end if
          if (msglvl .gt. 2) then
-            call pdvout(comm, logfil, 1, thres, ndigit,
+            call pdvout(comm, logfil, 1, [thres], ndigit,
      &           '_neupd: Threshold eigenvalue used for re-ordering')
          end if
 c
@@ -580,9 +580,9 @@ c
  10      continue
 c
          if (msglvl .gt. 2) then
-             call pivout(comm, logfil, 1, ktrord, ndigit,
+             call pivout(comm, logfil, 1, [ktrord], ndigit,
      &            '_neupd: Number of specified eigenvalues')
-             call pivout(comm, logfil, 1, nconv, ndigit,
+             call pivout(comm, logfil, 1, [nconv], ndigit,
      &            '_neupd: Number of "converged" eigenvalues')
          end if 
 c

--- a/mathlibs/src/parpack/pzngets.f
+++ b/mathlibs/src/parpack/pzngets.f
@@ -177,8 +177,8 @@ c
       tcgets = tcgets + (t1 - t0)
 c
       if (msglvl .gt. 0) then
-         call pivout (comm, logfil, 1, kev, ndigit, '_ngets: KEV is')
-         call pivout (comm, logfil, 1, np, ndigit, '_ngets: NP is')
+         call pivout (comm, logfil, 1, [kev], ndigit, '_ngets: KEV is')
+         call pivout (comm, logfil, 1, [np], ndigit, '_ngets: NP is')
          call pzvout (comm, logfil, kev+np, ritz, ndigit,
      &        '_ngets: Eigenvalues of current H matrix ')
          call pzvout (comm, logfil, kev+np, bounds, ndigit, 

--- a/mathlibs/src/parpack/pzngets.f
+++ b/mathlibs/src/parpack/pzngets.f
@@ -4,9 +4,9 @@ c\Name: pzngets
 c
 c Message Passing Layer: MPI
 c
-c\Description: 
+c\Description:
 c  Given the eigenvalues of the upper Hessenberg matrix H,
-c  computes the NP shifts AMU that are zeros of the polynomial of 
+c  computes the NP shifts AMU that are zeros of the polynomial of
 c  degree NP which filters out components of the unwanted eigenvectors
 c  corresponding to the AMU's based on some given criteria.
 c
@@ -44,8 +44,8 @@ c  RITZ    Complex*16 array of length KEV+NP.  (INPUT/OUTPUT)
 c          On INPUT, RITZ contains the the eigenvalues of H.
 c          On OUTPUT, RITZ are sorted so that the unwanted
 c          eigenvalues are in the first NP locations and the wanted
-c          portion is in the last KEV locations.  When exact shifts are 
-c          selected, the unwanted part corresponds to the shifts to 
+c          portion is in the last KEV locations.  When exact shifts are
+c          selected, the unwanted part corresponds to the shifts to
 c          be applied. Also, if ISHIFT .eq. 1, the unwanted eigenvalues
 c          are further sorted so that the ones with largest Ritz values
 c          are first.
@@ -53,7 +53,7 @@ c
 c  BOUNDS  Complex*16 array of length KEV+NP.  (INPUT/OUTPUT)
 c          Error bounds corresponding to the ordering in RITZ.
 c
-c  
+c
 c
 c\EndDoc
 c
@@ -74,9 +74,9 @@ c\Author
 c     Danny Sorensen               Phuong Vu
 c     Richard Lehoucq              CRPC / Rice University
 c     Dept. of Computational &     Houston, Texas
-c     Applied Mathematics 
-c     Rice University           
-c     Houston, Texas 
+c     Applied Mathematics
+c     Rice University
+c     Houston, Texas
 c
 c\Parallel Modifications
 c     Kristi Maschhoff
@@ -84,7 +84,7 @@ c
 c\Revision history:
 c     Starting Point: Serial Complex Code FILE: ngets.F   SID: 2.1
 c
-c\SCCS Information: 
+c\SCCS Information:
 c FILE: ngets.F   SID: 1.2   DATE OF SID: 4/19/96
 c
 c\Remarks
@@ -152,14 +152,14 @@ c     %-------------------------------%
 c     | Initialize timing statistics  |
 c     | & message level for debugging |
 c     %-------------------------------%
-c 
+c
       call second (t0)
       msglvl = mcgets
-c 
+c
       call zsortc (which, .true., kev+np, ritz, bounds)
-c     
+c
       if ( ishift .eq. 1 ) then
-c     
+c
 c        %-------------------------------------------------------%
 c        | Sort the unwanted Ritz values used as shifts so that  |
 c        | the ones with largest Ritz estimates are first        |
@@ -168,11 +168,11 @@ c        | forward instability of the iteration when the shifts  |
 c        | are applied in subroutine pznapps.                    |
 c        | Be careful and use 'SM' since we want to sort BOUNDS! |
 c        %-------------------------------------------------------%
-c     
+c
          call zsortc ( 'SM', .true., np, bounds, ritz )
 c
       end if
-c     
+c
       call second (t1)
       tcgets = tcgets + (t1 - t0)
 c
@@ -181,14 +181,14 @@ c
          call pivout (comm, logfil, 1, [np], ndigit, '_ngets: NP is')
          call pzvout (comm, logfil, kev+np, ritz, ndigit,
      &        '_ngets: Eigenvalues of current H matrix ')
-         call pzvout (comm, logfil, kev+np, bounds, ndigit, 
+         call pzvout (comm, logfil, kev+np, bounds, ndigit,
      &      '_ngets: Ritz estimates of the current KEV+NP Ritz values')
       end if
-c     
+c
       return
-c     
+c
 c     %----------------%
 c     | End of pzngets |
 c     %----------------%
-c     
+c
       end


### PR DESCRIPTION
The `?vout` functions expect their third argument to be of rank-1. Similarly, the `p?vout` functions expect their fourth argument to be of rank-1.
Newer compilers (e.g., GFortran 10 or newer) emit an error if it is not. That error is currently downgraded to a warning by adding `-fallow-argument-mismatch` to the Fortran compiler flags for GFortran.

Avoid that error/warning in the first place by passing the respective argument with the expected rank.

Also fix two instances where `pzvout` was called with a real argument in PARPACK.


This reduces the number of compiler warnings for me by a lot.

There should be no change in functionality by this PR. (Maybe apart from the `pzvout` being erroneously used in place of `pdvout` in PARPACK.)