### PR TITLE
Revise macOS compilation instructions for MPI and OpenMP

### DIFF
--- a/compilation_instructions/macOS.md
+++ b/compilation_instructions/macOS.md
@@ -4,23 +4,23 @@ Compilation for macOS
 (note: instructions may be out of date)
 
 
- * Download this repository either az a zip file via GitHub or using `git clone https://github.com/ElmerCSC/elmerfem.git`
- * Go to the downloaded directory `mkdir build` and `cd build`
- * Install Homebrew
- * Install GCC `brew install gcc`
- * Install CMake `brew install cmake`
- * Without MPI: 
-    ** `cmake .. -D WITH_OpenMP:BOOLEAN=TRUE`
- * With MPI:
-    ** Install OpenMPI `brew install open-mpi`
-    ** `cmake .. -D WITH_OpenMP:BOOLEAN=TRUE -D WITH_MPI:BOOLEAN=TRUE`
- * With ElmerGUI:
-    ** install qt4 with `brew install cartr/qt4/qt@4` 
-    ** install qwt with `brew install cartr/qt4/qwt-qt4`
-    ** `cmake .. -D WITH_OpenMP:BOOLEAN=TRUE -D WITH_MPI:BOOLEAN=TRUE -D WITH_ELMERGUI:BOOLEAN=TRUE`
- * With ElmerPost:
-    ** `brew cask install xquartz`
-    ** ....
- * `make`
- * `make install`
+ - Download this repository either az a zip file via GitHub or using `git clone https://github.com/ElmerCSC/elmerfem.git`
+ - Go to the downloaded directory `mkdir build` and `cd build`
+ - Install Homebrew
+ - Install GCC `brew install gcc`
+ - Install CMake `brew install cmake`
+ - Without MPI: 
+   - `cmake .. -D WITH_OpenMP:BOOLEAN=TRUE`
+ - With MPI:
+   - Install OpenMPI `brew install open-mpi`
+   - `cmake .. -D WITH_OpenMP:BOOLEAN=FALSE -D WITH_MPI:BOOLEAN=TRUE`
+ - With ElmerGUI:
+   - install qt4 with `brew install cartr/qt4/qt@4` 
+   - install qwt with `brew install cartr/qt4/qwt-qt4`
+   - `cmake .. -D WITH_OpenMP:BOOLEAN=FALSE -D WITH_MPI:BOOLEAN=TRUE -D WITH_ELMERGUI:BOOLEAN=TRUE`
+ - With ElmerPost:
+   - `brew cask install xquartz`
+   - ....
+ - `make`
+ - `make install`
 


### PR DESCRIPTION
Fixed formatting (using `**`is not being registered as a valid second indentation level). Fixed WITH_OpenMP=FALSE when WITH_MPI=TRUE (setting both to TRUE causes an error)