### PR TITLE
YAC Coupling: Require calendar, start time, and end time from sif

### DIFF
--- a/elmerice/Solvers/yac2elmer.F90
+++ b/elmerice/Solvers/yac2elmer.F90
@@ -114,8 +114,9 @@ SUBROUTINE YAC2Elmer( Model,Solver,dt,TransientSimulation )
   ! parameters to be read in from this solvers section in the sif
   LOGICAL :: couple_to_ebfm, couple_to_icon         ! define which component is coupled to Elmer
 
-  CHARACTER(LEN=1024) ::  config_file, model_tstep, coupling_timestep, grid_crs, proj_type
-  INTEGER :: i, t, ierr, dt_hours, coupling_hours
+  CHARACTER(LEN=1024) ::  config_file, coupling_timestep, grid_crs, proj_type
+  CHARACTER(LEN=1024) ::  yac_calendar, yac_start_time, yac_end_time
+  INTEGER :: i, t
   INTEGER, POINTER :: t_icePerm(:), smbPerm(:), runoffPerm(:)
   REAL(KIND=dp) :: central_meridian, latitude_of_origin
   REAL(KIND=dp) :: expected_central_meridian, expected_latitude_of_origin
@@ -154,6 +155,39 @@ SUBROUTINE YAC2Elmer( Model,Solver,dt,TransientSimulation )
   IF (.NOT. Found) THEN
      CALL FATAL(SolverName,'No keyword >Config File Name< found in yac2elmer solver')
   END IF
+
+  ! read YAC calendar
+  yac_calendar = GetString(SolverParams, 'Calendar', Found)
+  IF (.NOT. Found) THEN
+     CALL FATAL(SolverName,'No keyword >Calendar< found in yac2elmer solver')
+  END IF
+  yac_calendar = TRIM(ADJUSTL(yac_calendar))
+  SELECT CASE (yac_calendar)
+    CASE ('proleptic_gregorian', 'year_360', 'year_365')
+      CONTINUE
+    CASE DEFAULT
+      CALL FATAL(SolverName, "Unsupported >Calendar< value: '" // TRIM(yac_calendar) // &
+        "'. Accepted values are proleptic_gregorian, year_360, year_365.")
+  END SELECT
+
+  ! read YAC coupling start time (ISO 8601)
+  yac_start_time = GetString(SolverParams, 'Coupling Start Time', Found)
+  IF (.NOT. Found) THEN
+     CALL FATAL(SolverName,'No keyword >Coupling Start Time< found in yac2elmer solver')
+  END IF
+  IF (LEN_TRIM(yac_start_time) == 0) THEN
+    CALL FATAL(SolverName,'Keyword >Coupling Start Time< must not be empty')
+  END IF
+
+  ! read YAC coupling end time (ISO 8601)
+  yac_end_time = GetString(SolverParams, 'Coupling End Time', Found)
+  IF (.NOT. Found) THEN
+     CALL FATAL(SolverName,'No keyword >Coupling End Time< found in yac2elmer solver')
+  END IF
+  IF (LEN_TRIM(yac_end_time) == 0) THEN
+    CALL FATAL(SolverName,'Keyword >Coupling End Time< must not be empty')
+  END IF
+
   ! check if config file actually exists
   INQUIRE(FILE=TRIM(config_file), EXIST=USE_YAC)
   IF (.NOT. USE_YAC) THEN
@@ -177,18 +211,8 @@ SUBROUTINE YAC2Elmer( Model,Solver,dt,TransientSimulation )
   IF (.NOT. Found) THEN
      CALL FATAL(SolverName,'No keyword >Coupling Time Step< found in yac2elmer solver')
   END IF
