### PR TITLE
Fix compilation error CONTIG declaration for complex arrays

### DIFF
--- a/fem/src/Smoothers.F90
+++ b/fem/src/Smoothers.F90
@@ -750,7 +750,7 @@ CONTAINS
         REAL(KIND=dp) :: w
         INTEGER, POINTER CONTIG :: Cols(:),Rows(:)
         REAL(KIND=dp), POINTER CONTIG :: Values(:)
-        COMPLEX(KIND=dp) CONTIG :: x(n/2),b(n/2),r(n/2)
+        COMPLEX(KIND=dp) :: x(n/2),b(n/2),r(n/2)
 
         DO i=1,n/2
           x(i) = CMPLX( rx(2*i-1), rx(2*i), KIND=dp )


### PR DESCRIPTION
Hi,

I experience build failure on Linux. 

```
[ 57%] Building Fortran object fem/src/CMakeFiles/elmersolver.dir/ClusteringMethods.F90.o
[ 57%] Building Fortran object fem/src/CMakeFiles/elmersolver.dir/Smoothers.F90.o
/run/build/Elmer/fem/src/Smoothers.F90:753:48:

  753 |         COMPLEX(KIND=dp) CONTIG :: x(n/2),b(n/2),r(n/2)
      |                                                1~~~~~
Error: ‘b’ at (1) has the CONTIGUOUS attribute but is not an array pointer or an assumed-shape or assumed-rank array
/run/build/Elmer/fem/src/Smoothers.F90:753:55:

  753 |         COMPLEX(KIND=dp) CONTIG :: x(n/2),b(n/2),r(n/2)
      |                                                       1     
Error: ‘r’ at (1) has the CONTIGUOUS attribute but is not an array pointer or an assumed-shape or assumed-rank array
/run/build/Elmer/fem/src/Smoothers.F90:753:41:

  753 |         COMPLEX(KIND=dp) CONTIG :: x(n/2),b(n/2),r(n/2)
      |                                         1~~~~~
Error: ‘x’ at (1) has the CONTIGUOUS attribute but is not an array pointer or an assumed-shape or assumed-rank array
make[2]: *** [fem/src/CMakeFiles/elmersolver.dir/build.make:822: fem/src/CMakeFiles/elmersolver.dir/Smoothers.F90.o] Error 1
make[2]: *** Waiting for unfinished jobs....
make[1]: *** [CMakeFiles/Makefile2:27954: fem/src/CMakeFiles/elmersolver.dir/all] Error 2
make: *** [Makefile:166: all] Error 2
Error: module Elmer: Child process exited with code 2
```

The build failed on latest commit 85e16d005de298691faeeeaccde685fe5bac4da1
Fortran compiler identification is GNU 15.2.0
C compiler identification is GNU 15.2.0
CXX compiler identification is GNU 15.2.0

