### PR TITLE
Display more information for failed tests in all CI runners.

### DIFF
--- a/.github/workflows/build-macos-homebrew.yaml
+++ b/.github/workflows/build-macos-homebrew.yaml
@@ -108,6 +108,30 @@ jobs:
           CTEST_OUTPUT_ON_FAILURE: 1
         run: |
           cd ${GITHUB_WORKSPACE}/build
+          # get names of failed tests and strip potential "_np*" suffix
+          failed_tests=($(ctest . -N --rerun-failed | grep -E "Test\s+#.*" | awk '{print $3}' | sed -e 's/_np[0-9]*$//g'))
+          # remove duplicate test names
+          unique_failed_tests=($(echo "${failed_tests[@]}" | tr ' ' '\n' | sort -u | tr '\n' ' '))
+          for test in "${unique_failed_tests[@]}"; do
+            # check if test is from fem or ElmerIce
+            if [ -d fem/tests/${test} ]; then
+              test_root=fem/tests
+            else
+              test_root=elmerice/Tests
+            fi
+            echo "::group::Content of ${test_root}/${test}"
+            echo ---- Files ----
+            ls -Rl ${test_root}/${test}
+            if [ -f ${test_root}/${test}/test-stderr*.log ]; then
+              echo ---- Content of test-stderr*.log ----
+              cat ${test_root}/${test}/test-stderr*.log
+            fi
+            if [ -f ${test_root}/${test}/test-stdout*.log ]; then
+              echo ---- Content of test-stdout*.log ----
+              cat ${test_root}/${test}/test-stdout*.log
+            fi
+            echo "::endgroup::"
+          done
           echo "::group::Re-run failing tests"
           ctest --rerun-failed --output-on-failure --timeout 180 || true
           echo "::endgroup::"

--- a/.github/workflows/build-macos-homebrew.yaml
+++ b/.github/workflows/build-macos-homebrew.yaml
@@ -96,7 +96,10 @@ jobs:
           CTEST_OUTPUT_ON_FAILURE: 1
         run: |
           cd ${GITHUB_WORKSPACE}/build
-          ctest -L quick -j$(sysctl -n hw.logicalcpu)
+          ctest . \
+            -L quick \
+            -j$(sysctl -n hw.logicalcpu) \
+            --timeout 180
 
       - name: re-run tests
         if: always() && (steps.run-ctest.outcome == 'failure')
@@ -106,7 +109,7 @@ jobs:
         run: |
           cd ${GITHUB_WORKSPACE}/build
           echo "::group::Re-run failing tests"
-          ctest --rerun-failed --output-on-failure || true
+          ctest --rerun-failed --output-on-failure --timeout 180 || true
           echo "::endgroup::"
           echo "::group::Log from these tests"
           [ ! -f Testing/Temporary/LastTest.log ] || cat Testing/Temporary/LastTest.log

--- a/.github/workflows/build-windows-mingw.yaml
+++ b/.github/workflows/build-windows-mingw.yaml
@@ -140,7 +140,10 @@ jobs:
           CTEST_OUTPUT_ON_FAILURE: 1
         run: |
           cd ${GITHUB_WORKSPACE}/build
-          ctest -L quick -j$(nproc)
+          ctest . \
+            -L quick \
+            -j$(nproc) \
+            --timeout 180
 
       - name: re-run tests
         if: always() && (steps.run-ctest.outcome == 'failure')
@@ -150,7 +153,7 @@ jobs:
         run: |
           cd ${GITHUB_WORKSPACE}/build
           echo "::group::Re-run failing tests"
-          ctest --rerun-failed --output-on-failure || true
+          ctest --rerun-failed --output-on-failure --timeout 180 || true
           echo "::endgroup::"
           echo "::group::Log from these tests"
           [ ! -f Testing/Temporary/LastTest.log ] || cat Testing/Temporary/LastTest.log

--- a/.github/workflows/build-windows-mingw.yaml
+++ b/.github/workflows/build-windows-mingw.yaml
@@ -152,6 +152,30 @@ jobs:
           CTEST_OUTPUT_ON_FAILURE: 1
         run: |
           cd ${GITHUB_WORKSPACE}/build
