### PR TITLE
Fix segfault in mortar projectors with discontinuous Galerkin

### DIFF
--- a/fem/src/MortarUtils.F90
+++ b/fem/src/MortarUtils.F90
@@ -2853,7 +2853,7 @@ CONTAINS
         
         Element => BMesh1 % Elements(ind)        
         
-        nd = mGetElementDOFs(Indexes,Element)
+        nd = mGetElementDOFs(Indexes,Element,NotDG=.TRUE.)
         n = Element % TYPE % NumberOfNodes
         ne = 2
         
@@ -2971,7 +2971,7 @@ CONTAINS
                     
           ElementM => BMesh2 % Elements(indM)
           
-          ndM = mGetElementDOFs(IndexesM,ElementM)
+          ndM = mGetElementDOFs(IndexesM,ElementM,NotDG=.TRUE.)
           nM = ElementM % TYPE % NumberOfNodes
           neM = ElementM % TYPE % ElementCode / 100
           IF(.NOT.pElemBasis) ndM = nM
@@ -4519,7 +4519,7 @@ CONTAINS
           TrueElement => Mesh % Faces(Element % ElementIndex)
           nd = mGetElementDOFs(Indexes, TrueElement, notDG = .TRUE.)
         ELSE
-          nd = mGetElementDOFs(Indexes,Element)
+          nd = mGetElementDOFs(Indexes,Element,NotDG=.TRUE.)
         END IF
 
         n = Element % TYPE % NumberOfNodes
@@ -4700,7 +4700,7 @@ CONTAINS
             TrueElementM => Mesh % Faces(ElementM % ElementIndex)
             ndM = mGetElementDOFs(IndexesM,TrueElementM, notDG = .TRUE.)
           ELSE
-            ndM =  mGetElementDOFs(IndexesM,ElementM)
+            ndM =  mGetElementDOFs(IndexesM,ElementM,NotDG=.TRUE.)
           END IF
           
           neM = ElementM % TYPE % ElementCode / 100
@@ -6407,7 +6407,7 @@ CONTAINS
 
         Element => BMesh1 % Elements(ind)        
 
-        nd = mGetElementDOFs(Indexes,Element)
+        nd = mGetElementDOFs(Indexes,Element,NotDG=.TRUE.)
         n = Element % TYPE % NumberOfNodes
         IF(.NOT. pElemBasis) nd = n
 
@@ -6474,7 +6474,7 @@ CONTAINS
         DO indM=1,BMesh2 % NumberOfBulkElements
           
           ElementM => BMesh2 % Elements(indM)        
-          ndM = mGetElementDOFs(IndexesM,ElementM)
+          ndM = mGetElementDOFs(IndexesM,ElementM,NotDG=.TRUE.)
 
           nM = ElementM % TYPE % NumberOfNodes
           IF(.NOT.pElemBasis) ndM = nM


### PR DESCRIPTION
I kept hitting segfaults when combining discontinuous Galerkin with radial projectors. Simple test case: [dg-radial.zip](https://github.com/user-attachments/files/25843307/dg-radial.zip).

This fix adds `NotDG=.TRUE.` at a few places so nodes are indexed correctly. Only the final two of these (in `AddProjectorWeak1D`) are needed to fix my example, but my coding agent suggested applying the same fix to `NormalProjectorWeak1D` and `AddProjectorWeakGeneric`.