-  ! Consistency check: Coupling Time Step must be ISO 8601 duration string like 'PT3H', 'PT24H', etc.
-  IF (.NOT. (LEN_TRIM(coupling_timestep) >= 4 .AND. &
-       coupling_timestep(1:2) == 'pt' .AND. &
-       coupling_timestep(LEN_TRIM(coupling_timestep):LEN_TRIM(coupling_timestep)) == 'h')) THEN
-  CALL FATAL(SolverName, &
-    "'Coupling Time Step' must be provided as ISO 8601 duration string of the form " // &
-    "'PT3H', 'PT24H', etc. Other formats are currently not supported.")
-  END IF
-  ! Extract the number between 'PT' and 'H' and convert to integer
-  READ(coupling_timestep(3:LEN_TRIM(coupling_timestep)-1), *, IOSTAT=ierr) coupling_hours
-  IF (ierr /= 0) THEN
-     CALL FATAL(SolverName,"Could not parse number of hours from 'Coupling Time Step'")
+  IF (LEN_TRIM(coupling_timestep) == 0) THEN
+      CALL FATAL(SolverName, "Keyword >Coupling Time Step< must not be empty")
   END IF
 
 
@@ -240,21 +264,8 @@ SUBROUTINE YAC2Elmer( Model,Solver,dt,TransientSimulation )
   END IF
 
   !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-  ! retrieve the timestep in hours
   Mesh => Solver % Mesh
 
-  dt_hours = int(dt * 8760)
-  write(model_tstep, *) dt_hours
-  CALL INFO(SolverName, &
-    'ELMER timestep size in hours:' // I2S(dt_hours), Level=3)
-  ! Check if coupling_hours is greater than or equal to dt_hours
-  IF (coupling_hours < dt_hours) THEN
-     CALL FATAL(SolverName,"'Coupling Time Step' must be greater than or equal to Elmer time step size in hours")
-  END IF
-  ! Check if coupling_hours is an integer multiple of dt_hours
-  IF (MOD(coupling_hours, dt_hours) /= 0) THEN
-     CALL FATAL(SolverName,"'Coupling Time Step' must be an integer multiple of Elmer time step size in hours")
-  END IF
   IF (FirstTime) THEN
 
 
@@ -278,7 +289,12 @@ SUBROUTINE YAC2Elmer( Model,Solver,dt,TransientSimulation )
     CALL coupling_setup(lon_vertices, lat_vertices, lon_cells, lat_cells, &
               cell_to_vertex, num_vertices_per_cell, &
               cell_ids, vertex_ids, &
-              TRIM(grid_crs), TRIM(ADJUSTL(I2S(coupling_hours))), &
+              TRIM(grid_crs), &
+              TRIM(config_file), &
+              TRIM(yac_calendar), &
+              TRIM(yac_start_time), &
+              TRIM(yac_end_time), &
+              TRIM(coupling_timestep), &
               couple_to_ebfm, couple_to_icon)
 
     DEALLOCATE(lon_vertices, lat_vertices, lon_cells, lat_cells)

--- a/fem/src/SParIterComm.F90
+++ b/fem/src/SParIterComm.F90
@@ -259,7 +259,6 @@ CONTAINS
     INTEGER :: ierr
     INTEGER :: req, prov
     CHARACTER(LEN=*), PARAMETER :: xios_config_file = "iodef.xml"
-    CHARACTER(LEN=*), PARAMETER :: yac_config_file = "coupling.yaml"
 
 
     !******************************************************************
@@ -312,13 +311,7 @@ CONTAINS
 #endif
 
 #ifdef HAVE_YAC
-    WRITE(Message,'(A,A)') "Check for YAC config file", yac_config_file
-    INQUIRE(FILE=yac_config_file, EXIST=USE_YAC)
-    IF (USE_YAC) THEN
-        WRITE(Message,'(A,A)') "Use YAC with config file", yac_config_file
-    ELSE
-        WRITE(Message,'(A)') "YAC config file not found, not using YAC"
-    END IF
+    USE_YAC = .TRUE.
 #endif
 
 #ifdef ELMER_USE_MPI_HANDSHAKE
@@ -434,16 +427,11 @@ ParEnv % MyPE,ELMER_COMM_WORLD,ierr)
         CALL Fatal( 'ParCommInit', Message )
       END IF
 
