### PR TITLE
Skip CI job `ubuntu-parallel` on forks

### DIFF
--- a/.github/workflows/ubuntu-parallel.yaml
+++ b/.github/workflows/ubuntu-parallel.yaml
@@ -14,7 +14,7 @@ on:
 jobs:
 
   ubuntu:
-    if: ${{ github.repository == 'ElmerCSC/elmerfem' }}  # only run job for main repository (forks usually not have self-hosted runners)
+    if: ${{ github.repository == 'ElmerCSC/elmerfem' }}  # only run job for main repository (forks usually cannot access the "self-hosted" runner)
     runs-on: self-hosted
 
     name: ubuntu-parallel (${{ matrix.compiler }})

--- a/.github/workflows/ubuntu-parallel.yaml
+++ b/.github/workflows/ubuntu-parallel.yaml
@@ -14,7 +14,7 @@ on:
 jobs:
 
   ubuntu:
-    if: ${{ github.repository == 'ElmerCSC/elmerfem' }}  # only run job for main repository (forks usually cannot access the "self-hosted" runner)
+    if: ${{ github.repository == 'ElmerCSC/elmerfem' }}  # only run job for main repository (forks usually do not have self-hosted runners)
     runs-on: self-hosted
 
     name: ubuntu-parallel (${{ matrix.compiler }})

--- a/.github/workflows/ubuntu-parallel.yaml
+++ b/.github/workflows/ubuntu-parallel.yaml
@@ -71,7 +71,7 @@ jobs:
             -DCREATE_PKGCONFIG_FILE=ON \
             -DWITH_MPI=ON \
             -DMPI_TEST_MAXPROC=$(nproc) \
-            -DMPIEXEC_PREFLAGS="--allow-run-as-root --oversubscribe" \
+            -DMPIEXEC_PREFLAGS="--allow-run-as-root;--oversubscribe" \
             ..
 
       - name: build

--- a/.github/workflows/ubuntu-parallel.yaml
+++ b/.github/workflows/ubuntu-parallel.yaml
@@ -14,7 +14,14 @@ on:
 jobs:
 
   ubuntu:
-    runs-on: ${{ github.repository == 'ElmerCSC/elmerfem' && 'self-hosted' || 'ubuntu-latest' }}
+    runs-on: |-
+      # Conditional runner selection:
+      # - ElmerCSC/elmerfem repository -> self-hosted
+      # - Forks (default) -> ubuntu-latest
+      ${{ case(
+        github.repository == 'ElmerCSC/elmerfem', 'self-hosted',
+        'ubuntu-latest'                                       
+      ) }}
     
     name: ubuntu-parallel (${{ matrix.compiler }})
 

--- a/.github/workflows/ubuntu-parallel.yaml
+++ b/.github/workflows/ubuntu-parallel.yaml
@@ -72,7 +72,7 @@ jobs:
             -DCREATE_PKGCONFIG_FILE=ON \
             -DWITH_MPI=ON \
             -DMPI_TEST_MAXPROC=$(nproc) \
-            -DMPIEXEC_PREFLAGS="--allow-run-as-root\;--oversubscribe" \
+            -DMPIEXEC_PREFLAGS="--allow-run-as-root" \
             ..
 
       - name: build

--- a/.github/workflows/ubuntu-parallel.yaml
+++ b/.github/workflows/ubuntu-parallel.yaml
@@ -71,7 +71,7 @@ jobs:
             -DCREATE_PKGCONFIG_FILE=ON \
             -DWITH_MPI=ON \
             -DMPI_TEST_MAXPROC=$(nproc) \
-            -DMPIEXEC_PREFLAGS="--allow-run-as-root;--oversubscribe" \
+            -DMPIEXEC_PREFLAGS="--allow-run-as-root\;--oversubscribe" \
             ..
 
       - name: build

--- a/.github/workflows/ubuntu-parallel.yaml
+++ b/.github/workflows/ubuntu-parallel.yaml
@@ -14,15 +14,9 @@ on:
 jobs:
 
   ubuntu:
-    runs-on: |-
-      # Conditional runner selection:
-      # - ElmerCSC/elmerfem repository -> self-hosted
-      # - Forks (default) -> ubuntu-latest
-      ${{ case(
-        github.repository == 'ElmerCSC/elmerfem', 'self-hosted',
-        'ubuntu-latest'                                       
-      ) }}
-    
+    if: ${{ github.repository == 'ElmerCSC/elmerfem' }}  # only run job for main repository (forks usually not have self-hosted runners)
+    runs-on: self-hosted
+
     name: ubuntu-parallel (${{ matrix.compiler }})
 
     strategy:

--- a/.github/workflows/ubuntu-parallel.yaml
+++ b/.github/workflows/ubuntu-parallel.yaml
@@ -14,7 +14,7 @@ on:
 jobs:
 
   ubuntu:
-    runs-on: self-hosted
+    runs-on: ubuntu-latest
     
     name: ubuntu-parallel (${{ matrix.compiler }})
 

--- a/.github/workflows/ubuntu-parallel.yaml
+++ b/.github/workflows/ubuntu-parallel.yaml
@@ -71,7 +71,7 @@ jobs:
             -DCREATE_PKGCONFIG_FILE=ON \
             -DWITH_MPI=ON \
             -DMPI_TEST_MAXPROC=$(nproc) \
-            -DMPIEXEC_PREFLAGS="--allow-run-as-root" \
+            -DMPIEXEC_PREFLAGS="--allow-run-as-root --oversubscribe" \
             ..
 
       - name: build

--- a/.github/workflows/ubuntu-parallel.yaml
+++ b/.github/workflows/ubuntu-parallel.yaml
@@ -14,7 +14,7 @@ on:
 jobs:
 
   ubuntu:
-    runs-on: ubuntu-latest
+    runs-on: ${{ github.repository == 'ElmerCSC/elmerfem' && 'self-hosted' || 'ubuntu-latest' }}
     
     name: ubuntu-parallel (${{ matrix.compiler }})
 

--- a/flake.nix
+++ b/flake.nix
@@ -104,7 +104,7 @@
 
                 "-DWITH_ElmerIce:BOOL=TRUE"
 
-                "-DMPIEXEC_PREFLAGS=-oversubscribe"
+                "-DMPIEXEC_PREFLAGS=--oversubscribe"
 
                 "-Wno-dev"
               ]


### PR DESCRIPTION
When developing on my fork the test `ubuntu-parallel` always fails due to not having a self-hosted runner. I'm not sure why you are using a self-hosted runner but with some modifications one can also use `ubuntu-latest` and fix the test for forks.

If you really need a self-hosted runner: One could introduce a case distinction. (either deactivate test for forks or use `self-hosted` on `ElmerCSC/elmerfem` and `ubuntu-latest` else)