### PR TITLE
ElmerGui, minor fix to account for toLower() of FDNEUT, must compare the

### DIFF
--- a/ElmerGUI/Application/src/mainwindow.cpp
+++ b/ElmerGUI/Application/src/mainwindow.cpp
@@ -1651,7 +1651,7 @@ void MainWindow::readInputFile(QString fileName) {
       tetlibInputOk = true;
     }
 
-  } else if ((fileSuffix == "grd") || (fileSuffix == "FDNEUT") ||
+  } else if ((fileSuffix == "grd") || (fileSuffix == "fdneut") ||
              (fileSuffix == "msh") || (fileSuffix == "mphtxt") ||
              (fileSuffix == "inp") || (fileSuffix == "unv") ||
              (fileSuffix == "plt")) {


### PR DESCRIPTION
input to lower case 'fdneut'.  Needed in order to successfully load any FDNEUT input file.