### PR TITLE
Prevent undefined behavior of VTU output in eigen analysis

### DIFF
--- a/fem/src/modules/ResultOutputSolve/VtuOutputSolver.F90
+++ b/fem/src/modules/ResultOutputSolve/VtuOutputSolver.F90
@@ -514,7 +514,7 @@ SUBROUTINE VtuOutputSolver( Model,Solver,dt,TransientSimulation )
       END DO
     END IF
   END IF
-    
+  EigenVectorMode = 0
   IF( MaxModes > 0 ) THEN
     CALL Info(Caller,'Maximum number of eigen/harmonic modes: '//I2S(MaxModes),Level=7)
     Str = ListGetString( Params,'Eigen Vector Component', GotIt )


### PR DESCRIPTION
Prevent undefined behavior by assigning zero to EigenVectorMode variable in VtuOutputSolver.F90 This partially reverts commit b0b5ff8