### PR TITLE
CMake: Allow users to ignore package managers on macOS.

### DIFF
--- a/.github/workflows/build-macos-homebrew.yaml
+++ b/.github/workflows/build-macos-homebrew.yaml
@@ -86,6 +86,7 @@ jobs:
             -DCMAKE_Fortran_COMPILER=gfortran \
             -DCMAKE_INSTALL_PREFIX="${GITHUB_WORKSPACE}/usr" \
             -DBLA_VENDOR="OpenBLAS" \
+            -DUSE_MACOS_PACKAGE_MANAGER=OFF \
             -DCMAKE_PREFIX_PATH="$( [ "${{ matrix.openmp }}" == "with" ] && echo "${HOMEBREW_PREFIX}/opt/libomp;")${HOMEBREW_PREFIX}/opt/openblas;${HOMEBREW_PREFIX}/opt/qt;${HOMEBREW_PREFIX}/opt/qwt" \
             ${{ matrix.openmp == 'with'
               && '-DWITH_OpenMP=ON \

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,9 +23,12 @@ IF(APPLE)
   SET(CMAKE_MACOSX_RPATH 1)
 ENDIF()
 
+# Allow users to ignore package managers on macOS
+option(USE_MACOS_PACKAGE_MANAGER "Search for packages that are installed with Homebrew or MacPorts on macOS" ON)
+
 #shamelessly borrowed from FreeCAD project: https://github.com/FreeCAD/FreeCAD/blob/master/cMake/FreeCAD_Helpers/SetupPython.cmake
 # For building on OS X
-if(${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
+if(${CMAKE_SYSTEM_NAME} MATCHES "Darwin" AND USE_MACOS_PACKAGE_MANAGER)
 
   # If the user doesn't tell us which package manager they're using
   if(NOT DEFINED MACPORTS_PREFIX AND NOT DEFINED HOMEBREW_PREFIX)


### PR DESCRIPTION
Addresses the issue discussed in #594.

The original contributor (@viraptor) hasn't reacted on the feedback in a few month. I hope it is ok to pick it up and propose an alternative implementation.

The currently existing rules point to FreeCAD were that part was originally "borrowed". But that project dropped that part of the build rules entirely:
https://github.com/FreeCAD/FreeCAD/pull/8400

Maybe, ElmerFEM should do the same and also drop the package manager thing on macOS. (I'd be in favor of that.)

This PR proposes a less intrusive change that allows the user to optionally skip that part (and does so in the CI rules on macOS).

Please, let me know if you prefer to remove that section of the build rules instead. (Like I wrote, imho that would probably be preferable.)
