### PR TITLE
Fix building with quadruple-precision floating-point support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -86,6 +86,7 @@ SET(MPI_TEST_MAXPROC 8 CACHE STRING "Maximum number of tasks used in parallel te
 SET(MPI_TEST_MINPROC 1 CACHE STRING "Minimum number of tasks used in parallel tests")
 SET(WITH_OpenMP FALSE CACHE BOOL "Use OpenMP thread and SIMD (if available) parallelization")
 SET(WITH_MKL FALSE CACHE BOOL "Use Intel Math Kernel library")
+OPTION(HAVE_QP "Fortran compiler and runtime support quadruple-precision floating-point numbers" ON)
 SET(WITH_Mumps FALSE CACHE BOOL "Use Mumps sparse direct solver")
 SET(WITH_Hypre FALSE CACHE BOOL "Use Hypre linear algebra library")
 SET(WITH_CHOLMOD FALSE CACHE BOOL "Use CHOLMOD linear algebra library")

--- a/fem/src/ElementDescription.F90
+++ b/fem/src/ElementDescription.F90
@@ -11976,7 +11976,7 @@ BLOCK
   END FUNCTION mGetElementDOFs
 !------------------------------------------------------------------------------
 
-#ifdef HAVE_QP  
+#ifdef HAVE_QP
 !------------------------------------------------------------------------------
 !>    Check element by comparing determinants of the metric tensor computed
 !>    in double and quad precision.
@@ -12109,13 +12109,13 @@ BLOCK
      n = MIN( SIZE(x), nDOFs )
      dim  = elm % TYPE % DIMENSION
 
-#if HAVE_QP     
+#ifdef HAVE_QP
      IF(Elm % Status == 2) THEN
        IF (ElementMetricQP(nDOFs,Elm,Nodes,Metric,DetG,dLBasisdx,LtoGMap)) RETURN
        GOTO 100
      END IF
 #endif
-     
+
      eps = (EPSILON(eps))**dim
 !------------------------------------------------------------------------------
 !    Partial derivatives of global coordinates with respect to local coordinates
@@ -12203,7 +12203,7 @@ BLOCK
 
 100  CONTINUE
 
-#if HAVE_QP
+#ifdef HAVE_QP
      ! Try recursively with quadratic precision.
      ! With just double precision for very flat elements the DetJ may be poorly evaluated. 
      IF( Elm % Status /= 2) THEN

--- a/fem/src/LinearAlgebra.F90
+++ b/fem/src/LinearAlgebra.F90
@@ -42,6 +42,9 @@
 !>  matrix eigenvalues  (don't use this for anything big, use for example 
 !>  LAPACK routines instead...)
 !------------------------------------------------------------------------------
+
+#include "../config.h"
+
 MODULE LinearAlgebra
 
   USE Types
@@ -550,7 +553,7 @@ MODULE LinearAlgebra
   END SUBROUTINE InvertMatrix3x3
 !------------------------------------------------------------------------------
 
-#ifdef HAVE_QP  
+#ifdef HAVE_QP
 !------------------------------------------------------------------------------
 ! Quadratic precision version of the previous routine!
 !------------------------------------------------------------------------------


### PR DESCRIPTION
This essentially the same as #739 but doesn't add the CI runner using Flang.

I guess it is easier to merge just the parts that fix support for quadruple-precision floating-support first.
I'll rebase the other PR on top of this one (in case this PR is acceptable).
