### PR TITLE
Addrint valuelist and _Finalize

### DIFF
--- a/fem/src/Lists.F90
+++ b/fem/src/Lists.F90
@@ -62,6 +62,7 @@ MODULE Lists
    INTEGER, PARAMETER :: LIST_TYPE_VARIABLE_TENSOR = 10
    INTEGER, PARAMETER :: LIST_TYPE_CONSTANT_TENSOR_STR = 11
    INTEGER, PARAMETER :: LIST_TYPE_VARIABLE_TENSOR_STR = 12
+   INTEGER, PARAMETER :: LIST_TYPE_ADDRINT = 13
 
    INTEGER, PARAMETER :: SECTION_TYPE_BODY = 1
    INTEGER, PARAMETER :: SECTION_TYPE_MATERIAL = 2
@@ -3571,6 +3572,30 @@ CONTAINS
 
 
 !------------------------------------------------------------------------------
+!> Adds an address integer to the list.
+!------------------------------------------------------------------------------
+    SUBROUTINE ListAddAddressInteger( List,Name,AValue )
+!------------------------------------------------------------------------------
+      TYPE(ValueList_t), POINTER :: List
+      CHARACTER(LEN=*) :: Name
+      INTEGER(kind=AddrInt) :: AValue
+!------------------------------------------------------------------------------
+      INTEGER :: n
+      TYPE(ValueListEntry_t), POINTER :: ptr
+!------------------------------------------------------------------------------
+      ptr => ListAdd( List, Name )
+      ptr % PROCEDURE = Avalue
+
+      ptr % TYPE = LIST_TYPE_ADDRINT
+
+      n = LEN_TRIM(Name)
+      IF(ALLOCATED(ptr % Name)) DEALLOCATE(ptr % Name)
+      ALLOCATE(CHARACTER(n)::ptr % Name)
+      ptr % NameLen = StringToLowerCase( ptr % Name,Name )
+    END SUBROUTINE ListAddInteger
+!------------------------------------------------------------------------------
+
+!------------------------------------------------------------------------------
 !> Adds an integer to the list.
 !------------------------------------------------------------------------------
     SUBROUTINE ListAddInteger( List,Name,IValue,Proc )
@@ -4001,6 +4026,46 @@ CONTAINS
     END SUBROUTINE ListAddNewString
 !------------------------------------------------------------------------------
       
