### PR TITLE
Slightly modernize C syntax

### DIFF
--- a/fem/src/Load.c
+++ b/fem/src/Load.c
@@ -429,7 +429,7 @@ void *STDCALLBULL FC_FUNC(loadfunction,LOADFUNCTION) ( int *Quiet, int *abort_no
 /*--------------------------------------------------------------------------
   INTERNAL: Execute given function returning integer value
   -------------------------------------------------------------------------*/
-static int IntExec( int (STDCALLBULL *Function)(),void *Model )
+static int IntExec( int (STDCALLBULL *Function)(void *),void *Model )
 {
    return (*Function)( Model );
 }
@@ -449,8 +449,9 @@ int STDCALLBULL FC_FUNC(execintfunction,EXECINTFUNCTION) ( f_ptr Function,void *
 /*--------------------------------------------------------------------------
    INTERNAL: Execute given function returning double value
   -------------------------------------------------------------------------*/
-static void DoubleArrayExec( double *(STDCALLBULL *Function)(), void *Model,
-               int *Node, double *Value, double *Array )
+static void DoubleArrayExec(
+              double *(STDCALLBULL *Function)(void *, int *, double *, double *),
+              void *Model, int *Node, double *Value, double *Array )
 {
    (*Function)( Model,Node,Value,Array );
 }
@@ -463,18 +464,21 @@ void STDCALLBULL execrealarrayfunction_c( f_ptr Function, void *Model,
 										int *Node, double *Value, double *Array )
 #else
 void STDCALLBULL FC_FUNC(execrealarrayfunction,EXECREALARRAYFUNCTION)
-     ( f_ptr Function, void *Model,
-       int *Node, double *Value, double *Array )
+     ( f_ptr Function,
+       void *Model, int *Node, double *Value, double *Array )
 #endif
 {
-   DoubleArrayExec( (double*(STDCALLBULL *)())*Function,Model,Node,Value, Array );
+  DoubleArrayExec(
+    (double*(STDCALLBULL *)(void *, int *, double *, double *)) *Function,
+    Model, Node, Value, Array );
 }
 
 /*--------------------------------------------------------------------------
    INTERNAL: Execute given function returning double value
   -------------------------------------------------------------------------*/
-static double DoubleExec( double (STDCALLBULL *Function)(), void *Model,
-               int *Node, double *Value )
+static double DoubleExec(
+  double (STDCALLBULL *Function)(void *, int *, double *),
+  void *Model, int *Node, double *Value )
 {
    return (*Function)( Model,Node,Value );
 }
@@ -491,14 +495,17 @@ double STDCALLBULL FC_FUNC(execrealfunction,EXECREALFUNCTION)
        int *Node, double *Value )
 #endif
 {
-   return DoubleExec( (double (STDCALLBULL *)())*Function,Model,Node,Value );
+  return DoubleExec(
+    (double (STDCALLBULL *)(void *, int *, double *)) *Function,
+    Model, Node, Value );
 }
 
 /*--------------------------------------------------------------------------
    INTERNAL: Execute given function returning double value
   -------------------------------------------------------------------------*/
-static double ConstDoubleExec( double (STDCALLBULL *Function)(), void *Model,
-			       double *x, double *y, double *z )
+static double ConstDoubleExec(
+  double (STDCALLBULL *Function)(void *, double *, double *, double *),
+  void *Model, double *x, double *y, double *z )
 {
    return (*Function)( Model, x,y,z );
 }
@@ -515,7 +522,9 @@ double STDCALLBULL FC_FUNC(execconstrealfunction,EXECCONSTREALFUNCTION)
        double *x, double *y, double *z )
 #endif
 {
-   return ConstDoubleExec( (double (STDCALLBULL *)())*Function,Model,x,y,z );
+  return ConstDoubleExec(
+    (double (STDCALLBULL *)(void *, double *, double *, double *)) *Function,
+    Model, x, y, z );
 }
 
 
@@ -535,7 +544,8 @@ void *STDCALLBULL FC_FUNC(addrfunc,ADDRFUNC) ( void *Function )
    INTERNAL: Call solver routines at given address
   -------------------------------------------------------------------------*/
 static void DoExecSolver(
-  void (STDCALLBULL *SolverProc)(), void *Model, void *Solver, void *dt, void *Transient)
+  void (STDCALLBULL *SolverProc)(void *, void *, void *, void *),
+  void *Model, void *Solver, void *dt, void *Transient)
 {
   (*SolverProc)( Model,Solver,dt,Transient ); 
   return;
@@ -552,15 +562,18 @@ void STDCALLBULL FC_FUNC(execsolver,EXECSOLVER)
      ( f_ptr *SolverProc, void *Model, void *Solver, void *dt, void *Transient )
 #endif
 {
-  DoExecSolver( (void (STDCALLBULL *)())*SolverProc,Model,Solver,dt,Transient );
+  DoExecSolver(
+    (void (STDCALLBULL *)(void *, void *, void *, void *))*SolverProc,
+    Model, Solver, dt, Transient );
 }
 
 /*--------------------------------------------------------------------------
    INTERNAL: Call lin. solve routines at given address
   -------------------------------------------------------------------------*/
 static int DoLinSolveProcs(
-  int (STDCALLBULL *SolverProc)(), void *Model, void *Solver, void *Matrix, void *b, 
-                void *x, void *n, void *DOFs, void *Norm )
+  int (STDCALLBULL *SolverProc)(void *, void *, void *, void *, void *, void *, void *, void *),
+  void *Model, void *Solver, void *Matrix, void *b,
+  void *x, void *n, void *DOFs, void *Norm )
 {
    return (*SolverProc)( Model,Solver,Matrix,b,x,n, DOFs,Norm );
 }
@@ -577,7 +590,9 @@ int STDCALLBULL FC_FUNC(execlinsolveprocs,EXECLINSOLVEPROCS)
      ( f_ptr *SolverProc, void *Model, void *Solver, void *Matrix, void *b, void *x, void *n, void *DOFs, void *Norm )
 #endif
 {
-   return DoLinSolveProcs( (int (STDCALLBULL *)())*SolverProc,Model,Solver,Matrix,b,x,n,DOFs,Norm );
+  return DoLinSolveProcs(
+    (int (STDCALLBULL *)(void *, void *, void *, void *, void *, void *, void *, void *)) *SolverProc,
+    Model, Solver, Matrix, b, x, n, DOFs, Norm );
 }
 
 char *mtc_domath(char *);
