### PR TITLE
Bubble trouble

### DIFF
--- a/fem/src/BlockSolve.F90
+++ b/fem/src/BlockSolve.F90
@@ -4709,7 +4709,7 @@ CONTAINS
       ! These take monolithic splitting and only return the "BlockIndex" which tells to which
       ! block each dof belongs to. Then the same routine can split the matrices for all. 
       !-----------------------------------------------------------------------------------------------
-      n = SIZE( Solver % Variable % Values )      
+      n = SIZE( Solver % Variable % Perm )      
       ALLOCATE( BlockIndex(n) )
       BlockIndex = 0
       BlockDofs = 0

--- a/fem/src/BlockSolve.F90
+++ b/fem/src/BlockSolve.F90
@@ -551,7 +551,7 @@ CONTAINS
         IF( PRESENT(BlockIndex) ) THEN
           CALL Info('BlockInitVar','Using BlockIndex to pick variable and perm',Level=20)
           NULLIFY(VarPerm)
-          m = SIZE(Solver % Variable % Perm) 
+          m = SIZE(Solver % Variable % Values)
           ALLOCATE(VarPerm(m))
           VarPerm = 0
 

--- a/fem/src/BlockSolve.F90
+++ b/fem/src/BlockSolve.F90
@@ -556,7 +556,7 @@ CONTAINS
           VarPerm = 0
 
           k = 0
-          DO j=1,SIZE(Solver % Variable % Perm)
+          DO j=1,SIZE(Solver % Variable % Values)
             IF(BlockIndex(j) == i) THEN
               k = k+1
               VarPerm(j) = k
@@ -4709,7 +4709,7 @@ CONTAINS
       ! These take monolithic splitting and only return the "BlockIndex" which tells to which
       ! block each dof belongs to. Then the same routine can split the matrices for all. 
       !-----------------------------------------------------------------------------------------------
-      n = SIZE( Solver % Variable % Perm )      
+      n = SIZE( Solver % Variable % Values)      
       ALLOCATE( BlockIndex(n) )
       BlockIndex = 0
       BlockDofs = 0

--- a/fem/src/DefUtils.F90
+++ b/fem/src/DefUtils.F90
@@ -1673,7 +1673,7 @@ CONTAINS
      TYPE( Solver_t ), OPTIONAL, TARGET :: USolver
 
      TYPE( Solver_t ), POINTER :: Solver
-     INTEGER :: ind
+     INTEGER :: ind, n
 
      Solver => CurrentModel % Solver
      IF ( PRESENT( USolver ) ) Solver => USolver
@@ -1702,6 +1702,11 @@ CONTAINS
        ! May be used by user functions, not thread safe
        CurrentModel % CurrentElement => Element 
 #endif
+       ! Finally update the BDOFs field of the Element structure so that
+       ! the correct solverwise bubble count is returned by calling the function
+       ! GetElementNOFBDOFs without optional arguments in the assembly loop
+       !
+       n = GetElementNOFBDOFs(Element, Solver, Update =.TRUE.)
      ELSE
        WRITE( Message, * ) 'Invalid element number requested: ', t
        CALL Fatal( 'GetActiveElement', Message )
@@ -1906,7 +1911,7 @@ CONTAINS
 
      INTEGER :: i, j, k, id, ElemFamily, ParentFamily, face_type, face_id 
      INTEGER :: NDOFs
-     LOGICAL :: Found, GB, NeedEdges
+     LOGICAL :: Found, GB, NeedEdges, Bubbles
 
      IF ( PRESENT( USolver ) ) THEN
         Solver => USolver
@@ -2171,10 +2176,10 @@ CONTAINS
              IF (p > 1) BDOFs = GetBubbleDOFs(Element, p)
              BDOFs = MAX(nb, BDOFs)
            ELSE
-             ! The following is not an ideal way to obtain the bubble count
-             ! in order to support solverwise definitions, but we are not expected 
-             ! to end up in this branch anyway:
-             BDOFs = Element % BDOFs
+             Bubbles = ListGetLogical(Solver % Values, 'Bubbles', Found )
+             ! The following is not a right way to obtain the bubble count
+             ! in order to support solverwise definitions
+             IF (Bubbles) BDOFs = SIZE(Element % BubbleIndexes)
            END IF
            n = n + BDOFs
          END IF
@@ -2215,7 +2220,7 @@ CONTAINS
 
     TYPE(Element_t), POINTER  :: CurrElement
     TYPE(Solver_t), POINTER :: Solver
-    LOGICAL :: Found, GB, UpdateRequested
+    LOGICAL :: Found, GB, UpdateRequested,Bubbles
     INTEGER :: k, p, ElemFamily
 
     IF ( PRESENT( USolver ) ) THEN
@@ -2240,13 +2245,21 @@ CONTAINS
       p = Solver % Def_Dofs(ElemFamily, CurrElement % Bodyid, 6) 
 
       IF (k >= 0 .OR. p >= 1) THEN