-      WRITE(Message,'(A,A)') &
-        "Using YAC coupler with config-file:", &
-        TRIM(yac_config_file)
-
       CALL INFO("SparIterComm",Message,Level=25)
       ! TODO: Refactor to also provide GROUP_NAMES(XIOS_GROUP_IDX) here
-      ! CALL coupling_init(yac_config_file, ParEnv % MyPE ,&
+      ! CALL coupling_init(ParEnv % MyPE ,&
       ! GROUP_COMMS(COUPLER_GROUP_IDX), GROUP_NAMES(ELMER_GROUP_IDX))
-      CALL coupling_init(yac_config_file, ParEnv % MyPE ,&
-      GROUP_COMMS(COUPLER_GROUP_IDX))
+      CALL coupling_init(ParEnv % MyPE, GROUP_COMMS(COUPLER_GROUP_IDX))
     END IF
 #endif
 !-----------------------------------------------------------------------

--- a/fem/src/elmer_coupling.F90
+++ b/fem/src/elmer_coupling.F90
@@ -97,7 +97,7 @@ MODULE elmer_ebfm_coupling
     yac_fget_field_datetime, yac_fget_field_role, yac_fget_field_timestep, &
     yac_ffield_has_metadata, yac_fget_field_metadata, yac_fget_points_size, &
     yac_fget_field_source, yac_fget, yac_fput, yac_fupdate, yac_fget_action, &
-    YAC_TIME_UNIT_HOUR, &
+    YAC_TIME_UNIT_ISO_FORMAT, &
     YAC_ACTION_COUPLING, YAC_ACTION_GET_FOR_RESTART, &
     YAC_ACTION_PUT_FOR_RESTART, YAC_ACTION_REDUCTION, YAC_ACTION_NONE, &
     YAC_EXCHANGE_TYPE_SOURCE, YAC_EXCHANGE_TYPE_TARGET
@@ -140,12 +140,12 @@ MODULE elmer_ebfm_coupling
 CONTAINS
 
   SUBROUTINE construct_elmer_ebfm_coupling( &
-        comp_id, corner_point_id, timestepstring, cell_point_id)
+        comp_id, corner_point_id, iso8601_timestep, cell_point_id)
 
     INTEGER, INTENT(IN) :: comp_id
     INTEGER, INTENT(IN) :: corner_point_id
     INTEGER, INTENT(IN) :: cell_point_id
-    CHARACTER(LEN=*), INTENT(IN) :: timestepstring
+    CHARACTER(LEN=*), INTENT(IN) :: iso8601_timestep
 
     INTEGER :: nbr_vertices, nbr_cells
 
@@ -155,7 +155,7 @@ CONTAINS
     ! register T_ice field in YAC
     CALL yac_fdef_field( &
       t_ice_field_name, comp_id, (/corner_point_id/), 1, t_ice_collection_size, &
-      timestepstring, YAC_TIME_UNIT_HOUR, t_ice_field_id);
+      iso8601_timestep, YAC_TIME_UNIT_ISO_FORMAT, t_ice_field_id);
 
     ! allocate and initialise T_ice field buffer
     ALLOCATE(t_ice_field(nbr_vertices, t_ice_collection_size))
@@ -164,7 +164,7 @@ CONTAINS
     ! register smb field in YAC
     CALL yac_fdef_field( &
       smb_field_name, comp_id, (/cell_point_id/), 1, smb_collection_size, &
-      timestepstring, YAC_TIME_UNIT_HOUR, smb_field_id);
+      iso8601_timestep, YAC_TIME_UNIT_ISO_FORMAT, smb_field_id);
 
     ! allocate and initialise smb field buffer
     ALLOCATE(smb_field(nbr_cells, smb_collection_size))
@@ -173,7 +173,7 @@ CONTAINS
     ! register runoff field in YAC
     CALL yac_fdef_field( &
       runoff_field_name, comp_id, (/cell_point_id/), 1, runoff_collection_size, &
-      timestepstring, YAC_TIME_UNIT_HOUR, runoff_field_id);
+      iso8601_timestep, YAC_TIME_UNIT_ISO_FORMAT, runoff_field_id);
 
     ! allocate and initialise runoff field buffer
     ALLOCATE(runoff_field(nbr_cells, runoff_collection_size))
