### PR TITLE
CI: Avoid error with `cat` if there are multiple output log files per test

### DIFF
--- a/.github/workflows/build-macos-homebrew.yaml
+++ b/.github/workflows/build-macos-homebrew.yaml
@@ -132,12 +132,18 @@ jobs:
             echo ---- Files ----
             ls -Rl ${test_root}/${test}
             if [ -f ${test_root}/${test}/test-stderr*.log ]; then
-              echo ---- Content of test-stderr*.log ----
-              cat ${test_root}/${test}/test-stderr*.log
+              err_logs=($(ls ${test_root}/${test}/test-stderr*.log))
+              for err_log in "${err_logs[@]}"; do
+                echo ---- Content of ${err_log} ----
+                cat ${err_log}
+              done
             fi
             if [ -f ${test_root}/${test}/test-stdout*.log ]; then
-              echo ---- Content of test-stdout*.log ----
-              cat ${test_root}/${test}/test-stdout*.log
+              out_logs=($(ls ${test_root}/${test}/test-stdout*.log))
+              for out_log in "${out_logs[@]}"; do
+                echo ---- Content of ${out_log} ----
+                cat ${out_log}
+              done
             fi
             echo "::endgroup::"
           done

--- a/.github/workflows/build-windows-mingw.yaml
+++ b/.github/workflows/build-windows-mingw.yaml
@@ -170,12 +170,18 @@ jobs:
             echo ---- Files ----
             ls -Rl ${test_root}/${test}
             if [ -f ${test_root}/${test}/test-stderr*.log ]; then
-              echo ---- Content of test-stderr*.log ----
-              cat ${test_root}/${test}/test-stderr*.log
+              err_logs=($(ls ${test_root}/${test}/test-stderr*.log))
+              for err_log in "${err_logs[@]}"; do
+                echo ---- Content of ${err_log} ----
+                cat ${err_log}
+              done
             fi
             if [ -f ${test_root}/${test}/test-stdout*.log ]; then
-              echo ---- Content of test-stdout*.log ----
-              cat ${test_root}/${test}/test-stdout*.log
+              out_logs=($(ls ${test_root}/${test}/test-stdout*.log))
+              for out_log in "${out_logs[@]}"; do
+                echo ---- Content of ${out_log} ----
+                cat ${out_log}
+              done
             fi
             echo "::endgroup::"
           done

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -168,12 +168,18 @@ jobs:
             echo ---- Files ----
             ls -Rl ${test_root}/${test}
             if [ -f ${test_root}/${test}/test-stderr*.log ]; then
-              echo ---- Content of test-stderr*.log ----
-              cat ${test_root}/${test}/test-stderr*.log
+              err_logs=($(ls ${test_root}/${test}/test-stderr*.log))
+              for err_log in "${err_logs[@]}"; do
+                echo ---- Content of ${err_log} ----
+                cat ${err_log}
+              done
             fi
             if [ -f ${test_root}/${test}/test-stdout*.log ]; then
-              echo ---- Content of test-stdout*.log ----
-              cat ${test_root}/${test}/test-stdout*.log
+              out_logs=($(ls ${test_root}/${test}/test-stdout*.log))
+              for out_log in "${out_logs[@]}"; do
+                echo ---- Content of ${out_log} ----
+                cat ${out_log}
+              done
             fi
             echo "::endgroup::"
           done

--- a/.github/workflows/ubuntu-clang-full.yaml
+++ b/.github/workflows/ubuntu-clang-full.yaml
@@ -111,12 +111,18 @@ jobs:
             echo ---- Files ----
             ls -Rl ${test_root}/${test}
             if [ -f ${test_root}/${test}/test-stderr*.log ]; then
-              echo ---- Content of test-stderr*.log ----
-              cat ${test_root}/${test}/test-stderr*.log
+              err_logs=($(ls ${test_root}/${test}/test-stderr*.log))
+              for err_log in "${err_logs[@]}"; do
+                echo ---- Content of ${err_log} ----
+                cat ${err_log}
+              done
             fi
             if [ -f ${test_root}/${test}/test-stdout*.log ]; then
