### PR TITLE
WIP: YAC coupling: Bugfix MPI Handshake

### DIFF
--- a/fem/src/SParIterComm.F90
+++ b/fem/src/SParIterComm.F90
@@ -94,12 +94,12 @@ MODULE SParIterComm
 # endif
 #endif
 
-#ifdef HAVE_XIOS
-  USE XIOS, ONLY: xios_initialize, xios_context_finalize, xios_finalize
-#endif
-
 #ifdef HAVE_YAC
   USE elmer_coupling, ONLY: coupling_init, coupling_finalize, coupling_setup
+#endif
+
+#ifdef HAVE_XIOS
+  USE XIOS, ONLY: xios_initialize, xios_context_finalize, xios_finalize
 #endif
 
   IMPLICIT NONE

--- a/fem/src/SParIterComm.F90
+++ b/fem/src/SParIterComm.F90
@@ -89,6 +89,7 @@ MODULE SParIterComm
   ! prefer mpi_handshake from YAC if HAVE_YAC
   USE elmer_coupling, ONLY: mpi_handshake, MAX_GROUPNAME_LEN
 # elif defined(HAVE_XIOS)
+#   error "The mpi_handshake implementation in XIOS currently has a bug."
   ! use mpi_handshake from XIOS if only HAVE_XIOS used without HAVE_YAC
   USE XIOS, ONLY: mpi_handshake => xios_mpi_handshake, &
               MAX_GROUPNAME_LEN => xios_MAX_GROUPNAME_LEN

--- a/fem/src/SParIterComm.F90
+++ b/fem/src/SParIterComm.F90
@@ -75,15 +75,15 @@ MODULE SParIterComm
 #    error "This is incompatible with YAC."
 #  endif
 
-# ifdef HAVE_XIOS
-  USE XIOS, ONLY: xios_get_global_id
-# endif
-
+  ! import APIs to get code_id / global_id if needed
 # ifdef HAVE_YAC
   USE elmer_coupling, ONLY: coupler_get_code_id
 # endif
 
-  ! import mpi_handshake from YAC or XIOS
+# ifdef HAVE_XIOS
+  USE XIOS, ONLY: xios_get_global_id
+# endif
+
 # ifdef HAVE_XIOS
     ! prefer mpi_handshake from XIOS if XIOS is used
     USE XIOS, ONLY: mpi_handshake => xios_mpi_handshake, &

--- a/fem/src/SParIterComm.F90
+++ b/fem/src/SParIterComm.F90
@@ -88,9 +88,11 @@ MODULE SParIterComm
     ! prefer mpi_handshake from XIOS if XIOS is used
     USE XIOS, ONLY: mpi_handshake => xios_mpi_handshake, &
                 MAX_GROUPNAME_LEN => xios_MAX_GROUPNAME_LEN
-# else
+# elif defined(HAVE_YAC)
     ! use mpi_handshake from YAC if only HAVE_YAC used without HAVE_XIOS
     USE elmer_coupling, ONLY: mpi_handshake, MAX_GROUPNAME_LEN
+# else
+#   error "ELMER_USE_MPI_HANDSHAKE defined without HAVE_YAC or HAVE_XIOS"
 # endif
 #endif
 

--- a/fem/src/SParIterComm.F90
+++ b/fem/src/SParIterComm.F90
@@ -84,13 +84,14 @@ MODULE SParIterComm
   USE XIOS, ONLY: xios_get_global_id
 # endif
 
-# ifdef HAVE_XIOS
-    ! prefer mpi_handshake from XIOS if XIOS is used
-    USE XIOS, ONLY: mpi_handshake => xios_mpi_handshake, &
-                MAX_GROUPNAME_LEN => xios_MAX_GROUPNAME_LEN
-# elif defined(HAVE_YAC)
-    ! use mpi_handshake from YAC if only HAVE_YAC used without HAVE_XIOS
-    USE elmer_coupling, ONLY: mpi_handshake, MAX_GROUPNAME_LEN
+  ! import mpi_handshake from YAC or XIOS
+# ifdef HAVE_YAC
+  ! prefer mpi_handshake from YAC if HAVE_YAC
+  USE elmer_coupling, ONLY: mpi_handshake, MAX_GROUPNAME_LEN
+# elif defined(HAVE_XIOS)
+  ! use mpi_handshake from XIOS if only HAVE_XIOS used without HAVE_YAC
+  USE XIOS, ONLY: mpi_handshake => xios_mpi_handshake, &
+              MAX_GROUPNAME_LEN => xios_MAX_GROUPNAME_LEN
 # else
 #   error "ELMER_USE_MPI_HANDSHAKE defined without HAVE_YAC or HAVE_XIOS"
 # endif

--- a/fem/src/SParIterComm.F90
+++ b/fem/src/SParIterComm.F90
@@ -75,10 +75,16 @@ MODULE SParIterComm
 #    error "This is incompatible with YAC."
 #  endif
 
+# ifdef HAVE_XIOS
+  USE XIOS, ONLY: xios_get_global_id
+# endif
+
+# ifdef HAVE_YAC
+  USE elmer_coupling, ONLY: coupler_get_code_id
+# endif
+
   ! import mpi_handshake from YAC or XIOS
 # ifdef HAVE_XIOS
-    USE XIOS, ONLY: xios_get_global_id
-
     ! prefer mpi_handshake from XIOS if XIOS is used
     USE XIOS, ONLY: mpi_handshake => xios_mpi_handshake, &
                 MAX_GROUPNAME_LEN => xios_MAX_GROUPNAME_LEN
@@ -93,11 +99,7 @@ MODULE SParIterComm
 #endif
 
 #ifdef HAVE_YAC
-  USE elmer_coupling, ONLY: &
-       coupling_init, &
-       coupling_finalize, &
-       coupling_setup, &
-       coupler_get_code_id
+  USE elmer_coupling, ONLY: coupling_init, coupling_finalize, coupling_setup
 #endif
 
   IMPLICIT NONE


### PR DESCRIPTION
This PR fixes a regression we recently observed in https://github.com/ElmerCSC/elmerfem/tree/yac-coupling after merging https://github.com/ElmerCSC/elmerfem/commit/14a6ab2f0d0905a9c168d89abe25fc99839db9a0.

@ClemensSchannwell will perform some final tests in his production setup. After that we can merge this PR into `yac-coupling`

Main point: There seems to be a bug in the MPI Handshake implementation in our patched version of XIOS. A work-around for this problem is using the MPI Handshake implementation provided by YAC (see https://github.com/ElmerCSC/elmerfem/commit/8c60381da36307fec51b4ab1061ca1be5d77407f). I additionally, added a safeguard to avoid using the XIOS mpi handshake implementation (see https://github.com/ElmerCSC/elmerfem/commit/f97269433c7fb78acddbf1da4bb2e08e8c1f0612). This part needs a fix upstream.