### PR TITLE
CI: Fix typo in configure flags for Ubuntu-parallel workflow.

### DIFF
--- a/.github/workflows/ubuntu-parallel.yaml
+++ b/.github/workflows/ubuntu-parallel.yaml
@@ -67,7 +67,7 @@ jobs:
             -DHypre_INCLUDE_DIR="/usr/include/hypre" \
             -DWITH_ELMERGUI=ON \
             -DWITH_PARAVIEW=ON \
-            -DWITH_ELMERICE=ON \
+            -DWITH_ElmerIce=ON \
             -DCREATE_PKGCONFIG_FILE=ON \
             -DWITH_MPI=ON \
             -DMPI_TEST_MAXPROC=$(nproc) \


### PR DESCRIPTION
Currently, the rules build without ElmerIce.
Fix spelling of flag `WITH_ElmerIce` (CMake flags are case-sensitive).