### PR TITLE
Set number of OpenMP threads to something reasonable in tests

### DIFF
--- a/.github/workflows/build-windows-mingw.yaml
+++ b/.github/workflows/build-windows-mingw.yaml
@@ -142,7 +142,6 @@ jobs:
         timeout-minutes: 150
         env:
           CTEST_OUTPUT_ON_FAILURE: 1
-          OMP_NUM_THREADS: 1
         run: |
           cd ${GITHUB_WORKSPACE}/build
           ctest . \

--- a/cmake/Modules/test_macros.cmake
+++ b/cmake/Modules/test_macros.cmake
@@ -145,13 +145,34 @@ MACRO(RUN_ELMER_TEST)
     SET(ENV{PATH} "$ENV{ELMER_HOME};$ENV{ELMER_LIB};${BINARY_DIR}/fhutiter/src;${BINARY_DIR}/matc/src;${BINARY_DIR}/mathlibs/src/arpack;${BINARY_DIR}/mathlibs/src/parpack;${COMPILER_DIRECTORY};$ENV{PATH}")
   ENDIF(WIN32)
 
+  # Query number of physical CPU cores of the host
+  cmake_host_system_information(RESULT PHYS_CPU QUERY NUMBER_OF_PHYSICAL_CORES)
   IF(WITH_MPI)
+    IF(NOT DEFINED ENV{OMP_NUM_THREADS})
+      # Limit number of OpenMP threads to a sensible value
+      # Divide by ${MPIEXEC_NTASKS} and truncate to the nearest lower integer
+      MATH(EXPR n_openmp_threads "${PHYS_CPU} / ${MPIEXEC_NTASKS}")
+      IF(${n_openmp_threads} LESS 1)
+        # minimum of 1
+        SET(ENV{OMP_NUM_THREADS} 1)
+      ELSE()
+        # set limit
+        SET(ENV{OMP_NUM_THREADS} ${n_openmp_threads})
+      ENDIF()
+    ENDIF()
+
     EXECUTE_PROCESS(COMMAND "${MPIEXEC}" ${MPIEXEC_NUMPROC_FLAG} ${MPIEXEC_NTASKS} ${MPIEXEC_PREFLAGS} ${ELMERSOLVER_BIN} ${MPIEXEC_POSTFLAGS}
       OUTPUT_VARIABLE TEST_STDOUT_VARIABLE
       ERROR_VARIABLE TEST_STDERR_VARIABLE)
       FILE(WRITE "test-stdout_${MPIEXEC_NTASKS}.log" "${TEST_STDOUT_VARIABLE}")
       FILE(WRITE "test-stderr_${MPIEXEC_NTASKS}.log" "${TEST_STDERR_VARIABLE}")
   ELSE()
+    # Limit number of OpenMP threads to a sensible value
+    IF(NOT DEFINED ENV{OMP_NUM_THREADS})
+      # set limit
+      SET(ENV{OMP_NUM_THREADS} ${PHYS_CPU})
+    ENDIF()
+
     EXECUTE_PROCESS(COMMAND ${ELMERSOLVER_BIN}
       OUTPUT_VARIABLE TEST_STDOUT_VARIABLE
       ERROR_VARIABLE TEST_STDERR_VARIABLE)

--- a/elmerice/Tests/test_macros.cmake
+++ b/elmerice/Tests/test_macros.cmake
@@ -59,10 +59,20 @@ MACRO(RUN_ELMERICE_TEST)
     SET(ENV{PATH} "$ENV{ELMER_HOME};$ENV{ELMER_LIB};${BINARY_DIR}/fhutiter/src;${BINARY_DIR}/matc/src;${BINARY_DIR}/mathlibs/src/arpack;${BINARY_DIR}/mathlibs/src/parpack;${COMPILER_DIRECTORY};$ENV{PATH}")
   ENDIF(WIN32)
 
+  # Query number of physical CPU cores of the host
+  cmake_host_system_information(RESULT PHYS_CPU QUERY NUMBER_OF_PHYSICAL_CORES)
+
   # Optional arguments like WITH_MPI
   SET(LIST_VAR "${ARGN}")
   IF(LIST_VAR STREQUAL "")
     FILE(REMOVE "TEST.PASSED")
+
+    # Limit number of OpenMP threads to a sensible value
+    IF(NOT DEFINED ENV{OMP_NUM_THREADS})
+      # set limit
+      SET(ENV{OMP_NUM_THREADS} ${PHYS_CPU})
+    ENDIF()
+
     EXECUTE_PROCESS(COMMAND ${ELMERSOLVER_BIN}
       OUTPUT_FILE "test-stdout.log"
       ERROR_FILE "test-stderr.log")
@@ -71,12 +81,26 @@ MACRO(RUN_ELMERICE_TEST)
     SET(N "${NPROCS}")
     IF("${N}" STREQUAL "")
       MESSAGE(FATAL_ERROR "Test failed:variable <NPROC> not defined. Set <NPROC> in runTest.cmake")
-    ELSE()
-      FILE(REMOVE "TEST.PASSED_${N}")
-      EXECUTE_PROCESS(COMMAND "${MPIEXEC}" ${MPIEXEC_NUMPROC_FLAG} ${N} ${MPIEXEC_PREFLAGS} ${ELMERSOLVER_BIN} ${MPIEXEC_POSTFLAGS}
-        OUTPUT_FILE "test-stdout.log"
-        ERROR_FILE "test-stderr.log")
     ENDIF()
+
+    FILE(REMOVE "TEST.PASSED_${N}")
+
+    IF(NOT DEFINED ENV{OMP_NUM_THREADS})
+      # Limit number of OpenMP threads to a sensible value
+      # Divide by ${NPROCS} and truncate to the nearest lower integer
+      MATH(EXPR n_openmp_threads "${PHYS_CPU} / ${NPROCS}")
+      IF(${n_openmp_threads} LESS 1)
+        # minimum of 1
+        SET(ENV{OMP_NUM_THREADS} 1)
+      ELSE()
+        # set limit
+        SET(ENV{OMP_NUM_THREADS} ${n_openmp_threads})
+      ENDIF()
+    ENDIF()
+
+    EXECUTE_PROCESS(COMMAND "${MPIEXEC}" ${MPIEXEC_NUMPROC_FLAG} ${N} ${MPIEXEC_PREFLAGS} ${ELMERSOLVER_BIN} ${MPIEXEC_POSTFLAGS}
+      OUTPUT_FILE "test-stdout.log"
+      ERROR_FILE "test-stderr.log")
   ENDIF()
 
   IF(NPROCS GREATER "1")


### PR DESCRIPTION
Determine the number of physical processors of the build host and limit the number of OpenMP threads to that for each test.
If a test is involving multiple MPI processes, divide the number of physical processors by the number of used MPI processes. Set the number of OpenMP threads to the integer floor of that result.

If a user sets `OMP_NUM_THREADS` explicitly in the environment that takes precedence over the automatic selection.

With that, remove explicitly setting `OMP_NUM_THREADS` in the build rules for Windows MinGW.


That is essentially what @juharu suggested in https://github.com/ElmerCSC/elmerfem/pull/725#issuecomment-3589224677.