### PR TITLE
Avoid build error when building ElmerIce without MPI.

### DIFF
--- a/fem/src/mpif_stub.h
+++ b/fem/src/mpif_stub.h
@@ -1,5 +1,5 @@
 !
-! stub header for disabled mpi 
+! stub header for disabled mpi
 !
        INTEGER MPI_COMM_WORLD
        PARAMETER (MPI_COMM_WORLD=1)
@@ -42,3 +42,5 @@
        PARAMETER (MPI_THREAD_FUNNELED=1)
        INTEGER MPI_IN_PLACE
        PARAMETER (MPI_IN_PLACE=1)
+       INTEGER MPI_SUCCESS
+       PARAMETER (MPI_SUCCESS=0)


### PR DESCRIPTION
`MPI_SUCCESS` is used in ElmerIce. Even if building ElmerIce without MPI is currently(?) unsupported, add a definition for it to the MPI stub header anyway for completeness.