@@ -182,7 +182,7 @@ CONTAINS
     ! register surface_height field in YAC
     CALL yac_fdef_field( &
       surface_height_field_name, comp_id, (/corner_point_id/), 1, surface_height_collection_size, &
-      timestepstring, YAC_TIME_UNIT_HOUR, surface_height_field_id);
+      iso8601_timestep, YAC_TIME_UNIT_ISO_FORMAT, surface_height_field_id);
 
     ! allocate and initialise surface_height field buffer
     ALLOCATE(surface_height_field(nbr_vertices, surface_height_collection_size))
@@ -433,7 +433,7 @@ MODULE elmer_icon_coupling
     yac_fget_field_datetime, yac_fget_field_role, yac_fget_field_timestep, &
     yac_ffield_has_metadata, yac_fget_field_metadata, yac_fget_points_size, &
     yac_fget_field_source, yac_fget, yac_fput, yac_fupdate, yac_fget_action, &
-    YAC_TIME_UNIT_HOUR, &
+    YAC_TIME_UNIT_ISO_FORMAT, &
     YAC_ACTION_COUPLING, YAC_ACTION_GET_FOR_RESTART, &
     YAC_ACTION_PUT_FOR_RESTART, YAC_ACTION_REDUCTION, YAC_ACTION_NONE, &
     YAC_EXCHANGE_TYPE_SOURCE, YAC_EXCHANGE_TYPE_TARGET
@@ -462,12 +462,12 @@ MODULE elmer_icon_coupling
 CONTAINS
 
   SUBROUTINE construct_elmer_icon_coupling( &
-        comp_id, corner_point_id, timestepstring, cell_point_id)
+        comp_id, corner_point_id, iso8601_timestep, cell_point_id)
 
     INTEGER, INTENT(IN) :: comp_id
     INTEGER, INTENT(IN) :: corner_point_id
     INTEGER, INTENT(IN) :: cell_point_id
-    CHARACTER(LEN=*), INTENT(IN) :: timestepstring
+    CHARACTER(LEN=*), INTENT(IN) :: iso8601_timestep
 
     INTEGER :: nbr_vertices, nbr_cells
 
@@ -477,7 +477,7 @@ CONTAINS
     ! register total cloud cover field in YAC
     CALL yac_fdef_field( &
       clt_field_name, comp_id, (/corner_point_id/), 1, clt_collection_size, &
-      timestepstring, YAC_TIME_UNIT_HOUR, clt_field_id);
+      iso8601_timestep, YAC_TIME_UNIT_ISO_FORMAT, clt_field_id);
 
     ! allocate and initialise total cloud cover field buffer
     ALLOCATE(clt_field(nbr_vertices, clt_collection_size))
@@ -486,7 +486,7 @@ CONTAINS
     ! register precipitation flux field in YAC
     CALL yac_fdef_field( &
       pr_field_name, comp_id, (/cell_point_id/), 1, pr_collection_size, &
-      timestepstring, YAC_TIME_UNIT_HOUR, pr_field_id)
+      iso8601_timestep, YAC_TIME_UNIT_ISO_FORMAT, pr_field_id)
 
     ! allocate and initialise precipitation flux field buffer
     ALLOCATE(pr_field(nbr_cells, pr_collection_size))
@@ -663,7 +663,8 @@ MODULE elmer_coupling
     yac_finit_comm, yac_fread_config_yaml, yac_fdef_comp, yac_fdef_grid, &
     yac_fset_global_index, yac_fdef_points, yac_fsync_def, yac_fenddef, &
     yac_ffinalize, YAC_LOCATION_CELL, YAC_LOCATION_CORNER, &
-    yac_fdef_calendar, YAC_YEAR_OF_365_DAYS
+    yac_fdef_calendar, YAC_PROLEPTIC_GREGORIAN, YAC_YEAR_OF_360_DAYS, &
+    YAC_YEAR_OF_365_DAYS
   USE elmer_ebfm_coupling, ONLY: construct_elmer_ebfm_coupling, &
     construct_elmer_ebfm_coupling_post_sync, destruct_elmer_ebfm_coupling
   USE elmer_icon_coupling, ONLY: construct_elmer_icon_coupling, &
