### PR TITLE
Replace magic-nix-cache-action

### DIFF
--- a/.github/workflows/nix-cachix.yaml
+++ b/.github/workflows/nix-cachix.yaml
@@ -10,10 +10,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
-    - uses: cachix/install-nix-action@v27
+    - uses: nixbuild/nix-quick-install-action@v30
       with:
         nix_path: nixpkgs=channel:nixos-24.11
-    - uses: DeterminateSystems/magic-nix-cache-action@v2
+    - uses: nix-community/cache-nix-action@v6
+      with:
+        primary-key: nix-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('**/*.nix', '**/flake.lock') }}
+        restore-prefixes-first-match: nix-${{ runner.os }}-${{ runner.arch }}
     - uses: cachix/cachix-action@v14
       with:
         name: elmerfem

--- a/.github/workflows/nix-check.yaml
+++ b/.github/workflows/nix-check.yaml
@@ -8,9 +8,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
-    - uses: cachix/install-nix-action@v27
+    - uses: nixbuild/nix-quick-install-action@v30
       with:
         nix_path: nixpkgs=channel:nixos-24.11
-    - uses: DeterminateSystems/magic-nix-cache-action@v2
+    - uses: nix-community/cache-nix-action@v6
+      with:
+        primary-key: nix-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('**/*.nix', '**/flake.lock') }}
+        restore-prefixes-first-match: nix-${{ runner.os }}-${{ runner.arch }}
     - name: nix flake check
       run: nix flake check -L


### PR DESCRIPTION
The `DeterminateSystems/magic-nix-cache-action` action has been [deprecated](https://determinate.systems/posts/magic-nix-cache-free-tier-eol/) and no longer works. This PR replaces it with the `nix-community/cache-nix-action` action, which is actively maintained. It also replaces the `cachix/install-nix-action` action with the `nixbuild/nix-quick-install-action` action, which is required for the cache action to work. The cache has been configured to restore based on the runner's OS and architecture, so it should work on any runner.