### PR TITLE
Limiter restruct

### DIFF
--- a/fem/src/IterSolve.F90
+++ b/fem/src/IterSolve.F90
@@ -118,6 +118,9 @@ CONTAINS
 #ifndef HUTI_MPRGP_GAMMA
 #define HUTI_MPRGP_GAMMA dpar(6)
 #endif
+#ifndef HUTI_MPRGP_TOLFACTOR
+#define HUTI_MPRGP_TOLFACTOR dpar(7)
+#endif
 !#ifndef HUTI_MPRGP_BOUND
 !#define HUTI_MPRGP_BOUND ipar(19)
 !#endif
@@ -654,6 +657,8 @@ END FUNCTION MaskedNorm
       Internal = .TRUE.
       HUTI_MPRGP_GAMMA = ListGetConstReal( Params, 'Linear System MPRGP Gamma', GotIt )
       IF(.NOT. GotIt) HUTI_MPRGP_GAMMA = 1.0_dp
+      HUTI_MPRGP_TOLFACTOR = ListGetConstReal( Params, 'Linear System MPRGP TolFactor', GotIt )
+      IF(.NOT. GotIt) HUTI_MPRGP_TOLFACTOR = 5.0_dp
       !HUTI_MPRGP_BOUND = ListGetString( Params, 'Linear System MPRGP Bound Type', GotIt )
       !IF(.NOT. GotIt) HUTI_MPRGP_BOUND = 'lower' ! TODO: should write error if no bounds      
       HUTI_MPRGP_ADAPT = 1

--- a/fem/src/IterativeMethods.F90
+++ b/fem/src/IterativeMethods.F90
@@ -1952,7 +1952,7 @@ CONTAINS
     INTEGER :: n
 
     ! MPRGP parameters (passed from calling routine)
-    REAL(KIND=dp) :: Gamma
+    REAL(KIND=dp) :: Gamma, TolFactor
     LOGICAL :: adapt
     INTEGER :: bound
 
@@ -1975,6 +1975,7 @@ CONTAINS
     
     Gamma = HUTI_MPRGP_GAMMA
     Adapt = ( HUTI_MPRGP_ADAPT > 0 )
+    TolFactor = HUTI_MPRGP_TOLFACTOR
 
     IF (ASSOCIATED(CurrentModel % Solver % Variable % LowerLimit)) THEN
       bound = 0
@@ -1994,7 +1995,7 @@ CONTAINS
     Converged = .FALSE.
     Diverged = .FALSE.
     n = ndim
