### PR TITLE
MeshUtils.F90: set the value of MaxIndex based on the maximum value in the MeshPiece…

### DIFF
--- a/fem/src/MeshUtils.F90
+++ b/fem/src/MeshUtils.F90
@@ -25552,6 +25552,7 @@ CONTAINS
     CALL Info('CalculateMeshPieces','Mesh coloring loops: '//I2S(Loop),Level=6)
 
     ! Compute the true number of different pieces
+    MaxIndex = MAXVAL( MeshPiece )
     IF( MaxIndex == 1 ) THEN
       NoPieces = 1
       IF(PRESENT(PieceIndex)) PieceIndex = 1


### PR DESCRIPTION
… vector.    Calculate mesh pieces occasionally doesn't properly report the correct number of pieces in a mesh.  Issue #590  includes a sample case showing the issue.  Looking at the code, the value of MaxIndex is set based on the last element examined at the end of the DO WHILE loop, which may give a different value depending on the ordering of the elements.   This change will set MaxIndex to the maximum value in the entire MeshPieces vector.