### PR TITLE
CI (macos): Work around conflict between pre-installed and Homebrew Python

### DIFF
--- a/.github/workflows/build-macos-homebrew.yaml
+++ b/.github/workflows/build-macos-homebrew.yaml
@@ -35,10 +35,18 @@ jobs:
         uses: actions/checkout@v4
 
       - name: install dependencies
+
+        # Homebrew's Python conflicts with the Python that comes pre-installed
+        # on the GitHub runners. Some of the dependencies depend on different
+        # versions of Homebrew's Python. Enforce using the ones from Homebrew
+        # to avoid errors on updates.
+        # See: https://github.com/orgs/Homebrew/discussions/3928
+
         # It looks like "gfortran" isn't working correctly unless "gcc" is
         # re-installed.
         run: |
           brew update
+          brew install --overwrite python@3.12 python@3.13
           brew reinstall gcc
           brew install \
             cmake libomp openblas open-mpi suitesparse \


### PR DESCRIPTION
Installing packages from Homebrew currently fails with an error like the following:
```
==> Pouring python@3.13--3.13.0_1.ventura.bottle.tar.gz
Error: The `brew link` step did not complete successfully
The formula built, but is not symlinked into /usr/local
Error: The `brew link` step did not complete successfully
Could not symlink bin/idle3
Target /usr/local/bin/idle3
already exists. You may want to remove it:
  rm '/usr/local/bin/idle3'

To force the link and overwrite all conflicting files:
  brew link --overwrite python@3.13

To list all files that would be deleted:
  brew link --overwrite python@3.13 --dry-run

Possible conflicting files are:
/usr/local/bin/idle3 -> /Library/Frameworks/Python.framework/Versions/3.12/bin/idle3
/usr/local/bin/pydoc3 -> /Library/Frameworks/Python.framework/Versions/3.12/bin/pydoc3
/usr/local/bin/python3 -> /Library/Frameworks/Python.framework/Versions/3.12/bin/python3
/usr/local/bin/python3-config -> /Library/Frameworks/Python.framework/Versions/3.12/bin/python3-config
/usr/local/share/man/man1/python3.1 -> /usr/local/Cellar/python@3.12/3.12.7/share/man/man1/python3.1
/usr/local/lib/pkgconfig/python3-embed.pc -> /usr/local/Cellar/python@3.12/3.12.7/lib/pkgconfig/python3-embed.pc
/usr/local/lib/pkgconfig/python3.pc -> /usr/local/Cellar/python@3.12/3.12.7/lib/pkgconfig/python3.pc
/usr/local/Frameworks/Python.framework/Headers -> /usr/local/Cellar/python@3.12/3.12.7/Frameworks/Python.framework/Headers
/usr/local/Frameworks/Python.framework/Python -> /usr/local/Cellar/python@3.12/3.12.7/Frameworks/Python.framework/Python
/usr/local/Frameworks/Python.framework/Resources -> /usr/local/Cellar/python@3.12/3.12.7/Frameworks/Python.framework/Resources
/usr/local/Frameworks/Python.framework/Versions/Current -> /usr/local/Cellar/python@3.12/3.12.7/Frameworks/Python.framework/Versions/Current
==> /usr/local/Cellar/python@3.13/3.13.0_1/bin/python3.13 -Im ensurepip
==> /usr/local/Cellar/python@3.13/3.13.0_1/bin/python3.13 -Im pip install -v --n
==> Summary
🍺  /usr/local/Cellar/python@3.13/3.13.0_1: 3,253 files, 63.2MB
```

Force overwriting files from the version of Python that is pre-installed on the macOS runner images. They conflict with the files from Homebrew's versions of Python.

That likely means that this part needs to be updated about once every year (if Python keeps its release schedule of one major version release each year and Homebrew keeps up with that).
If someone with better knowledge of Homebrew has a better solution, please let me know. (Ideally one that doesn't require bumping the Python versions every year...)
