### PR TITLE
Add CI runner with LLVM Flang on Windows/MinGW

### DIFF
--- a/.github/workflows/build-windows-mingw.yaml
+++ b/.github/workflows/build-windows-mingw.yaml
@@ -29,13 +29,12 @@ jobs:
       fail-fast: false
 
       matrix:
-        msystem: [UCRT64]
+        msystem: [UCRT64, CLANG64]
         dependencies: [bundled, external]
         mpi: [with, without]
-        include:
-          - dependencies: external
-            external-packages: parpack:p
-            external-cmake-flags: -DEXTERNAL_UMFPACK=ON -DEXTERNAL_ARPACK=ON -DEXTERNAL_PARPACK=ON
+        exclude:
+          - msystem: CLANG64
+            dependencies: external
 
     steps:
       - name: get CPU name
@@ -66,6 +65,7 @@ jobs:
             fc:p
             cmake:p
             ${{ matrix.mpi == 'with' && 'msmpi:p' || 'openblas:p' }}
+            omp:p
             openblas:p
             ${{ matrix.mpi == 'with' && 'parmetis:p' || 'openblas:p' }}
             mumps:p
@@ -94,7 +94,7 @@ jobs:
             unixodbc:p
             utf8cpp:p
             opencascade:p
-            ${{ matrix.external-packages }}
+            ${{ matrix.dependencies == 'external' && 'parpack:p' || 'openblas:p' }}
 
       - name: install MSMPI
         if: matrix.mpi == 'with'
@@ -128,11 +128,17 @@ jobs:
                             "-DMumps_LIBRARIES=$(pkg-config --libs mumps-dto mumps-zto mumps-sto mumps-cto)"
                             "-DMumps_INCLUDE_DIR=$(pkg-config --variable=includedir mumps-dto)")
           fi
+          if [ "${{ matrix.dependencies }}" == "external" ]; then
+            _extra_config+=("-DEXTERNAL_UMFPACK=ON"
+                            "-DEXTERNAL_ARPACK=ON"
+                            "-DEXTERNAL_PARPACK=ON")
+          fi
           cmake \
             -DCMAKE_BUILD_TYPE="Release" \
             -DCMAKE_INSTALL_PREFIX="${GITHUB_WORKSPACE}/usr" \
             "${_extra_config[@]}" \
             -DCPACK_BUNDLE_EXTRA_WINDOWS_DLLS=OFF \
+            $([ "${{ matrix.msystem }}" == "CLANG64" ] && echo "-DHAVE_QP=OFF" || echo "-DHAVE_QP=ON") \
             -DBLA_VENDOR="OpenBLAS" \
             -DWITH_OpenMP=ON \
             -DWITH_LUA=ON \
@@ -144,7 +150,6 @@ jobs:
             -DWITH_MATC=ON \
             -DWITH_PARAVIEW=ON \
             -DCREATE_PKGCONFIG_FILE=ON \
-            ${{ matrix.external-cmake-flags }} \
             ..
 
       - name: exclude build output from Windows Defender scanning


### PR DESCRIPTION
The CLANG64 environment of MSYS2 is based on a LLVM toolchain. That means the compilers (`clang`, `clang++`, `flang`), linker (`lld`), other "binutils" (e.g., `ar`, `nm`), and runtime libraries (compiler runtime, OpenMP, ...) are from LLVM.

Use that environment to build a larger part of ElmerFEM with LLVM Flang (compared to the CI runner using Flang on Ubuntu).

Some features need to be disabled for the time being:
* ~~There is no MUMPS package for the CLANG64 environment of MSYS2 (see https://github.com/msys2/MINGW-packages/pull/27438).~~
* ~~Attempting to enable MATC leads to linker errors. If I understand correctly, that is because the symbol `listheaders` isn't exported correctly. (`ld.bfd` seems to be more lenient about that.)~~
* And finally, quadruple precision floating-point isn't supported by the Flang runtime that is distributed by MSYS2 either.


The proposed build rules are able to *build* ElmerFEM in that environment. But a lot of tests are failing. I haven't looked yet if these failures can be put into some categories.

@hmartinez82: I wrote that I'd ping you when I opened this PR. Does building with these rules work in the CLANGARM64 environment? I guess you'd need to disable MPI (because Microsoft hasn't (yet?) released MSMPI for Windows on ARM).
Are a similar number of tests failing for you?
