### PR TITLE
Add support for MUMPS CMake config file.

### DIFF
--- a/cmake/Modules/FindMumps.cmake
+++ b/cmake/Modules/FindMumps.cmake
@@ -13,6 +13,23 @@ IF(Mumps_LIBRARIES AND Mumps_INCLUDE_DIR)
    RETURN()
 ENDIF()
 
+# Try to find with CMake config file of upstream mumps-superbuild.
+FIND_PACKAGE(MUMPS CONFIG)
+
+IF(MUMPS_FOUND)
+  SET(Mumps_FOUND TRUE)
+  SET(Mumps_LIBRARIES ${MUMPS_LIBRARIES})
+  SET(Mumps_INCLUDE_DIR ${MUMPS_INCLUDE_DIRS})
+  IF(MUMPS_METIS_FOUND)
+    SET(Metis_FOUND TRUE)
+    SET(Metis_LIBRARIES ${METIS_LIBRARIES})
+    SET(Metis_INCLUDE_DIR ${METIS_INCLUDE_DIRS})
+  ENDIF()
+
+  RETURN()
+ENDIF()
+
+# Fall back to manual search
 SET(Mumps_FOUND FALSE)
 MESSAGE(STATUS "Finding Mumps")
 


### PR DESCRIPTION
The version of MUMPS from https://github.com/scivision/mumps installs a CMake config file.
The CMake module `FindMumps.cmake` in ElmerFEM "shadows" that CMake config file which makes it difficult to link to that version of MUMPS.

Adapt the existing CMake module to try to find MUMPS using a CMake config file and fall back to the existing implementation in case that was not successful.

This change picks up on #536. But it implements the support in a way that mirrors how the same situation is covered by `FindUMFPACK.cmake`.