### PR TITLE
Add OpenMP include directories to compiler and preprocessor flags

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -207,6 +207,9 @@ IF(WITH_OpenMP)
   SET(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${OpenMP_C_FLAGS}")
   SET(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} ${OpenMP_Fortran_FLAGS}")
   SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${OpenMP_CXX_FLAGS}")
+  IF(OpenMP_Fortran_INCLUDE_DIR)
+    INCLUDE_DIRECTORIES("${OpenMP_Fortran_INCLUDE_DIR}")
+  ENDIF()
 
   # Set variables for supported OpenMP version
   IF(OpenMP_Fortran_VERSION VERSION_GREATER_EQUAL 4.0)


### PR DESCRIPTION
Some implementations of OpenMP (e.g., LLVM libomp) require that the directory where the `omp_lib` module is installed is explicitly passed as a compiler/preprocessor flag.

Ideally that should be done by linking all CMake targets that use OpenMP with the respective OpenMP CMake target.
For the time being, add the directory manually (to all targets).