### PR TITLE
Overhaul CMake build rules for AMD and UMFPACK.

### DIFF
--- a/umfpack/src/amd/CMakeLists.txt
+++ b/umfpack/src/amd/CMakeLists.txt
@@ -1,73 +1,30 @@
-INCLUDE_DIRECTORIES(include)
-SET(UMFPACK_AMD_ORIG_SOURCES
-	amd_aat.c
-	amd_1.c
-	amd_2.c
-	amd_dump.c
-	amd_postorder.c
-	amd_post_tree.c
-	amd_defaults.c
-	amd_order.c
-	amd_control.c
-	amd_info.c
-	amd_valid.c
-	amd_preprocess.c
-)
-SET(UMFPACK_AMD_CPP_SOURCES
-	amd_i_aat.c
-	amd_i_1.c
-	amd_i_2.c
-	amd_i_dump.c
-	amd_i_postorder.c
-	amd_i_post_tree.c
-	amd_i_defaults.c
-	amd_i_order.c
-	amd_i_control.c
-	amd_i_info.c
-	amd_i_valid.c
-	amd_i_preprocess.c
-	amd_l_aat.c
-	amd_l_1.c
-	amd_l_2.c
-	amd_l_dump.c
-	amd_l_postorder.c
-	amd_l_post_tree.c
-	amd_l_defaults.c
-	amd_l_order.c
-	amd_l_control.c
-	amd_l_info.c
-	amd_l_valid.c
-	amd_l_preprocess.c
+set(UMFPACK_AMD_SOURCES
+  amd_aat.c
+  amd_1.c
+  amd_2.c
+  amd_dump.c
+  amd_postorder.c
+  amd_post_tree.c
+  amd_defaults.c
+  amd_order.c
+  amd_control.c
+  amd_info.c
+  amd_valid.c
+  amd_preprocess.c
 )
 
-SET(UMFMODIFIER_i_FLAGS -DDINT)
-SET(UMFMODIFIER_l_FLAGS -DDLONG)
+add_library(amd_i OBJECT ${UMFPACK_AMD_SOURCES})
+target_include_directories(amd_i PRIVATE include)
+target_compile_definitions(amd_i PRIVATE NBLAS DINT)
 
-SET(UMFPACK_AMD_INCLUDES -I${CMAKE_CURRENT_SOURCE_DIR}/include -I${PROJECT_BINARY_DIR})
-FOREACH(outfileName ${UMFPACK_AMD_CPP_SOURCES})
-  STRING(REGEX REPLACE "^amd_([a-z]*)_.*" "\\1" umfModifier "${outfileName}")
-  STRING(REGEX REPLACE "^amd_${umfModifier}_([a-zA-Z0-9_]*)\\.c" "\\1" stem "${outfileName}")
-  SET(infileName "amd_${stem}.c")
+add_library(amd_l OBJECT ${UMFPACK_AMD_SOURCES})
+target_include_directories(amd_l PRIVATE include)
+target_compile_definitions(amd_l PRIVATE NBLAS DLONG)
 
-  SET(flags ${UMFMODIFIER_${umfModifier}_FLAGS} -DNBLAS -E)
+add_library(amd STATIC $<TARGET_OBJECTS:amd_i> $<TARGET_OBJECTS:amd_l>)
+add_library(amdf77 STATIC amd.f amdbar.f)
 
-  ADD_CUSTOM_COMMAND(
-    OUTPUT ${outfileName}
-    COMMAND ${CMAKE_C_COMPILER}
-    ARGS ${UMFPACK_AMD_INCLUDES} ${flags} ${CMAKE_CURRENT_SOURCE_DIR}/${infileName} > ${outfileName}
-    DEPENDS ${infileName}
-  )
-
-ENDFOREACH(outfileName)
-ADD_CUSTOM_TARGET(umfpack_amd_srcs DEPENDS ${UMFPACK_AMD_ORIG_SOURCES})
-
-ADD_LIBRARY(amd STATIC amd_internal.h ${UMFPACK_AMD_CPP_SOURCES})
-ADD_LIBRARY(amdf77 STATIC amd.f amdbar.f)
-
-INSTALL(TARGETS amd amdf77 DESTINATION ${ELMER_INSTALL_LIB_DIR})
-
-IF(WIN32)
-  INSTALL(TARGETS amd amdf77 ARCHIVE DESTINATION ${ELMER_INSTALL_LIB_DIR}
-    RUNTIME DESTINATION ${ELMER_INSTALL_LIB_DIR})
-ENDIF()
-
+install(TARGETS amd amdf77
+  ARCHIVE DESTINATION ${ELMER_INSTALL_LIB_DIR}
+  RUNTIME DESTINATION ${ELMER_INSTALL_BIN_DIR}
+  LIBRARY DESTINATION ${ELMER_INSTALL_LIB_DIR})

--- a/umfpack/src/umfpack/CMakeLists.txt
+++ b/umfpack/src/umfpack/CMakeLists.txt
@@ -1,472 +1,166 @@
-INCLUDE_DIRECTORIES(include ../amd ../amd/include ${CMAKE_CURRENT_BINARY_DIR})
+set(UMFPACK_INCLUDE_DIRS include ../amd ../amd/include ${CMAKE_CURRENT_BINARY_DIR})
 
-SET(UMFPACK_ORIG_SOURCES
-	umf_usolve.c
-	umf_triplet.c
-	umfpack_get_determinant.c
-	umfpack_get_lunz.c
-	umfpack_get_symbolic.c
-	umfpack_report_numeric.c
-	umfpack_qsymbolic.c
-	umf_assemble.c
-	umf_local_search.c
-	umfpack_report_matrix.c
-	umfpack_defaults.c
-	umf_scale.c
-	umf_kernel_init.c
-	umfpack_solve.c
-	umf_start_front.c
-	umfpack_save_numeric.c
-	umfpack_numeric.c
-	umf_2by2.c
-	umfpack_col_to_triplet.c
-	umf_free.c
-	umf_lsolve.c
-	umfpack_save_symbolic.c
-	umf_grow_front.c
-	umfpack_free_numeric.c
-	umf_solve.c
-	umf_ltsolve.c
-	umf_kernel.c
-	umfpack_symbolic.c
-	umf_row_search.c
-	umf_mem_alloc_tail_block.c
-	umf_garbage_collection.c
-	umf_colamd.c
-	umf_fsize.c
-	umf_is_permutation.c
-	umf_get_memory.c
-	umf_mem_alloc_element.c
-	umf_mem_free_tail_block.c
-	umfpack_report_status.c
-	umfpack_report_control.c
-	umf_utsolve.c
-	umf_symbolic_usage.c
-	umf_valid_symbolic.c
-	umfpack_report_perm.c
-	umfpack_report_triplet.c
-	umfpack_report_symbolic.c
-	umfpack_report_vector.c
-	umf_dump.c
-	umf_blas3_update.c
-	umfpack_triplet_to_col.c
-	umfpack_get_numeric.c
-	umf_transpose.c
-	umf_kernel_wrapup.c
-	umfpack_free_symbolic.c
-	umf_tuple_lengths.c
-	umf_report_perm.c
-	umf_realloc.c
-	umf_mem_alloc_head_block.c
-	umfpack_load_numeric.c
-	umf_scale_column.c
-	umf_create_element.c
-	umf_apply_order.c
-	umfpack_scale.c
-	umf_set_stats.c
-	umf_extend_front.c
-	umf_mem_init_memoryspace.c
-	umf_valid_numeric.c
-	umf_init_front.c
-	umfpack_transpose.c
-	umfpack_report_info.c
-	umf_analyze.c
-	umfpack_load_symbolic.c
-	umf_malloc.c
-	umf_store_lu.c
-	umf_singletons.c
-	umf_report_vector.c
-	umf_build_tuples.c
+# source files which only depend on size of indices
+set(UMFPACK_INT_SOURCES
+  umf_analyze.c
+  umf_apply_order.c
+  umf_colamd.c
+  umf_free.c
+  umf_fsize.c
+  umf_is_permutation.c
+  umf_malloc.c
+  umf_realloc.c
+  umf_report_perm.c
+  umf_singletons.c
+)
+# source files which depend on size of indices and complex floating point
+set(UMFPACK_INT_FLOAT_SOURCES
+  umf_2by2.c
+  umf_assemble.c
+  umf_blas3_update.c
+  umf_build_tuples.c
+  umf_create_element.c
+  umf_dump.c
+  umf_extend_front.c
+  umf_garbage_collection.c
+  umf_get_memory.c
+  umf_grow_front.c
+  umf_init_front.c
+  umf_kernel.c
+  umf_kernel_init.c
+  umf_kernel_wrapup.c
+  umf_local_search.c
+  umf_lsolve.c
+  umf_ltsolve.c
+  umf_mem_alloc_element.c
+  umf_mem_alloc_head_block.c
+  umf_mem_alloc_tail_block.c
+  umf_mem_free_tail_block.c
+  umf_mem_init_memoryspace.c
+  umf_report_vector.c
+  umf_row_search.c
+  umf_scale.c
+  umf_scale_column.c
+  umf_set_stats.c
+  umf_solve.c
+  umf_start_front.c
+  umf_store_lu.c
+  umf_symbolic_usage.c
+  umf_transpose.c
+  umf_triplet.c
+  umf_tuple_lengths.c
+  umf_usolve.c
+  umf_utsolve.c
+  umf_valid_numeric.c
+  umf_valid_symbolic.c
+  umfpack_col_to_triplet.c
+  umfpack_defaults.c
+  umfpack_free_numeric.c
+  umfpack_free_symbolic.c
+  umfpack_get_determinant.c
+  umfpack_get_lunz.c
+  umfpack_get_numeric.c
+  umfpack_get_symbolic.c
+  umfpack_load_numeric.c
+  umfpack_load_symbolic.c
+  umfpack_numeric.c
+  umfpack_qsymbolic.c
+  umfpack_report_control.c
+  umfpack_report_info.c
+  umfpack_report_matrix.c
+  umfpack_report_numeric.c
+  umfpack_report_perm.c
+  umfpack_report_status.c
+  umfpack_report_symbolic.c
+  umfpack_report_triplet.c
+  umfpack_report_vector.c
+  umfpack_save_numeric.c
+  umfpack_save_symbolic.c
+  umfpack_scale.c
+  umfpack_solve.c
+  umfpack_symbolic.c
+  umfpack_transpose.c
+  umfpack_triplet_to_col.c
 )
 
-SET(UMFPACK_CPP_SOURCES
-	umf_i_analyze.c
-	umf_i_apply_order.c
-	umf_i_colamd.c
-	umf_i_free.c
-	umf_i_fsize.c
-	umf_i_is_permutation.c
-	umf_i_malloc.c
-	umf_i_realloc.c
-	umf_i_report_perm.c
-	umf_i_singletons.c
-	umf_l_analyze.c
-	umf_l_apply_order.c
-	umf_l_colamd.c
-	umf_l_free.c
-	umf_l_fsize.c
-	umf_l_is_permutation.c
-	umf_l_malloc.c
-	umf_l_realloc.c
-	umf_l_report_perm.c
-	umf_l_singletons.c
-	umf_di_lhsolve.c
-	umf_di_uhsolve.c
-	umf_di_triplet_map_nox.c
-	umf_di_triplet_nomap_x.c
-	umf_di_triplet_nomap_nox.c
-	umf_di_triplet_map_x.c
-	umf_di_assemble_fixq.c
-	umf_di_store_lu_drop.c
-	umf_di_assemble.c
-	umf_di_blas3_update.c
-	umf_di_build_tuples.c
-	umf_di_create_element.c
-	umf_di_dump.c
-	umf_di_extend_front.c
-	umf_di_garbage_collection.c
-	umf_di_get_memory.c
-	umf_di_init_front.c
-	umf_di_kernel.c
-	umf_di_kernel_init.c
-	umf_di_kernel_wrapup.c
-	umf_di_local_search.c
-	umf_di_lsolve.c
-	umf_di_ltsolve.c
-	umf_di_mem_alloc_element.c
-	umf_di_mem_alloc_head_block.c
-	umf_di_mem_alloc_tail_block.c
-	umf_di_mem_free_tail_block.c
-	umf_di_mem_init_memoryspace.c
-	umf_di_report_vector.c
-	umf_di_row_search.c
-	umf_di_scale_column.c
-	umf_di_set_stats.c
-	umf_di_solve.c
-	umf_di_symbolic_usage.c
-	umf_di_transpose.c
-	umf_di_tuple_lengths.c
-	umf_di_usolve.c
-	umf_di_utsolve.c
-	umf_di_valid_numeric.c
-	umf_di_valid_symbolic.c
-	umf_di_grow_front.c
-	umf_di_start_front.c
-	umf_di_2by2.c
-	umf_di_store_lu.c
-	umf_di_scale.c
-	umfpack_di_wsolve.c
-	umfpack_di_col_to_triplet.c
-	umfpack_di_defaults.c
-	umfpack_di_free_numeric.c
-	umfpack_di_free_symbolic.c
-	umfpack_di_get_numeric.c
-	umfpack_di_get_lunz.c
-	umfpack_di_get_symbolic.c
-	umfpack_di_get_determinant.c
-	umfpack_di_numeric.c
-	umfpack_di_qsymbolic.c
-	umfpack_di_report_control.c
-	umfpack_di_report_info.c
-	umfpack_di_report_matrix.c
-	umfpack_di_report_numeric.c
-	umfpack_di_report_perm.c
-	umfpack_di_report_status.c
-	umfpack_di_report_symbolic.c
-	umfpack_di_report_triplet.c
-	umfpack_di_report_vector.c
-	umfpack_di_solve.c
-	umfpack_di_symbolic.c
-	umfpack_di_transpose.c
-	umfpack_di_triplet_to_col.c
-	umfpack_di_scale.c
-	umfpack_di_load_numeric.c
-	umfpack_di_save_numeric.c
-	umfpack_di_load_symbolic.c
-	umfpack_di_save_symbolic.c
-	umf_dl_lhsolve.c
-	umf_dl_uhsolve.c
-	umf_dl_triplet_map_nox.c
-	umf_dl_triplet_nomap_x.c
-	umf_dl_triplet_nomap_nox.c
-	umf_dl_triplet_map_x.c
-	umf_dl_assemble_fixq.c
-	umf_dl_store_lu_drop.c
-	umf_dl_assemble.c
-	umf_dl_blas3_update.c
-	umf_dl_build_tuples.c
-	umf_dl_create_element.c
-	umf_dl_dump.c
-	umf_dl_extend_front.c
-	umf_dl_garbage_collection.c
-	umf_dl_get_memory.c
-	umf_dl_init_front.c
-	umf_dl_kernel.c
-	umf_dl_kernel_init.c
-	umf_dl_kernel_wrapup.c
-	umf_dl_local_search.c
-	umf_dl_lsolve.c
-	umf_dl_ltsolve.c
-	umf_dl_mem_alloc_element.c
-	umf_dl_mem_alloc_head_block.c
-	umf_dl_mem_alloc_tail_block.c
-	umf_dl_mem_free_tail_block.c
-	umf_dl_mem_init_memoryspace.c
-	umf_dl_report_vector.c
-	umf_dl_row_search.c
-	umf_dl_scale_column.c
-	umf_dl_set_stats.c
-	umf_dl_solve.c
-	umf_dl_symbolic_usage.c
-	umf_dl_transpose.c
-	umf_dl_tuple_lengths.c
-	umf_dl_usolve.c
-	umf_dl_utsolve.c
-	umf_dl_valid_numeric.c
-	umf_dl_valid_symbolic.c
-	umf_dl_grow_front.c
-	umf_dl_start_front.c
-	umf_dl_2by2.c
-	umf_dl_store_lu.c
-	umf_dl_scale.c
-	umfpack_dl_wsolve.c
-	umfpack_dl_col_to_triplet.c
-	umfpack_dl_defaults.c
-	umfpack_dl_free_numeric.c
-	umfpack_dl_free_symbolic.c
-	umfpack_dl_get_numeric.c
-	umfpack_dl_get_lunz.c
-	umfpack_dl_get_symbolic.c
-	umfpack_dl_get_determinant.c
-	umfpack_dl_numeric.c
-	umfpack_dl_qsymbolic.c
-	umfpack_dl_report_control.c
-	umfpack_dl_report_info.c
-	umfpack_dl_report_matrix.c
-	umfpack_dl_report_numeric.c
-	umfpack_dl_report_perm.c
-	umfpack_dl_report_status.c
-	umfpack_dl_report_symbolic.c
-	umfpack_dl_report_triplet.c
-	umfpack_dl_report_vector.c
-	umfpack_dl_solve.c
-	umfpack_dl_symbolic.c
-	umfpack_dl_transpose.c
-	umfpack_dl_triplet_to_col.c
-	umfpack_dl_scale.c
-	umfpack_dl_load_numeric.c
-	umfpack_dl_save_numeric.c
-	umfpack_dl_load_symbolic.c
-	umfpack_dl_save_symbolic.c
-	umf_zi_lhsolve.c
-	umf_zi_uhsolve.c
-	umf_zi_triplet_map_nox.c
-	umf_zi_triplet_nomap_x.c
-	umf_zi_triplet_nomap_nox.c
-	umf_zi_triplet_map_x.c
-	umf_zi_assemble_fixq.c
-	umf_zi_store_lu_drop.c
-	umf_zi_assemble.c
-	umf_zi_blas3_update.c
-	umf_zi_build_tuples.c
-	umf_zi_create_element.c
-	umf_zi_dump.c
-	umf_zi_extend_front.c
-	umf_zi_garbage_collection.c
-	umf_zi_get_memory.c
-	umf_zi_init_front.c
-	umf_zi_kernel.c
-	umf_zi_kernel_init.c
-	umf_zi_kernel_wrapup.c
-	umf_zi_local_search.c
-	umf_zi_lsolve.c
-	umf_zi_ltsolve.c
-	umf_zi_mem_alloc_element.c
-	umf_zi_mem_alloc_head_block.c
-	umf_zi_mem_alloc_tail_block.c
-	umf_zi_mem_free_tail_block.c
-	umf_zi_mem_init_memoryspace.c
-	umf_zi_report_vector.c
-	umf_zi_row_search.c
-	umf_zi_scale_column.c
-	umf_zi_set_stats.c
-	umf_zi_solve.c
-	umf_zi_symbolic_usage.c
-	umf_zi_transpose.c
-	umf_zi_tuple_lengths.c
-	umf_zi_usolve.c
-	umf_zi_utsolve.c
-	umf_zi_valid_numeric.c
-	umf_zi_valid_symbolic.c
-	umf_zi_grow_front.c
-	umf_zi_start_front.c
-	umf_zi_2by2.c
-	umf_zi_store_lu.c
-	umf_zi_scale.c
-	umfpack_zi_wsolve.c
-	umfpack_zi_col_to_triplet.c
-	umfpack_zi_defaults.c
-	umfpack_zi_free_numeric.c
-	umfpack_zi_free_symbolic.c
-	umfpack_zi_get_numeric.c
-	umfpack_zi_get_lunz.c
-	umfpack_zi_get_symbolic.c
-	umfpack_zi_get_determinant.c
-	umfpack_zi_numeric.c
-	umfpack_zi_qsymbolic.c
-	umfpack_zi_report_control.c
-	umfpack_zi_report_info.c
-	umfpack_zi_report_matrix.c
-	umfpack_zi_report_numeric.c
-	umfpack_zi_report_perm.c
-	umfpack_zi_report_status.c
-	umfpack_zi_report_symbolic.c
-	umfpack_zi_report_triplet.c
-	umfpack_zi_report_vector.c
-	umfpack_zi_solve.c
-	umfpack_zi_symbolic.c
-	umfpack_zi_transpose.c
-	umfpack_zi_triplet_to_col.c
-	umfpack_zi_scale.c
-	umfpack_zi_load_numeric.c
-	umfpack_zi_save_numeric.c
-	umfpack_zi_load_symbolic.c
-	umfpack_zi_save_symbolic.c
-	umf_zl_lhsolve.c
-	umf_zl_uhsolve.c
-	umf_zl_triplet_map_nox.c
-	umf_zl_triplet_nomap_x.c
-	umf_zl_triplet_nomap_nox.c
-	umf_zl_triplet_map_x.c
-	umf_zl_assemble_fixq.c
-	umf_zl_store_lu_drop.c
-	umf_zl_assemble.c
-	umf_zl_blas3_update.c
-	umf_zl_build_tuples.c
-	umf_zl_create_element.c
-	umf_zl_dump.c
-	umf_zl_extend_front.c
-	umf_zl_garbage_collection.c
-	umf_zl_get_memory.c
-	umf_zl_init_front.c
-	umf_zl_kernel.c
-	umf_zl_kernel_init.c
-	umf_zl_kernel_wrapup.c
-	umf_zl_local_search.c
-	umf_zl_lsolve.c
-	umf_zl_ltsolve.c
-	umf_zl_mem_alloc_element.c
-	umf_zl_mem_alloc_head_block.c
-	umf_zl_mem_alloc_tail_block.c
-	umf_zl_mem_free_tail_block.c
-	umf_zl_mem_init_memoryspace.c
-	umf_zl_report_vector.c
-	umf_zl_row_search.c
-	umf_zl_scale_column.c
-	umf_zl_set_stats.c
-	umf_zl_solve.c
-	umf_zl_symbolic_usage.c
-	umf_zl_transpose.c
-	umf_zl_tuple_lengths.c
-	umf_zl_usolve.c
-	umf_zl_utsolve.c
-	umf_zl_valid_numeric.c
-	umf_zl_valid_symbolic.c
-	umf_zl_grow_front.c
-	umf_zl_start_front.c
-	umf_zl_2by2.c
-	umf_zl_store_lu.c
-	umf_zl_scale.c
-	umfpack_zl_wsolve.c
-	umfpack_zl_col_to_triplet.c
-	umfpack_zl_defaults.c
-	umfpack_zl_free_numeric.c
-	umfpack_zl_free_symbolic.c
-	umfpack_zl_get_numeric.c
-	umfpack_zl_get_lunz.c
-	umfpack_zl_get_symbolic.c
-	umfpack_zl_get_determinant.c
-	umfpack_zl_numeric.c
-	umfpack_zl_qsymbolic.c
-	umfpack_zl_report_control.c
-	umfpack_zl_report_info.c
-	umfpack_zl_report_matrix.c
-	umfpack_zl_report_numeric.c
-	umfpack_zl_report_perm.c
-	umfpack_zl_report_status.c
-	umfpack_zl_report_symbolic.c
-	umfpack_zl_report_triplet.c
-	umfpack_zl_report_vector.c
-	umfpack_zl_solve.c
-	umfpack_zl_symbolic.c
-	umfpack_zl_transpose.c
-	umfpack_zl_triplet_to_col.c
-	umfpack_zl_scale.c
-	umfpack_zl_load_numeric.c
-	umfpack_zl_save_numeric.c
-	umfpack_zl_load_symbolic.c
-	umfpack_zl_save_symbolic.c
-)
+function(add_object_library target_name)
+  # Add an object library with specific preprocessor flags
+  cmake_parse_arguments(OBJ "" "" "SOURCES;FLAGS" ${ARGN})
+  add_library(${target_name} OBJECT ${OBJ_SOURCES})
+  target_include_directories(${target_name} PRIVATE ${UMFPACK_INCLUDE_DIRS})
+  target_compile_definitions(${target_name} PRIVATE NBLAS ${OBJ_FLAGS})
+endfunction()
 
-SET(UMFMODIFIER_i_FLAGS -DDINT)
-SET(UMFMODIFIER_l_FLAGS -DDLONG)
-SET(UMFMODIFIER_di_FLAGS -DDINT)
-SET(UMFMODIFIER_dl_FLAGS -DDLONG)
-SET(UMFMODIFIER_zi_FLAGS -DZINT)
-SET(UMFMODIFIER_zl_FLAGS -DZLONG)
+# add object libraries with the required preprocessor flags
+add_object_library(umfpack_i SOURCES ${UMFPACK_INT_SOURCES} FLAGS DINT)
+add_object_library(umfpack_l SOURCES ${UMFPACK_INT_SOURCES} FLAGS DLONG)
+add_object_library(umfpack_di SOURCES ${UMFPACK_INT_FLOAT_SOURCES} FLAGS DINT)
+add_object_library(umfpack_dl SOURCES ${UMFPACK_INT_FLOAT_SOURCES} FLAGS DLONG)
+add_object_library(umfpack_zi SOURCES ${UMFPACK_INT_FLOAT_SOURCES} FLAGS ZINT)
+add_object_library(umfpack_zl SOURCES ${UMFPACK_INT_FLOAT_SOURCES} FLAGS ZLONG)
 
-SET(UMFPACK_ODDITY_lhsolve ltsolve)
-SET(UMFPACK_ODDITY_lhsolve_FLAGS -DCONJUGATE_SOLVE)
-SET(UMFPACK_ODDITY_uhsolve utsolve)
-SET(UMFPACK_ODDITY_uhsolve_FLAGS -DCONJUGATE_SOLVE)
-SET(UMFPACK_ODDITY_triplet_map_nox triplet)
-SET(UMFPACK_ODDITY_triplet_map_nox_FLAGS -DMAP)
-SET(UMFPACK_ODDITY_triplet_nomap_x triplet)
-SET(UMFPACK_ODDITY_triplet_nomap_x_FLAGS -DDO_VALUES)
-SET(UMFPACK_ODDITY_triplet_nomap_nox triplet)
-SET(UMFPACK_ODDITY_triplet_nomap_nox_FLAGS)
-SET(UMFPACK_ODDITY_triplet_map_x triplet)
-SET(UMFPACK_ODDITY_triplet_map_x_FLAGS -DMAP -DDO_VALUES)
-SET(UMFPACK_ODDITY_assemble_fixq assemble)
-SET(UMFPACK_ODDITY_assemble_fixq_FLAGS -DFIXQ)
-SET(UMFPACK_ODDITY_store_lu_drop store_lu)
-SET(UMFPACK_ODDITY_store_lu_drop_FLAGS -DDROP)
-SET(UMFPACK_ODDITY_wsolve solve)
-SET(UMFPACK_ODDITY_wsolve_FLAGS -DWSOLVE)
+# add targets for objects that require a special set of flags
+add_object_library(hsolve_di SOURCES umf_ltsolve.c umf_utsolve.c FLAGS DINT CONJUGATE_SOLVE)
+add_object_library(hsolve_dl SOURCES umf_ltsolve.c umf_utsolve.c FLAGS DLONG CONJUGATE_SOLVE)
+add_object_library(hsolve_zi SOURCES umf_ltsolve.c umf_utsolve.c FLAGS ZINT CONJUGATE_SOLVE)
+add_object_library(hsolve_zl SOURCES umf_ltsolve.c umf_utsolve.c FLAGS ZLONG CONJUGATE_SOLVE)
 
-SET(UMFPACK_INCLUDES -I${CMAKE_CURRENT_SOURCE_DIR}/include 
-  -I${CMAKE_CURRENT_SOURCE_DIR}/../amd 
-  -I${CMAKE_CURRENT_SOURCE_DIR}/../amd/include 
-  -I${PROJECT_BINARY_DIR} 
-  -I${CMAKE_CURRENT_BINARY_DIR})
+add_object_library(triplet_map_nox_di SOURCES umf_triplet.c FLAGS DINT MAP)
+add_object_library(triplet_map_nox_dl SOURCES umf_triplet.c FLAGS DLONG MAP)
+add_object_library(triplet_map_nox_zi SOURCES umf_triplet.c FLAGS ZINT MAP)
+add_object_library(triplet_map_nox_zl SOURCES umf_triplet.c FLAGS ZLONG MAP)
 
-FOREACH(outfileName ${UMFPACK_CPP_SOURCES})
-  STRING(REGEX REPLACE "^(umf|umfpack)_([a-z]*)_.*" "\\1" prefix "${outfileName}")
-  STRING(REGEX REPLACE "^(umf|umfpack)_([a-z]*)_.*" "\\2" umfModifier "${outfileName}")
-  STRING(REGEX REPLACE "^(umf|umfpack)_${umfModifier}_([a-zA-Z0-9_]*)\\.c" "\\2" stem "${outfileName}")
-  SET(infileName "${prefix}_${stem}.c")
+add_object_library(triplet_nomap_x_di SOURCES umf_triplet.c FLAGS DINT DO_VALUES)
+add_object_library(triplet_nomap_x_dl SOURCES umf_triplet.c FLAGS DLONG DO_VALUES)
+add_object_library(triplet_nomap_x_zi SOURCES umf_triplet.c FLAGS ZINT DO_VALUES)
+add_object_library(triplet_nomap_x_zl SOURCES umf_triplet.c FLAGS ZLONG DO_VALUES)
 
-  SET(flags ${UMFMODIFIER_${umfModifier}_FLAGS} -DNBLAS -E)
-  IF(DEFINED UMFPACK_ODDITY_${stem}_FLAGS)
-    SET(flags ${flags} ${UMFPACK_ODDITY_${stem}_FLAGS})
-#    MESSAGE(${flags})
-  ENDIF(DEFINED UMFPACK_ODDITY_${stem}_FLAGS)
+add_object_library(triplet_map_x_di SOURCES umf_triplet.c FLAGS DINT MAP DO_VALUES)
+add_object_library(triplet_map_x_dl SOURCES umf_triplet.c FLAGS DLONG MAP DO_VALUES)
+add_object_library(triplet_map_x_zi SOURCES umf_triplet.c FLAGS ZINT MAP DO_VALUES)
+add_object_library(triplet_map_x_zl SOURCES umf_triplet.c FLAGS ZLONG MAP DO_VALUES)
 
-  IF(DEFINED UMFPACK_ODDITY_${stem})
-    SET(stem ${UMFPACK_ODDITY_${stem}})
-    SET(infileName "${prefix}_${stem}.c")
-  ENDIF(DEFINED UMFPACK_ODDITY_${stem})
+add_object_library(assemble_fixq_di SOURCES umf_assemble.c FLAGS DINT FIXQ)
+add_object_library(assemble_fixq_dl SOURCES umf_assemble.c FLAGS DLONG FIXQ)
+add_object_library(assemble_fixq_zi SOURCES umf_assemble.c FLAGS ZINT FIXQ)
+add_object_library(assemble_fixq_zl SOURCES umf_assemble.c FLAGS ZLONG FIXQ)
 
-  ADD_CUSTOM_COMMAND(
-    OUTPUT ${outfileName}
-    COMMAND ${CMAKE_C_COMPILER}
-    ARGS ${UMFPACK_INCLUDES} ${flags} ${CMAKE_CURRENT_SOURCE_DIR}/${infileName} > ${outfileName}
-    DEPENDS ${infileName}
-  )
+add_object_library(store_lu_drop_di SOURCES umf_store_lu.c FLAGS DINT DROP)
+add_object_library(store_lu_drop_dl SOURCES umf_store_lu.c FLAGS DLONG DROP)
+add_object_library(store_lu_drop_zi SOURCES umf_store_lu.c FLAGS ZINT DROP)
+add_object_library(store_lu_drop_zl SOURCES umf_store_lu.c FLAGS ZLONG DROP)
 
-ENDFOREACH(outfileName)
-ADD_CUSTOM_TARGET(umfpack_srcs DEPENDS ${UMFPACK_ORIG_SOURCES})
+add_object_library(wsolve_di SOURCES umfpack_solve.c FLAGS DINT WSOLVE)
+add_object_library(wsolve_dl SOURCES umfpack_solve.c FLAGS DLONG WSOLVE)
+add_object_library(wsolve_zi SOURCES umfpack_solve.c FLAGS ZINT WSOLVE)
+add_object_library(wsolve_zl SOURCES umfpack_solve.c FLAGS ZLONG WSOLVE)
 
-ADD_LIBRARY(umfpack STATIC umfpack_timer.c umfpack_tictoc.c ${UMFPACK_CPP_SOURCES})
-ADD_DEPENDENCIES(umfpack umfpack_srcs)
 
-IF(NOT(WIN32))
-INSTALL(TARGETS umfpack
-        DESTINATION ${ELMER_INSTALL_LIB_DIR})
-ENDIF()
+add_library(umfpack STATIC
+  umfpack_timer.c umfpack_tictoc.c
+  $<TARGET_OBJECTS:umfpack_i> $<TARGET_OBJECTS:umfpack_l>
+  $<TARGET_OBJECTS:umfpack_di> $<TARGET_OBJECTS:umfpack_dl>
+  $<TARGET_OBJECTS:umfpack_zi> $<TARGET_OBJECTS:umfpack_zl>
+  $<TARGET_OBJECTS:hsolve_di> $<TARGET_OBJECTS:hsolve_dl>
+  $<TARGET_OBJECTS:hsolve_zi> $<TARGET_OBJECTS:hsolve_zi>
+  $<TARGET_OBJECTS:triplet_map_nox_di> $<TARGET_OBJECTS:triplet_map_nox_dl>
+  $<TARGET_OBJECTS:triplet_map_nox_zi> $<TARGET_OBJECTS:triplet_map_nox_zl>
+  $<TARGET_OBJECTS:triplet_nomap_x_di> $<TARGET_OBJECTS:triplet_nomap_x_dl>
+  $<TARGET_OBJECTS:triplet_nomap_x_zi> $<TARGET_OBJECTS:triplet_nomap_x_zl>
+  $<TARGET_OBJECTS:triplet_map_x_di> $<TARGET_OBJECTS:triplet_map_x_dl>
+  $<TARGET_OBJECTS:triplet_map_x_zi> $<TARGET_OBJECTS:triplet_map_x_zl>
+  $<TARGET_OBJECTS:assemble_fixq_di> $<TARGET_OBJECTS:assemble_fixq_dl>
+  $<TARGET_OBJECTS:assemble_fixq_zi> $<TARGET_OBJECTS:assemble_fixq_zl>
+  $<TARGET_OBJECTS:store_lu_drop_di> $<TARGET_OBJECTS:store_lu_drop_dl>
+  $<TARGET_OBJECTS:store_lu_drop_zi> $<TARGET_OBJECTS:store_lu_drop_zl>
+  $<TARGET_OBJECTS:wsolve_di> $<TARGET_OBJECTS:wsolve_dl>
+  $<TARGET_OBJECTS:wsolve_zi> $<TARGET_OBJECTS:wsolve_zl>)
 
-IF(WIN32)
-  INSTALL(TARGETS umfpack ARCHIVE DESTINATION ${ELMER_INSTALL_LIB_DIR} 
-    RUNTIME DESTINATION ${ELMER_INSTALL_LIB_DIR}
-    LIBRARY DESTINATION ${ELMER_INSTALL_LIB_DIR})
-ENDIF()
+target_include_directories(umfpack PRIVATE ${UMFPACK_INCLUDE_DIRS})
+target_compile_definitions(umfpack PRIVATE NBLAS)
+
+
+install(TARGETS umfpack
+  ARCHIVE DESTINATION ${ELMER_INSTALL_LIB_DIR}
+  RUNTIME DESTINATION ${ELMER_INSTALL_BIN_DIR}
+  LIBRARY DESTINATION ${ELMER_INSTALL_LIB_DIR})


### PR DESCRIPTION
Avoid manually preprocessing the source files. Some compiler flags can easily be missed which can lead to compilation issues with the preprocessed sources.

Instead, use object libraries to build the same source files with different flags.

Potentially fixes the build issues described in #578.