### PR TITLE
CI: Remove automatic triggers for act_test workflow.

### DIFF
--- a/.github/workflows/act_test.yaml
+++ b/.github/workflows/act_test.yaml
@@ -1,14 +1,14 @@
 name: act_test
 on:
   workflow_dispatch:
-  push:
-    paths-ignore:
-      - '**.nix'
-      - 'flake.lock'
-  pull_request:
-    paths-ignore:
-      - '**.nix'
-      - 'flake.lock'
+  # push:
+  #   paths-ignore:
+  #     - '**.nix'
+  #     - 'flake.lock'
+  # pull_request:
+  #   paths-ignore:
+  #     - '**.nix'
+  #     - 'flake.lock'
 
 concurrency: act_test-${{ github.ref }}
 


### PR DESCRIPTION
The `act_test` workflow is meant for manual debugging. It probably doesn't need to run on a "regular" push or pull request.

Do not trigger automatically on push or pull request. Only keep the manual workflow dispatch trigger.