### PR TITLE
ElmerGUI, edf-extra for the coilsolver.  This is a fix for Issue #797.

### DIFF
--- a/ElmerGUI/Application/edf-extra/coilsolver.xml
+++ b/ElmerGUI/Application/edf-extra/coilsolver.xml
@@ -64,12 +64,12 @@
 		<Parameter Widget="CheckBox" >
 			<Name> Calculate Elemental Fields </Name>
 			<Type> Logical </Type>
-			<DefaultValue> True </DefaultValue>
 			<Whatis> Calculate elemental fields using Discontinuous Galerkin basis. </Whatis>
 		</Parameter>
 		<Parameter Widget="CheckBox" >
 			<Name> Calculate Nodal Fields </Name>
 			<Type> Logical </Type>
+			<DefaultValue> True </DefaultValue>
 			<Whatis> Calculate standard nodal fields. </Whatis>
 		</Parameter>
 		<Parameter Widget="CheckBox" >


### PR DESCRIPTION
The default setting in any ElmerGUI edf xml file must match with the default setting in the corresponding Fortran F90 source file.

In this case, the default in CoilSolver.F90 for 'Calculate Element Fields' is false, while the default for 'Calculate Nodal Fields' is true.

So actually there were two wrong settings in the coilsolver.xml edf file.