+        ! Apparently an "Element" command has been read from a solver section.
+        ! Therefore we return the value of the solverwise definition.
         IF (p > 1) n = GetBubbleDOFs(CurrElement, p)
         n = MAX(k,n)
-      ELSE 
-        n = CurrElement % BDOFs
+      ELSE
+        ! The element command hasn't been given, so the only way to activate the bubbles
+        ! should be the "Bubbles" command. The following is not a reliable way to obtain
+        ! the bubble count when solverwise definitions are used.   
+        Bubbles = ListGetLogical(Solver % Values, 'Bubbles', Found)
+        IF (Bubbles .AND. ASSOCIATED(Element % BubbleIndexes)) THEN
+          n = SIZE(Element % BubbleIndexes)
+        END IF
       END IF
 
-      IF (UpdateRequested .AND. n>=0) THEN
+      IF (UpdateRequested) THEN
         CurrElement % BDOFs = n
       END IF
     ELSE
@@ -2262,7 +2275,14 @@ CONTAINS
         IF (k >= 0 .OR. p >= 1) THEN
           IF (p > 1) n = GetBubbleDOFs(CurrElement, p)
           n = MAX(k,n)
-          IF ( n>=0 ) CurrElement % BDOFs = n
+          CurrElement % BDOFs = n
+        ELSE
+          Bubbles = ListGetLogical(Solver % Values, 'Bubbles', Found)
+          IF (Bubbles .AND. ASSOCIATED(Element % BubbleIndexes)) THEN
+            CurrElement % BDOFs = SIZE(Element % BubbleIndexes)
+          ELSE
+            CurrElement % BDOFs = 0
+          END IF
         END IF
         n = 0
       END IF

--- a/fem/src/DefUtils.F90
+++ b/fem/src/DefUtils.F90
@@ -1706,7 +1706,7 @@ CONTAINS
        ! the correct solverwise bubble count is returned by calling the function
        ! GetElementNOFBDOFs without optional arguments in the assembly loop
        !
-       n = GetElementNOFBDOFs(Element, Solver, Update =.TRUE.)
+       !n = GetElementNOFBDOFs(Element, Solver, Update =.TRUE.)
      ELSE
        WRITE( Message, * ) 'Invalid element number requested: ', t
        CALL Fatal( 'GetActiveElement', Message )

--- a/fem/src/DefUtils.F90
+++ b/fem/src/DefUtils.F90
@@ -1673,7 +1673,7 @@ CONTAINS
      TYPE( Solver_t ), OPTIONAL, TARGET :: USolver
 
      TYPE( Solver_t ), POINTER :: Solver
-     INTEGER :: ind, n
+     INTEGER :: ind
 
      Solver => CurrentModel % Solver
      IF ( PRESENT( USolver ) ) Solver => USolver
@@ -1702,11 +1702,6 @@ CONTAINS
        ! May be used by user functions, not thread safe
        CurrentModel % CurrentElement => Element 
 #endif
-       ! Finally update the BDOFs field of the Element structure so that
-       ! the correct solverwise bubble count is returned by calling the function
-       ! GetElementNOFBDOFs without optional arguments in the assembly loop
-       !
-       !n = GetElementNOFBDOFs(Element, Solver, Update =.TRUE.)
      ELSE
        WRITE( Message, * ) 'Invalid element number requested: ', t
        CALL Fatal( 'GetActiveElement', Message )

--- a/fem/src/ElementUtils.F90
+++ b/fem/src/ElementUtils.F90
@@ -3940,7 +3940,7 @@ CONTAINS
      TYPE(Element_t), POINTER :: Element, Parent, Face
      TYPE(Mesh_t), POINTER :: Mesh
 
-     LOGICAL :: Found, GB, DGDisable, NeedEdges
+     LOGICAL :: Found, GB, DGDisable, NeedEdges, Bubbles
      INTEGER :: i,j,k,id, nb, p, NDOFs, MaxNDOFs, EDOFs, MaxEDOFs, FDOFs, MaxFDOFs, BDOFs
      INTEGER :: Ind, ElemFamily, ParentFamily, face_type, face_id
      INTEGER :: NodalIndexOffset, EdgeIndexOffset, FaceIndexOffset
@@ -4300,10 +4300,10 @@ BLOCK
            IF (p > 1) BDOFs = GetBubbleDOFs(Element, p)
            BDOFs = MAX(nb, BDOFs)
          ELSE
-           ! The following is not an ideal way to obtain the bubble count
-           ! in order to support solverwise definitions, but we are not expected 
-           ! to end up in this branch anyway:
-           BDOFs = Element % BDOFs
+           Bubbles = ListGetLogical(Solver % Values, 'Bubbles', Found )
+           ! The following is not a right way to obtain the bubble count
+           ! in order to support solverwise definitions
+           IF (Bubbles) BDOFs = SIZE(Element % BubbleIndexes)
          END IF
          DO i=1,BDOFs
            nd = nd + 1

