### PR TITLE
Remove `USE Messages` from `MODULE Types`

### DIFF
--- a/fem/src/CMakeLists.txt
+++ b/fem/src/CMakeLists.txt
@@ -25,9 +25,9 @@ SET(solverlib_SOURCES AddrFunc.F90 NavierStokes.F90 NavierStokesGeneral.F90
   LinearAlgebra.F90 CoordinateSystems.F90 ListMatrix.F90 CRSMatrix.F90
   BandMatrix.F90 BandwidthOptimize.F90 BlockSolve.F90
   MaterialModels.F90 DirectSolve.F90 IterSolve.F90
-  IterativeMethods.F90 TimeIntegrate.F90 Types.F90 SolveBand.F90
-  ElementUtils.F90 Radiation.F90 fft.c Load.c Differentials.F90
-  FreeSurface.F90 
+  IterativeMethods.F90 TimeIntegrate.F90 Types.F90 TypesWrapper.F90
+  SolveBand.F90 ElementUtils.F90 Radiation.F90 fft.c Load.c Differentials.F90
+  FreeSurface.F90
   Walls.F90 SolverUtils.F90 SolveSBand.F90 CPUTime.c Interpolation.F90
   MainUtils.F90 Adaptive.F90 EigenSolve.F90 HashTable.F90 MortarUtils.F90
   MeshAllocations.F90 GeometryFitting.F90

--- a/fem/src/DirectSolve.F90
+++ b/fem/src/DirectSolve.F90
@@ -48,6 +48,8 @@
 
 MODULE DirectSolve
 
+   USE Messages, ONLY: EXIT_ERROR
+
    USE CRSMatrix
    USE BandMatrix
    USE SParIterSolve

--- a/fem/src/EigenSolve.F90
+++ b/fem/src/EigenSolve.F90
@@ -57,6 +57,8 @@
 
 MODULE EigenSolve
 
+   USE Messages, ONLY: Info, Error, Fatal
+
    IMPLICIT NONE
 
 CONTAINS

--- a/fem/src/ElmerSolver.F90
+++ b/fem/src/ElmerSolver.F90
@@ -89,6 +89,7 @@
      USE DefUtils, ONLY : GetSimulation, GetCompilationDate, GetRevision, GetVersion, GetBranch, &
          GetReal, GetCReal, GetLogical, GetElementNOFNodes, GetElementDOFs, GetBC, &
          GetElementFamily, GetElementNodes, VectorElementEdgeDOFs
+     USE Messages, ONLY : MaxOutputThread, OutputPE
 
      IMPLICIT NONE
 !------------------------------------------------------------------------------

--- a/fem/src/GeneralUtils.F90
+++ b/fem/src/GeneralUtils.F90
@@ -45,6 +45,7 @@
 MODULE GeneralUtils
 
 USE LoadMod
+USE Messages, ONLY: Message, Info, Warn, Error, Fatal
 
 #ifdef HAVE_LUA
 USE, INTRINSIC :: ISO_C_BINDING
@@ -2615,8 +2616,9 @@ END MODULE GeneralUtils
 !---------------------------------------------------------
 MODULE AscBinOutputUtils
   
-  
   USE Types
+  USE Messages, ONLY: Message, Info, Warn, Error, Fatal
+
   IMPLICIT NONE
   
   LOGICAL, PRIVATE :: AsciiOutput, SinglePrec, CalcSum = .FALSE.

--- a/fem/src/Integration.F90
+++ b/fem/src/Integration.F90
@@ -42,6 +42,7 @@
 !>  containing various integration routines.
 !-----------------------------------------------------------------------------
 MODULE Integration
+   USE Messages, ONLY: Warn, Fatal, Message
    USE LoadMod
 
    IMPLICIT NONE

--- a/fem/src/Interpolation.F90
+++ b/fem/src/Interpolation.F90
@@ -44,6 +44,7 @@
 MODULE Interpolation
 
    USE Types
+   USE Messages, ONLY: Message, Info, Warn, Fatal
    USE SParIterGlobals
    USE CoordinateSystems
    USE ElementDescription, ONLY : GlobalToLocal, ElementInfo, GetElementType, &

--- a/fem/src/LinearAlgebra.F90
+++ b/fem/src/LinearAlgebra.F90
@@ -48,6 +48,8 @@
 MODULE LinearAlgebra
 
   USE Types
+  USE Messages, ONLY: Message, Error, Fatal
+
   IMPLICIT NONE
 
  CONTAINS

--- a/fem/src/Lists.F90
+++ b/fem/src/Lists.F90
@@ -47,6 +47,7 @@
 MODULE Lists
 
    USE GeneralUtils
+   USE Messages, ONLY: InfoActive
    
    IMPLICIT NONE
 

--- a/fem/src/LoadMod.F90
+++ b/fem/src/LoadMod.F90
@@ -38,6 +38,7 @@
 
 MODULE LoadMod
     USE Types
+    USE Messages, ONLY: Error
     USE, INTRINSIC :: ISO_C_BINDING
     USE huti_interfaces
     IMPLICIT NONE

--- a/fem/src/MainUtils.F90
+++ b/fem/src/MainUtils.F90
@@ -71,6 +71,9 @@ MODULE MainUtils
       GetBodyForce, GetBC, Default2ndOrderTime, DefaultFinishBulkAssembly, &
       DefaultUpdateMass, DefaultFinishBoundaryAssembly, DefaultInitialize, &
       DefaultUpdateDamp, DefaultFinishAssembly, Default1stOrderTime
+
+  USE Messages, ONLY : OutputLevelMask, MaxOutputPE, MinOutputPE
+
 !------------------------------------------------------------------------------
   IMPLICIT NONE
 !------------------------------------------------------------------------------

--- a/fem/src/Messages.F90
+++ b/fem/src/Messages.F90
@@ -55,6 +55,8 @@ MODULE Messages
   USE XIOS
 #endif
 
+   USE Types_  ! Check for circular dependencies
+
    IMPLICIT NONE
    
    CHARACTER(LEN=512) :: Message = ' '

--- a/fem/src/PElementMaps.F90
+++ b/fem/src/PElementMaps.F90
@@ -47,6 +47,7 @@
 
 MODULE PElementMaps
   USE Types
+  USE Messages, ONLY: Info, Warn, Fatal, Message
   Use GeneralUtils, ONLY : I2S
 
   IMPLICIT NONE

--- a/fem/src/SParIterComm.F90
+++ b/fem/src/SParIterComm.F90
@@ -46,6 +46,10 @@
 
 MODULE SParIterComm
 
+  USE Messages, ONLY: Info, Fatal, Message, OutputPE, InfoActive
+#ifdef HAVE_XIOS
+  USE Messages, ONLY: USE_XIOS
+#endif
   USE LoadMod, ONLY : RealTime
   USE SParIterGlobals
 

--- a/fem/src/TimeIntegrate.F90
+++ b/fem/src/TimeIntegrate.F90
@@ -44,6 +44,7 @@
 MODULE TimeIntegrate
 
    USE Types
+   USE Messages, ONLY: Warn, Fatal, Message
 
    IMPLICIT NONE
 

--- a/fem/src/Types.F90
+++ b/fem/src/Types.F90
@@ -43,9 +43,8 @@
 
 #include "../config.h"
 
-MODULE Types
+MODULE Types_
  
-   USE Messages
    USE, INTRINSIC :: ISO_C_BINDING
 #ifdef _OPENMP
    USE omp_lib 
@@ -1152,6 +1151,6 @@ MODULE Types
 
     CHARACTER(len=MAX_NAME_LEN) :: ExecID
 !------------------------------------------------------------------------------
-END MODULE Types
+END MODULE Types_
 !------------------------------------------------------------------------------
 !> \}

