### PR TITLE
Use default number of OpenMP threads in CI on Windows again.

### DIFF
--- a/.github/workflows/build-windows-mingw.yaml
+++ b/.github/workflows/build-windows-mingw.yaml
@@ -141,7 +141,6 @@ jobs:
         timeout-minutes: 150
         env:
           CTEST_OUTPUT_ON_FAILURE: 1
-          OMP_NUM_THREADS: 1
         run: |
           cd ${GITHUB_WORKSPACE}/build
           ctest . \


### PR DESCRIPTION
It looks like it is no longer needed to limit the number of OpenMP threads to 1.

I ran the CI on Windows with that change three times in my fork. And none of the tests failed.
