### PR TITLE
Set locale "C" before formatting strings in MATC

### DIFF
--- a/matc/src/matc.c
+++ b/matc/src/matc.c
@@ -94,6 +94,8 @@ $  usage of the function and type of the parameters
  *
  */
 
+#include <locale.h>
+
 #define MODULE_MATC
 #include "elmer/matc.h"
 #include "str.h"
@@ -245,6 +247,8 @@ void mtc_init( FILE *input_file, FILE *output_file, FILE *error_file )
 
 char * mtc_domath( char *str )
 {
+  setlocale(LC_ALL, "C");
+
   VARIABLE *headsave;            /* this should not be here */
 
   jmp_buf jmp, *savejmp;         /* save program context */


### PR DESCRIPTION
When trying to run the test suite on a Windows system with a locale that uses "," as the decimal separator, multiple tests are failing with errors like the following:
```
ERROR:: SectionContents: Invalid characters for real 1 for keyword "timestep sizes": 0,00785398163397
```

Note the comma (instead of a point) in the string that is returned from MATC.

I tried to explicitly set the locale to "C" in `mtc_init`. But that didn't help. 

To debug that, I used the following change:
```diff
diff --git "a/matc/src/matc.c" "b/matc/src/matc.c"
index 6959cea91..514c209ea 100644
--- "a/matc/src/matc.c"
+++ "b/matc/src/matc.c"
@@ -111,6 +111,8 @@ $  usage of the function and type of the parameters
 ^=====================================================================*/
 void mtc_init( FILE *input_file, FILE *output_file, FILE *error_file )
 {
+   setlocale(LC_ALL, "C");
+
    VARIABLE *ptr;
 
    char str[256];
@@ -247,6 +249,8 @@ void mtc_init( FILE *input_file, FILE *output_file, FILE *error_file )
 
 char * mtc_domath( char *str )
 {
+  printf("MATC command: '%s'\n", str);
+  printf("MATC decimal point: '%s'\n", localeconv()->decimal_point);
 
   VARIABLE *headsave;            /* this should not be here */
 
```
That showed that the decimal separator is "." for the first few times that the function is called. But eventually, it changes to "," for some reason. E.g., for the test `AdvDiffFCT`, I'm seeing the following in the stdout.log:
```
MAIN: This program is free software licensed under (L)GPL
MAIN: Copyright 1st April 1995 - , CSC - IT Center for Science Ltd.
MAIN: Webpage http://www.csc.fi/elmer, Email elmeradm@csc.fi
MAIN: Version: 26.1 (Rev: c8faccba0a, Compiled: 2026-02-25)
MAIN:  Running one task without MPI parallelization.
MAIN:  Running with just one thread per task.
MAIN:  Lua interpreter linked in.
MAIN: =============================================================
MATC command: 'format( 12,"rowform")'
MATC decimal point: '.'
MATC command: ' function _i2str__(i) { __i2str__ = sprintf("%g",i); }'
MATC decimal point: '.'
MATC command: ' _ndim__=3'
MATC decimal point: ','
MATC command: ' _nexp__=10'
MATC decimal point: ','
MATC command: ' for(_i__=1:10) for(_j__=1:10) "Solver:String: 'Tensor Field " _i2str__(_i__) " Component " _i2str__(_j__) "'"'
MATC decimal point: ','
MATC command: ' for(_i__=1:_nexp__) "Solver:Integer: 'Exported Variable " _i2str__(_i__) " DOFs'"'
MATC decimal point: ','
MATC command: ' for(_i__=1:_nexp__) "Solver:Logical: 'Exported Variable " _i2str__(_i__) " Output'"'
MATC decimal point: ','
MATC command: ' for(_i__=1:_nexp__) for(_j__=1:_ndim__) "Solver:String: 'Vector Field " _i2str__(_i__) " Component " _i2str__(_j__) "'"'
MATC decimal point: ','
MAIN: 
MAIN: 
MAIN: -------------------------------------
MAIN: Reading Model: case.sif
LoadInputFile: Scanning input file: case.sif
LoadInputFile: Scanning only size info
LoadInputFile: First time visiting
LoadInputFile: Reading base load of sif file
MATC command: 'steps=400'
MATC decimal point: ','
MATC command: 'pi/steps'
MATC decimal point: ','
ERROR:: SectionContents: Invalid characters for real 1 for keyword "timestep sizes": 0,00785398163397
```
At some point (I don't know why) the locale seems to be changing to the system default.

If I re-run the test, the locale seems to be changing at a different point in the execution:
```
MATC command: 'format( 12,"rowform")'
MATC decimal point: '.'
MATC command: ' function _i2str__(i) { __i2str__ = sprintf("%g",i); }'
MATC decimal point: '.'
MATC command: ' _ndim__=3'
MATC decimal point: '.'
MATC command: ' _nexp__=10'
MATC decimal point: '.'
MATC command: ' for(_i__=1:10) for(_j__=1:10) "Solver:String: 'Tensor Field " _i2str__(_i__) " Component " _i2str__(_j__) "'"'
MATC decimal point: ','
MATC command: ' for(_i__=1:_nexp__) "Solver:Integer: 'Exported Variable " _i2str__(_i__) " DOFs'"'
MATC decimal point: ','
MATC command: ' for(_i__=1:_nexp__) "Solver:Logical: 'Exported Variable " _i2str__(_i__) " Output'"'
MATC decimal point: ','
MATC command: ' for(_i__=1:_nexp__) for(_j__=1:_ndim__) "Solver:String: 'Vector Field " _i2str__(_i__) " Component " _i2str__(_j__) "'"'
MATC decimal point: ','
```

The change here "fixes" that by setting the locale to "C" every time that `mtc_domath` is called. 
While that "fixes" the issue at hand for me, I don't really like doing that because changing the locale is computationally costly.

Do you have any idea which part of the execution could potentially affect the locale? If we knew where that is happening, we could potentially make the penalty for changing the locale more localized.