+!------------------------------------------------------------------------------
+!> Gets an address integer value from the list.
+!------------------------------------------------------------------------------
+   RECURSIVE FUNCTION ListGetAddressInteger( List,Name,Found,minv,maxv,UnfoundFatal,DefValue) RESULT(L)
+!------------------------------------------------------------------------------
+     TYPE(ValueList_t), POINTER :: List
+     CHARACTER(LEN=*) :: Name
+     INTEGER(KIND=AddrInt), OPTIONAL :: DefValue
+     INTEGER(KIND=AddrInt) :: L
+     LOGICAL, OPTIONAL :: Found, UnfoundFatal
+!------------------------------------------------------------------------------
+     TYPE(ValueListEntry_t), POINTER :: ptr
+!------------------------------------------------------------------------------
+     IF(PRESENT(DefValue)) THEN
+       L = DefValue
+     ELSE
+       L = 0
+     END IF
+
+     ptr => ListFind(List,Name,Found)
+     IF (.NOT.ASSOCIATED(ptr) ) THEN
+       IF(PRESENT(UnfoundFatal)) THEN
+         IF(UnfoundFatal) THEN
+           WRITE(Message, '(A,A)') "Failed to find integer: ",Name
+           CALL Fatal("ListGetInteger", Message)
+         END IF
+       END IF
+       RETURN
+     END IF
+
+     IF( ptr % type /= LIST_TYPE_ADDRINT ) THEN
+       CALL Fatal('ListGetInteger','Invalid list type for: '//TRIM(Name))
+     END IF
+     
+     L = ptr % PROCEDURE
+
+     END IF
+!------------------------------------------------------------------------------
+   END FUNCTION ListGetInteger
+!------------------------------------------------------------------------------
 
 !------------------------------------------------------------------------------
 !> Gets a integer value from the list.

--- a/fem/src/Lists.F90
+++ b/fem/src/Lists.F90
@@ -3592,7 +3592,7 @@ CONTAINS
       IF(ALLOCATED(ptr % Name)) DEALLOCATE(ptr % Name)
       ALLOCATE(CHARACTER(n)::ptr % Name)
       ptr % NameLen = StringToLowerCase( ptr % Name,Name )
-    END SUBROUTINE ListAddInteger
+    END SUBROUTINE ListAddAddressInteger
 !------------------------------------------------------------------------------
 
 !------------------------------------------------------------------------------
@@ -4029,7 +4029,7 @@ CONTAINS
 !------------------------------------------------------------------------------
 !> Gets an address integer value from the list.
 !------------------------------------------------------------------------------
-   RECURSIVE FUNCTION ListGetAddressInteger( List,Name,Found,minv,maxv,UnfoundFatal,DefValue) RESULT(L)
+   RECURSIVE FUNCTION ListGetAddressInteger( List,Name,Found,UnfoundFatal,DefValue) RESULT(L)
 !------------------------------------------------------------------------------
      TYPE(ValueList_t), POINTER :: List
      CHARACTER(LEN=*) :: Name
@@ -4062,9 +4062,8 @@ CONTAINS
      
      L = ptr % PROCEDURE
 
-     END IF
 !------------------------------------------------------------------------------
-   END FUNCTION ListGetInteger
+   END FUNCTION ListGetAddressInteger
 !------------------------------------------------------------------------------
 
 !------------------------------------------------------------------------------

--- a/fem/src/ModelDescription.F90
+++ b/fem/src/ModelDescription.F90
@@ -6255,11 +6255,39 @@ END SUBROUTINE GetNodalElementSize
       CALL Graph_Deallocate(Solver % ColourIndexList)
       DEALLOCATE( Solver % ColourIndexList )
     END IF
-        
+
 !------------------------------------------------------------------------------
   END SUBROUTINE FreeSolver
 !------------------------------------------------------------------------------
 
+!------------------------------------------------------------------------------
+!> Call <SolverName>_Finalize if exists
+!> TODO: Not tested
+!------------------------------------------------------------------------------
+SUBROUTINE FinalizeSolver(model, solver)
+!------------------------------------------------------------------------------
+
+  TYPE(Model_t) :: Model
+  TYPE(Solver_t) :: Solver
+  CHARACTER(:), ALLOCATABLE :: Name
+  LOGICAL :: Found, Transient
+  INTEGER(Kind=AddrInt) :: FinalProc
+!------------------------------------------------------------------------------
+
+  Name = ListGetString( Solver % values, 'Procedure', Found)
+  IF(Found) Then
+    FinalProc = GetProcAddr( Trim(Name)//'_Finalize', abort=.FALSE.)
+
+    IF (FinalProc /= 0) then 
+      Transient = ListGetString(Model % Simulation, 'Simulation Type',Found)=='transient'
+      CALL Info('FreeModel','Finalize Solver: > '//trim(Name) // ' <',Level=20)
+      CALL ExecSolver(FinalProc, Model, Solver, Solver% dt, Transient)
+    END IF
+  END IF
+
+!------------------------------------------------------------------------------
+END SUBROUTINE
+!------------------------------------------------------------------------------
 
 !------------------------------------------------------------------------------
 !> Releases value list which includes all the sif definitions, for example.
@@ -6287,7 +6315,7 @@ END SUBROUTINE GetNodalElementSize
 !------------------------------------------------------------------------------
 !> Releases the whole model. 
 !------------------------------------------------------------------------------
- SUBROUTINE FreeModel(Model)
+  SUBROUTINE FreeModel(Model)
 !------------------------------------------------------------------------------
    TYPE(Model_t), POINTER :: Model
 !------------------------------------------------------------------------------
@@ -6326,6 +6354,7 @@ END SUBROUTINE GetNodalElementSize
    CALL Info('FreeModel','Freeing solvers',Level=15)  
    DO i=1,Model % NumberOfSolvers
      CALL Info('FreeModel','Solver: '//I2S(i),Level=20)
+     CALL FinalizeSolver(Model, Model % Solvers(i))
      CALL FreeSolver(Model % Solvers(i))
    END DO
    DEALLOCATE(Model % Solvers)


### PR DESCRIPTION
Added two list subroutines:
- `ListAddAddressInteger`: adds integer of kind `AddrInt` to a valuelist. Uses `valuelistentry_t % PROCEDURE` field for that.
- `ListGetAddressInteger`: gets that integer of kind `AddrInt`.

Added mechanism for calling `<SolverName>_Finalize` subroutine if exists similarly to `<SolverName>_Init/_Init0`. The finalizer is called prior to calling FreeSolver. It is meant for solvers to release resources not managed by Elmer library (e.g. pointers managed by above `ListAddAddressInteger`/`ListGetAddressInteger` routines).