### PR TITLE
Move CI on Windows/MSYS2 from the MINGW64 to the UCRT64 environment

### DIFF
--- a/.github/workflows/build-windows-mingw.yaml
+++ b/.github/workflows/build-windows-mingw.yaml
@@ -29,8 +29,7 @@ jobs:
       fail-fast: false
 
       matrix:
-        # msystem: [MINGW64, CLANG64]
-        msystem: [MINGW64]
+        msystem: [UCRT64]
         dependencies: [bundled, external]
         include:
           - dependencies: external
@@ -69,6 +68,7 @@ jobs:
             qwt-qt6:p
             vtk:p
             adios2:p
+            anari-sdk:p 
             boost:p
             cgns:p
             cli11:p
@@ -78,9 +78,11 @@ jobs:
             gl2ps:p
             liblas:p
             libmariadbclient:p
+            netcdf:p 
             openslide:p
             openvdb:p
             pdal:p
+            scnlib:p 
             unixodbc:p
             utf8cpp:p
             opencascade:p


### PR DESCRIPTION
Microsoft started to re-implement their C runtime for Windows 10 (UCRT). That newer variant of the C runtime can be installed as an optional update on Windows 7 and later.
Among other things, the UCRT has better support for some standard functions compared to the previous C runtimes (MSVCRT).

The MINGW64 environment of MSYS2 is based on the MSVCRT which is also supported on even older versions of Windows. Their UCRT64 environment is based on the newer C runtime (UCRT). Some packagers of MSYS2 are pushing towards removing more and more packages from their MINGW64 environment.

Move the CI to the UCRT64 environment which probably is the more reasonable one for targeting all current Windows systems anyway.

This requires installing a few more (optional runtime) dependencies of VTK which are required dependencies when linking against VTK.