### PR TITLE
Avoid running tests using the same directory concurrently.

### DIFF
--- a/cmake/Modules/test_macros.cmake
+++ b/cmake/Modules/test_macros.cmake
@@ -72,6 +72,15 @@ MACRO(ADD_ELMER_TEST TestName)
           SET_PROPERTY(TEST ${_this_test_name} APPEND PROPERTY LABELS ${lbl})
         ENDFOREACH()
       ENDIF()
+      IF(${n} GREATER 0)
+        # Avoid running tests using the same directory concurrently.
+        # To achieve that, set test dependencies such that they are run in
+        # the order as they appear in the NPROCS argument.
+        MATH(EXPR n_prev "${n} - 1")
+        LIST(GET tests_list ${n_prev} _prev_test_name)
+        SET_TESTS_PROPERTIES(${_this_test_name} PROPERTIES
+          DEPENDS ${_prev_test_name})
+      ENDIF()
     ENDIF(_this_test_name)
   ENDFOREACH()
 ENDMACRO(ADD_ELMER_TEST)


### PR DESCRIPTION
Some tests are failing intermittently in CI. They are passing when they are re-run.
It looks like this is happening for tests which have a list of NPROCS with more than one element. In that case, it might happen that multiple instances of ElmerGrid are started in the same directory (if `ctest` is running with parallel jobs). This might lead to the (intermittent) issue that an ElmerFEM process is trying to read a grid folder that is currently being written to by an ElmerGrid process from a test running in parallel.

Avoid that potential concurrency issue by adding test dependencies between the tests that are running in the same directory so that not more than one test can run in the same directory at a time.