@@ -721,12 +722,11 @@ CONTAINS
   END SUBROUTINE coupler_get_code_id
 
   ! TODO: Refactor to also accept comp_name here
-  ! SUBROUTINE coupling_init(coupling_config_file, elmer_rank, yac_comm, comp_name)
-  SUBROUTINE coupling_init(coupling_config_file, elmer_rank, yac_comm)
+  ! SUBROUTINE coupling_init(elmer_rank, yac_comm, comp_name)
+  SUBROUTINE coupling_init(elmer_rank, yac_comm)
 
     IMPLICIT NONE
 
-    CHARACTER(LEN=*), INTENT(IN) :: coupling_config_file
     INTEGER, INTENT(IN) :: elmer_rank
     INTEGER, INTENT(IN) :: yac_comm
 
@@ -745,15 +745,6 @@ CONTAINS
     !     https://dkrz-sw.gitlab-pages.dkrz.de/yac/d4/d40/init_yac_detail.html)
     ! * will call MPI_Init, if not yet called by the user
     CALL yac_finit_comm (yac_comm)
-
-    ! define calendar
-    ! * currently hard-coded to 365 day calendar; can be made configurable if needed
-    CALL yac_fdef_calendar(YAC_YEAR_OF_365_DAYS)
-
-    ! read configuration file
-    ! * contains calendar, start- and end-date
-    ! * defines couplings
-    CALL yac_fread_config_yaml(TRIM(coupling_config_file))
 
     ! define component
     ! * is collective operation for all processes that initialised YAC
@@ -774,13 +765,22 @@ CONTAINS
   !> @param cell_ids Global cell IDs
   !> @param vertex_ids Global vertex IDs
   !> @param grid_crs Coordinate reference system (CRS) of the grid (e.g., "EPSG:3413")
-  !> @param timestepstring Timestep configuration string for YAC
+  !> @param coupling_config_file YAC coupling YAML configuration file
+  !> @param calendar Calendar type (e.g., "proleptic_gregorian")
+  !> @param iso8601_start_time Start time in ISO 8601 format (e.g., "2024-01-01T00:00:00Z")
+  !> @param iso8601_end_time End time in ISO 8601 format (e.g., "2024-12-31T23:59:59Z")
+  !> @param iso8601_timestep Timestep configuration string for YAC (e.g., "PT1H" for 1 hour)
   !> @param couple_to_ebfm_in Enable coupling to EBFM
   !> @param couple_to_icon_in Enable coupling to ICON
   SUBROUTINE coupling_setup(lon_vertices, lat_vertices, lon_cells, lat_cells, &
                             cell_to_vertex, num_vertices_per_cell, &
                             cell_ids, vertex_ids, &
-                            grid_crs, timestepstring, &
+                            grid_crs, &
+                            coupling_config_file, &
+                            calendar, &
+                            iso8601_start_time, &
+                            iso8601_end_time, &
+                            iso8601_timestep, &
                             couple_to_ebfm_in, couple_to_icon_in)
 
     USE, INTRINSIC :: iso_c_binding, ONLY: C_INT, C_DOUBLE, C_CHAR
@@ -797,16 +797,48 @@ CONTAINS
     INTEGER, INTENT(IN) :: cell_ids(:)
     INTEGER, INTENT(IN) :: vertex_ids(:)
     CHARACTER(LEN=*), INTENT(IN) :: grid_crs
-    CHARACTER(LEN=*), INTENT(IN) :: timestepstring
+    CHARACTER(LEN=*), INTENT(IN) :: coupling_config_file
+
+    ! Parameters for definition of time frame (must be consistent with other components)
+    CHARACTER(LEN=*), INTENT(IN) :: calendar
+    CHARACTER(LEN=*), INTENT(IN) :: iso8601_start_time
+    CHARACTER(LEN=*), INTENT(IN) :: iso8601_end_time
+    CHARACTER(LEN=*), INTENT(IN) :: iso8601_timestep
+
     LOGICAL, INTENT(IN) :: couple_to_ebfm_in, couple_to_icon_in
 
     ! Local variables
     INTEGER :: grid_id, corner_point_id, cell_point_id
     INTEGER(KIND=C_INT) :: nbr_vertices, nbr_cells
