### PR TITLE
Remove VTK Java wrappings

### DIFF
--- a/ElmerGUI/CMakeLists.txt
+++ b/ElmerGUI/CMakeLists.txt
@@ -144,6 +144,10 @@ ENDIF()
 IF(WITH_VTK)
   FIND_PACKAGE(VTK REQUIRED)
 
+  # We do not use Java wrappings and they make linking very difficult when
+  # building Debian/Ubuntu packages
+  LIST(REMOVE_ITEM VTK_LIBRARIES VTK::Java)
+
   INCLUDE(testVTKcapabilities)
 
   MESSAGE(STATUS "  [ElmerGUI] VTK version:       " ${VTK_VERSION})


### PR DESCRIPTION
Filter out VTK Java wrappers from the list of libraries that are linked into ElmerGUI. This dependency complicates the building of Debian/Ubuntu packages and we do not use the Java wrappers.