+          # get names of failed tests and strip potential "_np*" suffix
+          failed_tests=($(ctest . -N --rerun-failed | grep -E "Test\s+#.*" | awk '{print $3}' | sed -e 's/_np[0-9]*$//g'))
+          # remove duplicate test names
+          unique_failed_tests=($(echo "${failed_tests[@]}" | tr ' ' '\n' | sort -u | tr '\n' ' '))
+          for test in "${unique_failed_tests[@]}"; do
+            # check if test is from fem or ElmerIce
+            if [ -d fem/tests/${test} ]; then
+              test_root=fem/tests
+            else
+              test_root=elmerice/Tests
+            fi
+            echo "::group::Content of ${test_root}/${test}"
+            echo ---- Files ----
+            ls -Rl ${test_root}/${test}
+            if [ -f ${test_root}/${test}/test-stderr*.log ]; then
+              echo ---- Content of test-stderr*.log ----
+              cat ${test_root}/${test}/test-stderr*.log
+            fi
+            if [ -f ${test_root}/${test}/test-stdout*.log ]; then
+              echo ---- Content of test-stdout*.log ----
+              cat ${test_root}/${test}/test-stdout*.log
+            fi
+            echo "::endgroup::"
+          done
           echo "::group::Re-run failing tests"
           ctest --rerun-failed --output-on-failure --timeout 180 || true
           echo "::endgroup::"

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -134,12 +134,10 @@ jobs:
           CTEST_OUTPUT_ON_FAILURE: 1
         run: |
           cd ${GITHUB_WORKSPACE}/build
-          set -o pipefail && \
-            ctest . \
-              -L "quick|elmerice-fast" \
-              -j$(nproc) \
-              --timeout 180 \
-            | tee ./ctest_output.log
+          ctest . \
+            -L "quick|elmerice-fast" \
+            -j$(nproc) \
+            --timeout 180
 
       - name: Re-run tests
         if: always() && (steps.run-ctest.outcome == 'failure')
@@ -148,13 +146,10 @@ jobs:
           CTEST_OUTPUT_ON_FAILURE: 1
         run: |
           cd ${GITHUB_WORKSPACE}/build
-          # read names of failed tests from log and strip potential "_np*" suffix
-          failed_tests=($(sed -n 's/^.*#[0-9]*\:\s*\(\S*\).*Failed.*/\1/p' ./ctest_output.log | sed -e 's/_np[0-9]*$//g'))
+          # get names of failed tests and strip potential "_np*" suffix
+          failed_tests=($(ctest . -N --rerun-failed | grep -E "Test\s+#.*" | awk '{print $3}' | sed -e 's/_np[0-9]*$//g'))
           # remove duplicate test names
-          declare -A unique_failed_tests
-          for test in "${failed_tests[@]}"; do
-            unique_failed_tests["${test}"]="${test}";
-          done
+          unique_failed_tests=($(echo "${failed_tests[@]}" | tr ' ' '\n' | sort -u | tr '\n' ' '))
           for test in "${unique_failed_tests[@]}"; do
             # check if test is from fem or ElmerIce
             if [ -d fem/tests/${test} ]; then

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -134,7 +134,12 @@ jobs:
           CTEST_OUTPUT_ON_FAILURE: 1
         run: |
           cd ${GITHUB_WORKSPACE}/build
-          set -o pipefail && ctest -L "quick|elmerice-fast" -j$(nproc) . | tee ./ctest_output.log
+          set -o pipefail && \
+            ctest . \
+              -L "quick|elmerice-fast" \
+              -j$(nproc) \
+              --timeout 180 \
+            | tee ./ctest_output.log
 
       - name: Re-run tests
         if: always() && (steps.run-ctest.outcome == 'failure')
@@ -171,7 +176,7 @@ jobs:
             echo "::endgroup::"
           done
           echo "::group::Re-run failing tests"