-    CALL MPRGP(ndim, x, b, c, MinTol, Rounds, Gamma, adapt, bound, &
+    CALL MPRGP(ndim, x, b, c, MinTol, Rounds, Gamma, adapt, bound, TolFactor, &
         ncg, ne, np, iters, Converged, final_norm_gp )
 
     CALL Info('MPRGPSolver','MPRGP finished: iters='//I2S(iters)// &
@@ -2016,7 +2017,7 @@ CONTAINS
 !   Implementation of the MPRGP algorithm. 
 !   The subroutine MPRGP was written by D. Reeves during an internship at CSC.
 !----------------------------------------------------------------------------------- 
-    SUBROUTINE MPRGP(n, x, b, c, epsr, maxit, Gamma, adapt, bound, &
+    SUBROUTINE MPRGP(n, x, b, c, epsr, maxit, Gamma, adapt, bound, TolFactor, &
                       ncg, ne, np, iters, converged, final_norm_gp)
 !----------------------------------------------------------------------------------- 
       ! ---------------------------
@@ -2030,6 +2031,7 @@ CONTAINS
       REAL(KIND=dp), INTENT(IN) :: Gamma
       LOGICAL, INTENT(IN) :: adapt
       INTEGER, INTENT(IN) :: bound      ! 'lower' or 'upper'
+      REAL(KIND=dp), INTENT(IN) :: TolFactor
       INTEGER, INTENT(OUT) :: ncg, ne, np, iters
       LOGICAL, INTENT(OUT) :: converged
       REAL(KIND=dp), INTENT(OUT) :: final_norm_gp
@@ -2107,6 +2109,7 @@ CONTAINS
 
       ! estimate matrix norm ||A|| with a small power iteration
       CALL estimate_matrix_norm(n, 10, lAl)
+!      lal = 1.0_dp
       IF (lAl <= 0.0_dp) lAl = 1.0_dp
       alpha = 1.0_dp / lAl
 
@@ -2139,16 +2142,20 @@ CONTAINS
       DO WHILE ( normfun(n, gp, 1) > epsr .AND. iters < maxit )
 
         iters = iters + 1
-
         IF ( dotprodfun(n, gc, 1, gc, 1) <= (Gamma**2) * dotprodfun(n, gr, 1, gf, 1) ) THEN
           ! CG step
-
           CALL matvecsubr( p, Ap, ipar )        
           rtp = dotprodfun(n, z, 1, g, 1) ! residual * p
           pAp = dotprodfun(n, p, 1, Ap, 1)
 
           IF (ABS(pAp) < eps_local) THEN
-            CALL INFO('itermethod_mprgp','p''*A*p nearly zero, stopping')
+            ! We don't want to divide by zero, if norm of gp is small enough, we can stop
+            IF (normfun(n, gp, 1) < TolFactor * epsr) THEN
+              converged = .TRUE.
+              CALL Info('itermethod_mprgp','MPRGP converged')
+              EXIT
+            END IF
+            CALL FATAL('itermethod_mprgp','p''*A*p nearly zero, stopping')
             EXIT
           END IF
 
@@ -2271,11 +2278,16 @@ CONTAINS
 
         ELSE
           ! proportioning step
-          CALL matvecsubr( gc, Ap, ipar )        
-          !CALL C_matvec(gc, Ap, ipar, matvecsubr)
+          CALL matvecsubr( gc, Ap, ipar )    ! A*gc
           pAp = dotprodfun(n, gc, 1, Ap, 1)
           IF (ABS(pAp) < eps_local) THEN
-            CALL Info('itermethod_mprgp','denominator in proportioning nearly zero, stopping',Level=5)
+            IF (normfun(n, gp, 1) < TolFactor * epsr) THEN
+              converged = .TRUE.
+              CALL Info('itermethod_mprgp','MPRGP converged')
+              EXIT
+            END IF
+
+            CALL FATAL('itermethod_mprgp','denominator gc*A*gc in proportioning step nearly zero, stopping')
             EXIT
           END IF
           acg = dotprodfun(n, gc, 1, g, 1) / pAp
@@ -2327,7 +2339,10 @@ CONTAINS
       END DO  ! main loop
 
       final_norm_gp = normfun(n, gp, 1)
-      converged = (final_norm_gp <= epsr)
+      
+      IF (.NOT. converged) THEN ! can be set as converged in the main loop
+        converged = (final_norm_gp <= epsr)
+      END IF
 
       ! cleanup
       IF (ALLOCATED(D)) DEALLOCATE(D)

--- a/fem/tests/LimitTemperature_MPRGP1/case.sif
+++ b/fem/tests/LimitTemperature_MPRGP1/case.sif
@@ -48,14 +48,11 @@ Solver 1
 
   Linear System Limiter = Logical True
   Apply Limiter = Logical True
-  Limiter Load Tolerance = Real 1.0e-6
-  Limiter Value Tolerance = Real 1.0e-8
 
   Steady State Convergence Tolerance = 1.0e-5
 
-  Nonlinear System Convergence Tolerance = 1.0e-5
   Nonlinear System Max Iterations = 1 ! should this be enforced in the code?
-  Nonlinear System Convergence Measure = solution
+
 
   Linear System Solver = Iterative
   Linear System Iterative Method = MPRGP

--- a/fem/tests/LimitTemperature_MPRGP2/case.sif
+++ b/fem/tests/LimitTemperature_MPRGP2/case.sif
@@ -47,14 +47,10 @@ Solver 1
 
   Linear System Limiter = Logical True
   Apply Limiter = Logical True
-  Limiter Load Tolerance = Real 1.0e-6
-  Limiter Value Tolerance = Real 1.0e-8
 
   Steady State Convergence Tolerance = 1.0e-5
 
-  Nonlinear System Convergence Tolerance = 1.0e-5
   Nonlinear System Max Iterations = 1
-  Nonlinear System Convergence Measure = solution
 
   Linear System Solver = Iterative
   Linear System Iterative Method = MPRGP

--- a/fhutiter/include/huti_fdefs.h
+++ b/fhutiter/include/huti_fdefs.h
@@ -152,6 +152,8 @@
 #define HUTI_ROBUST_TOLERANCE dpar(3)
 #define HUTI_ROBUST_STEPSIZE dpar(4)
 #define HUTI_ROBUST_MAXTOLERANCE dpar(5)  
+#define HUTI_MPRGP_GAMMA dpar(6)
+#define HUTI_MPRGP_TOLFACTOR dpar(7)
 !  
 ! End of definitions
 !

--- a/fhutiter/src/huti_fdefs.h
+++ b/fhutiter/src/huti_fdefs.h
@@ -155,6 +155,7 @@
 #define HUTI_ROBUST_STEPSIZE dpar(4)
 #define HUTI_ROBUST_MAXTOLERANCE dpar(5)  
 #define HUTI_MPRGP_GAMMA dpar(6)
+#define HUTI_MPRGP_TOLFACTOR dpar(7)
 
 						 !  
 ! End of definitions


### PR DESCRIPTION
The MPRGP method would usually end with an division zero error. In most cases so far, the algorithm needed a couple more iterations to satisfy that the norm of the projected gradient would be small enough. SOLUTION: I added a tolerance parameter, which the user can define and if near zero division is to happen, we first check if the norm of gp is within tolerance * epsr.
