### PR TITLE
Fix CI on macOS runners

### DIFF
--- a/.github/workflows/build-macos-homebrew.yaml
+++ b/.github/workflows/build-macos-homebrew.yaml
@@ -38,7 +38,7 @@ jobs:
         # FIXME: Consider building with OpenMP again when this (potentially
         # upstream) issue has been fixed.
         include:
-          - os: macos-13
+          - os: macos-15-intel
             openmp: with
 
     steps:
@@ -74,13 +74,13 @@ jobs:
         env:
           LDFLAGS: ${{ matrix.openmp == 'with' && format('-L{0}/opt/libomp/lib -lomp', env.HOMEBREW_PREFIX) || '' }}
         # The tests `SD_H1BasisEvaluation` and `SD_LinearFormsAssembly` are
-        # failing on macos-13 (Intel CPU) at optimization level `-O3`.
+        # failing on macos-15-intel (Intel CPU) at optimization level `-O3`.
         # They are passing if ElmerFEM is built with optimization level `-O2`.
         run: |
           mkdir ${GITHUB_WORKSPACE}/build
           cd ${GITHUB_WORKSPACE}/build
           cmake \
-            -DCMAKE_BUILD_TYPE=${{ matrix.os == 'macos-13' && 'RelWithDebInfo' || 'Release' }} \
+            -DCMAKE_BUILD_TYPE=${{ matrix.os == 'macos-15-intel' && 'RelWithDebInfo' || 'Release' }} \
             -DCMAKE_C_COMPILER=clang \
             -DCMAKE_CXX_COMPILER=clang++ \
             -DCMAKE_Fortran_COMPILER=gfortran \

--- a/.github/workflows/build-macos-homebrew.yaml
+++ b/.github/workflows/build-macos-homebrew.yaml
@@ -67,7 +67,7 @@ jobs:
           brew install \
             cmake openblas open-mpi \
             ${{ matrix.openmp == 'with' && 'libomp suitesparse' || '' }} \
-            qwt vtk opencascade
+            qwt vtk opencascade expat
           echo "HOMEBREW_PREFIX=$(brew --prefix)" >> $GITHUB_ENV
 
       - name: configure
@@ -105,6 +105,7 @@ jobs:
             -DWITH_QT6=ON \
             -DQWT_INCLUDE_DIR="${HOMEBREW_PREFIX}/opt/qwt/lib/qwt.framework/Headers" \
             -DWITH_VTK=ON \
+            -DEXPAT_INCLUDE_DIR="${HOMEBREW_PREFIX}/opt/expat/include" \
             -DWITH_OCC=ON \
             -DWITH_MATC=ON \
             -DWITH_PARAVIEW=ON \


### PR DESCRIPTION
Apple and Homebrew ended support for macOS 13. 
Also, GitHub is deprecating their hosted macOS 13 runners. 

Switch those runners over to (newly) available hosted macOS 15 runners.
Use their hosted `macos-15-intel` runner as probably the last one to run on Intel x86_64 architecture.

Additionally, use the expat package from Homebrew.