### PR TITLE
ElmerGUI: Avoid buffer overflow.

### DIFF
--- a/ElmerGUI/netgen/libsrc/csg/csgeom.cpp
+++ b/ElmerGUI/netgen/libsrc/csg/csgeom.cpp
@@ -450,7 +450,7 @@ namespace netgen
   {
     static int cntsurfs = 0;
     cntsurfs++;
-    char name[15];
+    char name[17];
     sprintf (name, "nnsurf%d", cntsurfs);
     AddSurface (name, surf);
   }


### PR DESCRIPTION
Use a buffer that is large enough to catch the full range of possible `int` type values.

It might be unlikely to reach the number of faces for which this will become an actual issue. But it avoids the following compiler warning:
```
/home/runner/work/elmerfem/elmerfem/ElmerGUI/netgen/libsrc/csg/csgeom.cpp: In member function ‘void netgen::CSGeometry::AddSurface(netgen::Surface*)’:
/home/runner/work/elmerfem/elmerfem/ElmerGUI/netgen/libsrc/csg/csgeom.cpp:454:27: warning: ‘%d’ directive writing between 1 and 11 bytes into a region of size 9 [-Wformat-overflow=]
  454 |     sprintf (name, "nnsurf%d", cntsurfs);
      |                           ^~
/home/runner/work/elmerfem/elmerfem/ElmerGUI/netgen/libsrc/csg/csgeom.cpp:454:20: note: directive argument in the range [-2147483647, 2147483647]
```