### PR TITLE
Remove unsafe OpenMP parallel region around Lua evaluation

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -171,6 +171,7 @@ jobs:
         timeout-minutes: 150
         env:
           CTEST_OUTPUT_ON_FAILURE: 1
+          OMP_NUM_THREADS: 4
         run: |
           cd ${GITHUB_WORKSPACE}/build
           ctest . \

--- a/fem/src/GeneralUtils.F90
+++ b/fem/src/GeneralUtils.F90
@@ -1242,9 +1242,7 @@ CONTAINS
              closed_region = .FALSE.
            END IF
 
-           !$OMP PARALLEL DEFAULT(NONE) &
-           !$OMP FIRSTPRIVATE(tcmdstr, tninlen, lstat) &
-           !$OMP SHARED(lua_result, result_len, closed_region, i, j, inlen, first_bang)
+           !$OMP CRITICAL(LuaEval)
            IF(closed_region) THEN
              lstat = lua_dostring( LuaState, &
                  'return tostring('// tcmdstr(1:tninlen-1) // ')'//c_null_char, 1)
@@ -1252,7 +1250,7 @@ CONTAINS
              IF (i == 1 .and. first_bang .and. j == inlen) THEN  ! ' # <luacode>' case, do not do 'return tostring(..)'.
                ! Instead, just execute the line in the lua interpreter
 
-             lstat = lua_dostring( LuaState, tcmdstr(1:tninlen) // c_null_char, 1)
+               lstat = lua_dostring( LuaState, tcmdstr(1:tninlen) // c_null_char, 1)
 
              ELSE ! 'abc = # <luacode>' case, oneliners only
 
@@ -1260,10 +1258,8 @@ CONTAINS
                    'return tostring('// tcmdstr(1:tninlen) // ')'//c_null_char, 1)
              END IF
            END IF
-           !$OMP CRITICAL
            lua_result => lua_popstring(LuaState, result_len)
-           !$OMP END CRITICAL
-           !$OMP END PARALLEL
+           !$OMP END CRITICAL(LuaEval)
 
            matcstr(1:result_len) = lua_result(1:result_len)
            ninlen = result_len

--- a/fem/tests/Lua/case.sif
+++ b/fem/tests/Lua/case.sif
@@ -9,6 +9,7 @@ $refnorm = 3.03677250E+00
 !---LUA END
 
 # materialnum = 1
+#velo_2 = 1
 
 
 Header :: Mesh DB "." "square"
@@ -32,7 +33,8 @@ End
 
 Material 1
   Convection Velocity 1 = 0
-  Convection Velocity 2 = 1
+  Convection Velocity 2 = variable coordinate
+    real lua "velo_2"
   Convection Velocity 3 = 0
 
   diffusion coefficient = 1.0


### PR DESCRIPTION
The inner `!$OMP PARALLEL` section in `TrimLuaExpression` evaluated a single Lua expression in multiple threads while sharing `lua_result`, `result_len`, and several loop indices. This caused data races and intermittent segmentation faults, especially with LLVM Flang/MinGW.

Fix this by removing the inner parallel section and serializing the Lua evaluation.

I'm not an OpenMP expert. But I think this fixes an actual issue.