-              echo ---- Content of test-stdout*.log ----
-              cat ${test_root}/${test}/test-stdout*.log
+              out_logs=($(ls ${test_root}/${test}/test-stdout*.log))
+              for out_log in "${out_logs[@]}"; do
+                echo ---- Content of ${out_log} ----
+                cat ${out_log}
+              done
             fi
             echo "::endgroup::"
           done

--- a/.github/workflows/ubuntu-elmerice.yaml
+++ b/.github/workflows/ubuntu-elmerice.yaml
@@ -115,12 +115,18 @@ jobs:
             echo ---- Files ----
             ls -Rl ${test_root}/${test}
             if [ -f ${test_root}/${test}/test-stderr*.log ]; then
-              echo ---- Content of test-stderr*.log ----
-              cat ${test_root}/${test}/test-stderr*.log
+              err_logs=($(ls ${test_root}/${test}/test-stderr*.log))
+              for err_log in "${err_logs[@]}"; do
+                echo ---- Content of ${err_log} ----
+                cat ${err_log}
+              done
             fi
             if [ -f ${test_root}/${test}/test-stdout*.log ]; then
-              echo ---- Content of test-stdout*.log ----
-              cat ${test_root}/${test}/test-stdout*.log
+              out_logs=($(ls ${test_root}/${test}/test-stdout*.log))
+              for out_log in "${out_logs[@]}"; do
+                echo ---- Content of ${out_log} ----
+                cat ${out_log}
+              done
             fi
             echo "::endgroup::"
           done

--- a/.github/workflows/ubuntu-gcc-full.yaml
+++ b/.github/workflows/ubuntu-gcc-full.yaml
@@ -111,12 +111,18 @@ jobs:
             echo ---- Files ----
             ls -Rl ${test_root}/${test}
             if [ -f ${test_root}/${test}/test-stderr*.log ]; then
-              echo ---- Content of test-stderr*.log ----
-              cat ${test_root}/${test}/test-stderr*.log
+              err_logs=($(ls ${test_root}/${test}/test-stderr*.log))
+              for err_log in "${err_logs[@]}"; do
+                echo ---- Content of ${err_log} ----
+                cat ${err_log}
+              done
             fi
             if [ -f ${test_root}/${test}/test-stdout*.log ]; then
-              echo ---- Content of test-stdout*.log ----
-              cat ${test_root}/${test}/test-stdout*.log
+              out_logs=($(ls ${test_root}/${test}/test-stdout*.log))
+              for out_log in "${out_logs[@]}"; do
+                echo ---- Content of ${out_log} ----
+                cat ${out_log}
+              done
             fi
             echo "::endgroup::"
           done

--- a/.github/workflows/ubuntu-parallel.yaml
+++ b/.github/workflows/ubuntu-parallel.yaml
@@ -115,12 +115,18 @@ jobs:
             echo ---- Files ----
             ls -Rl ${test_root}/${test}
             if [ -f ${test_root}/${test}/test-stderr*.log ]; then
-              echo ---- Content of test-stderr*.log ----
-              cat ${test_root}/${test}/test-stderr*.log
+              err_logs=($(ls ${test_root}/${test}/test-stderr*.log))
+              for err_log in "${err_logs[@]}"; do
+                echo ---- Content of ${err_log} ----
+                cat ${err_log}
+              done
             fi
             if [ -f ${test_root}/${test}/test-stdout*.log ]; then
-              echo ---- Content of test-stdout*.log ----
-              cat ${test_root}/${test}/test-stdout*.log
+              out_logs=($(ls ${test_root}/${test}/test-stdout*.log))
+              for out_log in "${out_logs[@]}"; do
+                echo ---- Content of ${out_log} ----
+                cat ${out_log}
+              done
             fi
             echo "::endgroup::"
           done


### PR DESCRIPTION
If a test is run with multiple (different) numbers of parallel processes, a separate set of `test-stderr*.log` and `test-stdout*.log` files is created for each number of parallel processes. If one of these tests fails for some reason, `cat` is essentially called with multiple file arguments (which it doesn't support).

Avoid that error by iterating through the list of `test-stderr*.log` and `test-stdout*.log` files.