### PR TITLE
Fix tests that run ElmerSolver multiple times.

### DIFF
--- a/fem/tests/InternalPartitioning/runtest.cmake
+++ b/fem/tests/InternalPartitioning/runtest.cmake
@@ -1,4 +1,4 @@
 include(test_macros)
 execute_process(COMMAND ${ELMERGRID_BIN} 1 2 angle)
-execute_process(COMMAND ${ELMERSOLVER_BIN} part.sif)
+EXECUTE_ELMER_SOLVER(part.sif)
 RUN_ELMER_TEST()

--- a/fem/tests/InternalPartitioning2/runtest.cmake
+++ b/fem/tests/InternalPartitioning2/runtest.cmake
@@ -1,4 +1,4 @@
 include(test_macros)
 execute_process(COMMAND ${ELMERGRID_BIN} 1 2 angle)
-execute_process(COMMAND ${ELMERSOLVER_BIN} part.sif)
+EXECUTE_ELMER_SOLVER(part.sif)
 RUN_ELMER_TEST()

--- a/fem/tests/InternalPartitioning3/runtest.cmake
+++ b/fem/tests/InternalPartitioning3/runtest.cmake
@@ -1,4 +1,4 @@
 include(test_macros)
 execute_process(COMMAND ${ELMERGRID_BIN} 1 2 angle)
-execute_process(COMMAND ${ELMERSOLVER_BIN} part.sif)
+EXECUTE_ELMER_SOLVER(part.sif)
 RUN_ELMER_TEST()

--- a/fem/tests/mgdyn_steady_quad_extruded_restart/runtest.cmake
+++ b/fem/tests/mgdyn_steady_quad_extruded_restart/runtest.cmake
@@ -1,4 +1,4 @@
 include(test_macros)
 execute_process(COMMAND ${ELMERGRID_BIN} 1 2 quads.grd -nooverwrite)
-execute_process(COMMAND ${ELMERSOLVER_BIN} case2d.sif)
+EXECUTE_ELMER_SOLVER(case2d.sif)
 RUN_ELMER_TEST()


### PR DESCRIPTION
Use CMake macro EXECUTE_ELMER_SOLVER that sets up necessary environment variables before executing the ElmerSolver binary.

This fixes the test `mgdyn_steady_quad_extruded_restart` that is currently failing in CI on Windows MinGW.
The other tests would have failed only for higher numbers of parallel processes than what is available on the free GitHub hosted runners.