-          ctest --rerun-failed --output-on-failure || true
+          ctest --rerun-failed --output-on-failure --timeout 180 || true
           echo "::endgroup::"
           echo "::group::Log from these tests"
           [ ! -f Testing/Temporary/LastTest.log ] || cat Testing/Temporary/LastTest.log

--- a/.github/workflows/ubuntu-clang-full.yaml
+++ b/.github/workflows/ubuntu-clang-full.yaml
@@ -87,7 +87,7 @@ jobs:
           CTEST_OUTPUT_ON_FAILURE: 1
         run: |
           cd ${GITHUB_WORKSPACE}/build
-          set -o pipefail && ctest . -j$(nproc) | tee ./ctest_output.log
+          ctest . -j$(nproc)
 
       - name: re-run tests
         if: always() && (steps.run-ctest.outcome == 'failure')
@@ -96,13 +96,10 @@ jobs:
           CTEST_OUTPUT_ON_FAILURE: 1
         run: |
           cd ${GITHUB_WORKSPACE}/build
-          # read names of failed tests from log and strip potential "_np*" suffix
-          failed_tests=($(sed -n 's/^.*#[0-9]*\:\s*\(\S*\).*Failed.*/\1/p' ./ctest_output.log | sed -e 's/_np[0-9]*$//g'))
+          # get names of failed tests and strip potential "_np*" suffix
+          failed_tests=($(ctest . -N --rerun-failed | grep -E "Test\s+#.*" | awk '{print $3}' | sed -e 's/_np[0-9]*$//g'))
           # remove duplicate test names
-          declare -A unique_failed_tests
-          for test in "${failed_tests[@]}"; do
-            unique_failed_tests["${test}"]="${test}";
-          done
+          unique_failed_tests=($(echo "${failed_tests[@]}" | tr ' ' '\n' | sort -u | tr '\n' ' '))
           for test in "${unique_failed_tests[@]}"; do
             # check if test is from fem or ElmerIce
             if [ -d fem/tests/${test} ]; then

--- a/.github/workflows/ubuntu-elmerice.yaml
+++ b/.github/workflows/ubuntu-elmerice.yaml
@@ -93,3 +93,40 @@ jobs:
           cd ${GITHUB_WORKSPACE}/build
           ctest -L elmerice -j$(nproc) --output-on-failure
 
+      - name: re-run tests
+        if: always() && (steps.run-ctest.outcome == 'failure')
+        timeout-minutes: 60
+        env:
+          CTEST_OUTPUT_ON_FAILURE: 1
+        run: |
+          cd ${GITHUB_WORKSPACE}/build
+          # get names of failed tests and strip potential "_np*" suffix
+          failed_tests=($(ctest . -N --rerun-failed | grep -E "Test\s+#.*" | awk '{print $3}' | sed -e 's/_np[0-9]*$//g'))
+          # remove duplicate test names
+          unique_failed_tests=($(echo "${failed_tests[@]}" | tr ' ' '\n' | sort -u | tr '\n' ' '))
+          for test in "${unique_failed_tests[@]}"; do
+            # check if test is from fem or ElmerIce
+            if [ -d fem/tests/${test} ]; then
+              test_root=fem/tests
+            else
+              test_root=elmerice/Tests
+            fi
+            echo "::group::Content of ${test_root}/${test}"
+            echo ---- Files ----
+            ls -Rl ${test_root}/${test}
+            if [ -f ${test_root}/${test}/test-stderr*.log ]; then
+              echo ---- Content of test-stderr*.log ----
+              cat ${test_root}/${test}/test-stderr*.log
+            fi
+            if [ -f ${test_root}/${test}/test-stdout*.log ]; then
+              echo ---- Content of test-stdout*.log ----
+              cat ${test_root}/${test}/test-stdout*.log
+            fi
+            echo "::endgroup::"
+          done
+          echo "::group::Re-run failing tests"
+          ctest --rerun-failed --output-on-failure || true
+          echo "::endgroup::"
+          echo "::group::Log from these tests"
+          [ ! -f Testing/Temporary/LastTest.log ] || cat Testing/Temporary/LastTest.log
+          echo "::endgroup::"

