### PR TITLE
Use assumed length for `grid_dir`

### DIFF
--- a/fem/src/elmer_coupling.F90
+++ b/fem/src/elmer_coupling.F90
@@ -368,7 +368,7 @@ CONTAINS
 
     IMPLICIT NONE
 
-    CHARACTER(LEN=1024), INTENT(IN) :: grid_dir
+    CHARACTER(LEN=*), INTENT(IN) :: grid_dir
     CHARACTER(LEN=*), INTENT(IN) :: timestepstring
     INTEGER, INTENT(IN) :: num_parts
 


### PR DESCRIPTION
* fixed length (`LEN=1024`) is less robust
* fixed length leads to incorrect `grid_dir` and crash on Ubuntu