--- a/fem/src/TypesWrapper.F90
+++ b/fem/src/TypesWrapper.F90
@@ -1,0 +1,51 @@
+!/*****************************************************************************/
+! *
+! *  Elmer, A Finite Element Software for Multiphysical Problems
+! *
+! *  Copyright 1st April 1995 - , CSC - IT Center for Science Ltd., Finland
+! * 
+! * This library is free software; you can redistribute it and/or
+! * modify it under the terms of the GNU Lesser General Public
+! * License as published by the Free Software Foundation; either
+! * version 2.1 of the License, or (at your option) any later version.
+! *
+! * This library is distributed in the hope that it will be useful,
+! * but WITHOUT ANY WARRANTY; without even the implied warranty of
+! * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+! * Lesser General Public License for more details.
+! * 
+! * You should have received a copy of the GNU Lesser General Public
+! * License along with this library (in file ../LGPL-2.1); if not, write 
+! * to the Free Software Foundation, Inc., 51 Franklin Street, 
+! * Fifth Floor, Boston, MA  02110-1301  USA
+! *
+! *****************************************************************************/
+!
+!/******************************************************************************
+! *
+! *  Authors: Benjamin Rodenberg
+! *  Email:   rodenberg@dkrz.de
+! *  Web:     http://www.csc.fi/elmer
+! *  Address: CSC - IT Center for Science Ltd.
+! *           Keilaranta 14
+! *           02101 Espoo, Finland 
+! *
+! *  Original Date: 2026
+! *
+! *****************************************************************************/
+
+!> \ingroup ElmerLib
+!> \{
+
+!------------------------------------------------------------------------------
+! This is a wrapper module to include all type definitions to be used by legacy
+! code that relies on automatically including Messages when using Types module.
+!
+! It is recommended to USE Types_ and USE Messages modules directly in new code.
+!------------------------------------------------------------------------------
+MODULE Types
+  USE Types_
+  USE Messages
+END MODULE Types
+!------------------------------------------------------------------------------
+!> \}


### PR DESCRIPTION
Remove implicit re-export of `Messages` through `Types` module and add explicit `USE Messages, ONLY: <symbols>` to all affected files. This clarifies dependencies and prepares for upcoming YAC coupling integration, which would otherwise create a circular dependency (`Messages -> elmer_coupling -> Types -> Messages`).

See https://github.com/BenjaminRodenberg/elmerfem/pull/1 for an example where the circular dependency caused problems. https://github.com/BenjaminRodenberg/elmerfem/pull/1 is a draft for https://github.com/ElmerCSC/elmerfem/issues/723.