### PR TITLE
ElmerGUI: Remove deprecated compiler flag.

### DIFF
--- a/ElmerGUI/netgen/CMakeLists.txt
+++ b/ElmerGUI/netgen/CMakeLists.txt
@@ -13,11 +13,6 @@ ADD_DEFINITIONS("-DNO_PARALLEL_THREADS")
 #QMAKE_CXXFLAGS_DEBUG += -g
 #QMAKE_CXXFLAGS += -g
 
-#unix: QMAKE_CXXFLAGS += -ffriend-injection
-IF(UNIX)
-   ADD_DEFINITIONS("-ffriend-injection")
-ENDIF()
-
 #------------------------------------------------------------------------------
 # Input files:
 #------------------------------------------------------------------------------

--- a/ElmerGUI/netgen/netgen.pro
+++ b/ElmerGUI/netgen/netgen.pro
@@ -18,8 +18,6 @@ INCLUDEPATH = libsrc/include
 QMAKE_CXXFLAGS_DEBUG += -g
 QMAKE_CXXFLAGS += -g
 
-unix: QMAKE_CXXFLAGS += -ffriend-injection
-
 #------------------------------------------------------------------------------
 # Input files:
 #------------------------------------------------------------------------------


### PR DESCRIPTION
Support for `-ffriend-injection` was removed in GCC 9 (released May 2019). 
See: https://gcc.gnu.org/onlinedocs/gcc-8.1.0/gcc/Deprecated-Features.html#Deprecated-Features 
And: https://gcc.gnu.org/onlinedocs/gcc-9.1.0/gcc/Deprecated-Features.html#Deprecated-Features

The flag no longer has any effect for modern compilers. Adding it causes warnings during compilation. E.g.:
```
g++: warning: switch ‘-ffriend-injection’ is no longer supported
```

IIUC, it was originally added here (approx. 15 years ago in 2009) to work around an issue with GCC 4.3:
https://sourceforge.net/p/elmerfem/code/3936/

Remove that flag from the build rules. If a user has a compiler that still needs that flag, they should add it in the CMake configuration flags or in the environment variable `CXXFLAGS` when they configure locally.
