### PR TITLE
Avoid build error when building without MPI.

### DIFF
--- a/elmerice/Solvers/BasalMelt3D.F90
+++ b/elmerice/Solvers/BasalMelt3D.F90
@@ -323,7 +323,7 @@
 #else
       CALL MPI_AllReduce(MPI_IN_PLACE, &
 #endif
-           TotalArea, 1, MPI_DOUBLE, MPI_SUM, MPI_COMM_WORLD, ierr)
+           TotalArea, 1, MPI_DOUBLE_PRECISION, MPI_SUM, MPI_COMM_WORLD, ierr)
 
 #ifdef ELMER_BROKEN_MPI_IN_PLACE
       buffer = TotalBMelt
@@ -331,7 +331,7 @@
 #else
       CALL MPI_AllReduce(MPI_IN_PLACE, &
 #endif
-           TotalBMelt, 1, MPI_DOUBLE, MPI_SUM, MPI_COMM_WORLD, ierr)
+           TotalBMelt, 1, MPI_DOUBLE_PRECISION, MPI_SUM, MPI_COMM_WORLD, ierr)
 
       IF(ParEnv % MyPE == 0) THEN
         IF(.NOT. Visited) THEN

--- a/elmerice/Solvers/PlumeSolver.F90
+++ b/elmerice/Solvers/PlumeSolver.F90
@@ -932,21 +932,21 @@
 #else
       CALL MPI_AllReduce(MPI_IN_PLACE, &
 #endif
-           TotalArea, 1, MPI_DOUBLE, MPI_SUM, MPI_COMM_WORLD, ierr)
+           TotalArea, 1, MPI_DOUBLE_PRECISION, MPI_SUM, MPI_COMM_WORLD, ierr)
 #ifdef ELMER_BROKEN_MPI_IN_PLACE
       buffer = TotalPMelt
       CALL MPI_AllReduce(buffer, &
 #else
       CALL MPI_AllReduce(MPI_IN_PLACE, &
 #endif
-           TotalPMelt, 1, MPI_DOUBLE, MPI_SUM, MPI_COMM_WORLD, ierr)
+           TotalPMelt, 1, MPI_DOUBLE_PRECISION, MPI_SUM, MPI_COMM_WORLD, ierr)
 #ifdef ELMER_BROKEN_MPI_IN_PLACE
       buffer = TotalBMelt
       CALL MPI_AllReduce(buffer, &
 #else
       CALL MPI_AllReduce(MPI_IN_PLACE, &
 #endif
-           TotalBMelt, 1, MPI_DOUBLE, MPI_SUM, MPI_COMM_WORLD, ierr)
+           TotalBMelt, 1, MPI_DOUBLE_PRECISION, MPI_SUM, MPI_COMM_WORLD, ierr)
       IF(RemoveToe) THEN
 #ifdef ELMER_BROKEN_MPI_IN_PLACE
         buffer = TotalToeMelt
@@ -954,7 +954,7 @@
 #else
         CALL MPI_AllReduce(MPI_IN_PLACE, &
 #endif
-             TotalToeMelt, 1, MPI_DOUBLE, &
+             TotalToeMelt, 1, MPI_DOUBLE_PRECISION, &
              MPI_SUM, MPI_COMM_WORLD, ierr)
       END IF
 

--- a/fem/src/modules/SaveGridData.F90
+++ b/fem/src/modules/SaveGridData.F90
@@ -1166,7 +1166,7 @@ END SUBROUTINE SaveGridData
           END DO ! k
 
           IF(Parallel) THEN
-            CALL MPI_REDUCE(Array,PArray,nx*ny*nz,MPI_DOUBLE,MPI_MAX,0,ELMER_COMM_WORLD, ierr)
+            CALL MPI_REDUCE(Array,PArray,nx*ny*nz,MPI_DOUBLE_PRECISION,MPI_MAX,0,ELMER_COMM_WORLD, ierr)
             IF(Part == 0) Array=PArray
           END IF
         


### PR DESCRIPTION
Use `MPI_DOUBLE_PRECISION` instead of `MPI_DOUBLE`.