### PR TITLE
Build ARPACK and PARPACK as static libraries

### DIFF
--- a/mathlibs/src/arpack/CMakeLists.txt
+++ b/mathlibs/src/arpack/CMakeLists.txt
@@ -12,14 +12,14 @@ SET(arpack_SRCS cgetv0.f cnaitr.f cnapps.f cnaup2.f cnaupd.f cneigh.f
 	icopy.f iset.f iswap.f ivout.f second.f smout.f svout.f
 	zmout.f zvout.f)
 
-ADD_LIBRARY(arpack SHARED ${arpack_SRCS})
+ADD_LIBRARY(arpack STATIC ${arpack_SRCS})
 
 IF(APPLE)
-  TARGET_LINK_LIBRARIES(arpack ${BLAS_LIBRARIES} ${LAPACK_LIBRARIES})
+  TARGET_LINK_LIBRARIES(arpack PUBLIC ${BLAS_LIBRARIES} ${LAPACK_LIBRARIES})
 ENDIF()
 
 IF(WIN32)
-  TARGET_LINK_LIBRARIES(arpack ${BLAS_LIBRARIES} ${LAPACK_LIBRARIES})
+  TARGET_LINK_LIBRARIES(arpack PUBLIC ${BLAS_LIBRARIES} ${LAPACK_LIBRARIES})
 ENDIF()
 
 INSTALL(TARGETS arpack

--- a/mathlibs/src/parpack/CMakeLists.txt
+++ b/mathlibs/src/parpack/CMakeLists.txt
@@ -12,18 +12,18 @@ SET(parpack_SRCS pcgetv0.f pclarnv.f pcnaitr.f pcnapps.f pcnaup2.f
 	pdmout.f pdvout.f pivout.f psmout.f psvout.f pzmout.f pzvout.f
 	stat.h)
 
-ADD_LIBRARY(parpack SHARED ${parpack_SRCS})
+ADD_LIBRARY(parpack STATIC ${parpack_SRCS})
 
 ADD_DEPENDENCIES(parpack arpack)
 
-TARGET_LINK_LIBRARIES(parpack Elmer::MPI_Fortran)
+TARGET_LINK_LIBRARIES(parpack PUBLIC Elmer::MPI_Fortran)
 
 IF(WIN32)
-  TARGET_LINK_LIBRARIES(parpack arpack ${BLAS_LIBRARIES} ${LAPACK_LIBRARIES})
+  TARGET_LINK_LIBRARIES(parpack PUBLIC arpack ${BLAS_LIBRARIES} ${LAPACK_LIBRARIES})
 ENDIF()
 
 IF(APPLE)
-  TARGET_LINK_LIBRARIES(parpack arpack ${BLAS_LIBRARIES} ${LAPACK_LIBRARIES})
+  TARGET_LINK_LIBRARIES(parpack PUBLIC arpack ${BLAS_LIBRARIES} ${LAPACK_LIBRARIES})
 ENDIF()
 
 INSTALL(TARGETS parpack


### PR DESCRIPTION
This avoids any potential issues if conflicting versions are installed as shared libraries.

Also, emit warnings if external versions of the libraries are used.
