### PR TITLE
Simplify CI rules on Windows MinGW by merging almost identical files

### DIFF
--- a/.github/workflows/build-windows-mingw.yaml
+++ b/.github/workflows/build-windows-mingw.yaml
@@ -1,4 +1,4 @@
-name: build-windows-mingw1+2
+name: build-windows-mingw
 on:
   workflow_dispatch:
   push:
@@ -119,9 +119,9 @@ jobs:
             -DWITH_ELMERGUI=ON \
             -DWITH_QT6=ON \
             -DWITH_VTK=ON \
-            -DWITH_OCC= ON \
+            -DWITH_OCC=ON \
             -DWITH_MATC=ON \
-            -DWITH_PARAVIEW=ON\
+            -DWITH_PARAVIEW=ON \
             -DCREATE_PKGCONFIG_FILE=ON \
             ${{ matrix.external-cmake-flags }} \
             ..
@@ -141,9 +141,10 @@ jobs:
         timeout-minutes: 150
         env:
           CTEST_OUTPUT_ON_FAILURE: 1
+          OMP_NUM_THREADS: 1
         run: |
           cd ${GITHUB_WORKSPACE}/build
-          export OMP_NUM_THREADS=1; ctest . \
+          ctest . \
             -LE slow \
             --timeout 300
 

--- a/.github/workflows/build-windows-mingw.yaml
+++ b/.github/workflows/build-windows-mingw.yaml
@@ -105,7 +105,7 @@ jobs:
             -DWITH_OpenMP=ON \
             -DWITH_LUA=ON \
             -DWITH_MPI=ON \
-            -DMPI_TEST_MAXPROC=2 \
+            -DMPI_TEST_MAXPROC=$(nproc) \
             -DMPIEXEC_EXECUTABLE="$(cygpath -m "${MSMPI_BIN}")/mpiexec.exe" \
             -DWITH_Zoltan=ON \
             -DCMAKE_C_FLAGS="-Wno-error=incompatible-pointer-types" \


### PR DESCRIPTION
The CI rules for Windows (MinGW) have recently been split into two files. These two files are basically identical.

There is no reason (that I'm aware of) to not define the two variations of the rules using a matrix in a single file. Doing that also simplifies the maintenance in the future in case anything in the build rules needs to be changed. (Update just one file instead of two.)

The proposed change deletes the `build-windows-mingw2.yaml` file and enables the configuration that was covered by that file in `build-windows-mingw.yaml` again.
