### PR TITLE
Link `FourierLoss` library to `MagnetoDynamics`

### DIFF
--- a/fem/src/modules/CMakeLists.txt
+++ b/fem/src/modules/CMakeLists.txt
@@ -22,6 +22,7 @@ endif()
 
 if(TARGET FourierLoss)
   ADD_DEPENDENCIES(FourierLoss MagnetoDynamics)
+  TARGET_LINK_LIBRARIES(FourierLoss MagnetoDynamics)
 endif()
 
 


### PR DESCRIPTION
Depending on the optimization level, linking the `FourierLoss` library can fail on Windows (where all symbols need to be resolved when linking) with errors like the following:
```
ld.lld: error: undefined symbol: _QMmagnetodynamicsutilsEjfixphase
>>> referenced by fem/src/modules/CMakeFiles/FourierLoss.dir/FourierLoss.F90.obj:(.debug_info)

ld.lld: error: undefined symbol: _QMmagnetodynamicsutilsEjfixrhs
>>> referenced by fem/src/modules/CMakeFiles/FourierLoss.dir/FourierLoss.F90.obj:(.debug_info)

ld.lld: error: undefined symbol: _QMmagnetodynamicsutilsEjfixrhsc
>>> referenced by fem/src/modules/CMakeFiles/FourierLoss.dir/FourierLoss.F90.obj:(.debug_info)

ld.lld: error: undefined symbol: _QMmagnetodynamicsutilsEjfixsurfaceperm
>>> referenced by fem/src/modules/CMakeFiles/FourierLoss.dir/FourierLoss.F90.obj:(.debug_info)

ld.lld: error: undefined symbol: _QMmagnetodynamicsutilsEjfixsurfacevec
>>> referenced by fem/src/modules/CMakeFiles/FourierLoss.dir/FourierLoss.F90.obj:(.debug_info)

ld.lld: error: undefined symbol: _QMmagnetodynamicsutilsEjfixsurfacevecc
>>> referenced by fem/src/modules/CMakeFiles/FourierLoss.dir/FourierLoss.F90.obj:(.debug_info)
flang: error: linker command failed with exit code 1 (use -v to see invocation)
```

Avoid that by linking to the library that exports these symbols.