--- a/.github/workflows/ubuntu-gcc-full.yaml
+++ b/.github/workflows/ubuntu-gcc-full.yaml
@@ -87,7 +87,7 @@ jobs:
           CTEST_OUTPUT_ON_FAILURE: 1
         run: |
           cd ${GITHUB_WORKSPACE}/build
-          set -o pipefail && ctest . -j$(nproc) | tee ./ctest_output.log
+          ctest . -j$(nproc)
 
       - name: re-run tests
         if: always() && (steps.run-ctest.outcome == 'failure')
@@ -96,13 +96,10 @@ jobs:
           CTEST_OUTPUT_ON_FAILURE: 1
         run: |
           cd ${GITHUB_WORKSPACE}/build
-          # read names of failed tests from log and strip potential "_np*" suffix
-          failed_tests=($(sed -n 's/^.*#[0-9]*\:\s*\(\S*\).*Failed.*/\1/p' ./ctest_output.log | sed -e 's/_np[0-9]*$//g'))
+          # get names of failed tests and strip potential "_np*" suffix
+          failed_tests=($(ctest . -N --rerun-failed | grep -E "Test\s+#.*" | awk '{print $3}' | sed -e 's/_np[0-9]*$//g'))
           # remove duplicate test names
-          declare -A unique_failed_tests
-          for test in "${failed_tests[@]}"; do
-            unique_failed_tests["${test}"]="${test}";
-          done
+          unique_failed_tests=($(echo "${failed_tests[@]}" | tr ' ' '\n' | sort -u | tr '\n' ' '))
           for test in "${unique_failed_tests[@]}"; do
             # check if test is from fem or ElmerIce
             if [ -d fem/tests/${test} ]; then

--- a/.github/workflows/ubuntu-parallel.yaml
+++ b/.github/workflows/ubuntu-parallel.yaml
@@ -100,6 +100,30 @@ jobs:
           CTEST_OUTPUT_ON_FAILURE: 1
         run: |
           cd ${GITHUB_WORKSPACE}/build
+          # get names of failed tests and strip potential "_np*" suffix
+          failed_tests=($(ctest . -N --rerun-failed | grep -E "Test\s+#.*" | awk '{print $3}' | sed -e 's/_np[0-9]*$//g'))
+          # remove duplicate test names
+          unique_failed_tests=($(echo "${failed_tests[@]}" | tr ' ' '\n' | sort -u | tr '\n' ' '))
+          for test in "${unique_failed_tests[@]}"; do
+            # check if test is from fem or ElmerIce
+            if [ -d fem/tests/${test} ]; then
+              test_root=fem/tests
+            else
+              test_root=elmerice/Tests
+            fi
+            echo "::group::Content of ${test_root}/${test}"
+            echo ---- Files ----
+            ls -Rl ${test_root}/${test}
+            if [ -f ${test_root}/${test}/test-stderr*.log ]; then
+              echo ---- Content of test-stderr*.log ----
+              cat ${test_root}/${test}/test-stderr*.log
+            fi
+            if [ -f ${test_root}/${test}/test-stdout*.log ]; then
+              echo ---- Content of test-stdout*.log ----
+              cat ${test_root}/${test}/test-stdout*.log
+            fi
+            echo "::endgroup::"
+          done
           echo "::group::Re-run failing tests"
           ctest --rerun-failed --output-on-failure || true
           echo "::endgroup::"


### PR DESCRIPTION
Use the same approach (that doesn't rely on bash-isms or reading files) for gathering that information in all actions, also for the actions that already had similar logic.

Additionally, reduce the timeout for a single test from 1500 seconds (25 minutes is the default for ctest) to 180 seconds (3 minutes) for the actions that only run tests with the "quick" label.
None of the tests with the "quick" label should be taking longer than that. And it isn't worth blocking the CI runners for any longer if it is likely the case that the test would be stuck indefinitely if they are taking that long.