### PR TITLE
GUI: Add parenthesis in condition for clarity.

### DIFF
--- a/ElmerGUI/Application/src/glwidget.cpp
+++ b/ElmerGUI/Application/src/glwidget.cpp
@@ -680,7 +680,7 @@ void GLWidget::mousePressEvent(QMouseEvent *event)
 //-----------------------------------------------------------------------------
 void GLWidget::mouseReleaseEvent(QMouseEvent *event)
 {
-  if(event->button() == Qt::RightButton & event->pos() == lastPressPos){
+  if((event->button() == Qt::RightButton) && (event->pos() == lastPressPos)) {
 #if WITH_QT6
     ((MainWindow*)parent())->showContextMenu(event->globalPosition().toPoint());
 #else


### PR DESCRIPTION
Also use a short-cut AND operator.

This helps with source clarity and avoids a compiler warning with clang++.