### PR TITLE
Read command line arguments in executable

### DIFF
--- a/fem/src/ElmerSolver.F90
+++ b/fem/src/ElmerSolver.F90
@@ -54,7 +54,7 @@
 !------------------------------------------------------------------------------
 !> The main program for Elmer. Solves the equations as defined by the input files.
 !------------------------------------------------------------------------------
-   SUBROUTINE ElmerSolver(initialize)
+   SUBROUTINE ElmerSolver(initialize, args, NoArgs)
 !------------------------------------------------------------------------------
 
      USE Lists
@@ -93,6 +93,8 @@
 !------------------------------------------------------------------------------
 
      INTEGER :: Initialize
+     INTEGER :: NoArgs
+     CHARACTER(LEN=*) :: args(:)
 
 !------------------------------------------------------------------------------
 !    Local variables
@@ -140,7 +142,6 @@
      LOGICAL :: Silent=.FALSE., Version=.FALSE., GotModelName, FinishEarly=.FALSE.
      LOGICAL :: FirstLoad = .TRUE., FirstTime=.TRUE., Found
 
-     INTEGER :: iargc, NoArgs
      INTEGER :: iostat, iSweep = 1, OptimIters
      LOGICAL :: GotOptimIters
      INTEGER :: MeshIndex
@@ -152,7 +153,7 @@
      INTEGER, ALLOCATABLE :: ipar(:)
      REAL(KIND=dp), ALLOCATABLE :: rpar(:)
      CHARACTER(LEN=MAX_PATH_LEN) :: MeshDir, MeshName
-     
+
      ! Start the watches, store later
      !--------------------------------
      RT0 = RealTime()
@@ -171,7 +172,6 @@
        !
        ! Print banner to output:
        ! -----------------------
-       NoArgs = COMMAND_ARGUMENT_COUNT()
        ! Info Level is always true until the model has been read!
        ! This makes it possible to cast something 
        Silent = .FALSE.
@@ -181,16 +181,16 @@
          i = 0
          DO WHILE( i < NoArgs )
            i = i + 1 
-           CALL GET_COMMAND_ARGUMENT(i, OptionString)
+           OptionString = args(i)
            IF( OptionString=='-rpar' ) THEN
              ! Followed by number of parameters + the parameter values
              i = i + 1
-             CALL GET_COMMAND_ARGUMENT(i, OptionString)
-             READ( OptionString,*) nr             
+             OptionString = args(i)
+             READ( OptionString,*) nr
              ALLOCATE( rpar(nr) )
              DO j=1,nr
                i = i + 1
-               CALL GET_COMMAND_ARGUMENT(i, OptionString)
+               OptionString = args(i)
                READ( OptionString,*) rpar(j)
              END DO
              CALL Info('MAIN','Read '//I2S(nr)//' real parameters from command line!')
@@ -200,12 +200,13 @@
            IF( OptionString=='-ipar' ) THEN
              ! Followed by number of parameters + the parameter values
              i = i + 1
-             CALL GET_COMMAND_ARGUMENT(i, OptionString)
-             READ( OptionString,*) ni             
+             OptionString = args(i)
+             PRINT *, OptionString
+             READ( OptionString,*) ni
              ALLOCATE( ipar(nr) )
              DO j=1,ni
                i = i + 1
-               CALL GET_COMMAND_ARGUMENT(i, OptionString)
+               OptionString = args(i)
                READ( OptionString,*) ipar(j)
              END DO
              CALL Info('MAIN','Read '//I2S(ni)//' integer parameters from command line!')
@@ -318,10 +319,10 @@
      !----------------------------------------------------------------------
      GotModelName = .FALSE.
      IF ( NoArgs > 0 ) THEN
-       CALL GET_COMMAND_ARGUMENT(1, ModelName)
+       ModelName = args(1)
        IF( ModelName(1:1) /= '-') THEN 
          GotModelName = .TRUE.
-         IF (NoArgs > 1) CALL GET_COMMAND_ARGUMENT(2, eq)
+         IF (NoArgs > 1) eq = args(2)
        END IF
      END IF
 

--- a/fem/src/Solver.F90
+++ b/fem/src/Solver.F90
@@ -42,6 +42,20 @@ PROGRAM Solver
    CHARACTER(:), ALLOCATABLE :: DateStr
    CHARACTER(LEN=MAX_NAME_LEN) :: toutput
 
+   INTEGER :: iargc, nargs, arglen
+   CHARACTER(LEN=MAX_STRING_LEN) :: buf
+   CHARACTER(LEN=MAX_STRING_LEN), ALLOCATABLE :: args(:)
+
+   INTERFACE
+     SUBROUTINE ElmerSolver(initialize, args, NoArgs)
+       USE Types
+       IMPLICIT NONE
+       INTEGER, INTENT(IN) :: initialize
+       INTEGER, INTENT(IN) :: NoArgs
+       CHARACTER(LEN=*), INTENT(IN) :: args(:)
+     END SUBROUTINE ElmerSolver
+   END INTERFACE
+
    CALL envir( 'ELMERSOLVER_OUTPUT_TOTAL', toutput, tlen )
    Silent = toutput(1:1)=='0' .OR. toutput(1:5)=='false'
 
@@ -54,7 +68,21 @@ PROGRAM Solver
      CALL FLUSH(6)
    END IF
 
-   CALL ElmerSolver(Initialize)
+   ! Get number of command line arguments
+   nargs = COMMAND_ARGUMENT_COUNT()
+   ALLOCATE( args(nargs) )
+
+   ! Collect command line arguments
+   IF( nargs > 0 ) THEN 
+     iargc = 0
+     DO WHILE( iargc < nargs )
+       iargc = iargc + 1 
+       CALL GET_COMMAND_ARGUMENT(iargc, buf, length=arglen)
+       args(iargc) = buf(1:arglen)
+     END DO
+   END IF
+
+   CALL ElmerSolver(Initialize, args, nargs)
 
    IF ( .NOT. Silent ) THEN
      IF ( ParEnv % myPE == 0 ) THEN


### PR DESCRIPTION
The Flang runtime on Windows is static. That means that there are separate instances of the Flang runtime in each executable and DLL. The command line arguments are stored in the Flang runtime. Since they are different instances, the Flang runtime in the DLL has no way of knowing the command line arguments of the executable.
That looks like a design issue of the Flang runtime on Windows.

Work around that by collecting the command line arguments in the context of the executable and passing them to the entry point (`ElmerSolver`) of the DLL.