### PR TITLE
Update MMG Free_all and Init_mesh calls to use the latest API and fix Hypre import

### DIFF
--- a/elmerice/Solvers/CalvingRemeshMMG.F90
+++ b/elmerice/Solvers/CalvingRemeshMMG.F90
@@ -575,9 +575,9 @@ SUBROUTINE CalvingRemeshMMG( Model, Solver, dt, Transient )
       mmgLs  = 0
       mmgMet  = 0
 
-      CALL MMG3D_Init_mesh(MMG5_ARG_start, &
-          MMG5_ARG_ppMesh,mmgMesh,MMG5_ARG_ppLs,mmgLs, &
-          MMG5_ARG_end)
+      CALL MMG3D_Init_mesh((/MMG5_ARG_start, &
+          MMG5_ARG_ppMesh,LOC(mmgMesh),MMG5_ARG_ppLs,LOC(mmgLs), &
+          MMG5_ARG_end/), ierr)
 
       !  now Set_MMG3D_Mesh(Mesh, Parallel, EdgePairs, PairCount)
       CALL Set_MMG3D_Mesh(GatheredMesh, .TRUE., EdgePairs, PairCount)
@@ -674,9 +674,9 @@ SUBROUTINE CalvingRemeshMMG( Model, Solver, dt, Transient )
       IF ( ierr == MMG5_STRONGFAILURE ) THEN
         PRINT*,"BAD ENDING OF MMG3DLS: UNABLE TO SAVE MESH", Time
         !! Release mmg mesh
-        CALL MMG3D_Free_all(MMG5_ARG_start, &
-            MMG5_ARG_ppMesh,mmgMesh,MMG5_ARG_ppMet,mmgSol, &
-            MMG5_ARG_end)
+        CALL MMG3D_Free_all((/MMG5_ARG_start, &
+            MMG5_ARG_ppMesh,LOC(mmgMesh),MMG5_ARG_ppMet,LOC(mmgSol), &
+            MMG5_ARG_end/), ierr)
         WRITE(Message, '(A,F10.5,A,F10.5)') 'Levelset failed with Hmin ',Hmin, ' and Hausd ', Hausd
         CALL WARN(SolverName, Message)
         IF(mmgloops==MaxLsetIter) THEN
@@ -709,9 +709,9 @@ SUBROUTINE CalvingRemeshMMG( Model, Solver, dt, Transient )
       IF ( Counter > 0 ) THEN
         PRINT*,"Bad elements detected - reruning levelset"
         !! Release mmg mesh
-        CALL MMG3D_Free_all(MMG5_ARG_start, &
-            MMG5_ARG_ppMesh,mmgMesh,MMG5_ARG_ppMet,mmgSol, &
-            MMG5_ARG_end)
+        CALL MMG3D_Free_all((/MMG5_ARG_start, &
+            MMG5_ARG_ppMesh,LOC(mmgMesh),MMG5_ARG_ppMet,LOC(mmgSol), &
+            MMG5_ARG_end/), ierr)
           WRITE(Message, '(A,F10.5,A,F10.5)') 'Levelset failed with Hmin ',Hmin, ' and Hausd ', Hausd
         CALL WARN(SolverName, Message)
         IF(mmgloops==MaxLsetIter) THEN
@@ -838,9 +838,9 @@ SUBROUTINE CalvingRemeshMMG( Model, Solver, dt, Transient )
       END DO
 
       !! Release mmg mesh
-      CALL MMG3D_Free_all(MMG5_ARG_start, &
-          MMG5_ARG_ppMesh,mmgMesh,MMG5_ARG_ppLs,mmgLs, &
-          MMG5_ARG_end)
+      CALL MMG3D_Free_all((/MMG5_ARG_start, &
+          MMG5_ARG_ppMesh,LOC(mmgMesh),MMG5_ARG_ppLs,LOC(mmgLs), &
+          MMG5_ARG_end/), ierr)
 
       !MMG3DLS returns constraint = 10 on newly formed boundary elements
       !(i.e. the new calving front). Here it is set to front_BC_id

--- a/elmerice/Solvers/CalvingRemeshparMMG.F90
+++ b/elmerice/Solvers/CalvingRemeshparMMG.F90
@@ -458,9 +458,9 @@ SUBROUTINE CalvingRemeshParMMG( Model, Solver, dt, Transient )
 
       CALL MeshVolume(GatheredMesh, .FALSE., PreCalveVolume)
 
-      CALL MMG3D_Init_mesh(MMG5_ARG_start, &
-          MMG5_ARG_ppMesh,mmgMesh,MMG5_ARG_ppLs,mmgLs, &
-          MMG5_ARG_end)
+      CALL MMG3D_Init_mesh((/MMG5_ARG_start, &
+          MMG5_ARG_ppMesh,LOC(mmgMesh),MMG5_ARG_ppLs,LOC(mmgLs), &
+          MMG5_ARG_end/), ierr)
 
       CALL GetCalvingEdgeNodes(GatheredMesh, .FALSE., EdgePairs, PairCount)
       !  now Set_MMG3D_Mesh(Mesh, Parallel, EdgePairs, PairCount)
