### PR TITLE
cmake: Add missing keyword for `TARGET` form of `add_custom_command`.

### DIFF
--- a/elmerice/Tests/CMakeLists.txt
+++ b/elmerice/Tests/CMakeLists.txt
@@ -57,11 +57,13 @@ ADD_CUSTOM_TARGET(ElmerIceTests_package
 FOREACH(_file ${ELMERICE_TEST_FILES})
   IF(NOT(IS_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/${_file}))
     ADD_CUSTOM_COMMAND(TARGET ElmerIceTests
+      POST_BUILD
       COMMAND "${CMAKE_COMMAND}" "-E" "copy"
       "${CMAKE_CURRENT_SOURCE_DIR}/${_file}"
       "${CMAKE_BINARY_DIR}/elmerice-tests/${_file}")
   ELSE()
     ADD_CUSTOM_COMMAND(TARGET ElmerIceTests
+      POST_BUILD
       COMMAND "${CMAKE_COMMAND}" "-E" "copy_directory"
       "${CMAKE_CURRENT_SOURCE_DIR}/${_file}"
       "${CMAKE_BINARY_DIR}/elmerice-tests/${_file}")

--- a/fem/tests/CMakeLists.txt
+++ b/fem/tests/CMakeLists.txt
@@ -90,11 +90,13 @@ ADD_CUSTOM_TARGET(ElmerTests_package
 FOREACH(_file ${ELMER_TEST_FILES})
   IF(NOT(IS_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/${_file}))
     ADD_CUSTOM_COMMAND(TARGET ElmerTests
+      POST_BUILD
       COMMAND "${CMAKE_COMMAND}" "-E" "copy"
       "${CMAKE_CURRENT_SOURCE_DIR}/${_file}"
       "${CMAKE_BINARY_DIR}/elmerfem-tests/${_file}")
   ELSE()
     ADD_CUSTOM_COMMAND(TARGET ElmerTests
+      POST_BUILD
       COMMAND "${CMAKE_COMMAND}" "-E" "copy_directory"
       "${CMAKE_CURRENT_SOURCE_DIR}/${_file}"
       "${CMAKE_BINARY_DIR}/elmerfem-tests/${_file}")


### PR DESCRIPTION
The `TARGET` form of `add_custom_command` requires a keyword that defines the target build order. Newer versions of CMake (version 3.31 or later) warn if that keyword is missing. See:
https://cmake.org/cmake/help/latest/policy/CMP0175.html#policy:CMP0175

Add the keyword `POST_BUILD` that prior versions of CMake assumed by default. (That keyword is available since at least CMake 3.0 - the oldest version for which documentation is still hosted on the CMake website.)