### PR TITLE
ElmerGrid, add input checks when reading gmsh msh files. 

### DIFF
--- a/ElmerGUI/Application/plugins/egmesh.cpp
+++ b/ElmerGUI/Application/plugins/egmesh.cpp
@@ -1342,7 +1342,7 @@ void CreateKnots(struct GridType *grid,struct CellType *cell,
   for(cellj=1;cellj<= grid->ycells ;cellj++) {        /* cells direction up     */
     for(j=1; j<=grid->yelems[cellj]; j++)             /* lines inside cells     */
       for(celli=1;celli<= grid->xcells; celli++)      /* cells direction right  */
-	if(k=grid->numbered[cellj][celli]) {
+	if((k=grid->numbered[cellj][celli])) {
 	  material = cell[k].material;
 	  for(i=1; i<=grid->xelems[celli]; i++) {
 
@@ -1958,7 +1958,7 @@ int CreateNewNodes(struct FemType *data,int *order,int material,int newknots)
     newz[j] = data->z[i];
 
     for(k=1;k<MAXDOFS;k++) {
-      if(lmax = data->edofs[k])
+      if((lmax = data->edofs[k]))
 	for(l=1;l<=lmax;l++) 
 	  newdofs[k][lmax*(j-1)+l] = data->dofs[k][lmax*(i-1)+l];
     }
@@ -1971,7 +1971,7 @@ int CreateNewNodes(struct FemType *data,int *order,int material,int newknots)
       newz[j] = data->z[i];
 
       for(k=1;k<MAXDOFS;k++) {
-	if(lmax = data->edofs[k])
+	if((lmax = data->edofs[k]))
 	  for(l=1;l<=lmax;l++) 
 	    newdofs[k][lmax*(j-1)+l] = data->dofs[k][lmax*(i-1)+l];
       }
@@ -3673,7 +3673,7 @@ static void ReorderAutomatic(struct FemType *data,int iterations,
     dz = 0.0;
 
     for(l=1;l<=maxnodes;l++){
-      if(ind = neighbours[j][l]) {
+      if((ind = neighbours[j][l])) {
 	nolocal++;
 	localtmp[l] = ind;
 	dx = data->x[l] - data->x[ind];
@@ -6052,7 +6052,7 @@ void CreateKnotsExtruded(struct FemType *dataxy,struct BoundaryType *boundxy,
 	z = grid->z[cellk-1] + k*grid->dz[cellk];
       }
       else {
-	if(k<=grid->zelems[cellk]/2) {
+	if((k<=grid->zelems[cellk]/2)) {
 	  z = grid->z[cellk-1] + grid->dz[cellk] *
 	    (1.- pow(grid->zratios[cellk],(Real)(k))) / (1.-grid->zratios[cellk]);
 	}
@@ -7462,7 +7462,7 @@ int SideAndBulkMappings(struct FemType *data,struct BoundaryType *bound,struct E
       if(!bound[j].created) continue;
 	
 	for(i=1; i <= bound[j].nosides; i++) {
-	  if(currenttype = bound[j].types[i]) {
+	  if((currenttype = bound[j].types[i])) {
 	    for(l=0;l<eg->sidemappings;l++) {
 	      if(currenttype >= eg->sidemap[3*l] && currenttype <= eg->sidemap[3*l+1]) {
 		bound[j].types[i] = eg->sidemap[3*l+2];
@@ -8118,7 +8118,7 @@ omstart:
 
 	    if(data->material[parent] == layerparents[k])
 	      dolayer = k + 1;
-	    else if(parent = bound[j].parent2[i]) {
+	    else if((parent = bound[j].parent2[i])) {
 	      if(data->material[parent] == layerparents[k]) {
 		use2 = TRUE;
 		dolayer = k + 1;
@@ -8242,7 +8242,7 @@ omstart:
 	    parent = bound[j].parent[i];
 	    if(data->material[parent] == layerparents[k])
 	      dolayer = TRUE;
-	    else if(parent = bound[j].parent2[i]) {
+	    else if((parent = bound[j].parent2[i])) {
 	      if(data->material[parent] == layerparents[k]) {
 		dolayer = TRUE;
 	      }

--- a/ElmerGUI/Application/plugins/egnative.cpp
+++ b/ElmerGUI/Application/plugins/egnative.cpp
@@ -1952,7 +1952,7 @@ int GetSideInfo(struct CellType *cell,int cellno,int side,int element,
     case 0:
       more = FALSE;
       elemind[0] = GetElementIndices(&(cell[cellno]),1,element,&(ind[0]));
-      if(sideno = cell[cellno].neighbour[LEFT])
+      if((sideno = cell[cellno].neighbour[LEFT]))
 	elemind[1] = GetElementIndices(&(cell[sideno]),cell[sideno].xelem,element,&(ind[0]));
       else 
 	elemind[1] = 0;
@@ -1962,7 +1962,7 @@ int GetSideInfo(struct CellType *cell,int cellno,int side,int element,
     case 1:
       more = FALSE; 
       elemind[0] = GetElementIndices(&(cell)[cellno],cell[cellno].xelem,element,&(ind[0]));
-      if(sideno = cell[cellno].neighbour[RIGHT])
+      if((sideno = cell[cellno].neighbour[RIGHT]))
 	elemind[1] = GetElementIndices(&(cell[sideno]),1,element,&(ind[0]));
       else 
 	elemind[1] = 0;
@@ -1978,7 +1978,7 @@ int GetSideInfo(struct CellType *cell,int cellno,int side,int element,
   case LEFT:
     if(element == cell[cellno].yelem) more = FALSE;
     elemind[0] = GetElementIndices(&(cell[cellno]),1,element,&(ind[0]));
-    if(sideno = cell[cellno].neighbour[LEFT])
+    if((sideno = cell[cellno].neighbour[LEFT]))
       elemind[1] = GetElementIndices(&(cell[sideno]),cell[sideno].xelem,element,&(ind[0]));
     else 
       elemind[1] = 0;
@@ -1987,7 +1987,7 @@ int GetSideInfo(struct CellType *cell,int cellno,int side,int element,
   case RIGHT:
     if(element == cell[cellno].yelem) more = FALSE; 
     elemind[0] = GetElementIndices(&(cell)[cellno],cell[cellno].xelem,element,&(ind[0]));
-    if(sideno = cell[cellno].neighbour[RIGHT])
+    if((sideno = cell[cellno].neighbour[RIGHT]))
       elemind[1] = GetElementIndices(&(cell[sideno]),1,element,&(ind[0]));
     else 
       elemind[1] = 0;
@@ -1996,7 +1996,7 @@ int GetSideInfo(struct CellType *cell,int cellno,int side,int element,
   case DOWN:
     if(element == cell[cellno].xelem) more = FALSE;
     elemind[0] = GetElementIndices(&(cell)[cellno],element,1,&(ind[0]));
-    if(sideno = cell[cellno].neighbour[DOWN])
+    if((sideno = cell[cellno].neighbour[DOWN]))
       elemind[1] = GetElementIndices(&(cell[sideno]),element,cell[sideno].yelem,&(ind[0]));
     else 
       elemind[1] = 0;
@@ -2005,7 +2005,7 @@ int GetSideInfo(struct CellType *cell,int cellno,int side,int element,
   case UP:
     if(element == cell[cellno].xelem) more = FALSE; 
     elemind[0] = GetElementIndices(&(cell)[cellno],element,cell[cellno].yelem,&(ind[0]));
-    if(sideno = cell[cellno].neighbour[UP])
+    if((sideno = cell[cellno].neighbour[UP]))
       elemind[1] = GetElementIndices(&(cell[sideno]),element,1,&(ind[0]));
     else 
       elemind[1] = 0;
@@ -4398,7 +4398,7 @@ int LoadCommands(char *prefix,struct ElmergridType *eg,
   iodebug = FALSE;
 
   if( mode == 0) {  
-    if (in = fopen("ELMERGRID_STARTINFO","r")) {
+    if ((in = fopen("ELMERGRID_STARTINFO","r"))) {
       iostat = fscanf(in,"%s",filename);
       fclose(in);
       printf("Using the file %s defined in ELMERGRID_STARTINFO\n",filename);
@@ -5367,7 +5367,7 @@ int LoadElmerInput(struct FemType *data,struct BoundaryType *bound,
 
 
   sprintf(filename,"%s","mesh.names");
-  if (in = fopen(filename,"r") ) {
+  if ((in = fopen(filename,"r") )) {
     int isbody,started,nameproblem;
     
     isbody = TRUE;
@@ -5525,7 +5525,7 @@ int SaveElmerInput(struct FemType *data,struct BoundaryType *bound,
   else {
     if(info) printf("Reusing an existing directory\n");
     if(nooverwrite) {
-      if (out = fopen("mesh.header", "r")) {
+      if ((out = fopen("mesh.header", "r"))) {
 	printf("Mesh seems to already exist, writing is cancelled!\n"); 
 	return(1);
       }


### PR DESCRIPTION
 Detect currently  valid gmsh formats and if ElmerGrid doesn't support the format, print an informative message, including how to fix it, and call fatal error.  This change enables reading of gmsh format 1 msh files, which wasn't working before. Gmsh type 3 msh files are detected and reported as unsupported.  As before, binary files are detected.  This PR is an extension related to Issue #603 and PR #604, where detection and reporting of binary files was added.  This completes upgrading reading of current gmsh file formats, so the user will know positively if a format is or is not supported.  A small archive with eight test cases is included.
[gmsh-all-formats-examples.zip](https://github.com/user-attachments/files/17966844/gmsh-all-formats-examples.zip)
