### PR TITLE
ElmerGrid and ElmerGUI, add check for Gmsh binary input file format a…

### DIFF
--- a/ElmerGUI/Application/plugins/egconvert.cpp
+++ b/ElmerGUI/Application/plugins/egconvert.cpp
@@ -5280,9 +5280,9 @@ int LoadGmshInput(struct FemType *data,struct BoundaryType *bound,
   }
 
   if(strstr(line,"$")) {
-    int verno,minorno;
+    int verno,minorno,gmshformat;
     char *cp;
-    
+
     Getrow(line,in,FALSE);
     cp = line;    
     verno = next_int(&cp);
@@ -5290,7 +5290,14 @@ int LoadGmshInput(struct FemType *data,struct BoundaryType *bound,
     minorno = next_int(&cp);
 
     if(info) printf("Gmsh version is %d.%d\n",verno,minorno);
-    
+
+    cp++;
+    gmshformat = next_int(&cp);
+    if(gmshformat == 1){
+      printf("Error: Gmsh input file is in binary format! Exiting.\n");
+      bigerror("Gmsh input file is in binary format!");
+    }
+
     fclose(in);
     
     if( verno == 4 ) {

--- a/elmergrid/src/egconvert.c
+++ b/elmergrid/src/egconvert.c
@@ -5280,9 +5280,9 @@ int LoadGmshInput(struct FemType *data,struct BoundaryType *bound,
   }
 
   if(strstr(line,"$")) {
-    int verno,minorno;
+    int verno,minorno,gmshformat;
     char *cp;
-    
+
     Getrow(line,in,FALSE);
     cp = line;    
     verno = next_int(&cp);
@@ -5290,7 +5290,14 @@ int LoadGmshInput(struct FemType *data,struct BoundaryType *bound,
     minorno = next_int(&cp);
 
     if(info) printf("Gmsh version is %d.%d\n",verno,minorno);
-    
+
+    cp++;
+    gmshformat = next_int(&cp);
+    if(gmshformat == 1){
+      printf("Error: Gmsh input file is in binary format! Exiting.\n");
+      bigerror("Gmsh input file is in binary format!");
+    }
+
     fclose(in);
     
     if( verno == 4 ) {


### PR DESCRIPTION
…nd exit

if binary format is detected.  Both printf and bigerror are needed to print error messages to the console in both ElmerGrid and ElmerGUI, since bigerror doesn't seem to print to console in ElmerGUI.

This is in response to Issue #603.  If gmsh binary format is detected, print a message and exit.  Works for both gmsh formats 2 and 4.