### PR TITLE
Add warning to ElmerGrid about including -autoclean option for input

### DIFF
--- a/ElmerGUI/Application/plugins/egnative.cpp
+++ b/ElmerGUI/Application/plugins/egnative.cpp
@@ -3624,6 +3624,7 @@ void InitParameters(struct ElmergridType *eg)
   eg->removelowdim = FALSE;
   eg->removeintbcs = FALSE;
   eg->removeunused = FALSE;
+  eg->autoclean = FALSE;
   eg->dim = 3;
   eg->center = FALSE;
   eg->scale = FALSE;
@@ -3961,6 +3962,7 @@ int InlineParameters(struct ElmergridType *eg,int argc,char *argv[],int first,in
       eg->boundorder = TRUE;
       eg->removeunused = TRUE;
       printf("Lower dimensional boundaries will be removed\n");
+      eg->autoclean = TRUE;
       printf("Materials and boundaries will be renumbered\n");
       printf("Nodes that do not appear in any element will be removed\n");
     }   

--- a/ElmerGUI/Application/plugins/egtypes.h
+++ b/ElmerGUI/Application/plugins/egtypes.h
@@ -335,6 +335,7 @@ struct ElmergridType {
     removelowdim,
     removeunused,
     removeintbcs,
+    autoclean,
     increase,
     reducemat1,
     reducemat2,

--- a/elmergrid/src/egnative.c
+++ b/elmergrid/src/egnative.c
@@ -3624,6 +3624,7 @@ void InitParameters(struct ElmergridType *eg)
   eg->removelowdim = FALSE;
   eg->removeintbcs = FALSE;
   eg->removeunused = FALSE;
+  eg->autoclean = FALSE;
   eg->dim = 3;
   eg->center = FALSE;
   eg->scale = FALSE;
@@ -3961,6 +3962,7 @@ int InlineParameters(struct ElmergridType *eg,int argc,char *argv[],int first,in
       eg->boundorder = TRUE;
       eg->removeunused = TRUE;
       printf("Lower dimensional boundaries will be removed\n");
+      eg->autoclean = TRUE;
       printf("Materials and boundaries will be renumbered\n");
       printf("Nodes that do not appear in any element will be removed\n");
     }   

--- a/elmergrid/src/egtypes.h
+++ b/elmergrid/src/egtypes.h
@@ -335,6 +335,7 @@ struct ElmergridType {
     removelowdim,
     removeunused,
     removeintbcs,
+    autoclean,
     increase,
     reducemat1,
     reducemat2,

--- a/elmergrid/src/fempre.c
+++ b/elmergrid/src/fempre.c
@@ -137,6 +137,15 @@ int main(int argc, char *argv[])
 
   timer_show();
   
+  if(info){
+    if(!eg.autoclean && (inmethod > 2)){
+      printf("Notice: Input file type %d, -autoclean option not entered.\n",inmethod);
+      printf("For this type of input file, running ElmerGrid with the -autoclean option\n");
+      printf("is usually the preferred method.  Advanced users of Elmer who definitely\n");
+      printf("know they don't want -autoclean, may safely ignore this notice.\n\n");
+    }
+  }
+
   switch (inmethod) {
 
   case 1:        


### PR DESCRIPTION
files such as gmsh or unv input files.  This is a follow up to a recent forum post where a new user did not include -autoclean when converting a gmsh input file.  The change will print a polite notice in the console output suggesting to include -autoclean whenever converting input files of type greater than 2.  Nothing new will be printed if -autoclean exists or when converting a grd file or an elmer mesh.