--- a/fem/src/Lists.F90
+++ b/fem/src/Lists.F90
@@ -222,7 +222,7 @@ CONTAINS
      INTEGER :: NodalIndexOffset, EdgeIndexOffset, FaceIndexOffset, Indexes(128)
      INTEGER, POINTER :: Def_Dofs(:)
      INTEGER, ALLOCATABLE :: EdgeDOFs(:), FaceDOFs(:)
-     LOGICAL :: FoundDG, DG, DB, GB, Found, Radiation
+     LOGICAL :: FoundDG, DG, DB, GB, Bubbles, Found, Radiation
      TYPE(Element_t),POINTER :: Element, Edge, Face
      CHARACTER(*), PARAMETER :: Caller = 'InitialPermutation'
 !------------------------------------------------------------------------------
@@ -575,13 +575,19 @@ CONTAINS
          BDOFs = Def_Dofs(5)
          j = Def_Dofs(6)
          IF (BDOFs >= 0 .OR. j >= 1) THEN
+           ! Apparently an "Element" command has been given so we use
+           ! the given definition
            IF (j > 1) ndofs = GetBubbleDOFs(Element, j)
            ndofs = MAX(BDOFs, ndofs) 
          ELSE
-           ! The following is not an ideal way to obtain the bubble count
-           ! in order to support solverwise definitions, but we are not expected 
-           ! to end up in this branch anyway:
-           ndofs = Element % BDOFs
+           ! Apparently no "Element" command has been given which should
+           ! activate the use of bubbles. Then the only way to activate the use of
+           ! bubbles seems to be "Bubbles" command. If this not present, we 
+           ! see no reason to add the indexes for bubble DOFs
+           Bubbles = ListGetLogical(Solver % Values, 'Bubbles', Found )
+           ! The following is not a right way to obtain the bubble count
+           ! in order to support solverwise definitions
+           IF (Bubbles) ndofs = Element % BDOFs
          END IF
 
          DO i=1,ndofs

--- a/fem/src/Lists.F90
+++ b/fem/src/Lists.F90
@@ -582,12 +582,12 @@ CONTAINS
          ELSE
            ! Apparently no "Element" command has been given which should
            ! activate the use of bubbles. Then the only way to activate the use of
-           ! bubbles seems to be "Bubbles" command. If this not present, we 
+           ! bubbles seems to be "Bubbles" command. If this is not present, we 
            ! see no reason to add the indexes for bubble DOFs
            Bubbles = ListGetLogical(Solver % Values, 'Bubbles', Found )
            ! The following is not a right way to obtain the bubble count
            ! in order to support solverwise definitions
-           IF (Bubbles) ndofs = Element % BDOFs
+           IF (Bubbles) ndofs = SIZE(Element % BubbleIndexes)
          END IF
 
          DO i=1,ndofs

--- a/fem/tests/NaturalConvectionRestartCycle/case.sif
+++ b/fem/tests/NaturalConvectionRestartCycle/case.sif
@@ -193,6 +193,6 @@ Boundary Condition 4
   Temperature = 293.0
 End
 
-Solver 2 :: Reference Norm = Real 0.41304525E-03
+Solver 2 :: Reference Norm = Real 3.23628807E-04
 Solver 2 :: Reference Norm Tolerance = Real 1.0e-4
 RUN

--- a/fem/tests/RotatingBCMagnetoDynamicsGeneric/case.sif
+++ b/fem/tests/RotatingBCMagnetoDynamicsGeneric/case.sif
@@ -26,7 +26,7 @@ Header
 End
    
 Simulation
-  Max Output Level = 5
+  Max Output Level = 35
   Coordinate System = Cartesian
   Coordinate Mapping(3) = 1 2 3
   Simulation Type = Transient

--- a/fem/tests/RotatingBCMagnetoDynamicsGeneric/case.sif
+++ b/fem/tests/RotatingBCMagnetoDynamicsGeneric/case.sif
@@ -26,7 +26,7 @@ Header
 End
    
 Simulation
-  Max Output Level = 35
+  Max Output Level = 5
   Coordinate System = Cartesian
   Coordinate Mapping(3) = 1 2 3
   Simulation Type = Transient


### PR DESCRIPTION
Fix the handling of bubble DOFs

1. Fix the creation of permutation vector for bubble DOFs. Now one should get
indices for bubble DOFs only when the solver has
"Bubbles In Global System = True" (the default) together with

(i) either an "Element" command leading to bubble DOFs
(ii) or the command "Bubbles = True".

In the case of "Bubbles = True" the count of bubble DOFs cannot be controlled in
a solverwise manner (the maximal count of available bubble indices is returned).
Otherwise the count of bubble DOFs is determined in a solverwise manner, so
for the best control of bubble DOFs it is recommended to use an Element command.

2. Change the subroutines GetElementNOFDOFs, GetElementNOFBDOFs and
GetElementDOFs so that they are consistent with the handling of bubbles
explained in the first item.

A test case NaturalConvectionRestartCycle has suffered from having permutations
of wrong sizes and also needed a fix of norm.  

In addition to these changes, this commit contains an unrelated fix for
BlockSolve to avoid processing outside array bounds. 