### PR TITLE
Global bubble issue

### DIFF
--- a/fem/src/BlockSolve.F90
+++ b/fem/src/BlockSolve.F90
@@ -193,8 +193,8 @@ CONTAINS
       MaxFDOFs  = MAX( MaxFDOFs,  Element % BDOFs )
     END DO
     
-    GlobalBubbles = ListGetLogical( Params, 'Bubbles in Global System', Found )
-    IF (.NOT.Found) GlobalBubbles = .TRUE.
+    ! Inherit the bubbles from primary solver
+    GlobalBubbles = Solver % GlobalBubbles
     
     Ndeg = Ndeg + Mesh % NumberOfNodes
     IF ( MaxEDOFs > 0 ) Ndeg = Ndeg + MaxEDOFs * Mesh % NumberOFEdges

--- a/fem/src/ElmerSolver.F90
+++ b/fem/src/ElmerSolver.F90
@@ -85,7 +85,7 @@
      USE MortarUtils, ONLY : PeriodicProjector
      USE MainUtils, ONLY : AddEquationBasics, AddEquationSolution, AddExecWhenFlag, &
          PredictorCorrectorControl, SingleSolver, SolveEquations, SolverActivate, &
-         SwapMesh
+         SetGlobalBubblesFlag, SwapMesh
      USE DefUtils, ONLY : GetSimulation, GetCompilationDate, GetRevision, GetVersion, GetBranch, &
          GetReal, GetCReal, GetLogical, GetElementNOFNodes, GetElementDOFs, GetBC, &
          GetElementFamily, GetElementNodes, VectorElementEdgeDOFs
@@ -826,8 +826,7 @@
            
          CALL FreeMatrix( iSolver % Matrix)
 
-         GB = ListGetLogical( iSolver % Values,'Bubbles in Global System', Found )
-         IF ( .NOT. Found ) GB = .TRUE.
+         GB = SetGlobalBubblesFlag(iSolver)
 
          BO = ListGetLogical( iSolver % Values,'Optimize Bandwidth', Found )
          IF ( .NOT. Found ) BO = .TRUE.
@@ -2072,14 +2071,25 @@
        CALL SetCurrentMesh( CurrentModel, Mesh )
 
        IF( InfoActive( 30 ) ) THEN
