### PR TITLE
Tell ctest how many processors are needed for tests with multiple MPI threads

### DIFF
--- a/cmake/Modules/test_macros.cmake
+++ b/cmake/Modules/test_macros.cmake
@@ -49,8 +49,8 @@ MACRO(ADD_ELMER_TEST TestName)
         COMMAND ${CMAKE_COMMAND}
         -DCMAKE_MODULE_PATH=${CMAKE_MODULE_PATH}
         -DELMERGRID_BIN=${ELMERGRID_BIN}
-	-DVIEWFACTORS_BIN=${VIEWFACTORS_BIN}
-	-DRADIATORS_BIN=${RADIATORS_BIN}
+        -DVIEWFACTORS_BIN=${VIEWFACTORS_BIN}
+        -DRADIATORS_BIN=${RADIATORS_BIN}
         -DELMERSOLVER_BIN=${ELMERSOLVER_BIN}
         -DFINDNORM_BIN=${FINDNORM_BIN}
         -DMESH2D_BIN=${MESH2D_BIN}
@@ -73,6 +73,11 @@ MACRO(ADD_ELMER_TEST TestName)
         FOREACH(lbl ${_parsedArgs_LABELS})
           SET_PROPERTY(TEST ${_this_test_name} APPEND PROPERTY LABELS ${lbl})
         ENDFOREACH()
+      ENDIF()
+      IF(WITH_MPI)
+        # Tell ctest how many processors this test requires.
+        SET_TESTS_PROPERTIES(${_this_test_name} PROPERTIES
+          PROCESSORS ${n})
       ENDIF()
       IF(${n} GREATER 0)
         # Avoid running tests using the same directory concurrently.

--- a/elmerice/Tests/test_macros.cmake
+++ b/elmerice/Tests/test_macros.cmake
@@ -21,6 +21,11 @@ MACRO(ADD_ELMERICE_TEST test_name)
       -DWITH_MPI=${WITH_MPI}
       -P ${CMAKE_CURRENT_SOURCE_DIR}/runTest.cmake)
   SET_TESTS_PROPERTIES(${test_name} PROPERTIES LABELS "elmerice")
+  IF(WITH_MPI AND DEFINED NPROCS)
+    # Tell ctest how many processors this test requires.
+    SET_TESTS_PROPERTIES(${test_name} PROPERTIES
+      PROCESSORS ${NPROCS})
+  ENDIF()
 ENDMACRO()
 
 MACRO(ADD_ELMERICETEST_MODULE test_name module_name file_name)


### PR DESCRIPTION
If ctest is told how many processors are needed for tests with multiple MPI threads, it can plan accordingly when ctests are run in parallel.

See: https://cmake.org/cmake/help/latest/prop_test/PROCESSORS.html
