### PR TITLE
Fix initialization of halo nodes/elements when working with halo meshes

### DIFF
--- a/elmerice/Solvers/GroundedSolver.F90
+++ b/elmerice/Solvers/GroundedSolver.F90
@@ -82,7 +82,7 @@ SUBROUTINE GroundedSolver( Model,Solver,dt,TransientSimulation )
   LOGICAL :: AllocationsDone = .FALSE., GotIt, stat,UnFoundFatal=.TRUE.,&
              AllGrounded = .FALSE., useLSvar = .FALSE., Active
 
-  INTEGER :: i, mn, n, t, Nn, istat, DIM, MSum, ZSum, bedrockSource
+  INTEGER :: i, mn, n, t, Nn, istat, DIM, MSum, ZSum, bedrockSource, k
   INTEGER, POINTER :: Permutation(:), bedrockPerm(:), LSvarPerm(:)
 
   REAL(KIND=dp), POINTER :: VariableValues(:)

--- a/elmerice/Solvers/GroundedSolver.F90
+++ b/elmerice/Solvers/GroundedSolver.F90
@@ -105,6 +105,14 @@ SUBROUTINE GroundedSolver( Model,Solver,dt,TransientSimulation )
 
   Active = ANY(Permutation > 0)
 
+  ! Initialize GroundedMask for all active DOFs. 
+  ! This avoids leaving halo/ghost nodes with default value 0
+  IF (Active) THEN
+    DO k = 1, SIZE(VariableValues)
+      IF (Permutation(k) > 0) VariableValues(Permutation(k)) = 1.0_dp
+    END DO
+  END IF
+
   CALL INFO(SolverName, 'Computing grounded mask from geometry', level=3)
 
   !--------------------------------------------------------------

--- a/fem/src/modules/FreeSurfaceSolver.F90
+++ b/fem/src/modules/FreeSurfaceSolver.F90
@@ -514,6 +514,7 @@ SUBROUTINE FreeSurfaceSolver( Model,Solver,dt,TransientSimulation )
         CALL Fatal(SolverName,'Memory allocation error 4, Aborting.')
       END IF
       ActiveNode = .FALSE.
+      LimitedSolution = .FALSE.
       ResidualVector = 0.0_dp
     END IF
 


### PR DESCRIPTION
I found and fixed two bugs linked to missing initializations for halo nodes when using partitioned meshes with halos elements. Some halo nodes were never explicitly assigned in the loop on ActiveElements. 

The fix should not change anything to simulations conducted in serial or without halos. An example of the issue for the groundedsolver on a 48 partition mesh is presented hereafter: 

<img width="505" height="480" alt="image" src="https://github.com/user-attachments/assets/2cd1ed53-6545-4525-ab66-7c96ec448405" />

After the fix, all 0 values at the partition interfaces are correctly assigned. 