@@ -670,9 +670,9 @@ SUBROUTINE CalvingRemeshParMMG( Model, Solver, dt, Transient )
       END DO
 
       !! Release mmg mesh
-      CALL MMG3D_Free_all(MMG5_ARG_start, &
-          MMG5_ARG_ppMesh,mmgMesh,MMG5_ARG_ppLs,mmgLs, &
-          MMG5_ARG_end)
+      CALL MMG3D_Free_all((/MMG5_ARG_start, &
+          MMG5_ARG_ppMesh, LOC(mmgMesh),MMG5_ARG_ppLs, LOC(mmgLs), &
+          MMG5_ARG_end/), ierr)
 
       !MMG3DLS returns constraint = 10 on newly formed boundary elements
       !(i.e. the new calving front). Here it is set to front_BC_id

--- a/elmerice/Solvers/MMG3DSolver.F90
+++ b/elmerice/Solvers/MMG3DSolver.F90
@@ -29,9 +29,9 @@ SUBROUTINE OptimizeMesh_MMG3D(Model,Solver,dt,TransientSimulation)
   mmgMesh = 0
   mmgSol  = 0
 
-  CALL MMG3D_Init_mesh(MMG5_ARG_start, &
-       MMG5_ARG_ppMesh,mmgMesh,MMG5_ARG_ppMet,mmgSol, &
-       MMG5_ARG_end)
+  CALL MMG3D_Init_mesh((/MMG5_ARG_start, &
+       MMG5_ARG_ppMesh,LOC(mmgMesh),MMG5_ARG_ppMet,LOC(mmgSol), &
+       MMG5_ARG_end/), ier)
 
   CALL SET_MMG3D_MESH(Mesh)
 

--- a/elmerice/Solvers/MeshAdaptation_2D/MMG2DSolver.F90
+++ b/elmerice/Solvers/MeshAdaptation_2D/MMG2DSolver.F90
@@ -176,9 +176,9 @@
       CALL Info('MMGSolver','Initialization of MMG',Level=20)
       mmgMesh = 0
       mmgSol  = 0
-      CALL MMG2D_Init_mesh(MMG5_ARG_start, &
-             MMG5_ARG_ppMesh,mmgMesh,MMG5_ARG_ppMet,mmgSol, &
-             MMG5_ARG_end)
+      CALL MMG2D_Init_mesh((/MMG5_ARG_start, &
+             MMG5_ARG_ppMesh,LOC(mmgMesh),MMG5_ARG_ppMet,LOC(mmgSol), &
+             MMG5_ARG_end/), ier)
       
       ! SET PARAMETERS 
       CALL Info('MMGSolver','Set MMG2D Parameters',Level=20)
@@ -324,9 +324,9 @@
       CALL INFO('MMGSolver',trim(Message),level=5)
       
 !!!! Free the MMG3D5 structures
-      CALL MMG2D_Free_all(MMG5_ARG_start, &
-          MMG5_ARG_ppMesh,mmgMesh,MMG5_ARG_ppMet,mmgSol, &
-          MMG5_ARG_end)      
+      CALL MMG2D_Free_all((/MMG5_ARG_start, &
+          MMG5_ARG_ppMesh,LOC(mmgMesh),MMG5_ARG_ppMet,LOC(mmgSol), &
+          MMG5_ARG_end/), ier)      
      
 
 !-------------------------------------