@@ -665,8 +680,10 @@ void STDCALLBULL FC_FUNC(matc_c,MATC) (char *cmd,int *cmdlen,char *result,*resle
 /*--------------------------------------------------------------------------
   INTERNAL: execute user material function
   -------------------------------------------------------------------------*/
-static double DoViscFunction(double (STDCALLBULL *SolverProc)(), void *Model, void *Element, void *Nodes, void *n,
-     void *Basis, void *GradBasis, void *Viscosity, void *Velo, void *GradV )
+static double DoViscFunction(
+  double (STDCALLBULL *SolverProc)(void *, void *, void *, void *, void *, void *, void *, void *, void *),
+  void *Model, void *Element, void *Nodes, void *n,
+  void *Basis, void *GradBasis, void *Viscosity, void *Velo, void *GradV )
 {
    double s;
    s = (*SolverProc)( Model,Element,Nodes,n,Basis,GradBasis,
@@ -685,14 +702,15 @@ double STDCALLBULL FC_FUNC(materialuserfunction,MATERIALUSERFUNCTION)
   ( f_ptr Function, void *Model, void *Element, void *Nodes, void *n, void *nd, void *Basis, void *GradBasis, void *Viscosity, void *Velo, void *gradV )
 #endif
 {
-   return DoViscFunction( (double (STDCALLBULL *)())*Function,Model,Element,Nodes,n,Basis,
-                  GradBasis,Viscosity,Velo,gradV );
+   return DoViscFunction(
+    (double (STDCALLBULL *)(void *, void *, void *, void *, void *, void *, void *, void *, void *)) *Function,
+    Model, Element, Nodes, n, Basis, GradBasis, Viscosity, Velo, gradV );
 }
 
 /*--------------------------------------------------------------------------
   INTERNAL: execute user material function
   -------------------------------------------------------------------------*/
-static void DoSimulationProc( void (STDCALLBULL *SimulationProc)(), void *Model )
+static void DoSimulationProc( void (STDCALLBULL *SimulationProc)(void *), void *Model )
 { 
   (*SimulationProc)( Model ); 
 }
@@ -707,21 +725,28 @@ void STDCALLBULL FC_FUNC(execsimulationproc,EXECSIMULATIONPROC)
      ( f_ptr Function, void *Model )
 #endif
 {
-   DoSimulationProc( (void (STDCALLBULL *)())*Function,Model );
+   DoSimulationProc( (void (STDCALLBULL *)(void *)) *Function, Model );
 }
 
 
 /*--------------------------------------------------------------------------
   INTERNAL: execute (Krylov) iterator 
   -------------------------------------------------------------------------*/
-static void DoIterCall( void (STDCALLBULL *iterProc)(),
-       void *x,void *b,void *ipar,void *dpar,void *work,
-       void (STDCALLBULL *mvProc)(),
-       void (STDCALLBULL *pcondProc)(),
-       void (STDCALLBULL *pcondrProc)(),
-       void (STDCALLBULL *dotProc)(),
-       void (STDCALLBULL *normProc)(),
-       void (STDCALLBULL *STOPC)() )
+static void DoIterCall(
+  void (STDCALLBULL *iterProc)(void *,void *,void *,void *,void *,
+                               void (STDCALLBULL *)(),
+                               void (STDCALLBULL *)(),
+                               void (STDCALLBULL *)(),
+                               void (STDCALLBULL *)(),
+                               void (STDCALLBULL *)(),
+                               void (STDCALLBULL *)()),
+  void *x,void *b,void *ipar,void *dpar,void *work,
+  void (STDCALLBULL *mvProc)(),
+  void (STDCALLBULL *pcondProc)(),
+  void (STDCALLBULL *pcondrProc)(),
+  void (STDCALLBULL *dotProc)(),
+  void (STDCALLBULL *normProc)(),
+  void (STDCALLBULL *STOPC)() )
 { 
   (*iterProc)( x,b,ipar,dpar,work,mvProc,pcondProc, 
        pcondrProc,dotProc,normProc,STOPC );
@@ -739,7 +764,14 @@ void STDCALLBULL FC_FUNC(itercall,ITERCALL)
        f_ptr mvProc, f_ptr pcondProc, f_ptr pcondrProc, f_ptr dotProc, f_ptr normProc, f_ptr STOPC )
 #endif
 {
-   DoIterCall( (void (STDCALLBULL *)())*iterProc,x,b,ipar,dpar,work,
+   DoIterCall( (void (STDCALLBULL *)(void *,void *,void *,void *,void *,
+                                     void (STDCALLBULL *)(),
+                                     void (STDCALLBULL *)(),
+                                     void (STDCALLBULL *)(),
+                                     void (STDCALLBULL *)(),
+                                     void (STDCALLBULL *)(),
+                                     void (STDCALLBULL *)())) *iterProc,
+       x,b,ipar,dpar,work,
        (void (STDCALLBULL *)())*mvProc, 
        (void (STDCALLBULL *)())*pcondProc,
        (void (STDCALLBULL *)())*pcondrProc,
@@ -751,8 +783,9 @@ void STDCALLBULL FC_FUNC(itercall,ITERCALL)
 /*--------------------------------------------------------------------------
   INTERNAL: execute localmatrix call
   -------------------------------------------------------------------------*/
-static void DoLocalCall( void (STDCALLBULL *localProc)(),
-  void *Model,void *Solver,void *G, void *F, void *Element,void *n,void *nd )
+static void DoLocalCall(
+  void (STDCALLBULL *localProc)(void *, void *, void *, void *, void *, void *, void *),
+  void *Model, void *Solver, void *G, void *F, void *Element, void *n, void *nd )
 { 
   (*localProc)( Model, Solver, G, F, Element, n, nd );
 }
@@ -768,7 +801,9 @@ void STDCALLBULL FC_FUNC(execlocalproc, EXECLOCALPROC )
      ( f_ptr localProc, void *Model,void *Solver,void *G, void *F, void *Element,void *n,void *nd )
 #endif
 {
-   DoLocalCall( (void (STDCALLBULL *)())*localProc,Model,Solver,G,F,Element,n,nd );
+  DoLocalCall(
+    (void (STDCALLBULL *)(void *, void *, void *, void *, void *, void *, void *)) *localProc,
+    Model, Solver, G, F, Element, n, nd );
 }
 
 
@@ -776,7 +811,8 @@ void STDCALLBULL FC_FUNC(execlocalproc, EXECLOCALPROC )
 /*--------------------------------------------------------------------------
   INTERNAL: execute complete localmatrix call
   -------------------------------------------------------------------------*/
-static void DoLocalAssembly( void (STDCALLBULL *LocalAssembly)(),
+static void DoLocalAssembly(
+  void (STDCALLBULL *LocalAssembly)(void *, void *, void *, void *, void *, void *, void *,void *, void *, void *, void *),
   void *Model,void *Solver,void *dt,void *transient,void *M, void *D, void *S,void *F, void *Element,void *n,void *nd )
 { 
   (*LocalAssembly)( Model, Solver, dt, transient, M, D, S, F, Element, n, nd );
@@ -795,7 +831,9 @@ void STDCALLBULL FC_FUNC(execlocalassembly, EXECLOCALASSEMBLY )
      ( f_ptr LocalAssembly, void *Model,void *Solver,void *dt,void *transient,void *M, void *D, void *S,void *F,void *Element,void *n,void *nd )
 #endif
 {
-   DoLocalAssembly( (void (STDCALLBULL *)())*LocalAssembly,Model,Solver,dt,transient,M,D,S,F,Element,n,nd );
+  DoLocalAssembly(
+    (void (STDCALLBULL *)(void *, void *, void *, void *, void *, void *, void *,void *, void *, void *, void *)) *LocalAssembly,
+    Model, Solver, dt, transient, M, D, S, F, Element, n, nd );
 }
 
 
@@ -803,8 +841,9 @@ void STDCALLBULL FC_FUNC(execlocalassembly, EXECLOCALASSEMBLY )
 /*--------------------------------------------------------------------------
   INTERNAL: execute complete localmatrix call
   -------------------------------------------------------------------------*/
-static void DoMatVecSubr( void (STDCALLBULL *matvec)(),
-  void **SpMV,void *n,void *rows,void *cols,void *vals,void *u, void *v, void *reinit )
+static void DoMatVecSubr(
+  void (STDCALLBULL *matvec)(void **, void *, void *, void *,void *, void *, void *, void *),
+  void **SpMV, void *n, void *rows, void *cols, void *vals, void *u, void *v, void *reinit )
 { 
   (*matvec)( SpMV,n,rows,cols,vals,u,v,reinit);
 }
@@ -820,5 +859,7 @@ void STDCALLBULL FC_FUNC(matvecsubr, MMATVECSUBR)
      ( f_ptr matvec, void **SpMV, void *n, void *rows, void *cols, void *vals, void *u, void *v,void *reinit )
 #endif
 {
-   DoMatVecSubr( (void (STDCALLBULL *)())*matvec,SpMV,n,rows,cols,vals,u,v,reinit);
+  DoMatVecSubr(
+    (void (STDCALLBULL *)(void **, void *, void *, void *,void *, void *, void *, void *)) *matvec,
+    SpMV, n, rows, cols, vals, u, v, reinit);
 }

--- a/fem/src/Load.c
+++ b/fem/src/Load.c
@@ -3,7 +3,7 @@
 ! *  Elmer, A Finite Element Software for Multiphysical Problems
 ! *
 ! *  Copyright 1st April 1995 - , CSC - IT Center for Science Ltd., Finland
-! * 
+! *
 ! *  This library is free software; you can redistribute it and/or
 ! *  modify it under the terms of the GNU Lesser General Public
 ! *  License as published by the Free Software Foundation; either
@@ -13,10 +13,10 @@
 ! *  but WITHOUT ANY WARRANTY; without even the implied warranty of
 ! *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
 ! *  Lesser General Public License for more details.
-! * 
+! *
 ! *  You should have received a copy of the GNU Lesser General Public
-! *  License along with this library (in file ../LGPL-2.1); if not, write 
-! *  to the Free Software Foundation, Inc., 51 Franklin Street, 
+! *  License along with this library (in file ../LGPL-2.1); if not, write
+! *  to the Free Software Foundation, Inc., 51 Franklin Street,
 ! *  Fifth Floor, Boston, MA  02110-1301  USA
 ! *
 ! ******************************************************************************
@@ -31,7 +31,7 @@
 ! *  Web:     http://www.csc.fi/elmer
 ! *  Address: CSC - IT Center for Science Ltd.
 ! *           Keilaranta 14
-! *           02101 Espoo, Finland 
+! *           02101 Espoo, Finland
 ! *
 ! *  Original Date: 02 Jun 1997
 ! *
@@ -64,7 +64,7 @@
 /* pc needs more bits on 64bit arch  */
 #ifdef ARCH_32_BITS
 #define f_ptr int32_t *
-#else 
+#else
 #define f_ptr int64_t *
 #endif
 
@@ -86,7 +86,7 @@
 #ifdef USE_ISO_C_BINDINGS
 void STDCALLBULL getsolverhome( char *solverDir, int *len)
 #else
-void STDCALLBULL FC_FUNC(getsolverhome,GETSOLVERHOME) 
+void STDCALLBULL FC_FUNC(getsolverhome,GETSOLVERHOME)
      ( char *solverDir, int *len)
 #endif
 {
@@ -188,14 +188,14 @@ void STDCALLBULL FC_FUNC(envir,ENVIR) (char *Name, char *Value, int *len)
 static void STDCALLBULL fortranMangle(char *orig, char *mangled)
 {
   int uscore, i;
-  
+
   strcpy( mangled, orig );
 
   if(ELMER_LINKTYP == 1 || ELMER_LINKTYP == 3 || ELMER_LINKTYP == 4)
   {
     for( i=0 ; i<strlen(mangled) ; i++ ) /* to lower case */
     {
-      if ( mangled[i] >= 'A'  && mangled[i] <= 'Z' ) 
+      if ( mangled[i] >= 'A'  && mangled[i] <= 'Z' )
 	mangled[i] += 'a' - 'A';
     }
   }
@@ -203,11 +203,11 @@ static void STDCALLBULL fortranMangle(char *orig, char *mangled)
   {
     for( i=0; i<strlen(mangled); i++ ) /* to upper case */
     {
-      if ( mangled[i] >= 'a'  && mangled[i] <= 'z' ) 
+      if ( mangled[i] >= 'a'  && mangled[i] <= 'z' )
 	mangled[i] += 'A' - 'a';
     }
   }
-  
+
   if(ELMER_LINKTYP == 1) /* underscore */
   {
       strcat( mangled, "_" );
@@ -218,12 +218,12 @@ static void STDCALLBULL fortranMangle(char *orig, char *mangled)
     for( i=0; i<strlen(mangled); i++ )
       if(mangled[i] == '_')
 	uscore++;
-    
+
     if(uscore == 0)
     {
       strcat( mangled, "_" );
-    } 
-    else 
+    }
+    else
     {
       strcat( mangled, "__" );
     }
@@ -327,7 +327,7 @@ try_open_solver(char *SearchPath, char *Library, void **Handle, char *errorBuf)
   loaded library and name of the routine.
   -------------------------------------------------------------------------*/
 #ifdef USE_ISO_C_BINDINGS
-void *STDCALLBULL loadfunction_c( int *Quiet, int *abort_not_found, 
+void *STDCALLBULL loadfunction_c( int *Quiet, int *abort_not_found,
         char *Library, char *Name, int *mangle )
 #else
 void *STDCALLBULL FC_FUNC(loadfunction,LOADFUNCTION) ( int *Quiet, int *abort_not_found,
@@ -404,7 +404,7 @@ void *STDCALLBULL FC_FUNC(loadfunction,LOADFUNCTION) ( int *Quiet, int *abort_no
       fprintf(stderr, "%s", ErrorBuffer);
       exit(0);
    }
-   
+
 #ifdef HAVE_DLOPEN_API
 
    if ( (Function = (void(*)())dlsym( Handle,NewName)) == NULL && *abort_not_found )
@@ -547,7 +547,7 @@ static void DoExecSolver(
   void (STDCALLBULL *SolverProc)(void *, void *, void *, void *),
   void *Model, void *Solver, void *dt, void *Transient)
 {
-  (*SolverProc)( Model,Solver,dt,Transient ); 
+  (*SolverProc)( Model,Solver,dt,Transient );
   return;
 }
 
@@ -604,7 +604,7 @@ void mtc_init(FILE *,FILE *, FILE *);
 #ifdef USE_ISO_C_BINDINGS
 void STDCALLBULL matc_get_array(char *name, double *values, int *nrows, int *ncols )
 #else
-void STDCALLBULL FC_FUNC_(matc_get_array,MATC_GET_ARRAY) (char *name, 
+void STDCALLBULL FC_FUNC_(matc_get_array,MATC_GET_ARRAY) (char *name,
            double *values, int *nrows, int *ncols )
 #endif
 {
@@ -633,7 +633,7 @@ void STDCALLBULL FC_FUNC(matc_c,MATC) (char *cmd,int *cmdlen,char *result,*resle
 
    slen = *len;
    if ( been_here==0 ) {
-     mtc_init( NULL, stdout, stderr ); 
+     mtc_init( NULL, stdout, stderr );
      strcpy( cc, "format( 12,\"rowform\")" );
      mtc_domath( cc );
      been_here = 1;
@@ -711,8 +711,8 @@ double STDCALLBULL FC_FUNC(materialuserfunction,MATERIALUSERFUNCTION)
   INTERNAL: execute user material function
   -------------------------------------------------------------------------*/
 static void DoSimulationProc( void (STDCALLBULL *SimulationProc)(void *), void *Model )
-{ 
-  (*SimulationProc)( Model ); 
+{
+  (*SimulationProc)( Model );
 }
 
 /*--------------------------------------------------------------------------
@@ -730,7 +730,7 @@ void STDCALLBULL FC_FUNC(execsimulationproc,EXECSIMULATIONPROC)
 
 
 /*--------------------------------------------------------------------------
-  INTERNAL: execute (Krylov) iterator 
+  INTERNAL: execute (Krylov) iterator
   -------------------------------------------------------------------------*/
 static void DoIterCall(
   void (STDCALLBULL *iterProc)(void *,void *,void *,void *,void *,
@@ -747,8 +747,8 @@ static void DoIterCall(
   void (STDCALLBULL *dotProc)(),
   void (STDCALLBULL *normProc)(),
   void (STDCALLBULL *STOPC)() )
-{ 
-  (*iterProc)( x,b,ipar,dpar,work,mvProc,pcondProc, 
+{
+  (*iterProc)( x,b,ipar,dpar,work,mvProc,pcondProc,
        pcondrProc,dotProc,normProc,STOPC );
 }
 
@@ -760,7 +760,7 @@ void STDCALLBULL itercall_c( f_ptr iterProc, void *x, void *b, void *ipar, void 
        f_ptr mvProc, f_ptr pcondProc, f_ptr pcondrProc, f_ptr dotProc, f_ptr normProc, f_ptr STOPC )
 #else
 void STDCALLBULL FC_FUNC(itercall,ITERCALL)
-     ( f_ptr iterProc, void *x, void *b, void *ipar, void *dpar, void *work, 
+     ( f_ptr iterProc, void *x, void *b, void *ipar, void *dpar, void *work,
        f_ptr mvProc, f_ptr pcondProc, f_ptr pcondrProc, f_ptr dotProc, f_ptr normProc, f_ptr STOPC )
 #endif
 {
@@ -772,7 +772,7 @@ void STDCALLBULL FC_FUNC(itercall,ITERCALL)
                                      void (STDCALLBULL *)(),
                                      void (STDCALLBULL *)())) *iterProc,
        x,b,ipar,dpar,work,
-       (void (STDCALLBULL *)())*mvProc, 
+       (void (STDCALLBULL *)())*mvProc,
        (void (STDCALLBULL *)())*pcondProc,
        (void (STDCALLBULL *)())*pcondrProc,
        (void (STDCALLBULL *)())*dotProc,
@@ -786,7 +786,7 @@ void STDCALLBULL FC_FUNC(itercall,ITERCALL)
 static void DoLocalCall(
   void (STDCALLBULL *localProc)(void *, void *, void *, void *, void *, void *, void *),
   void *Model, void *Solver, void *G, void *F, void *Element, void *n, void *nd )
-{ 
+{
   (*localProc)( Model, Solver, G, F, Element, n, nd );
 }
 
@@ -814,7 +814,7 @@ void STDCALLBULL FC_FUNC(execlocalproc, EXECLOCALPROC )
 static void DoLocalAssembly(
   void (STDCALLBULL *LocalAssembly)(void *, void *, void *, void *, void *, void *, void *,void *, void *, void *, void *),
   void *Model,void *Solver,void *dt,void *transient,void *M, void *D, void *S,void *F, void *Element,void *n,void *nd )
-{ 
+{
   (*LocalAssembly)( Model, Solver, dt, transient, M, D, S, F, Element, n, nd );
 }
 
@@ -844,7 +844,7 @@ void STDCALLBULL FC_FUNC(execlocalassembly, EXECLOCALASSEMBLY )
 static void DoMatVecSubr(
   void (STDCALLBULL *matvec)(void **, void *, void *, void *,void *, void *, void *, void *),
   void **SpMV, void *n, void *rows, void *cols, void *vals, void *u, void *v, void *reinit )
-{ 
+{
   (*matvec)( SpMV,n,rows,cols,vals,u,v,reinit);
 }
 

--- a/fem/src/fft.c
+++ b/fem/src/fft.c
@@ -386,9 +386,7 @@ static int _FFT_Level;
  *                        / the number of bits.
  * T: COMPLEX[N]          / the array to be operated on.
  */
-void BitReverseArray( N, T )
-    int N;
-    COMPLEX *T;
+void BitReverseArray(int N, COMPLEX *T)
 {
     COMPLEX swap;
 
@@ -456,10 +454,7 @@ void sort_shift(int lbeg,int lend,double *Key,int *Ord)
    }
 
 }
-void sort( N, Key, Ord )
-    int N;
-    int *Ord;
-    double *Key;
+void sort(int N, double *Key, int *Ord)
 {
   int lend,lbeg;
 
@@ -483,7 +478,7 @@ void sort( N, Key, Ord )
  *
  * Parameters: NONE.
  */
-static int FFTInit( )
+static void FFTInit(void)
 {
     static int InitDone = FALSE;
 
@@ -491,7 +486,7 @@ static int FFTInit( )
     int n;
 
     if ( InitDone ) {
-        return 0;
+        return;
         }
 
     n = ( 1 << _FFT_MAX_LEVELS );
@@ -518,10 +513,7 @@ static int FFTInit( )
  * T(n) = sum(F(k)*exp(-i*2*pi*n*k/N)), k=0..N-1,n=0..N-1
  *
  */
-static int FFTKernel( N, F, T )
-    int N;
-    COMPLEX *F;
-    COMPLEX *T;
+static void FFTKernel(int N, COMPLEX *F, COMPLEX *T)
 {
     double ExpR;
     double ExpI;
@@ -576,7 +568,7 @@ static int FFTKernel( N, F, T )
         T[_FFT_I].Imag = TempI - F[3].Imag;
         _FFT_I++;
 
-        return 0;
+        return;
         }
    
     N /= 2;
@@ -630,10 +622,7 @@ static int FFTKernel( N, F, T )
  *
  * F(n) = sum(T(k)*exp(-i*2*pi*n*k/N)), k=0..N-1,n=0..N-1
  */
-void cfftf( N, T, F )
-    int N;
-    COMPLEX *T;
-    COMPLEX *F;
+void cfftf(int N, COMPLEX *T, COMPLEX *F)
 {
     int logN;
     int k;
@@ -665,10 +654,7 @@ void cfftf( N, T, F )
  * T(n) = sum(F(k)*exp(i*2*pi*n*k/N)), k=0..N-1,N=0..N-1
  *
  */
-void cfftb( N, F, T )
-    int N;
-    COMPLEX *F;
-    COMPLEX *T;
+void cfftb(int N, COMPLEX *F, COMPLEX *T)
 {
     int logN;
     int k;
@@ -682,18 +668,12 @@ void cfftb( N, F, T )
 }
 
 #ifdef USE_ISO_C_BINDINGS
-void fcfftb( N, F, T )
-    int *N;
-    COMPLEX *F;
-    COMPLEX *T;
+void fcfftb(int *N, COMPLEX *F, COMPLEX *T)
 {
     cfftb( *N, F, T );
 }
 #else
-void FC_FUNC(fcfftb,FCFFTB)( N, F, T )
-    int *N;
-    COMPLEX *F;
-    COMPLEX *T;
+void FC_FUNC(fcfftb,FCFFTB)(int *N, COMPLEX *F, COMPLEX *T)
 {
     cfftb( *N, F, T );
 }
@@ -713,10 +693,7 @@ void FC_FUNC(fcfftb,FCFFTB)( N, F, T )
  * F(n) = sum(T(k)*exp(-i*2*pi*n*k/N)), k=0..N-1,n=0..N/2
  *
  */
-void rfftf( N, T, F )
-    int N;
-    double   *T;
-    COMPLEX *F;
+void rfftf(int N, double *T, COMPLEX *F)
 {
     COMPLEX *W;
 
@@ -793,10 +770,7 @@ void rfftf( N, T, F )
  * T(n) = sum(F(k)*exp(i*2*pi*n*k/N)), k=0..N-1,N=0..N-1
  *
  */
-void rfftb( N, F, T )
-    int N;
-    COMPLEX *F;
-    double   *T;
+void rfftb(int N, COMPLEX *F, double *T)
 {
     COMPLEX *W;
 
@@ -883,18 +857,12 @@ void rfftb( N, F, T )
 }
 
 #ifdef USE_ISO_C_BINDINGS
-void frfftb( N, F, T )
-    int *N;
-    COMPLEX *F;
-    double   *T;
+void frfftb(int *N, COMPLEX *F, double *T)
 {
    rfftb( *N, F, T );
 }
 #else
-FC_FUNC(frfftb,FRFFTB)( N, F, T )
-    int *N;
-    COMPLEX *F;
-    double   *T;
+FC_FUNC(frfftb,FRFFTB)(int *N, COMPLEX *F, double *T)
 {
    rfftb( *N, F, T ); 
 }
@@ -922,11 +890,7 @@ FC_FUNC(frfftb,FRFFTB)( N, F, T )
  *       }
  *
  */
-void gfftb( nF, freq, nT, time )
-    int nT;
-    int nF;
-    double *time;
-    FREQ  *freq;
+void gfftb(int nF, FREQ *freq, int nT, double *time)
 {
     COMPLEX *F;
 
@@ -976,11 +940,7 @@ void gfftb( nF, freq, nT, time )
  *       int FBin;
  *       }
  */
-void gfftf( nT, time, nF, freq )
-    int nT;
-    int nF;
-    FREQ *freq;
-    double *time;
+void gfftf(int nT, double *time, int nF, FREQ *freq)
 {
     COMPLEX *F;
 
@@ -1032,10 +992,7 @@ void gfftf( nT, time, nF, freq )
  *
  * F(m,n) = sum(T(k,l)*exp(-i*2*pi*(m*k/M+n*l/N))), k,m=0..M-1; l,n=0..N-1
  */
-void cfftf2D( M, N, T, F ) 
-    int M,N;
-    COMPLEX *T;
-    COMPLEX *F;
+void cfftf2D(int M, int N, COMPLEX *T, COMPLEX *F)
 {
     COMPLEX *W;
 
@@ -1070,10 +1027,7 @@ void cfftf2D( M, N, T, F )
  *
  * T(m,n) = sum(F(k,l)*exp(i*2*pi*(m*k/M+n*l/N))), k,m=0..M-1; l,n=0..N-1
  */
-void cfftb2D( M, N, F, T ) 
-    int M,N;
-    COMPLEX *F;
-    COMPLEX *T;
+void cfftb2D(int M, int N, COMPLEX *F, COMPLEX *T)
 {
     COMPLEX *W;
 
@@ -1102,10 +1056,7 @@ void cfftb2D( M, N, F, T )
  * F(l,m,n) = sum(T(i,j,k)*exp(-i*2*pi*(l*i/L+m*j/M+n*k/N))), 
  *                                         l,i=0..L-1; m,j=0..M-1; k,n=0..N-1
  */
-void cfftf3D( L, M, N, T, F )
-    int L,M,N;
-    COMPLEX *T;
-    COMPLEX *F;
+void cfftf3D(int L, int M, int N, COMPLEX *T, COMPLEX *F)
 {
     COMPLEX *W;
 
@@ -1140,10 +1091,7 @@ void cfftf3D( L, M, N, T, F )
  * T(l,m,n) = sum(F(i,j,k)*exp(i*2*pi*(l*i/L+m*j/M+n*k/N))), 
  *                                         l,i=0..L-1; m,j=0..M-1; k,n=0..N-1
  */
-void cfftb3D( L, M, N, F, T )
-    int L,M,N;
-    COMPLEX *F;
-    COMPLEX *T;
+void cfftb3D(int L, int M, int N, COMPLEX *F, COMPLEX *T)
 {
     int k;
 
@@ -1169,11 +1117,7 @@ void cfftb3D( L, M, N, F, T )
  * F   : COMPLEX F[D[N-1]][D[N-2]]...[D[0]]    / transform array.
  *                                             / may point to same memory as T.
  */
-void cfftfND( N, D, T, F )
-    int  N;
-    int *D;
-    COMPLEX *T;
-    COMPLEX *F;
+void cfftfND(int N, int *D, COMPLEX *T, COMPLEX *F)
 {
     COMPLEX *W;
 
@@ -1246,11 +1190,7 @@ void cfftfND( N, D, T, F )
  * T   : COMPLEX F[D[N-1]][D[N-2]]...[D[0]]    / output array.
  *                                             / may point to same memory as T.
  */
-void cfftbND( N, D, F, T )
-    int  N;
-    int *D;
-    COMPLEX *F;
-    COMPLEX *T;
+void cfftbND(int N, int *D, COMPLEX *F, COMPLEX *T)
 {
     int TotN;
     int k;

--- a/fem/src/fft.c
+++ b/fem/src/fft.c
@@ -1,21 +1,21 @@
-/*  
+/*
    Elmer, A Finite Element Software for Multiphysical Problems
-  
+
    Copyright 1st April 1995 - , CSC - IT Center for Science Ltd., Finland
-   
+
    This library is free software; you can redistribute it and/or
    modify it under the terms of the GNU Lesser General Public
    License as published by the Free Software Foundation; either
    version 2.1 of the License, or (at your option) any later version.
-  
+
    This library is distributed in the hope that it will be useful,
    but WITHOUT ANY WARRANTY; without even the implied warranty of
    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
    Lesser General Public License for more details.
-   
+
    You should have received a copy of the GNU Lesser General Public
-   License along with this library (in file ../../LGPL-2.1); if not, write 
-   to the Free Software Foundation, Inc., 51 Franklin Street, 
+   License along with this library (in file ../../LGPL-2.1); if not, write
+   to the Free Software Foundation, Inc., 51 Franklin Street,
    Fifth Floor, Boston, MA  02110-1301  USA
 */
 
@@ -73,7 +73,7 @@
  *
  * Parameters:
  *
- * N     : int            / length of sequences. 
+ * N     : int            / length of sequences.
  * T     : COMPLEX[N]     / input sequence.
  * F     : COMPLEX[N]     / transform sequence. may point to same memory as T.
  *
@@ -98,9 +98,9 @@
  *
  * Parameters:
  *
- * N     : int              / length of input sequence. 
+ * N     : int              / length of input sequence.
  * T     : double[N]         / input sequence.
- * F     : COMPLEX[N/2+1]   / transform sequence. may point to same memory 
+ * F     : COMPLEX[N/2+1]   / transform sequence. may point to same memory
  *                          / as T (which must then be of length (N+2)).
  *
  * F(n) = sum(T(k)*exp(-i*2*pi*n*k/N)), k=0..N-1,n=0..N/2
@@ -115,7 +115,7 @@
  * then
  * 2*G(n) = (1/(N/2))*sum(g(l)*exp(-i*2*pi*n*l/(N/2)),l=0..N/2-1,(k=2*l)
  * 2*H(n) = (1/(N/2))*sum(h(l)*exp(-i*2*pi*n*l/(N/2)),l=0..N/2-1,(k=2*l+1)
- * and 
+ * and
  * F(n) = G(n) + exp(-i*2*pi*n/N)*H(n), n=0..N/2-1
  * Now take
  * y(k) = g(k) + i*h(k), k=0..N/2-1
@@ -126,7 +126,7 @@
  * where
  *       G_even is even part of G, G_odd odd part of G,
  *       H_even is even part of H, and H_odd odd part of H.
- * now 
+ * now
  * 2*G_even(n) = Real( Y(n) + Y(N/2-n))
  * 2*G_odd(n)  = Imag( Y(n) - Y(N/2-n))
  * 2*H_even(n) = Imag( Y(n) + Y(N/2-n))
@@ -134,10 +134,10 @@
  * and (at last)
  * F(n)=G_even(n)+i*G_odd(n)+exp(-i*2*pi*n/N)*(H_even(n)+i*H_odd(n)), n=0..N/2-1
  * F(n)=Real(F(N-n))-i*Imag(F(N-n)), n=N/2+1..N-1
- * 
+ *
  *------------------------------------------------------------------------------
  *
- * rfftb: inverse real FFT. 
+ * rfftb: inverse real FFT.
  *
  * Parameters:
  *
@@ -159,11 +159,11 @@
  * now
  * h(k) = (exp(i*2*pi*k/N)-exp(-i*2*pi*k/N))*x(k)
  *      = i*2*sin(2*pi*k/N)*x(k)
- * where 
+ * where
  * X(n) = F(2*n+1), k=0..N/2-1
  * x(k) = sum(X(l)*exp(i*2*pi*k*l/(N/2))), l=0..N/2-1,(n=2*l+1)
  * g(k) = sum(G(l)*exp(i*2*pi*k*l/(N/2))), l=0..N/2-1,(n=2*l)
- * take 
+ * take
  * Y(n) = G(n) + H(n)
  * so
  * y(k) = g(k) + h(k)
@@ -215,7 +215,7 @@
  * T     : COMPLEX[L][M][N]   / input array.
  * F     : COMPLEX[L][M][N]   / transform array. may point to same memory as T.
  *
- * F(l,m,n) = sum(T(i,j,k)*exp(-i*2*pi*(l*i/L+m*j/M+n*k/N))), 
+ * F(l,m,n) = sum(T(i,j,k)*exp(-i*2*pi*(l*i/L+m*j/M+n*k/N))),
  *                                         l,i=0..L-1; m,j=0..M-1; k,n=0..N-1
  *
  *------------------------------------------------------------------------------
@@ -228,7 +228,7 @@
  * F     : COMPLEX[L][M][N]   / transform array.
  * T     : COMPLEX[L][M][N]   / output array. may point to same memory as T.
  *
- * T(l,m,n) = sum(F(i,j,k)*exp(i*2*pi*(l*i/L+m*j/M+n*k/N))), 
+ * T(l,m,n) = sum(F(i,j,k)*exp(i*2*pi*(l*i/L+m*j/M+n*k/N))),
  *                                         l,i=0..L-1; m,j=0..M-1; k,n=0..N-1
  *
  *------------------------------------------------------------------------------
@@ -295,9 +295,9 @@
  *     double Mag;
  *     int FBin;
  *     } FREQ;
- * 
+ *
  * The magnitude entry is returned by gfftf(), not used by gfftb().
- * 
+ *
  * Juha Ruokolainen / CSC
  * LAST CHANGE: 19.3. -92
  *
@@ -416,7 +416,7 @@ void BitReverseArray(int N, COMPLEX *T)
  *       another (integer) array accordingly. the latter can be used as track
  *       keeper of where an element in the sorted order at position (k) was in
  *       in the original order (Ord[k]), if it is initialized to contain
- *       numbers (0..N-1) before calling sort. 
+ *       numbers (0..N-1) before calling sort.
  *
  * Parameters:
  *
@@ -491,8 +491,8 @@ static void FFTInit(void)
 
     n = ( 1 << _FFT_MAX_LEVELS );
     for( k = 0; k < _FFT_MAX_LEVELS; k++ ) {
-        _FFT_COS[k] =  cos( _FFT_PI / n );    
-        _FFT_SIN[k] = -sin( _FFT_PI / n );    
+        _FFT_COS[k] =  cos( _FFT_PI / n );
+        _FFT_SIN[k] = -sin( _FFT_PI / n );
         n /= 2;
         }
 
@@ -570,9 +570,9 @@ static void FFTKernel(int N, COMPLEX *F, COMPLEX *T)
 
         return;
         }
-   
+
     N /= 2;
- 
+
     /*
      *  ExpR + i*ExpI = exp(-i*2*pi*k/N ) = exp(-i*2*pi/N)^(k)
      */
@@ -616,7 +616,7 @@ static void FFTKernel(int N, COMPLEX *F, COMPLEX *T)
  *
  * Parameters:
  *
- * N     : int            / length of sequences. 
+ * N     : int            / length of sequences.
  * T     : COMPLEX[N]     / input sequence.
  * F     : COMPLEX[N]     / transform sequence. may point to same memory as T.
  *
@@ -638,7 +638,7 @@ void cfftf(int N, COMPLEX *T, COMPLEX *F)
         for( k = 0; k < N; k++ ) F[k] = T[k];
         }
 
-    FFTKernel( N, F, F ); 
+    FFTKernel( N, F, F );
     BitReverseArray( N, F );
 }
 
@@ -685,9 +685,9 @@ void FC_FUNC(fcfftb,FCFFTB)(int *N, COMPLEX *F, COMPLEX *T)
  *
  * parameters:
  *
- * N     : int              / length of input sequence. 
+ * N     : int              / length of input sequence.
  * T     : double[N]         / input sequence.
- * F     : COMPLEX[N/2+1]   / transform sequence. may point to same memory 
+ * F     : COMPLEX[N/2+1]   / transform sequence. may point to same memory
  *                          / as T (which must then be of length (N+2)).
  *
  * F(n) = sum(T(k)*exp(-i*2*pi*n*k/N)), k=0..N-1,n=0..N/2
@@ -719,7 +719,7 @@ void rfftf(int N, double *T, COMPLEX *F)
  *     W[k].Imag = T[2*k+1];
  *     }
  *
- *  and replace 
+ *  and replace
  *     cfftf( N, (COMPLEX *)T, W );
  *  by
  *     cfftf( N, W, W );
@@ -750,7 +750,7 @@ void rfftf(int N, double *T, COMPLEX *F)
 
         F[k].Real /= 2; F[k].Imag /= 2;
 
-        t = ExpR;                   
+        t = ExpR;
         ExpR = CO * t - SI * ExpI;
         ExpI = CO * ExpI + SI * t;
         }
@@ -759,7 +759,7 @@ void rfftf(int N, double *T, COMPLEX *F)
 }
 
 /*
- * rfftb: inverse real FFT. 
+ * rfftb: inverse real FFT.
  *
  * Parameters:
  *
@@ -837,7 +837,7 @@ void rfftb(int N, COMPLEX *F, double *T)
     SI  = sin( pi );
 
     for( k = 1; k < N; k++ ) {
-        t = ExpR;                   
+        t = ExpR;
         ExpR = CO * t - SI * ExpI;
         ExpI = CO * ExpI + SI * t;
 
@@ -864,7 +864,7 @@ void frfftb(int *N, COMPLEX *F, double *T)
 #else
 FC_FUNC(frfftb,FRFFTB)(int *N, COMPLEX *F, double *T)
 {
-   rfftb( *N, F, T ); 
+   rfftb( *N, F, T );
 }
 #endif /* USE_ISO_C_BINDINGS */
 
@@ -896,20 +896,20 @@ void gfftb(int nF, FREQ *freq, int nT, double *time)
 
     int k;
 
-    /* 
-     * if you change the COMPLEX type replace 
+    /*
+     * if you change the COMPLEX type replace
      *     F = (COMPLEX *)time;
      *     bzero( F, ( nT / 2 + 1 ) * sizeof( COMPLEX ) );
      * by
      *     F = (COMPLEX *)calloc( ( nT / 2 + 1, sizeof( COMPLEX ) );
-     * and add 
+     * and add
      *     free( F );
      * to end of the routine.
-     */ 
+     */
     F = (COMPLEX *)time;
     /* bzero( F, ( nT / 2 + 1 ) * sizeof( COMPLEX ) ); */
     memset( F, 0, ( nT / 2 + 1 ) * sizeof( COMPLEX ) );
-        
+
     for( k = 0; k < nF; k++ ) {
         F[freq[k].FBin].Real = freq[k].Real;
         F[freq[k].FBin].Imag = freq[k].Imag;
@@ -975,7 +975,7 @@ void gfftf(int nT, double *time, int nF, FREQ *freq)
         freq[i].Mag  = Magnitude[k];
         freq[i].FBin = Order[k];
         }
- 
+
     free( F );
     free( Order );
     free( Magnitude );
@@ -1053,7 +1053,7 @@ void cfftb2D(int M, int N, COMPLEX *F, COMPLEX *T)
  * T     : COMPLEX[L][M][N]   / input array.
  * F     : COMPLEX[L][M][N]   / transform array. may point to same memory as T.
  *
- * F(l,m,n) = sum(T(i,j,k)*exp(-i*2*pi*(l*i/L+m*j/M+n*k/N))), 
+ * F(l,m,n) = sum(T(i,j,k)*exp(-i*2*pi*(l*i/L+m*j/M+n*k/N))),
  *                                         l,i=0..L-1; m,j=0..M-1; k,n=0..N-1
  */
 void cfftf3D(int L, int M, int N, COMPLEX *T, COMPLEX *F)
@@ -1066,7 +1066,7 @@ void cfftf3D(int L, int M, int N, COMPLEX *T, COMPLEX *F)
 
     W = (COMPLEX *)malloc( L * sizeof( COMPLEX ) );
 
-    for( k = 0; k < L; k++ ) cfftf2D( M, N, &T[k*M*N], &F[k*M*N] ); 
+    for( k = 0; k < L; k++ ) cfftf2D( M, N, &T[k*M*N], &F[k*M*N] );
 
     for( j = 0; j < M * N; j++ ) {
         for( k = 0, n = j; k < L; k++, n += M * N ) W[k] = F[n];
@@ -1088,7 +1088,7 @@ void cfftf3D(int L, int M, int N, COMPLEX *T, COMPLEX *F)
  * F     : COMPLEX[L][M][N]   / transform array.
  * T     : COMPLEX[L][M][N]   / output array. may point to same memory as T.
  *
- * T(l,m,n) = sum(F(i,j,k)*exp(i*2*pi*(l*i/L+m*j/M+n*k/N))), 
+ * T(l,m,n) = sum(F(i,j,k)*exp(i*2*pi*(l*i/L+m*j/M+n*k/N))),
  *                                         l,i=0..L-1; m,j=0..M-1; k,n=0..N-1
  */
 void cfftb3D(int L, int M, int N, COMPLEX *F, COMPLEX *T)
@@ -1132,7 +1132,7 @@ void cfftfND(int N, int *D, COMPLEX *T, COMPLEX *F)
 
     int S[32];
     int P[32];
-    
+
     WN = D[0];
     TotN = 1;
     for( i = 0; i < N; i++ ) {
@@ -1194,7 +1194,7 @@ void cfftbND(int N, int *D, COMPLEX *F, COMPLEX *T)
 {
     int TotN;
     int k;
-    
+
     TotN = D[0];
     for( k = 1; k < N; k++ ) TotN *= D[k];
 


### PR DESCRIPTION
Modern C compilers emit warnings like the following:
```
/Users/runner/work/elmerfem/elmerfem/fem/src/fft.c:389:6: warning: a function definition without a prototype is deprecated in all versions of C and is not supported in C2x [-Wdeprecated-non-prototype]
void BitReverseArray( N, T )
     ^
```
or:
```
/Users/runner/work/elmerfem/elmerfem/fem/src/Load.c:434:22: warning: passing arguments to a function without a prototype is deprecated in all versions of C and is not supported in C2x [-Wdeprecated-non-prototype]
   return (*Function)( Model );
                     ^
```

Slightly modernize the syntax by fully qualifying the function prototypes.