+         j = 0
          CALL Info('InitCond','Initial conditions for '//I2S(Mesh % MeshDim)//'D mesh:'//TRIM(Mesh % Name))
          Var => Mesh % Variables
          DO WHILE( ASSOCIATED(Var) ) 
            IF( ListCheckPresentAnyIC( CurrentModel, Var % Name ) ) THEN
-             CALL VectorValuesRange(Var % Values,SIZE(Var % Values),'PreInit: '//TRIM(Var % Name))       
+             !CALL VectorValuesRange(Var % Values,SIZE(Var % Values),'PreInit: '//TRIM(Var % Name))       
+           END IF
+           IF(Var % TYPE == Variable_on_nodes ) THEN
+             IF( ASSOCIATED(Var % Perm) ) THEN
+               IF(MAXVAL(Var % Perm) /= COUNT(Var % Perm > 0) ) THEN
+                 PRINT *,'Perm range for: '//TRIM(Var % Name), MAXVAL(Var % Perm), COUNT(Var % Perm /= 0), &
+                     SIZE(Var % Perm)
+                 j = j+1
+               END IF
+             END IF
            END IF
            Var => Var % Next
          END DO
+         IF(j>0) CALL Fatal('InitCond','Mismatch in '//I2S(j)//' nodal permutations!')         
        END IF
        
        m = Mesh % MaxElementDofs

--- a/fem/src/MainUtils.F90
+++ b/fem/src/MainUtils.F90
@@ -1099,6 +1099,63 @@ CONTAINS
      
    END SUBROUTINE PrintProblemSize
    
+
+   !-----------------------------------------------------------------------------
+   !> This routine tries to combine all historical and more recent logic how the
+   !> bubble degrees of freedom are treated in the code. By default the bubbles
+   !> are not active, but there are many exceptions. 
+   !-----------------------------------------------------------------------------
+   FUNCTION SetGlobalBubblesFlag(Solver) RESULT( GlobalBubbles ) 
+     TYPE(Solver_t) :: Solver
+     LOGICAL :: GlobalBubbles
+     
+     LOGICAL :: Found
+     INTEGER :: i,j,k
+     INTEGER, POINTER :: ActiveSolvers(:)
+     CHARACTER(:), ALLOCATABLE :: str
+
+     
+     GlobalBubbles = ListGetLogical( Solver % Values, 'Bubbles in Global System', Found )
+     IF(.NOT. Found) THEN            
+       str = ListGetString( Solver % Values,'Element',Found)
+       IF(Found) THEN
+         i = INDEX( str,'p:') + INDEX(str,'b:')
+         GlobalBubbles = (i>0)
+       END IF
+       IF(.NOT. Found) THEN
+         ! Element not given, check if there is something to inherit from Equation section. 
+         DO j=1,CurrentModel % NumberOFEquations
+           ActiveSolvers => ListGetIntegerArray( CurrentModel % Equations(j) % Values, &
+               'Active Solvers', Found )
+           IF(Found) THEN
+             IF(ANY(ActiveSolvers == Solver % SolverId)) THEN              
+               str = ListGetString( CurrentModel % Equations(j) % Values,'Element',Found)
+               IF(Found) THEN
+                 i = INDEX( str,'p:') + INDEX(str,'b:')
+                 IF(i>0) GlobalBubbles = .TRUE.
+               END IF
+             END IF
+           END IF
+         END DO
+       END IF
+       IF(.NOT. Found ) THEN
+         DO j=1,CurrentModel % NumberOFBodies 
+           str = ListGetString( CurrentModel % Bodies(j) % Values,&
+               'Solver '//I2S(Solver % SolverId)//': Element',Found)
+           IF(Found) THEN
+             i = INDEX( str,'p:') + INDEX(str,'b:')
+             IF(i>0) GlobalBubbles = .TRUE.
+           END IF
+         END DO
+       END IF
+     END IF
+     IF( GlobalBubbles .AND. .NOT. Solver % GlobalBubbles) THEN
+       CALL Info('SetGlobalBubblesFlag','Setting global bubbles to true because of element type chosen!',Level=7)
+       Solver % GlobalBubbles = GlobalBubbles
+     END IF
+   END FUNCTION SetGlobalBubblesFlag
+     
+
    
 !------------------------------------------------------------------------------
 !> Add the generic stuff related to each Solver. 
@@ -1112,9 +1169,7 @@ CONTAINS
     CHARACTER(LEN=*) :: Name
 !------------------------------------------------------------------------------
     REAL(KIND=dp), POINTER :: Solution(:)
-
     INTEGER, POINTER :: Perm(:)
-
     INTEGER(KIND=AddrInt) :: InitProc, AssProc
 
     INTEGER :: MaxDGDOFs, MaxNDOFs, MaxEDOFs, MaxFDOFs, MaxBDOFs, MaxDOFsPerNode
@@ -1624,10 +1679,9 @@ CONTAINS
             CurrentElement => Solver % Mesh % Faces(i)
             MaxFDOFs  = MAX( MaxFDOFs,  CurrentElement % BDOFs )
           END DO
-          
-          GlobalBubbles = ListGetLogical( SolverParams, 'Bubbles in Global System', Found )
-          IF (.NOT.Found) GlobalBubbles = .TRUE.
 
+          GlobalBubbles = SetGlobalBubblesFlag( Solver ) 
+          
           Ndeg = Ndeg + MaxDOFsPerNode * Solver % Mesh % NumberOfNodes 
           IF ( GlobalBubbles ) THEN
             Ndeg = Ndeg + MaxBDOFs * Solver % Mesh % NumberOfBulkElements
@@ -1727,7 +1781,6 @@ CONTAINS
         Solver % Matrix => CreateMatrix( CurrentModel, Solver, Solver % Mesh, &
             Perm, DOFs, MatrixFormat, BandwidthOptimize, eq(1:LEN_TRIM(eq)), DG, &
             GlobalBubbles=GlobalBubbles, ThreadedStartup=ThreadedStartup )
-        Solver % GlobalBubbles = GlobalBubbles
 
         Nrows = DOFs * Ndeg
         IF (ASSOCIATED(Solver % Matrix)) THEN
@@ -2892,8 +2945,9 @@ CONTAINS
      Lvalue = ListGetLogical( Solver % Values,'Bubbles in Global System',Found )
      IF( Found ) THEN
        CALL ListAddNewLogical( ChildSolver % Values,'Bubbles in Global System',Lvalue )
+       Solver % GlobalBubbles = SetGlobalBubblesFlag( ChildSolver ) 
      END IF
-     
+          
      IF( ASSOCIATED( ParentSolver % ActiveElements ) ) THEN
        Solver % ActiveElements => ParentSolver % ActiveElements
        Solver % NumberOfActiveElements = ParentSolver % NumberOfActiveElements
@@ -5587,14 +5641,14 @@ END BLOCK
      LOGICAL :: stat, Found, TimeDerivativeActive, Timing, IsPassiveBC, &
          GotCoordTransform, NamespaceFound
      INTEGER :: i, j, k, n, BDOFs, timestep, timei, timei0, PassiveBcId, Execi
-     INTEGER, POINTER :: ExecIntervals(:),ExecIntervalsOffset(:)
+     INTEGER, POINTER :: ExecIntervals(:),ExecIntervalsOffset(:),ActiveSolvers(:)
      REAL(KIND=dp) :: tcond, t0, rt0, st, rst, ct
      TYPE(Variable_t), POINTER :: TimeVar, IterV
      TYPE(ValueList_t), POINTER :: Params
      INTEGER, POINTER :: UpdateComponents(:)
 
      INTEGER :: ScanningLoops, scan, sOutputPE
-     LOGICAL :: GotLoops
+     LOGICAL :: GotLoops, GlobalBubbles
      TYPE(Variable_t), POINTER :: ScanVar, Var
      CHARACTER(:), ALLOCATABLE :: str, CoordTransform
      TYPE(Mesh_t), POINTER :: Mesh, pMesh
@@ -5692,8 +5746,9 @@ END BLOCK
 ! Set solver parameters to avoid list operations during assembly
 !-------------------------------------------------------------------------------
      Solver % DG = ListGetLogical(Params, 'Discontinuous Galerkin', Found)
-     Solver % GlobalBubbles = ListGetLogical(Params, 'Bubbles in Global System', Found)
-     IF(.NOT. Found) Solver % GlobalBubbles = .TRUE.
+
+     GlobalBubbles = SetGlobalBubblesFlag( Solver ) 
+     
      IF(GetString(Params, 'Linear System Direct Method', Found) == 'permon') THEN
        Solver % DirectMethod = DIRECT_PERMON
      END IF

--- a/fem/src/MeshUtils.F90
+++ b/fem/src/MeshUtils.F90
@@ -6631,7 +6631,6 @@ CONTAINS
     END IF
 
     PreserveBaseline = ListGetLogical( CurrentModel % Simulation,'Preserve Baseline',Found )
-    IF(.NOT. Found) PreserveBaseline = .FALSE.
 
     CollectExtrudedBCs = ListGetLogical( CurrentModel % Simulation,'Extruded BCs Collect',Found )
     
@@ -8509,6 +8508,7 @@ CONTAINS
     
     CALL CheckMeshBulkHits()
     CALL CheckMeshBoundaryHits()
+    CALL CheckBCTags()
     CALL CheckParentIndeces()
     CALL CheckMeshGeomSize()
     CALL CheckMeshSerendipity()
@@ -8539,7 +8539,7 @@ CONTAINS
         IF(.NOT. ASSOCIATED( Element % TYPE ) ) THEN
           CALL Fatal(Caller,'Element type not associated for bulk elem: '//I2S(t))
         END IF
-        i = Element % TYPE % ElementCode
+        i = Element % TYPE % ElementCode        
         TypeHits(i) = TypeHits(i)+1
         IF(ANY(Element % NodeIndexes < 1 ) ) THEN
           PRINT *,'NodeIndexes:', Element % NodeIndexes 
@@ -8553,7 +8553,13 @@ CONTAINS
           PRINT *,'NodeIndexes:',Element % NodeIndexes
           CALL Fatal(Caller,'Non-positive node index encountered')
         END IF
-        NodeHits(Element % NodeIndexes) = NodeHits(Element % NodeIndexes) + 1
+        IF(ANY(Element % NodeIndexes < 1) ) THEN
+          PRINT *,'Too small bulk element index: ',t, Element % NodeIndexes
+        ELSE IF(ANY(Element % NodeIndexes > nn) ) THEN
+          PRINT *,'Too large bulk element index: ',t, Element % NodeIndexes
+        ELSE
+          NodeHits(Element % NodeIndexes) = NodeHits(Element % NodeIndexes) + 1
+        END IF
       END DO
 
       Dbg(1) = na
@@ -8568,6 +8574,7 @@ CONTAINS
       END DO
       
       t=MAXVAL(NodeHits)
+
       IF( InfoActive(25)) THEN
         DO i=0,t
           j = COUNT( NodeHits == i)
@@ -8576,6 +8583,8 @@ CONTAINS
       END IF
       dbg(4) = t      
       Dbg(5) = COUNT(TypeHits>0)
+
+
       WRITE(Message,*) 'Bulk Checksum: ',Dbg(1:5)
       CALL Info(Caller,Message)      
       
@@ -8695,6 +8704,68 @@ CONTAINS
       
     END SUBROUTINE CheckParentIndeces
 
+
+    SUBROUTINE CheckBCTags()
+      INTEGER :: Misses, Tag, MinTag, MaxTag
+      INTEGER, ALLOCATABLE :: TagCount(:), BCNodeCount(:)
+
+      ! Not BCs to go through
+      IF(nb==0) RETURN
+
+      Misses = 0
+      MinTag = HUGE(MinTag)
+      MaxTag = -HUGE(MaxTag)
+
+      DO k=1,2
+        DO t=na+1,na+nb
+          Element => Mesh % Elements(t)
+          IF(.NOT. ASSOCIATED(Element % BoundaryInfo)) THEN
+            IF(k==1) Misses = Misses + 1
+            CYCLE
+          END IF
+          Tag = Element % BoundaryInfo % Constraint
+          IF(k==1) THEN
+            MinTag = MIN(MinTag,Tag)
+            MaxTag = MAX(MaxTag,Tag)
+          ELSE
+            TagCount(Tag) = TagCount(Tag) + 1
+          END IF
+        END DO
+        IF(k==1) THEN
+          ! Not tags defined in this partition
+          IF(MinTag > MaxTag) THEN
+            EXIT
+          ELSE
+            ALLOCATE(TagCount(MinTag:MaxTag))
+            TagCount = 0
+          END IF
+        END IF
+      END DO
+
+      ALLOCATE(BCNodeCount(MinTag:MaxTag))
+      BCNodeCount = 0
+      
+      DO k=1, MaxTag
+        IF(TagCount(k)==0) CYCLE
+        NodeHits = 0
+        DO t=na+1,na+nb
+          Element => Mesh % Elements(t)
+          IF(.NOT. ASSOCIATED(Element % BoundaryInfo)) CYCLE
+          Tag = Element % BoundaryInfo % Constraint
+          IF(Tag==k) NodeHits(Element % NodeIndexes) = 1
+        END DO
+        BCNodeCount(k) = COUNT(NodeHits == 1)
+      END DO
+
+      DO k=MinTag,MaxTag
+        IF(TagCount(k) > 0) THEN
+          PRINT *,'BC'//I2S(k)//': elems '//I2S(TagCount(k))//' nodes '//I2S(BCNodeCount(k))
+        END IF
+      END DO           
+      
+    END SUBROUTINE CheckBCTags
+
+    
     
     SUBROUTINE CheckMeshGeomSize()
 
@@ -8877,7 +8948,7 @@ CONTAINS
       WRITE(Message,*) 'Edges Checksum: ',Dbg(1:5)
       CALL Info(Caller,Message)                  
 
-      IF(ANY(Dbg < 0) ) Halt = .TRUE.
+      !IF(ANY(Dbg < 0) ) Halt = .TRUE.
 
     END SUBROUTINE CheckMeshEdges
 
@@ -8915,7 +8986,7 @@ CONTAINS
       WRITE(Message,*) 'Faces Checksum: ',Dbg(1:5)
       CALL Info(Caller,Message)                  
 
-      IF(ANY(Dbg < 0) ) Halt = .TRUE.
+      !IF(ANY(Dbg < 0) ) Halt = .TRUE.
       
     END SUBROUTINE CheckMeshFaces
 
@@ -10624,10 +10695,7 @@ END SUBROUTINE FindNeighbourNodes
      END IF
      Permutation = 0
      
-     
-     GlobalBubbles = ListGetLogical( Solver % Values, &
-         'Bubbles in Global System', Found )
-     IF ( .NOT. Found ) GlobalBubbles = .TRUE.
+     GlobalBubbles = Solver % GlobalBubbles
      
      OptimizeBandwidth = ListGetLogical( Solver % Values, 'Optimize Bandwidth', Found )
      IF ( .NOT. Found ) OptimizeBandwidth = .TRUE.

--- a/fem/src/ModelDescription.F90
+++ b/fem/src/ModelDescription.F90
@@ -2795,11 +2795,6 @@ CONTAINS
           EXIT
         END IF
       END DO
-     
-      !Solver % GlobalBubbles = ListGetLogical(Solver % Values, &
-      !    'Bubbles in Global System', stat)
-      !IF(.NOT. stat) Solver % GlobalBubbles = .TRUE.
-      
       i = i + 1
     END DO
 
@@ -4744,10 +4739,10 @@ CONTAINS
         ! Note that Var % Perm is the permutation associated with the current field
         ! while Perm will be the permutation associated with the saved field. 
         ! They could be different, even though the usually are not!
-        CALL Info(Caller,'Reading permutation order for: '//TRIM(Row),Level=12)
+        CALL Info(Caller,'Reading permutation order for: '//TRIM(Row),Level=20)
         CALL ReadPerm( RestartUnit, Perm, GotPerm )           
         IF( GotPerm ) THEN
-          CALL Info(Caller,'Succesfully read permutation order for: '//TRIM(Row),Level=20)
+          CALL Info(Caller,'Maximum value for permutation order for "'//TRIM(Row)//'" is '//I2S(MAXVAL(Perm)),Level=12)
         END IF
           
         IF( LoadThis ) THEN
@@ -4760,7 +4755,7 @@ CONTAINS
           ELSE
             n = FieldSize
           END IF
-          CALL Info(Caller,'Size of load loop is '//I2S(n),Level=15)
+          CALL Info(Caller,'Size of load loop is '//I2S(n),Level=20)
 
           ! If we are renaming the variable also then do it
           j = FileVariableInfo(i,4) 

--- a/fem/src/ParallelUtils.F90
+++ b/fem/src/ParallelUtils.F90
@@ -425,9 +425,8 @@ CONTAINS
            END DO
          END DO
 
-         GB = ListGetLogical( Solver % Values, 'Bubbles in Global System', Found )
-         IF (.NOT.Found) GB = .TRUE.
-
+         GB = Solver % GlobalBubbles 
+         
          maxnode = MAXVAL(Mesh % ParallelInfo % GlobalDOFs)
          maxnode = ParallelReduction(maxnode,2)
 

--- a/fem/src/SolverUtils.F90
+++ b/fem/src/SolverUtils.F90
@@ -2177,9 +2177,7 @@ CONTAINS
      pContact = IsActivePelement(Mesh % Elements(1), Solver)
      IF( pContact ) THEN
        ! We only have to deal with the middle dofs if they are not condensated away!
-       IF( .NOT. ListGetLogical( Params,'Bubbles in Global System',Found ) ) THEN
-         IF(Found) pContact = .FALSE.   
-       END IF
+       pContact = Solver % GlobalBubbles 
      END IF
      IF( ListGetLogical( Params,'Contact Linear Basis',Found ) ) THEN
        pContact = .FALSE.

--- a/fem/src/modules/ElasticSolve.F90
+++ b/fem/src/modules/ElasticSolve.F90
@@ -264,6 +264,7 @@ SUBROUTINE ElasticSolver( Model, Solver, dt, TransientSimulation )
   USE DefUtils
   USE MaterialModels
   USE StressLocal
+  USE MainUtils, ONLY : SetGlobalBubblesFlag
   
   IMPLICIT NONE
 
@@ -3345,8 +3346,12 @@ CONTAINS
 
        OptimizeBW = GetLogical( StSolver % Values, 'Optimize Bandwidth', Found )
        IF ( .NOT. Found ) OptimizeBW = .TRUE.
-       GlobalBubbles = GetLogical( StSolver % Values, 'Bubbles in Global System', Found )
-       IF ( .NOT. Found ) GlobalBubbles = .TRUE.
+
+       GlobalBubbles = GetLogical( Solver % Values, 'Bubbles in Global System', Found )
+       IF(Found) THEN
+         CALL ListAddLogical( StSolver % Values, 'Bubbles in Global System', GlobalBubbles )
+       END IF
+       GlobalBubbles = SetGlobalBubblesFlag( stSolver )
 
        IF( ListGetLogicalAnyEquation( Model,'Calculate Strains' ) ) THEN
           UseMask = .TRUE.
@@ -3611,8 +3616,12 @@ CONTAINS
 
        OptimizeBW = GetLogical( StSolver % Values, 'Optimize Bandwidth', Found )
        IF ( .NOT. Found ) OptimizeBW = .TRUE.
-       GlobalBubbles = GetLogical( StSolver % Values, 'Bubbles in Global System', Found )
-       IF ( .NOT. Found ) GlobalBubbles = .TRUE.
+
+       GlobalBubbles = GetLogical( Solver % Values, 'Bubbles in Global System', Found )
+       IF(Found) THEN
+         CALL ListAddLogical( StSolver % Values, 'Bubbles in Global System', GlobalBubbles )
+       END IF
+       GlobalBubbles = SetGlobalBubblesFlag( stSolver )
 
        IF( ListGetLogicalAnyEquation( Model,'Calculate Stresses' ) ) THEN
           UseMask = .TRUE.
@@ -3898,8 +3907,12 @@ CONTAINS
 
        OptimizeBW = GetLogical( StSolver % Values, 'Optimize Bandwidth', Found )
        IF ( .NOT. Found ) OptimizeBW = .TRUE.
-       GlobalBubbles = GetLogical( StSolver % Values, 'Bubbles in Global System', Found )
-       IF ( .NOT. Found ) GlobalBubbles = .TRUE.
+
+       GlobalBubbles = GetLogical( Solver % Values, 'Bubbles in Global System', Found )
+       IF(Found) THEN
+         CALL ListAddLogical( StSolver % Values, 'Bubbles in Global System', GlobalBubbles )
+       END IF
+       GlobalBubbles = SetGlobalBubblesFlag( stSolver )
 
        IF( ListGetLogicalAnyEquation( Model,'Calculate Stresses' ) ) THEN
           UseMask = .TRUE.

--- a/fem/src/modules/ResultOutputSolve/VtuOutputSolver.F90
+++ b/fem/src/modules/ResultOutputSolve/VtuOutputSolver.F90
@@ -719,7 +719,7 @@ CONTAINS
     INTEGER, PARAMETER :: VtuUnit = 58
     INTEGER :: i,ii,j,jj,k,dofs,Rank,n,m,dim,vari,sdofs,dispdofs, dispBdofs, Offset, &
         NoFields, NoFields2, IndField, iField, iField0, NoModes, NoModes2, NoFieldsWritten, &
-        cumn, iostat
+        cumn, iostat, NoTooBig, nofs
     CHARACTER(LEN=1024) :: Txt, ScalarFieldName, VectorFieldName, TensorFieldName, &
         FieldName, FieldNameB, OutStr
     CHARACTER :: lf
@@ -1225,10 +1225,11 @@ CONTAINS
                   CALL Fatal(Caller,'InvFieldPerm not associated!')
                 END IF
               END IF
+              NoTooBig = 0
+              nofs = 0
               
               IF( BinaryOutput ) WRITE( VtuUnit ) k
-
-              vals = 0
+              
               DO ii = 1, NumberOfDofNodes
 
                 IF( NoPermutation ) THEN
@@ -1238,11 +1239,18 @@ CONTAINS
                 END IF
 
                 IF( ASSOCIATED( Perm ) .AND. LagN == 0 ) THEN
-                  j = Perm(i)
+                  j = 0
+                  IF(i<1 .OR. i>SIZE(Perm)) THEN
+                    NoTooBig = NoTooBig + 1
+                  ELSE
+                    j = Perm(i)
+                  END IF
                 ELSE
                   j = i
                 END IF
 
+                IF(j>0) nofs = nofs + 1
+                
                 Use2 = .FALSE.
                 IF( ComplementExists ) THEN
                   IF( j == 0 ) THEN
@@ -1250,8 +1258,8 @@ CONTAINS
                     j = PermB(i)
                   END IF
                 END IF
-
                 
+                vals = 0.0_dp
                 DO k=1,sdofs              
                   IF(j==0 .OR. k > dofs) THEN
                     vals(k) = 0.0_dp
@@ -1346,6 +1354,14 @@ CONTAINS
 
               CALL AscBinRealWrite( 0.0_dp, .TRUE. )
 
+              IF(NoTooBig > 0) THEN
+                CALL Fatal(Caller,'Too big index for Perm in '//I2S(NoTooBig)//' nodes for '//TRIM(FieldName))
+              END IF
+              IF(ASSOCIATED(Perm)) THEN
+                CALL Info(Caller,'Number of nonzeros for "'&
+                    //TRIM(FieldName)//'" is '//I2S(nofs)//' of '//I2S(NumberOfDofNodes),Level=15)
+              END IF
+                
             END IF
 
             IF( AsciiOutput ) THEN

--- a/fem/tests/LinearFormsAssembly/linearftest.sif
+++ b/fem/tests/LinearFormsAssembly/linearftest.sif
@@ -32,6 +32,8 @@ Solver 1
   Variable DOFs = 1
   Procedure = "LinearFormsAssembly" "LinearFormsAssembly"
 
+  Bubbles in global system = true
+
   Norm Variable Index = Integer 1
 
   Optimize Bandwidth = False

--- a/fem/tests/SD_LinearFormsAssembly/linearftest.sif
+++ b/fem/tests/SD_LinearFormsAssembly/linearftest.sif
@@ -30,6 +30,8 @@ Solver 1
   Variable DOFs = 1
   Procedure = "LinearFormsAssembly" "LinearFormsAssembly"
 
+  Bubbles in global system = true
+
   Norm Variable Index = Integer 1
 
   Optimize Bandwidth = False


### PR DESCRIPTION
Set the default value of "Bubbles in Global System" to False, was True before. The reason for this is that when adding new solvers with bubble space potentially active the other solvers by default started to use them even though they were not even designed for this. This resulted to a lot of unnecessary flags "Bubbles in Global System = False" needed to be set. Now a single subroutine "SetGlobalBubblesFlag()" checks the finite element basis and defined the default value based on the "Element" definition provided.  