--- a/fem/src/MeshRemeshing.F90
+++ b/fem/src/MeshRemeshing.F90
@@ -1585,8 +1585,9 @@ SUBROUTINE RemeshMMG3D(Model, InMesh,OutMesh,EdgePairs,PairCount,&
     Success = .TRUE.
     IF( mmgloops > 1 ) THEN
       !! Redoing adaptive mesh, release the previous mmg mesh
-      CALL MMG3D_Free_all(MMG5_ARG_start, &
-          MMG5_ARG_ppMesh,mmgMesh,MMG5_ARG_ppMet,mmgSol, MMG5_ARG_end)      
+      CALL MMG3D_Free_all((/MMG5_ARG_start, &
+          MMG5_ARG_ppMesh,LOC(mmgMesh),MMG5_ARG_ppMet,LOC(mmgSol), MMG5_ARG_end/), ierr)      
+      IF ( ierr == 0 ) CALL Fatal(FuncName,'Call to MMG3D_Free_all failed!')
     END IF
         
     ! Enable external depende on "mmg loop"
@@ -1594,9 +1595,10 @@ SUBROUTINE RemeshMMG3D(Model, InMesh,OutMesh,EdgePairs,PairCount,&
     
     mmgMesh = 0
     mmgSol  = 0
-    CALL MMG3D_Init_mesh(MMG5_ARG_start, &
-        MMG5_ARG_ppMesh,mmgMesh,MMG5_ARG_ppMet,mmgSol, &
-        MMG5_ARG_end)
+    CALL MMG3D_Init_mesh((/MMG5_ARG_start, &
+        MMG5_ARG_ppMesh,LOC(mmgMesh),MMG5_ARG_ppMet,LOC(mmgSol), &
+        MMG5_ARG_end/), ierr)
+    IF ( ierr == 0 ) CALL Fatal(FuncName,'Call to MMG3D_Init_mesh failed!')
 
     IF(MultipleInputs) THEN
       CALL ListAddConstReal(FuncParams, 'adaptive min h', hminarray(mmgloops, 1))
@@ -1742,9 +1744,10 @@ SUBROUTINE RemeshMMG3D(Model, InMesh,OutMesh,EdgePairs,PairCount,&
   CALL GET_MMG3D_MESH(OutMesh,Parallel, Calving=MultipleInputs)
 
   ! Release the mesh from mmg mesh format
-  CALL MMG3D_Free_all(MMG5_ARG_start, &
-  MMG5_ARG_ppMesh,mmgMesh,MMG5_ARG_ppMet,mmgSol, &
-  MMG5_ARG_end)
+  CALL MMG3D_Free_all((/MMG5_ARG_start, &
+  MMG5_ARG_ppMesh,LOC(mmgMesh),MMG5_ARG_ppMet,LOC(mmgSol), &
+  MMG5_ARG_end/), ierr)
+  IF ( ierr == 0 ) CALL Fatal(FuncName,'Call to MMG3D_Free_all failed!')
 
   NBulk = OutMesh % NumberOfBulkElements
   NBdry = OutMesh % NumberOfBoundaryElements
@@ -2929,9 +2932,10 @@ SUBROUTINE DistributedRemeshParMMG(Model, InMesh,OutMesh,EdgePairs,PairCount,&
     
     IF( mmgloops > 1 ) THEN
       !! Redoing adaptive mesh, release the previous mmg mesh
-      CALL MMG3D_Free_all(MMG5_ARG_start, &
-          MMG5_ARG_ppMesh,mmgMesh,MMG5_ARG_ppMet,mmgSol, &
-          MMG5_ARG_end)      
+      CALL MMG3D_Free_all((/MMG5_ARG_start, &
+          MMG5_ARG_ppMesh,LOC(mmgMesh),MMG5_ARG_ppMet,LOC(mmgSol), &
+          MMG5_ARG_end/), ierr)
+          IF ( ierr == 0 ) CALL Fatal(FuncName,'Call to MMG3D_Free_all failed!')
     END IF
     
     IF( mmgloops == MaxRemeshIter ) GOTO 20
@@ -3871,10 +3875,11 @@ CONTAINS
     CALL Info(FuncName,'Initialization of MMG',Level=20)
     mmgMesh = 0
     mmgSol  = 0
-    CALL MMG2D_Init_mesh(MMG5_ARG_start, &
-        MMG5_ARG_ppMesh,mmgMesh,MMG5_ARG_ppMet,mmgSol, &
-        MMG5_ARG_end)
-    
+    CALL MMG2D_Init_mesh((/MMG5_ARG_start, &
+        MMG5_ARG_ppMesh,LOC(mmgMesh),MMG5_ARG_ppMet,LOC(mmgSol), &
+        MMG5_ARG_end/), ier)
+    IF ( ier == 0 ) CALL Fatal(FuncName,'Call to MMG2D_Init_mesh failed!')
+
     CALL SET_MMG2D_Parameters(SolverParams)
 
     IF( PRESENT( Solver ) ) THEN

--- a/fem/src/SolveHypre.c
+++ b/fem/src/SolveHypre.c
@@ -45,7 +45,7 @@
 #ifdef HAVE_HYPRE
 #include <math.h>
 #include "_hypre_utilities.h"
-#include "krylov.h"
+#include "_hypre_krylov.h"
 #include "HYPRE.h"
 #include "HYPRE_parcsr_ls.h"
 


### PR DESCRIPTION
I noticed that Elmer compilation fails with the latest version of both Hypre and MMG.

This PR changes the MMG calls to follow the example from MMG "develop"branch:  https://github.com/MmgTools/mmg/commits/develop/libexamples/mmg3d/adaptation_example0_fortran/example0_a/main.F90

NOTE: This change is most likely not compatible with MMG master branch which is roughly year outdated from "develop"


HYPRE compilation is fixed by simple changing a single import from "krylov.h" to "_hypre_krylov.h"