+    INTEGER :: yac_calendar
 
     ! Store coupling flags in module variables for later use
     couple_to_ebfm = couple_to_ebfm_in
     couple_to_icon = couple_to_icon_in
+
+    SELECT CASE (TRIM(ADJUSTL(calendar)))
+      CASE ("proleptic_gregorian")
+        yac_calendar = YAC_PROLEPTIC_GREGORIAN
+      CASE ("year_360")
+        yac_calendar = YAC_YEAR_OF_360_DAYS
+      CASE ("year_365")
+        yac_calendar = YAC_YEAR_OF_365_DAYS
+      CASE DEFAULT
+        IF (is_root_rank) THEN
+          WRITE(*,'(A,A,A)') "ELMER: unsupported calendar '", &
+            TRIM(calendar), "'. Accepted values are proleptic_gregorian, year_360, year_365."
+        END IF
+        ERROR STOP "ELMER: invalid calendar setting for YAC"
+    END SELECT
+
+    ! define calendar before reading YAML config
+    CALL yac_fdef_calendar(yac_calendar)
+
+    ! define start and end time
+    CALL yac_fdef_datetime(iso8601_start_time, iso8601_end_time)
+
+    ! read coupling configuration file
+    CALL yac_fread_config_yaml(TRIM(coupling_config_file))
 
     ! Infer sizes from input arrays
     nbr_vertices = SIZE(lon_vertices)
@@ -836,10 +868,10 @@ CONTAINS
 
     ! construct coupling between Elmer/Ice and ICON
     IF (couple_to_icon) THEN
-        CALL construct_elmer_icon_coupling(comp_id, corner_point_id, timestepstring, cell_point_id)
+        CALL construct_elmer_icon_coupling(comp_id, corner_point_id, iso8601_timestep, cell_point_id)
     END IF
     IF (couple_to_ebfm) THEN
-        CALL construct_elmer_ebfm_coupling(comp_id, corner_point_id, timestepstring, cell_point_id)
+        CALL construct_elmer_ebfm_coupling(comp_id, corner_point_id, iso8601_timestep, cell_point_id)
     END IF
     ! sychronizes all definitions between all components
     ! * afterwards the exchange information can be queried


### PR DESCRIPTION
This PR changes how the time frame in a coupled simulation is defined:

* The user must specify start time, end time, and coupling time step (all in ISO8601). Additionally, the user must specify a calendar. YAC will check whether these definitions are consistent with the definitions given in the coupling configuration and the configuration of other components.
* Elmer does not mirror these definitions internally. To my knowledge Elmer does not offer support for Gregorian calendars. Therefore, it is the user's responsibility to provide a consistent set of parameters. This is especially true for the number and size of internal time steps which must be consistent with the start time, end time, and coupling time step to prevent deadlocks.

Pitfall: Leap years may require the user to perform additional internal time steps.

From a technical point of view defining the calendar and start/end time is not necessary but it allows YAC to perform consistency checks. Additionally, this information acts as documentation in the sif file.

Snippet of my sif file:

```
Simulation
  ...
 ! Define time stepping
 ! Covers period from 2014-01-20 00:00:00 to 2014-01-21 00:00:00
 ! Reference calendar is proleptic_gregorian
  Timestep Intervals(1) = 8
  Timestep Sizes(1) = 0.00034246575342465754
  ...
End  
...
Solver 2
  Equation = "YAC"
  ...
  Calendar = String "proleptic_gregorian"
  Coupling Start Time = String "2014-01-20 00:00:00"
  Coupling End Time = String "2014-01-21 00:00:00"
  Coupling Time Step = String "PT3H"
  ...
End
```

