### PR TITLE
Fix segfault in mortar projectors with discontinuous Galerkin

### DIFF
--- a/fem/src/MortarUtils.F90
+++ b/fem/src/MortarUtils.F90
@@ -4519,7 +4519,7 @@ CONTAINS
           TrueElement => Mesh % Faces(Element % ElementIndex)
           nd = mGetElementDOFs(Indexes, TrueElement, notDG = .TRUE.)
         ELSE
-          nd = mGetElementDOFs(Indexes,Element)
+          nd = mGetElementDOFs(Indexes,Element,NotDG=.TRUE.)
         END IF
 
         n = Element % TYPE % NumberOfNodes
@@ -4700,7 +4700,7 @@ CONTAINS
             TrueElementM => Mesh % Faces(ElementM % ElementIndex)
             ndM = mGetElementDOFs(IndexesM,TrueElementM, notDG = .TRUE.)
           ELSE
-            ndM =  mGetElementDOFs(IndexesM,ElementM)
+            ndM =  mGetElementDOFs(IndexesM,ElementM,NotDG=.TRUE.)
           END IF
           
           neM = ElementM % TYPE % ElementCode / 100
@@ -6407,7 +6407,7 @@ CONTAINS
 
         Element => BMesh1 % Elements(ind)        
 
-        nd = mGetElementDOFs(Indexes,Element)
+        nd = mGetElementDOFs(Indexes,Element,NotDG=.TRUE.)
         n = Element % TYPE % NumberOfNodes
         IF(.NOT. pElemBasis) nd = n
 


### PR DESCRIPTION
The fix in https://github.com/ElmerCSC/elmerfem/commit/03be2de16aa3013af58de75d963d9a92abef7625 added a few `NotDG`s compared to my #787, but also removed a few. I still get segfaults.

This PR restores the remaining `NotDG`s from #787. To reiterate: the final one is the one that fixes everything for me. The other two are suggestions from my coding agent and I don't know how to test them. I'm very happy to be told that this is not the correct fix, and I'll convert to an issue instead.