### PR TITLE
Increase path buffer size in SaveScalars and VTUoutput solvers

### DIFF
--- a/fem/src/modules/ResultOutputSolve/ResultOutputSolver.F90
+++ b/fem/src/modules/ResultOutputSolve/ResultOutputSolver.F90
@@ -50,7 +50,7 @@ SUBROUTINE ResultOutputSolver( Model,Solver,dt,TransientSimulation )
 
   TYPE(Mesh_t), POINTER :: Mesh, iMesh, MyMesh
   CHARACTER(10) :: OutputFormat
-  CHARACTER(LEN=MAX_NAME_LEN) :: FilePrefix, MeshName, iMeshName, ListMeshName
+  CHARACTER(LEN=MAX_PATH_LEN) :: FilePrefix, MeshName, iMeshName, ListMeshName
   LOGICAL :: SubroutineVisited=.FALSE.,Found, SaveThisMesh, NowSave
   TYPE(ValueList_t), POINTER :: Params
   TYPE(Variable_t), POINTER :: ModelVariables

--- a/fem/src/modules/ResultOutputSolve/VtuOutputSolver.F90
+++ b/fem/src/modules/ResultOutputSolve/VtuOutputSolver.F90
@@ -265,8 +265,8 @@ SUBROUTINE VtuOutputSolver( Model,Solver,dt,TransientSimulation )
   
   INTEGER, SAVE :: nTime = 0
   LOGICAL :: GotIt, Parallel, FixedMesh, DG, DN, DoAve
-  CHARACTER(MAX_NAME_LEN) :: FilePrefix
-  CHARACTER(MAX_NAME_LEN) :: BaseFile, VtuFile, PvtuFile, PvdFile, DataSetFile
+  CHARACTER(MAX_PATH_LEN) :: FilePrefix
+  CHARACTER(MAX_PATH_LEN) :: BaseFile, VtuFile, PvtuFile, PvdFile, DataSetFile
   TYPE(Mesh_t), POINTER :: Mesh
   INTEGER :: i, j, k, l, n, m, Partitions, Part, ExtCount, FileindexOffSet, MeshDim, PrecBits, &
              PrecSize, IntSize, FileIndex

--- a/fem/src/modules/SaveData/SaveScalars.F90
+++ b/fem/src/modules/SaveData/SaveScalars.F90
@@ -169,10 +169,10 @@ SUBROUTINE SaveScalars( Model,Solver,dt,TransientSimulation )
   INTEGER, POINTER :: PointIndex(:), NodeIndexes(:), SaveIndex(:)
   INTEGER, ALLOCATABLE, TARGET :: ClosestIndex(:)
   CHARACTER(LEN=MAX_NAME_LEN), ALLOCATABLE :: ValueNames(:)
-  CHARACTER(LEN=MAX_NAME_LEN) :: ScalarsFile, ScalarNamesFile, DateStr, &
-      VariableName, OldVariableName, ResultPrefix, Suffix, Oper, Oper0, OldOper0, ParOper, Name, &
-      CoefficientName, ScalarParFile, MinOper, MaxOper, &
-      MaskName, OldMaskName, SaveName
+  CHARACTER(LEN=MAX_PATH_LEN) :: ScalarsFile, ScalarNamesFile, ScalarParFile
+  CHARACTER(LEN=MAX_NAME_LEN) ::  DateStr, VariableName, OldVariableName, ResultPrefix, &
+      Suffix, Oper, Oper0, OldOper0, ParOper, Name, CoefficientName, &
+      MinOper, MaxOper, MaskName, OldMaskName, SaveName
   CHARACTER(:), ALLOCATABLE :: OutputDirectory
   INTEGER :: i,j,k,l,lpar,q,n,ierr,No,NoPoints,NoCoordinates,NoLines,NumberOfVars,&
       NoDims, NoDofs, NoOper, NoElements, NoVar, NoValues, PrevNoValues, DIM, &


### PR DESCRIPTION
This PR adds support for long output paths/filenames of over 128 characters in selected solvers

Issue: https://github.com/ElmerCSC/elmerfem/issues/413