### PR TITLE
nix-workflows: Remove argument that is no longer supported by the action

### DIFF
--- a/.github/workflows/nix-cachix.yaml
+++ b/.github/workflows/nix-cachix.yaml
@@ -11,8 +11,6 @@ jobs:
     steps:
     - uses: actions/checkout@v6
     - uses: nixbuild/nix-quick-install-action@v34
-      with:
-        nix_path: nixpkgs=channel:nixos-25.05
     - uses: nix-community/cache-nix-action@v7
       with:
         primary-key: nix-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('**/*.nix', '**/flake.lock') }}

--- a/.github/workflows/nix-check.yaml
+++ b/.github/workflows/nix-check.yaml
@@ -9,8 +9,6 @@ jobs:
     steps:
     - uses: actions/checkout@v6
     - uses: nixbuild/nix-quick-install-action@v34
-      with:
-        nix_path: nixpkgs=channel:nixos-25.05
     - uses: nix-community/cache-nix-action@v7
       with:
         primary-key: nix-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('**/*.nix', '**/flake.lock') }}


### PR DESCRIPTION
The nixbuild/nix-quick-install-action action no longer(?) supports the parameter `nix_path`.

@mk3z confirmed that it can be removed:
https://github.com/ElmerCSC/elmerfem/pull/795#issuecomment-4118989364