### PR TITLE
Add CI runner building with LLVM Flang

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -28,6 +28,7 @@ jobs:
       matrix:
         os: [ubuntu-24.04]
         compiler: [gcc]
+        fc: [gfortran]
         mpi: [with]
         openmp: [with]
         include:
@@ -71,6 +72,15 @@ jobs:
             mpi: with
             openmp: without
             openmp-cmake-flags: "-DWITH_OpenMP=OFF"
+          - os: ubuntu-24.04
+            compiler: flang
+            compiler-pkgs: "clang-20 flang-20"
+            cc: "clang-20"
+            cxx: "clang++-20"
+            fc: "flang-20"
+            mpi: without
+            openmp: without
+            openmp-cmake-flags: "-DWITH_OpenMP=OFF"
           # - compiler: clang
           #   compiler-pkgs: "clang libomp-dev"
           #   cc: "clang"
@@ -82,6 +92,7 @@ jobs:
     env:
       CC: ${{ matrix.cc }}
       CXX: ${{ matrix.cxx }}
+      FC: ${{ matrix.fc }}
 
     steps:
       - name: get CPU information
@@ -125,6 +136,7 @@ jobs:
           cmake \
             -DCMAKE_BUILD_TYPE="Release" \
             -DCMAKE_INSTALL_PREFIX="${GITHUB_WORKSPACE}/usr" \
+            $([ "${{ matrix.compiler }}" == "flang" ] && echo "-DHAVE_QP=OFF" || echo "-DHAVE_QP=ON") \
             $([ "${{ matrix.os }}" == "ubuntu-24.04-arm" ] && echo "-DBLA_VENDOR=Generic" || echo "-DBLA_VENDOR=OpenBLAS") \
             ${{ matrix.openmp-cmake-flags }} \
             -DWITH_LUA=ON \


### PR DESCRIPTION
Disable MPI because Ubuntu does not provide Fortran bindings for LLVM Flang.
Disable quadruple-precision math because Ubuntu distributes a Flang compiler runtime without support for it. (And reportedly [[1]](https://github.com/ElmerCSC/elmerfem/issues/609#issuecomment-3670736937), the upstream support for quadruple-precision floating-point math in Flang isn't ready yet either if I understood correctly.)

~~Also fix some build errors after configuring with `-DHAVE_QP=ON` and enable it by default (like until recently).~~ (Addressed in #745.)
