### PR TITLE
Coupling from Elmer/Ice to ICON-O

### DIFF
--- a/elmerice/Solvers/SubShelfMeltLinearTF.F90
+++ b/elmerice/Solvers/SubShelfMeltLinearTF.F90
@@ -264,7 +264,7 @@ SUBROUTINE SubShelfMeltLinearTF (Model, Solver, dt, Transient)
 
      T_far = T_oce_vals(T_oce_Perm(ii))
 
-     meltRate = gammaT * (rhoo * SWCp / (rhoi * Lf)) * (T_far - T_freeze) *  seconds_per_year
+     meltRate = MAX(gammaT * (rhoo * SWCp / (rhoi * Lf)) * (T_far - T_freeze) *  seconds_per_year, 0.0_dp)
      IF (wct_sc) THEN
         wct         = z_iceBase % Values(z_iceBase % Perm(ii)) &
                     - z_bedrock % Values(z_bedrock % Perm(ii))

--- a/elmerice/Solvers/SubShelfMeltLinearTF.F90
+++ b/elmerice/Solvers/SubShelfMeltLinearTF.F90
@@ -27,11 +27,11 @@
 ! *  gammaT is a heat exchange velocity (m/s).
 ! *  The result is converted to m/yr.
 ! *
-! *  Required Constants (in sif):
-! *    Ice Density            (kg/m3)
-! *    Water Density          (kg/m3)
-! *    Latent Heat SI         (J/kg)
-! *    SW Cp                  (J/kg/K)
+! *  Required Constants in sif. In parentheses are the are variable names used in this function.:
+! *    Ice Density (rhoi)            (kg/m3)
+! *    Water Density (rhoo)          (kg/m3)
+! *    Latent Heat SI (Lf)           (J/kg)
+! *    SW Cp (SWcp)                  (J/kg/K)
 ! *
 ! *  Required Solver keywords (in sif):
 ! *    lower surface variable name  = string "Zb"
@@ -266,7 +266,12 @@ SUBROUTINE SubShelfMeltLinearTF (Model, Solver, dt, Transient)
 
      !TODO: At the moment, we do not allow negative melt rates (i.e. freezing) at the ice-ocean interface.
      !      Should probably be revisited in the future.
-     meltRate = MAX(gammaT * (rhoo * SWCp / (rhoi * Lf)) * (T_far - T_freeze) *  seconds_per_year, 0.0_dp)
+     meltRate = gammaT * (rhoo * SWCp / (rhoi * Lf)) * (T_far - T_freeze) *  seconds_per_year
+     IF (meltRate < 0.0_dp) THEN
+        CALL INFO(SolverName, &
+          'Negative melt rate (freezing) computed and clamped to zero at node ' // I2S(ii), Level=4)
+     END IF
+     meltRate = MAX(meltRate, 0.0_dp)
      IF (wct_sc) THEN
         wct         = z_iceBase % Values(z_iceBase % Perm(ii)) &
                     - z_bedrock % Values(z_bedrock % Perm(ii))

--- a/elmerice/Solvers/SubShelfMeltLinearTF.F90
+++ b/elmerice/Solvers/SubShelfMeltLinearTF.F90
@@ -264,6 +264,8 @@ SUBROUTINE SubShelfMeltLinearTF (Model, Solver, dt, Transient)
 
      T_far = T_oce_vals(T_oce_Perm(ii))
 
+     !TODO: At the moment, we do not allow negative melt rates (i.e. freezing) at the ice-ocean interface.
+     !      Should probably be revisited in the future.
      meltRate = MAX(gammaT * (rhoo * SWCp / (rhoi * Lf)) * (T_far - T_freeze) *  seconds_per_year, 0.0_dp)
      IF (wct_sc) THEN
         wct         = z_iceBase % Values(z_iceBase % Perm(ii)) &

--- a/elmerice/Solvers/SubShelfMeltLinearTF.F90
+++ b/elmerice/Solvers/SubShelfMeltLinearTF.F90
@@ -313,7 +313,9 @@ SUBROUTINE SubShelfMeltLinearTF (Model, Solver, dt, Transient)
            END IF
         END DO
 
-        elemFlux = elemFlux + Sw * detJ * meltRate_gp
+        ! Convert ice-equivalent melt rate to water-equivalent melt rate
+        ! (rhoi/rhoo) before integrating, so that elemFlux is water-equivalent
+        elemFlux = elemFlux + Sw * detJ * meltRate_gp * (rhoi / rhoo)
      END DO
 
      ! checks if the element is active in the flux variable and assigns the integrated flux

--- a/elmerice/Solvers/yac2elmer.F90
+++ b/elmerice/Solvers/yac2elmer.F90
@@ -149,7 +149,7 @@ SUBROUTINE YAC2Elmer( Model,Solver,dt,TransientSimulation )
   USE elmer_ebfm_coupling, ONLY: elmer_ebfm_interface, t_ice_field, smb_field, &
                                  runoff_field, surface_height_field
   USE elmer_icon_coupling, ONLY: elmer_icon_interface, t_oce_post_field, &
-                                 sal_oce_post_field
+                                 sal_oce_post_field, liquid_flux_field
 
   IMPLICIT NONE
 
@@ -178,7 +178,7 @@ SUBROUTINE YAC2Elmer( Model,Solver,dt,TransientSimulation )
   LOGICAL :: Parallel, FirstTime=.TRUE., UnFoundFatal=.TRUE.
   TYPE(Mesh_t),POINTER :: Mesh
   TYPE(Variable_t), POINTER :: t_iceVar, smbVar, runoffVar, ZsSol
-  TYPE(Variable_t), POINTER :: t_oceVar, sal_oceVar
+  TYPE(Variable_t), POINTER :: t_oceVar, sal_oceVar, bmb_fluxVar
   REAL(KIND=dp), ALLOCATABLE :: lon_vertices(:), lat_vertices(:)
   REAL(KIND=dp), ALLOCATABLE :: lon_cells(:), lat_cells(:)
   INTEGER, ALLOCATABLE :: cell_to_vertex(:), num_vertices_per_cell(:)
@@ -476,6 +476,12 @@ SUBROUTINE YAC2Elmer( Model,Solver,dt,TransientSimulation )
       END DO
       CALL DefaultVariableAdd('temp_oce', dofs=1, Perm = t_ocePerm)
       CALL DefaultVariableAdd('sal_oce', dofs=1, Perm = sal_ocePerm)
+      ! Initialize bmb_flux_field for first time step
+      bmb_fluxVar => VariableGet( Model % Mesh % Variables, "bmb_flux", UnFoundFatal=UnFoundFatal)
+      DO t=1, GetNOFActive(Solver)
+        liquid_flux_field(t,1) = bmb_fluxVar % Values(bmb_fluxVar % Perm(t))
+      END DO
+>>>>>>> Stashed changes
     END IF
 
     FirstTime = .FALSE.
@@ -538,6 +544,11 @@ SUBROUTINE YAC2Elmer( Model,Solver,dt,TransientSimulation )
 
   IF (couple_to_icon) THEN
       CALL INFO(SolverName, 'BEFORE ELMER ICON-O INTERFACE', Level=3)
+      ! Update bmb_flux_field before sending to ICON
+      bmb_fluxVar => VariableGet( Model % Mesh % Variables, "bmb_flux", UnFoundFatal=UnFoundFatal)
+      DO t=1, GetNOFActive(Solver)
+        liquid_flux_field(t,1) = bmb_fluxVar % Values(bmb_fluxVar % Perm(t))
+      END DO
       ! couple with ICON-O
       CALL elmer_icon_interface(is_root_rank)
       CALL INFO(SolverName, 'AFTER ELMER ICON-O INTERFACE', Level=3)

--- a/elmerice/Solvers/yac2elmer.F90
+++ b/elmerice/Solvers/yac2elmer.F90
@@ -137,65 +137,272 @@ SUBROUTINE collect_coupling_grid_data(ThisMesh, lon_vertices, lat_vertices, &
 
 END SUBROUTINE collect_coupling_grid_data
 
-SUBROUTINE YAC2Elmer( Model,Solver,dt,TransientSimulation )
-  USE DefUtils, ONLY: GetSolverParams, GetMesh, GetNOFActive, &
-    DefaultVariableAdd, GetLogical, GetString, GetConstReal, &
-    ListGetString, ListGetConstReal, &
-    GetSimulation, MAX_NAME_LEN, VariableGet, ParEnv, variable_on_elements, &
-    GetActiveElement
-  USE GeneralUtils, ONLY: I2S
-  USE Types, ONLY: Model_t, Solver_t, Mesh_t, Variable_t, ValueList_t, dp, Element_t
-  USE Messages, ONLY: Message, FATAL, INFO, USE_YAC
-  USE elmer_coupling, ONLY: coupling_setup, is_root_rank
-  USE elmer_ebfm_coupling, ONLY: elmer_ebfm_interface, t_ice_field, smb_field, &
-                                 runoff_field, surface_height_field
-  USE elmer_icon_coupling, ONLY: elmer_icon_interface, t_oce_post_field, &
-                                 sal_oce_post_field, liquid_ice_sheet_flux_field, &
-                                 solid_ice_sheet_flux_field
-  USE MPI
+!> Initialize Elmer-side variables for receiving fields from ICON-O
+SUBROUTINE setup_icon_variables(Model, Solver, Mesh, seconds_per_year, UnFoundFatal)
+  USE Types, ONLY: Model_t, Solver_t, Mesh_t, Variable_t, dp
+  USE DefUtils, ONLY: DefaultVariableAdd, GetNOFActive, VariableGet
+  USE elmer_icon_coupling, ONLY: liquid_ice_sheet_flux_field, solid_ice_sheet_flux_field
 
   IMPLICIT NONE
 
   TYPE(Model_t),  INTENT(IN) :: Model
   TYPE(Solver_t), INTENT(IN) :: Solver
-  REAL(KIND=dp),  INTENT(IN) :: dt
-  LOGICAL,        INTENT(IN) :: TransientSimulation
+  TYPE(Mesh_t), POINTER :: Mesh
+  REAL(KIND=dp), INTENT(IN) :: seconds_per_year
+  LOGICAL, INTENT(IN) :: UnFoundFatal
 
+  INTEGER, POINTER :: t_ocePerm(:), sal_ocePerm(:)
+  TYPE(Variable_t), POINTER :: bmb_fluxVar, calving_fluxVar
+  INTEGER :: i, t
+
+  ALLOCATE(t_ocePerm(Mesh % NumberOfNodes), sal_ocePerm(Mesh % NumberOfNodes))
+  DO i=1,Mesh % NumberOfNodes
+    t_ocePerm(i) = i
+    sal_ocePerm(i) = i
+  END DO
+  CALL DefaultVariableAdd('temp_oce', dofs=1, Perm = t_ocePerm)
+  CALL DefaultVariableAdd('sal_oce', dofs=1, Perm = sal_ocePerm)
+
+  ! Initialize bmb_flux_field and calving_flux field for first time step
+  bmb_fluxVar => VariableGet( Model % Mesh % Variables, "bmb_flux", UnFoundFatal=UnFoundFatal)
+  calving_fluxVar => VariableGet( Model % Mesh % Variables, "calving_front_flux_total", UnFoundFatal=UnFoundFatal)
+  DO t=1, GetNOFActive(Solver)
+    liquid_ice_sheet_flux_field(t,1) = bmb_fluxVar % Values(bmb_fluxVar % Perm(t)) / seconds_per_year
+    solid_ice_sheet_flux_field(t,1) = calving_fluxVar % Values(calving_fluxVar % Perm(t)) / seconds_per_year
+  END DO
+
+END SUBROUTINE setup_icon_variables
+
+!> Initialize Elmer-side variables for receiving fields from EBFM
+SUBROUTINE setup_ebfm_variables(Model, Solver, Mesh, UnFoundFatal)
+  USE Types, ONLY: Model_t, Solver_t, Mesh_t, Variable_t, dp
+  USE DefUtils, ONLY: DefaultVariableAdd, GetNOFActive, VariableGet, variable_on_elements
+  USE elmer_ebfm_coupling, ONLY: surface_height_field
+
+  IMPLICIT NONE
+
+  TYPE(Model_t),  INTENT(IN) :: Model
+  TYPE(Solver_t), INTENT(IN) :: Solver
+  TYPE(Mesh_t), POINTER :: Mesh
+  LOGICAL, INTENT(IN) :: UnFoundFatal
+
+  INTEGER, POINTER :: t_icePerm(:), smbPerm(:), runoffPerm(:)
+  TYPE(Variable_t), POINTER :: ZsSol
+  INTEGER :: i, t
+
+  ! setting up Elmer-side variables for receiving YAC variables
+  ! this coul dbe replaced by an automatic picking of the names and the DOFs
+  ! from the coupling-deifnitions
+  ! nodal variable
+  ALLOCATE(t_icePerm(Mesh % NumberOfNodes), runoffPerm(GetNOFActive(Solver)), &
+      smbPerm(GetNOFActive(Solver)))
+  DO i=1,Mesh % NumberOfNodes
+    t_icePerm(i) = i
+  END DO
+
+  ! This is for a element(cell) variables
+  DO t=1,GetNOFActive(Solver)
+    smbPerm(t) = t
+    runoffPerm(t) = t
+  END DO
+
+  ! nodal variables (everything that is not a flux)
+  CALL DefaultVariableAdd('T_ice', dofs=1, Perm = t_icePerm)
+  !CALL DefaultVariableAdd('runoff', dofs=1, Perm = runoffPerm)
+
+  ! element wise (cell) variable
+  CALL DefaultVariableAdd('smb', dofs=1, VariableType = Variable_on_elements, Perm = smbPerm)
+  CALL DefaultVariableAdd('runoff', dofs=1, VariableType = Variable_on_elements, Perm = runoffPerm)
+
+  ! get surface elevation from Elmer for the first time step
+  ZsSol => VariableGet( Model % Mesh % Variables, "Zs" ,UnFoundFatal=UnFoundFatal)
+  DO i=1, Mesh % NumberOfNodes
+    surface_height_field(i,1) = ZsSol % Values(ZsSol % Perm(i))
+  END DO
+
+END SUBROUTINE setup_ebfm_variables
+
+!> Couple Elmer -> ICON-O: send flux fields, run interface, retrieve ocean fields
+SUBROUTINE update_and_exchange_icon_variables(Model, Solver, Mesh, seconds_per_year, UnFoundFatal)
+  USE Types, ONLY: Model_t, Solver_t, Mesh_t, Variable_t, Element_t, dp
+  USE DefUtils, ONLY: GetNOFActive, VariableGet, GetActiveElement, ParEnv
+  USE Messages, ONLY: Message, INFO, FATAL
+  USE elmer_coupling, ONLY: is_root_rank
+  USE elmer_icon_coupling, ONLY: elmer_icon_interface, t_oce_post_field, &
+                                 sal_oce_post_field, liquid_ice_sheet_flux_field, &
+                                 solid_ice_sheet_flux_field
+  USE MPI, ONLY: MPI_Allreduce, MPI_DOUBLE_PRECISION, MPI_SUM
+
+  IMPLICIT NONE
+
+  TYPE(Model_t),  INTENT(IN) :: Model
+  TYPE(Solver_t), INTENT(IN) :: Solver
+  TYPE(Mesh_t), POINTER :: Mesh
+  REAL(KIND=dp), INTENT(IN) :: seconds_per_year
+  LOGICAL, INTENT(IN) :: UnFoundFatal
+
+  CHARACTER(LEN=1024) :: SolverName='update_and_exchange_icon_variables'
+  TYPE(Variable_t), POINTER :: t_oceVar, sal_oceVar, bmb_fluxVar, calving_fluxVar
+  TYPE(Element_t), POINTER :: Element
+  REAL(KIND=dp) :: local_liquid_flux_sum, global_liquid_flux_sum
+  REAL(KIND=dp) :: local_solid_flux_sum, global_solid_flux_sum
+  INTEGER :: i, t, ierr
+
+  CALL INFO(SolverName, 'Starting coupling Elmer -> ICON-O', Level=3)
+  CALL INFO(SolverName, 'Getting Elmer liquid and solid flux variables', Level=30)
+
+  ! Update bmb_flux_field before sending to ICON
+  bmb_fluxVar => VariableGet( Model % Mesh % Variables, "bmb_flux", UnFoundFatal=UnFoundFatal)
+  calving_fluxVar => VariableGet( Model % Mesh % Variables, "calving_front_flux_total", UnFoundFatal=UnFoundFatal)
+  DO t=1, GetNOFActive(Solver)
+    liquid_ice_sheet_flux_field(t,1) = bmb_fluxVar % Values(bmb_fluxVar % Perm(t)) / seconds_per_year
+    solid_ice_sheet_flux_field(t,1) = calving_fluxVar % Values(calving_fluxVar % Perm(t)) / seconds_per_year
+  END DO
+
+  ! Write total liquid and total solid ice sheet flux to log
+  local_liquid_flux_sum = 0.0_dp
+  local_solid_flux_sum = 0.0_dp
+  DO t = 1, GetNOFActive(Solver)
+    Element => GetActiveElement(t, Solver)
+    IF (ParEnv % myPe /= Element % partIndex) CYCLE
+    local_liquid_flux_sum = local_liquid_flux_sum + liquid_ice_sheet_flux_field(t,1)
+    local_solid_flux_sum = local_solid_flux_sum + solid_ice_sheet_flux_field(t,1)
+  END DO
+  CALL MPI_Allreduce(local_liquid_flux_sum, global_liquid_flux_sum, 1, MPI_DOUBLE_PRECISION, &
+                     MPI_SUM, ParEnv % ActiveComm, ierr)
+  CALL MPI_Allreduce(local_solid_flux_sum, global_solid_flux_sum, 1, MPI_DOUBLE_PRECISION, &
+                     MPI_SUM, ParEnv % ActiveComm, ierr)
+  WRITE(Message,'(A,F15.3,A)') 'Sum of liquid_ice_sheet_flux_field: ', global_liquid_flux_sum, ' m^3/s'
+  CALL INFO(SolverName, Message, Level=3)
+  WRITE(Message,'(A,F15.3,A)') 'Sum of solid_ice_sheet_flux_field: ', global_solid_flux_sum, ' m^3/s'
+  CALL INFO(SolverName, Message, Level=3)
+
+  ! couple with ICON-O
+  CALL elmer_icon_interface(is_root_rank)
+  CALL INFO(SolverName, 'Finished coupling Elmer -> ICON-O', Level=3)
+  CALL INFO(SolverName, 'Writing variables from ICON-O into Elmer variables...', Level=30)
+
+  t_oceVar => VariableGet( Mesh % Variables, 'temp_oce' )
+  sal_oceVar => VariableGet( Mesh % Variables, 'sal_oce' )
+  IF ((.NOT.ASSOCIATED(t_oceVar)) .OR. (.NOT.ASSOCIATED(sal_oceVar))) THEN
+    CALL FATAL(SolverName,'Elmer variables not associated')
+  END IF
+
+  ! write over values for nodes
+  DO i=1, Mesh % NumberOfNodes
+    t_oceVar % Values(t_oceVar % Perm(i)) = t_oce_post_field(i,1)
+    sal_oceVar % Values(sal_oceVar % Perm(i)) = sal_oce_post_field(i,1)
+  END DO
+
+END SUBROUTINE update_and_exchange_icon_variables
+
+!> Couple Elmer -> EBFM: run interface, retrieve variables into Elmer
+SUBROUTINE update_and_exchange_ebfm_variables(Model, Solver, Mesh, is_root_rank, UnFoundFatal)
+  USE Types, ONLY: Model_t, Solver_t, Mesh_t, Variable_t, dp
+  USE DefUtils, ONLY: GetNOFActive, VariableGet
+  USE Messages, ONLY: INFO, FATAL
+  USE elmer_ebfm_coupling, ONLY: elmer_ebfm_interface, t_ice_field, smb_field, &
+                                 runoff_field, surface_height_field
+
+  IMPLICIT NONE
+
+  TYPE(Model_t),  INTENT(IN) :: Model
+  TYPE(Solver_t), INTENT(IN) :: Solver
+  TYPE(Mesh_t), POINTER :: Mesh
+  LOGICAL, INTENT(IN) :: is_root_rank
+  LOGICAL, INTENT(IN) :: UnFoundFatal
+
+  CHARACTER(LEN=1024) :: SolverName='update_and_exchange_ebfm_variables'
+  TYPE(Variable_t), POINTER :: t_iceVar, smbVar, runoffVar, ZsSol
+  INTEGER :: i, t
+
+  CALL INFO(SolverName, 'Starting coupling Elmer -> EBFM', Level=3)
+  ! couple with EBFM
+  CALL elmer_ebfm_interface(is_root_rank)
+  CALL INFO(SolverName, 'Finished coupling Elmer -> EBFM', Level=3)
+  CALL INFO(SolverName, 'Writing variables from EBFM into Elmer variables...', Level=30)
+  t_iceVar => VariableGet( Mesh % Variables, 'T_ice' )
+  smbVar => VariableGet( Mesh % Variables, 'smb' )
+  runoffVar => VariableGet( Mesh % Variables, 'runoff' )
+  ZsSol => VariableGet( Model % Mesh % Variables, "Zs" ,UnFoundFatal=UnFoundFatal)
+  IF ((.NOT.ASSOCIATED(t_iceVar)) .OR. (.NOT.ASSOCIATED(smbVar)) .OR. (.NOT.ASSOCIATED(runoffVar))) THEN
+    CALL FATAL(SolverName,'Elmer variables not associated')
+  END IF
+
+  ! Validate element variable permutations. In a parallel run, element
+  ! variables declared via "Exported Variable = -elem" in the SIF get a
+  ! proper parallel Perm (built by SetActiveElementsTable). Without that
+  ! declaration, the variable may end up with an invalid Perm.
+
+  ! ! "smb" is known to require this declaration
+  IF (MINVAL(smbVar % Perm(1:GetNOFActive(Solver))) <= 0) THEN
+    CALL FATAL(SolverName, &
+      'smb variable has zero/invalid Perm entries. ' // &
+      'Add  Exported Variable = -elem "smb"  to the YAC2Elmer solver block in the SIF.')
+  END IF
+
+  ! "runoff" did not cause issues, but adding the same check for safety
+  IF (MINVAL(runoffVar % Perm(1:GetNOFActive(Solver))) <= 0) THEN
+    CALL FATAL(SolverName, &
+      'runoff variable has zero/invalid Perm entries. ' // &
+      'Add  Exported Variable = -elem "runoff"  to the YAC2Elmer solver block in the SIF.')
+  END IF
+
+  CALL INFO(SolverName, 'Writing nodal variables...', Level=30)
+  !write over values for nodes
+  DO i=1, Mesh % NumberOfNodes
+    t_iceVar % Values(t_iceVar % Perm(i)) = t_ice_field(i,1)
+    surface_height_field(i,1) = ZsSol % Values(ZsSol % Perm(i))
+  END DO
+  CALL INFO(SolverName, 'Writing cell variables....', Level=30)
+  ! write over values for elements
+  DO t=1, GetNOFActive(Solver)
+     smbVar  % Values(smbVar %  Perm(t)) = smb_field(t,1)
+     runoffVar  % Values(runoffVar %  Perm(t)) = runoff_field(t,1)
+  END DO
+
+END SUBROUTINE update_and_exchange_ebfm_variables
+
+SUBROUTINE YAC2Elmer( Model,Solver,dt,TransientSimulation )
+  USE DefUtils, ONLY: GetSolverParams, GetMesh, GetNOFActive, &
+    DefaultVariableAdd, GetLogical, GetString, GetConstReal, &
+    ListGetString, ListGetConstReal, &
+    GetSimulation, MAX_NAME_LEN, VariableGet, ParEnv, variable_on_elements
+  USE GeneralUtils, ONLY: I2S
+  USE Types, ONLY: Model_t, Solver_t, Mesh_t, Variable_t, ValueList_t, dp
+  USE Messages, ONLY: Message, FATAL, INFO, USE_YAC
+  USE elmer_coupling, ONLY: coupling_setup, is_root_rank
+
+  IMPLICIT NONE
 
   TYPE(ValueList_t), POINTER :: SolverParams
   TYPE(Mesh_t), POINTER :: ThisMesh
   CHARACTER(LEN=MAX_NAME_LEN):: SolverName='YAC2Elmer'
   ! parameters to be read in from this solvers section in the sif
   LOGICAL :: couple_to_ebfm, couple_to_icon         ! define which component is coupled to Elmer
-
   CHARACTER(LEN=1024) ::  config_file, grid_crs, proj_type
   CHARACTER(LEN=1024) ::  coupling_timestep
-  REAL(KIND=dp) :: coupling_timestep_in_years, local_liquid_flux_sum, global_liquid_flux_sum
-  REAL(KIND=dp) :: local_solid_flux_sum, global_solid_flux_sum
+  REAL(KIND=dp) :: coupling_timestep_in_years
   CHARACTER(LEN=1024) ::  yac_calendar, yac_start_time, yac_end_time
-  INTEGER :: i, t, ierr
-  INTEGER, POINTER :: t_icePerm(:), smbPerm(:), runoffPerm(:)
-  INTEGER, POINTER :: t_ocePerm(:), sal_ocePerm(:)
   REAL(KIND=dp) :: central_meridian, latitude_of_origin, seconds_per_year
   REAL(KIND=dp) :: expected_central_meridian, expected_latitude_of_origin
   CHARACTER(LEN=16) :: expected_central_meridian_str, expected_latitude_of_origin_str
-  LOGICAL :: Parallel, FirstTime=.TRUE., UnFoundFatal=.TRUE.
+  LOGICAL :: FirstTime=.TRUE., UnFoundFatal=.TRUE.
   TYPE(Mesh_t),POINTER :: Mesh
-  TYPE(Variable_t), POINTER :: t_iceVar, smbVar, runoffVar, ZsSol
-  TYPE(Variable_t), POINTER :: t_oceVar, sal_oceVar, bmb_fluxVar
-  TYPE(Variable_t), POINTER :: calving_fluxVar
-  TYPE(Element_t), POINTER :: Element
   REAL(KIND=dp), ALLOCATABLE :: lon_vertices(:), lat_vertices(:)
   REAL(KIND=dp), ALLOCATABLE :: lon_cells(:), lat_cells(:)
   INTEGER, ALLOCATABLE :: cell_to_vertex(:), num_vertices_per_cell(:)
   INTEGER, ALLOCATABLE :: cell_ids(:), vertex_ids(:)
   LOGICAL, ALLOCATABLE :: boundary_corner_mask(:)
-
   ! Variables needed for user output
   CHARACTER(LEN=1024) :: coupling_timestep_in_years_str
   CHARACTER(LEN=1024) :: dt_str
-
   LOGICAL        :: Found
+  TYPE(Model_t),  INTENT(IN) :: Model
+  TYPE(Solver_t), INTENT(IN) :: Solver
+  REAL(KIND=dp),  INTENT(IN) :: dt
+  LOGICAL,        INTENT(IN) :: TransientSimulation
+
 
   INTERFACE
     SUBROUTINE collect_coupling_grid_data(ThisMesh, lon_vertices, lat_vertices, &
@@ -212,6 +419,45 @@ SUBROUTINE YAC2Elmer( Model,Solver,dt,TransientSimulation )
       INTEGER, ALLOCATABLE, INTENT(OUT) :: cell_ids(:), vertex_ids(:)
       LOGICAL, ALLOCATABLE, INTENT(OUT) :: boundary_corner_mask(:)
     END SUBROUTINE collect_coupling_grid_data
+
+    SUBROUTINE setup_icon_variables(Model, Solver, Mesh, seconds_per_year, UnFoundFatal)
+      USE Types, ONLY: Model_t, Solver_t, Mesh_t, dp
+      IMPLICIT NONE
+      TYPE(Model_t),  INTENT(IN) :: Model
+      TYPE(Solver_t), INTENT(IN) :: Solver
+      TYPE(Mesh_t), POINTER :: Mesh
+      REAL(KIND=dp), INTENT(IN) :: seconds_per_year
+      LOGICAL, INTENT(IN) :: UnFoundFatal
+    END SUBROUTINE setup_icon_variables
+
+    SUBROUTINE setup_ebfm_variables(Model, Solver, Mesh, UnFoundFatal)
+      USE Types, ONLY: Model_t, Solver_t, Mesh_t
+      IMPLICIT NONE
+      TYPE(Model_t),  INTENT(IN) :: Model
+      TYPE(Solver_t), INTENT(IN) :: Solver
+      TYPE(Mesh_t), POINTER :: Mesh
+      LOGICAL, INTENT(IN) :: UnFoundFatal
+    END SUBROUTINE setup_ebfm_variables
+
+    SUBROUTINE update_and_exchange_icon_variables(Model, Solver, Mesh, seconds_per_year, UnFoundFatal)
+      USE Types, ONLY: Model_t, Solver_t, Mesh_t, dp
+      IMPLICIT NONE
+      TYPE(Model_t),  INTENT(IN) :: Model
+      TYPE(Solver_t), INTENT(IN) :: Solver
+      TYPE(Mesh_t), POINTER :: Mesh
+      REAL(KIND=dp), INTENT(IN) :: seconds_per_year
+      LOGICAL, INTENT(IN) :: UnFoundFatal
+    END SUBROUTINE update_and_exchange_icon_variables
+
+    SUBROUTINE update_and_exchange_ebfm_variables(Model, Solver, Mesh, is_root_rank, UnFoundFatal)
+      USE Types, ONLY: Model_t, Solver_t, Mesh_t
+      IMPLICIT NONE
+      TYPE(Model_t),  INTENT(IN) :: Model
+      TYPE(Solver_t), INTENT(IN) :: Solver
+      TYPE(Mesh_t), POINTER :: Mesh
+      LOGICAL, INTENT(IN) :: is_root_rank
+      LOGICAL, INTENT(IN) :: UnFoundFatal
+    END SUBROUTINE update_and_exchange_ebfm_variables
   END INTERFACE
 
   SolverParams => GetSolverParams()
@@ -445,53 +691,11 @@ SUBROUTINE YAC2Elmer( Model,Solver,dt,TransientSimulation )
     DEALLOCATE(cell_to_vertex, num_vertices_per_cell, cell_ids, vertex_ids)
     DEALLOCATE(boundary_corner_mask)
 
-    IF (couple_to_ebfm) THEN
-      ! setting up Elmer-side variables for receiving YAC variables
-      ! this coul dbe replaced by an automatic picking of the names and the DOFs
-      ! from the coupling-deifnitions
-      ! nodal variable
-      ALLOCATE(t_icePerm(Mesh % NumberOfNodes), runoffPerm(GetNOFActive(Solver)), &
-          smbPerm(GetNOFActive(Solver)))
-      DO i=1,Mesh % NumberOfNodes
-        t_icePerm(i) = i
-      END DO
-
-      ! This is for a element(cell) variables
-      DO t=1,GetNOFActive(Solver)
-        smbPerm(t) = t
-        runoffPerm(t) = t
-      END DO
-
-      ! nodal variables (everything that is not a flux)
-      CALL DefaultVariableAdd('T_ice', dofs=1, Perm = t_icePerm)
-      !CALL DefaultVariableAdd('runoff', dofs=1, Perm = runoffPerm)
-
-      ! element wise (cell) variable
-      CALL DefaultVariableAdd('smb', dofs=1, VariableType = Variable_on_elements, Perm = smbPerm)
-      CALL DefaultVariableAdd('runoff', dofs=1, VariableType = Variable_on_elements, Perm = runoffPerm)
-
-      ! get surface elevation from Elmer for the first time step
-      ZsSol => VariableGet( Model % Mesh % Variables, "Zs" ,UnFoundFatal=UnFoundFatal)
-      DO i=1, Mesh % NumberOfNodes
-        surface_height_field(i,1) = ZsSol % Values(ZsSol % Perm(i))
-      END DO
-    END IF
-
     IF (couple_to_icon) THEN
-      ALLOCATE(t_ocePerm(Mesh % NumberOfNodes), sal_ocePerm(Mesh % NumberOfNodes))
-      DO i=1,Mesh % NumberOfNodes
-        t_ocePerm(i) = i
-        sal_ocePerm(i) = i
-      END DO
-      CALL DefaultVariableAdd('temp_oce', dofs=1, Perm = t_ocePerm)
-      CALL DefaultVariableAdd('sal_oce', dofs=1, Perm = sal_ocePerm)
-      ! Initialize bmb_flux_field and calving_flux field for first time step
-      bmb_fluxVar => VariableGet( Model % Mesh % Variables, "bmb_flux", UnFoundFatal=UnFoundFatal)
-      calving_fluxVar => VariableGet( Model % Mesh % Variables, "calving_front_flux_total", UnFoundFatal=UnFoundFatal)
-      DO t=1, GetNOFActive(Solver)
-        liquid_ice_sheet_flux_field(t,1) = bmb_fluxVar % Values(bmb_fluxVar % Perm(t)) / seconds_per_year
-        solid_ice_sheet_flux_field(t,1) = calving_fluxVar % Values(calving_fluxVar % Perm(t)) / seconds_per_year
-      END DO
+      CALL setup_icon_variables(Model, Solver, Mesh, seconds_per_year, UnFoundFatal)
+    END IF
+    IF (couple_to_ebfm) THEN
+      CALL setup_ebfm_variables(Model, Solver, Mesh, UnFoundFatal)
     END IF
 
     FirstTime = .FALSE.
@@ -500,97 +704,11 @@ SUBROUTINE YAC2Elmer( Model,Solver,dt,TransientSimulation )
   END IF
 !!!!!!!!!! DO WE HAVE TO INITIALIZE WITH EVERY CALL ? !!!!!!!!!!!!!!
   IF (couple_to_icon) THEN
-      CALL INFO(SolverName, 'Starting coupling Elmer -> ICON-O', Level=3)
-      CALL INFO(SolverName, 'Getting Elmer liquid and solid flux variables', Level=30)
-      ! Update bmb_flux_field before sending to ICON
-      bmb_fluxVar => VariableGet( Model % Mesh % Variables, "bmb_flux", UnFoundFatal=UnFoundFatal)
-      calving_fluxVar => VariableGet( Model % Mesh % Variables, "calving_front_flux_total", UnFoundFatal=UnFoundFatal)
-      DO t=1, GetNOFActive(Solver)
-        liquid_ice_sheet_flux_field(t,1) = bmb_fluxVar % Values(bmb_fluxVar % Perm(t)) / seconds_per_year
-        solid_ice_sheet_flux_field(t,1) = calving_fluxVar % Values(calving_fluxVar % Perm(t)) / seconds_per_year
-      END DO
-      ! Write total liquid and total solid ice sheet flux to log
-      local_liquid_flux_sum = 0.0_dp
-      local_solid_flux_sum = 0.0_dp
-      DO t = 1, GetNOFActive(Solver)
-        Element => GetActiveElement(t, Solver)
-        IF (ParEnv % myPe /= Element % partIndex) CYCLE
-        local_liquid_flux_sum = local_liquid_flux_sum + liquid_ice_sheet_flux_field(t,1)
-        local_solid_flux_sum = local_solid_flux_sum + solid_ice_sheet_flux_field(t,1)
-      END DO
-      CALL MPI_Allreduce(local_liquid_flux_sum, global_liquid_flux_sum, 1, MPI_DOUBLE_PRECISION, &
-                         MPI_SUM, ParEnv % ActiveComm, ierr)
-      CALL MPI_Allreduce(local_solid_flux_sum, global_solid_flux_sum, 1, MPI_DOUBLE_PRECISION, &
-                         MPI_SUM, ParEnv % ActiveComm, ierr)
-      WRITE(Message,'(A,F15.3,A)') 'Sum of liquid_ice_sheet_flux_field: ', global_liquid_flux_sum, ' m^3/s'
-      CALL INFO(SolverName, Message, Level=3)
-      WRITE(Message,'(A,F15.3,A)') 'Sum of solid_ice_sheet_flux_field: ', global_solid_flux_sum, ' m^3/s'
-      CALL INFO(SolverName, Message, Level=3)
-      ! couple with ICON-O
-      CALL elmer_icon_interface(is_root_rank)
-      CALL INFO(SolverName, 'Finished coupling Elmer -> ICON-O', Level=3)
-      CALL INFO(SolverName, 'Writing variables from ICON-O into Elmer variables...', Level=30)
-      t_oceVar => VariableGet( Mesh % Variables, 'temp_oce' )
-      sal_oceVar => VariableGet( Mesh % Variables, 'sal_oce' )
-      IF ((.NOT.ASSOCIATED(t_oceVar)) .OR. (.NOT.ASSOCIATED(sal_oceVar))) THEN
-        CALL FATAL(SolverName,'Elmer variables not associated')
-      END IF
-      ! write over values for nodes
-      DO i=1, Mesh % NumberOfNodes
-        t_oceVar % Values(t_oceVar % Perm(i)) = t_oce_post_field(i,1)
-        sal_oceVar % Values(sal_oceVar % Perm(i)) = sal_oce_post_field(i,1)
-      END DO
+      CALL update_and_exchange_icon_variables(Model, Solver, Mesh, seconds_per_year, UnFoundFatal)
   END IF
 
   IF (couple_to_ebfm) THEN
-      CALL INFO(SolverName, 'Starting coupling Elmer -> EBFM', Level=3)
-      ! couple with EBFM
-      CALL elmer_ebfm_interface(is_root_rank)
-      CALL INFO(SolverName, 'Finished coupling Elmer -> EBFM', Level=3)
-      CALL INFO(SolverName, 'Writing variables from EBFM into Elmer variables...', Level=30)
-      t_iceVar => VariableGet( Mesh % Variables, 'T_ice' )
-      smbVar => VariableGet( Mesh % Variables, 'smb' )
-      runoffVar => VariableGet( Mesh % Variables, 'runoff' )
-      ZsSol => VariableGet( Model % Mesh % Variables, "Zs" ,UnFoundFatal=UnFoundFatal)
-      IF ((.NOT.ASSOCIATED(t_iceVar)) .OR. (.NOT.ASSOCIATED(smbVar)) .OR. (.NOT.ASSOCIATED(runoffVar))) THEN
-        CALL FATAL(SolverName,'Elmer variables not associated')
-      END IF
-
-      ! Validate element variable permutations. In a parallel run, element
-      ! variables declared via "Exported Variable = -elem" in the SIF get a
-      ! proper parallel Perm (built by SetActiveElementsTable). Without that
-      ! declaration, the variable may end up with an invalid Perm.
-
-      ! ! "smb" is known to require this declaration
-      IF (MINVAL(smbVar % Perm(1:GetNOFActive(Solver))) <= 0) THEN
-        CALL FATAL(SolverName, &
-          'smb variable has zero/invalid Perm entries. ' // &
-          'Add  Exported Variable = -elem "smb"  to the YAC2Elmer solver block in the SIF.')
-      END IF
-
-      ! "runoff" did not cause issues, but adding the same check for safety
-      IF (MINVAL(runoffVar % Perm(1:GetNOFActive(Solver))) <= 0) THEN
-        CALL FATAL(SolverName, &
-          'runoff variable has zero/invalid Perm entries. ' // &
-          'Add  Exported Variable = -elem "runoff"  to the YAC2Elmer solver block in the SIF.')
-      END IF
-
-      CALL INFO(SolverName, 'Writing nodal variables...', Level=30)
-       !write over values for nodes
-      DO i=1, Mesh % NumberOfNodes
-        t_iceVar % Values(t_iceVar % Perm(i)) = t_ice_field(i,1)
-        surface_height_field(i,1) = ZsSol % Values(ZsSol % Perm(i))
-      END DO
-      CALL INFO(SolverName, 'Writing cell variables....', Level=30)
-      ! write over values for elements
-      DO t=1, GetNOFActive(Solver)
-         smbVar  % Values(smbVar %  Perm(t)) = smb_field(t,1)
-         runoffVar  % Values(runoffVar %  Perm(t)) = runoff_field(t,1)
-      END DO
-      !CALL INFO(SolverName, "Test output start", Level=1)
-      !PRINT *, "Size of clt_field", SIZE(clt_field, 1),"First entry:", clt_field(1,1)
-      !CALL INFO(SolverName, "Test output start", Level=1)
-      !CALL MPI_BARRIER( ELMER_COMM_WORLD, ierr )
+      CALL update_and_exchange_ebfm_variables(Model, Solver, Mesh, is_root_rank, UnFoundFatal)
   END IF
 
   CALL INFO(SolverName,'Coupling step done', Level=1)

--- a/elmerice/Solvers/yac2elmer.F90
+++ b/elmerice/Solvers/yac2elmer.F90
@@ -150,6 +150,7 @@ SUBROUTINE YAC2Elmer( Model,Solver,dt,TransientSimulation )
                                  runoff_field, surface_height_field
   USE elmer_icon_coupling, ONLY: elmer_icon_interface, t_oce_post_field, &
                                  sal_oce_post_field, liquid_ice_sheet_flux_field
+  USE MPI
 
   IMPLICIT NONE
 
@@ -167,9 +168,9 @@ SUBROUTINE YAC2Elmer( Model,Solver,dt,TransientSimulation )
 
   CHARACTER(LEN=1024) ::  config_file, grid_crs, proj_type
   CHARACTER(LEN=1024) ::  coupling_timestep
-  REAL(KIND=dp) :: coupling_timestep_in_years
+  REAL(KIND=dp) :: coupling_timestep_in_years, local_flux_sum, global_flux_sum
   CHARACTER(LEN=1024) ::  yac_calendar, yac_start_time, yac_end_time
-  INTEGER :: i, t
+  INTEGER :: i, t, ierr
   INTEGER, POINTER :: t_icePerm(:), smbPerm(:), runoffPerm(:)
   INTEGER, POINTER :: t_ocePerm(:), sal_ocePerm(:)
   REAL(KIND=dp) :: central_meridian, latitude_of_origin
@@ -497,7 +498,11 @@ SUBROUTINE YAC2Elmer( Model,Solver,dt,TransientSimulation )
         liquid_ice_sheet_flux_field(t,1) = bmb_fluxVar % Values(bmb_fluxVar % Perm(t))
       END DO
       ! Write total liquid ice sheet flux to log
-      WRITE(Message,'(A,F15.3)') 'Sum of liquid_ice_sheet_flux_field: ', SUM(liquid_ice_sheet_flux_field(:,1))
+
+      local_flux_sum = SUM(liquid_ice_sheet_flux_field(:,1))
+      CALL MPI_Allreduce(local_flux_sum, global_flux_sum, 1, MPI_DOUBLE_PRECISION, &
+                         MPI_SUM, ParEnv % ActiveComm, ierr)
+      WRITE(Message,'(A,F15.3)') 'Sum of liquid_ice_sheet_flux_field: ', global_flux_sum
       CALL INFO(SolverName, Message, Level=3)
       ! couple with ICON-O
       CALL elmer_icon_interface(is_root_rank)

--- a/elmerice/Solvers/yac2elmer.F90
+++ b/elmerice/Solvers/yac2elmer.F90
@@ -141,6 +141,7 @@ END SUBROUTINE collect_coupling_grid_data
 SUBROUTINE setup_icon_variables(Model, Solver, Mesh, seconds_per_year, UnFoundFatal)
   USE Types, ONLY: Model_t, Solver_t, Mesh_t, Variable_t, dp
   USE DefUtils, ONLY: DefaultVariableAdd, GetNOFActive, VariableGet
+  USE Messages, ONLY: FATAL
   USE elmer_icon_coupling, ONLY: liquid_ice_sheet_flux_field, solid_ice_sheet_flux_field
 
   IMPLICIT NONE
@@ -151,9 +152,10 @@ SUBROUTINE setup_icon_variables(Model, Solver, Mesh, seconds_per_year, UnFoundFa
   REAL(KIND=dp), INTENT(IN) :: seconds_per_year
   LOGICAL, INTENT(IN) :: UnFoundFatal
 
+  CHARACTER(LEN=1024) :: SolverName='setup_icon_variables'
   INTEGER, POINTER :: t_ocePerm(:), sal_ocePerm(:)
   TYPE(Variable_t), POINTER :: bmb_fluxVar, calving_fluxVar
-  INTEGER :: i, t
+  INTEGER :: i, t, n
 
   ALLOCATE(t_ocePerm(Mesh % NumberOfNodes), sal_ocePerm(Mesh % NumberOfNodes))
   DO i=1,Mesh % NumberOfNodes
@@ -166,10 +168,17 @@ SUBROUTINE setup_icon_variables(Model, Solver, Mesh, seconds_per_year, UnFoundFa
   ! Initialize bmb_flux_field and calving_flux field for first time step
   bmb_fluxVar => VariableGet( Model % Mesh % Variables, "bmb_flux", UnFoundFatal=UnFoundFatal)
   calving_fluxVar => VariableGet( Model % Mesh % Variables, "calving_front_flux_total", UnFoundFatal=UnFoundFatal)
-  DO t=1, GetNOFActive(Solver)
-    liquid_ice_sheet_flux_field(t,1) = bmb_fluxVar % Values(bmb_fluxVar % Perm(t)) / seconds_per_year
-    solid_ice_sheet_flux_field(t,1) = calving_fluxVar % Values(calving_fluxVar % Perm(t)) / seconds_per_year
-  END DO
+  n = GetNOFActive(Solver)
+  IF (MINVAL(bmb_fluxVar % Perm(1:n)) <= 0) THEN
+    CALL FATAL(SolverName, 'bmb_flux variable has zero/invalid Perm entries. ' // &
+      'This is exported by another solver; check its parallel element-variable declaration.')
+  END IF
+  IF (MINVAL(calving_fluxVar % Perm(1:n)) <= 0) THEN
+    CALL FATAL(SolverName, 'calving_front_flux_total variable has zero/invalid Perm entries. ' // &
+      'This is exported by another solver; check its parallel element-variable declaration.')
+  END IF
+  liquid_ice_sheet_flux_field(1:n,1) = bmb_fluxVar % Values(bmb_fluxVar % Perm(1:n)) / seconds_per_year
+  solid_ice_sheet_flux_field(1:n,1) = calving_fluxVar % Values(calving_fluxVar % Perm(1:n)) / seconds_per_year
 
 END SUBROUTINE setup_icon_variables
 
@@ -246,7 +255,7 @@ SUBROUTINE update_and_exchange_icon_variables(Model, Solver, Mesh, seconds_per_y
   TYPE(Element_t), POINTER :: Element
   REAL(KIND=dp) :: local_liquid_flux_sum, global_liquid_flux_sum
   REAL(KIND=dp) :: local_solid_flux_sum, global_solid_flux_sum
-  INTEGER :: i, t, ierr
+  INTEGER :: i, t, n, ierr
 
   CALL INFO(SolverName, 'Starting coupling Elmer -> ICON-O', Level=3)
   CALL INFO(SolverName, 'Getting Elmer liquid and solid flux variables', Level=30)
@@ -254,10 +263,17 @@ SUBROUTINE update_and_exchange_icon_variables(Model, Solver, Mesh, seconds_per_y
   ! Update bmb_flux_field before sending to ICON
   bmb_fluxVar => VariableGet( Model % Mesh % Variables, "bmb_flux", UnFoundFatal=UnFoundFatal)
   calving_fluxVar => VariableGet( Model % Mesh % Variables, "calving_front_flux_total", UnFoundFatal=UnFoundFatal)
-  DO t=1, GetNOFActive(Solver)
-    liquid_ice_sheet_flux_field(t,1) = bmb_fluxVar % Values(bmb_fluxVar % Perm(t)) / seconds_per_year
-    solid_ice_sheet_flux_field(t,1) = calving_fluxVar % Values(calving_fluxVar % Perm(t)) / seconds_per_year
-  END DO
+  n = GetNOFActive(Solver)
+  IF (MINVAL(bmb_fluxVar % Perm(1:n)) <= 0) THEN
+    CALL FATAL(SolverName, 'bmb_flux variable has zero/invalid Perm entries. ' // &
+      'This is exported by another solver; check its parallel element-variable declaration.')
+  END IF
+  IF (MINVAL(calving_fluxVar % Perm(1:n)) <= 0) THEN
+    CALL FATAL(SolverName, 'calving_front_flux_total variable has zero/invalid Perm entries. ' // &
+      'This is exported by another solver; check its parallel element-variable declaration.')
+  END IF
+  liquid_ice_sheet_flux_field(1:n,1) = bmb_fluxVar % Values(bmb_fluxVar % Perm(1:n)) / seconds_per_year
+  solid_ice_sheet_flux_field(1:n,1) = calving_fluxVar % Values(calving_fluxVar % Perm(1:n)) / seconds_per_year
 
   ! Write total liquid and total solid ice sheet flux to log
   local_liquid_flux_sum = 0.0_dp
@@ -289,10 +305,8 @@ SUBROUTINE update_and_exchange_icon_variables(Model, Solver, Mesh, seconds_per_y
   END IF
 
   ! write over values for nodes
-  DO i=1, Mesh % NumberOfNodes
-    t_oceVar % Values(t_oceVar % Perm(i)) = t_oce_post_field(i,1)
-    sal_oceVar % Values(sal_oceVar % Perm(i)) = sal_oce_post_field(i,1)
-  END DO
+  t_oceVar % Values(t_oceVar % Perm(1:Mesh % NumberOfNodes)) = t_oce_post_field(1:Mesh % NumberOfNodes,1)
+  sal_oceVar % Values(sal_oceVar % Perm(1:Mesh % NumberOfNodes)) = sal_oce_post_field(1:Mesh % NumberOfNodes,1)
 
 END SUBROUTINE update_and_exchange_icon_variables
 

--- a/elmerice/Solvers/yac2elmer.F90
+++ b/elmerice/Solvers/yac2elmer.F90
@@ -150,7 +150,8 @@ SUBROUTINE YAC2Elmer( Model,Solver,dt,TransientSimulation )
   USE elmer_ebfm_coupling, ONLY: elmer_ebfm_interface, t_ice_field, smb_field, &
                                  runoff_field, surface_height_field
   USE elmer_icon_coupling, ONLY: elmer_icon_interface, t_oce_post_field, &
-                                 sal_oce_post_field, liquid_ice_sheet_flux_field
+                                 sal_oce_post_field, liquid_ice_sheet_flux_field, &
+                                 solid_ice_sheet_flux_field
   USE MPI
 
   IMPLICIT NONE
@@ -169,7 +170,8 @@ SUBROUTINE YAC2Elmer( Model,Solver,dt,TransientSimulation )
 
   CHARACTER(LEN=1024) ::  config_file, grid_crs, proj_type
   CHARACTER(LEN=1024) ::  coupling_timestep
-  REAL(KIND=dp) :: coupling_timestep_in_years, local_flux_sum, global_flux_sum
+  REAL(KIND=dp) :: coupling_timestep_in_years, local_liquid_flux_sum, global_liquid_flux_sum
+  REAL(KIND=dp) :: local_solid_flux_sum, global_solid_flux_sum
   CHARACTER(LEN=1024) ::  yac_calendar, yac_start_time, yac_end_time
   INTEGER :: i, t, ierr
   INTEGER, POINTER :: t_icePerm(:), smbPerm(:), runoffPerm(:)
@@ -181,6 +183,7 @@ SUBROUTINE YAC2Elmer( Model,Solver,dt,TransientSimulation )
   TYPE(Mesh_t),POINTER :: Mesh
   TYPE(Variable_t), POINTER :: t_iceVar, smbVar, runoffVar, ZsSol
   TYPE(Variable_t), POINTER :: t_oceVar, sal_oceVar, bmb_fluxVar
+  TYPE(Variable_t), POINTER :: calving_fluxVar
   TYPE(Element_t), POINTER :: Element
   REAL(KIND=dp), ALLOCATABLE :: lon_vertices(:), lat_vertices(:)
   REAL(KIND=dp), ALLOCATABLE :: lon_cells(:), lat_cells(:)
@@ -482,10 +485,12 @@ SUBROUTINE YAC2Elmer( Model,Solver,dt,TransientSimulation )
       END DO
       CALL DefaultVariableAdd('temp_oce', dofs=1, Perm = t_ocePerm)
       CALL DefaultVariableAdd('sal_oce', dofs=1, Perm = sal_ocePerm)
-      ! Initialize bmb_flux_field for first time step
+      ! Initialize bmb_flux_field and calving_flux field for first time step
       bmb_fluxVar => VariableGet( Model % Mesh % Variables, "bmb_flux", UnFoundFatal=UnFoundFatal)
+      calving_fluxVar => VariableGet( Model % Mesh % Variables, "calving_front_flux_total", UnFoundFatal=UnFoundFatal)
       DO t=1, GetNOFActive(Solver)
         liquid_ice_sheet_flux_field(t,1) = bmb_fluxVar % Values(bmb_fluxVar % Perm(t)) / seconds_per_year
+        solid_ice_sheet_flux_field(t,1) = calving_fluxVar % Values(calving_fluxVar % Perm(t)) / seconds_per_year
       END DO
     END IF
 
@@ -499,19 +504,27 @@ SUBROUTINE YAC2Elmer( Model,Solver,dt,TransientSimulation )
       CALL INFO(SolverName, 'Getting Elmer liquid and solid flux variables', Level=30)
       ! Update bmb_flux_field before sending to ICON
       bmb_fluxVar => VariableGet( Model % Mesh % Variables, "bmb_flux", UnFoundFatal=UnFoundFatal)
+      calving_fluxVar => VariableGet( Model % Mesh % Variables, "calving_front_flux_total", UnFoundFatal=UnFoundFatal)
       DO t=1, GetNOFActive(Solver)
         liquid_ice_sheet_flux_field(t,1) = bmb_fluxVar % Values(bmb_fluxVar % Perm(t)) / seconds_per_year
+        solid_ice_sheet_flux_field(t,1) = calving_fluxVar % Values(calving_fluxVar % Perm(t)) / seconds_per_year
       END DO
-      ! Write total liquid ice sheet flux to log
-      local_flux_sum = 0.0_dp
+      ! Write total liquid and total solid ice sheet flux to log
+      local_liquid_flux_sum = 0.0_dp
+      local_solid_flux_sum = 0.0_dp
       DO t = 1, GetNOFActive(Solver)
         Element => GetActiveElement(t, Solver)
         IF (ParEnv % myPe /= Element % partIndex) CYCLE
-        local_flux_sum = local_flux_sum + liquid_ice_sheet_flux_field(t,1)
+        local_liquid_flux_sum = local_liquid_flux_sum + liquid_ice_sheet_flux_field(t,1)
+        local_solid_flux_sum = local_solid_flux_sum + solid_ice_sheet_flux_field(t,1)
       END DO
-      CALL MPI_Allreduce(local_flux_sum, global_flux_sum, 1, MPI_DOUBLE_PRECISION, &
+      CALL MPI_Allreduce(local_liquid_flux_sum, global_liquid_flux_sum, 1, MPI_DOUBLE_PRECISION, &
                          MPI_SUM, ParEnv % ActiveComm, ierr)
-      WRITE(Message,'(A,F15.3,A)') 'Sum of liquid_ice_sheet_flux_field: ', global_flux_sum, ' m^3/s'
+      CALL MPI_Allreduce(local_solid_flux_sum, global_solid_flux_sum, 1, MPI_DOUBLE_PRECISION, &
+                         MPI_SUM, ParEnv % ActiveComm, ierr)
+      WRITE(Message,'(A,F15.3,A)') 'Sum of liquid_ice_sheet_flux_field: ', global_liquid_flux_sum, ' m^3/s'
+      CALL INFO(SolverName, Message, Level=3)
+      WRITE(Message,'(A,F15.3,A)') 'Sum of solid_ice_sheet_flux_field: ', global_solid_flux_sum, ' m^3/s'
       CALL INFO(SolverName, Message, Level=3)
       ! couple with ICON-O
       CALL elmer_icon_interface(is_root_rank)

--- a/elmerice/Solvers/yac2elmer.F90
+++ b/elmerice/Solvers/yac2elmer.F90
@@ -141,7 +141,8 @@ SUBROUTINE YAC2Elmer( Model,Solver,dt,TransientSimulation )
   USE DefUtils, ONLY: GetSolverParams, GetMesh, GetNOFActive, &
     DefaultVariableAdd, GetLogical, GetString, GetConstReal, &
     ListGetString, ListGetConstReal, &
-    GetSimulation, MAX_NAME_LEN, VariableGet, ParEnv, variable_on_elements
+    GetSimulation, MAX_NAME_LEN, VariableGet, ParEnv, variable_on_elements, &
+    GetActiveElement
   USE GeneralUtils, ONLY: I2S
   USE Types, ONLY: Model_t, Solver_t, Mesh_t, Variable_t, ValueList_t, dp, Element_t
   USE Messages, ONLY: Message, FATAL, INFO, USE_YAC
@@ -180,6 +181,7 @@ SUBROUTINE YAC2Elmer( Model,Solver,dt,TransientSimulation )
   TYPE(Mesh_t),POINTER :: Mesh
   TYPE(Variable_t), POINTER :: t_iceVar, smbVar, runoffVar, ZsSol
   TYPE(Variable_t), POINTER :: t_oceVar, sal_oceVar, bmb_fluxVar
+  TYPE(Element_t), POINTER :: Element
   REAL(KIND=dp), ALLOCATABLE :: lon_vertices(:), lat_vertices(:)
   REAL(KIND=dp), ALLOCATABLE :: lon_cells(:), lat_cells(:)
   INTEGER, ALLOCATABLE :: cell_to_vertex(:), num_vertices_per_cell(:)
@@ -498,8 +500,12 @@ SUBROUTINE YAC2Elmer( Model,Solver,dt,TransientSimulation )
         liquid_ice_sheet_flux_field(t,1) = bmb_fluxVar % Values(bmb_fluxVar % Perm(t))
       END DO
       ! Write total liquid ice sheet flux to log
-
-      local_flux_sum = SUM(liquid_ice_sheet_flux_field(:,1))
+      local_flux_sum = 0.0_dp
+      DO t = 1, GetNOFActive(Solver)
+        Element => GetActiveElement(t, Solver)
+        IF (ParEnv % myPe /= Element % partIndex) CYCLE
+        local_flux_sum = local_flux_sum + liquid_ice_sheet_flux_field(t,1)
+      END DO
       CALL MPI_Allreduce(local_flux_sum, global_flux_sum, 1, MPI_DOUBLE_PRECISION, &
                          MPI_SUM, ParEnv % ActiveComm, ierr)
       WRITE(Message,'(A,F15.3)') 'Sum of liquid_ice_sheet_flux_field: ', global_flux_sum

--- a/elmerice/Solvers/yac2elmer.F90
+++ b/elmerice/Solvers/yac2elmer.F90
@@ -497,7 +497,7 @@ SUBROUTINE YAC2Elmer( Model,Solver,dt,TransientSimulation )
         liquid_ice_sheet_flux_field(t,1) = bmb_fluxVar % Values(bmb_fluxVar % Perm(t))
       END DO
       ! Write total liquid ice sheet flux to log
-      WRITE(Message,'(A,E14.6)') 'Sum of liquid_ice_sheet_flux_field: ', SUM(liquid_ice_sheet_flux_field(:,1))
+      WRITE(Message,'(A,F15.3)') 'Sum of liquid_ice_sheet_flux_field: ', SUM(liquid_ice_sheet_flux_field(:,1))
       CALL INFO(SolverName, Message, Level=3)
       ! couple with ICON-O
       CALL elmer_icon_interface(is_root_rank)

--- a/elmerice/Solvers/yac2elmer.F90
+++ b/elmerice/Solvers/yac2elmer.F90
@@ -391,7 +391,7 @@ SUBROUTINE YAC2Elmer( Model,Solver,dt,TransientSimulation )
 
   TYPE(ValueList_t), POINTER :: SolverParams
   TYPE(Mesh_t), POINTER :: ThisMesh
-  CHARACTER(LEN=MAX_NAME_LEN):: SolverName='YAC2Elmer'
+  CHARACTER(LEN=MAX_NAME_LEN), PARAMETER :: SolverName='YAC2Elmer'
   ! parameters to be read in from this solvers section in the sif
   LOGICAL :: couple_to_ebfm, couple_to_icon         ! define which component is coupled to Elmer
   CHARACTER(LEN=1024) ::  config_file, grid_crs, proj_type
@@ -401,7 +401,8 @@ SUBROUTINE YAC2Elmer( Model,Solver,dt,TransientSimulation )
   REAL(KIND=dp) :: central_meridian, latitude_of_origin, seconds_per_year
   REAL(KIND=dp) :: expected_central_meridian, expected_latitude_of_origin
   CHARACTER(LEN=16) :: expected_central_meridian_str, expected_latitude_of_origin_str
-  LOGICAL :: FirstTime=.TRUE., UnFoundFatal=.TRUE.
+  LOGICAL :: FirstTime=.TRUE.
+  LOGICAL, PARAMETER :: UnFoundFatal=.TRUE.
   TYPE(Mesh_t),POINTER :: Mesh
   REAL(KIND=dp), ALLOCATABLE :: lon_vertices(:), lat_vertices(:)
   REAL(KIND=dp), ALLOCATABLE :: lon_cells(:), lat_cells(:)

--- a/elmerice/Solvers/yac2elmer.F90
+++ b/elmerice/Solvers/yac2elmer.F90
@@ -488,6 +488,27 @@ SUBROUTINE YAC2Elmer( Model,Solver,dt,TransientSimulation )
     CALL INFO(SolverName, "YAC coupling setup done", Level=1)
   END IF
 !!!!!!!!!! DO WE HAVE TO INITIALIZE WITH EVERY CALL ? !!!!!!!!!!!!!!
+  IF (couple_to_icon) THEN
+      CALL INFO(SolverName, 'BEFORE ELMER ICON-O INTERFACE', Level=3)
+      ! Update bmb_flux_field before sending to ICON
+      bmb_fluxVar => VariableGet( Model % Mesh % Variables, "bmb_flux", UnFoundFatal=UnFoundFatal)
+      DO t=1, GetNOFActive(Solver)
+        liquid_ice_sheet_flux_field(t,1) = bmb_fluxVar % Values(bmb_fluxVar % Perm(t))
+      END DO
+      ! couple with ICON-O
+      CALL elmer_icon_interface(is_root_rank)
+      CALL INFO(SolverName, 'AFTER ELMER ICON-O INTERFACE', Level=3)
+      t_oceVar => VariableGet( Mesh % Variables, 'temp_oce' )
+      sal_oceVar => VariableGet( Mesh % Variables, 'sal_oce' )
+      IF ((.NOT.ASSOCIATED(t_oceVar)) .OR. (.NOT.ASSOCIATED(sal_oceVar))) THEN
+        CALL FATAL(SolverName,'Elmer variables not associated')
+      END IF
+      ! write over values for nodes
+      DO i=1, Mesh % NumberOfNodes
+        t_oceVar % Values(t_oceVar % Perm(i)) = t_oce_post_field(i,1)
+        sal_oceVar % Values(sal_oceVar % Perm(i)) = sal_oce_post_field(i,1)
+      END DO
+  END IF
 
   IF (couple_to_ebfm) THEN
       CALL INFO(SolverName, 'BEFORE ELMER EBFM INTERFACE', Level=3)
@@ -539,28 +560,6 @@ SUBROUTINE YAC2Elmer( Model,Solver,dt,TransientSimulation )
       !PRINT *, "Size of clt_field", SIZE(clt_field, 1),"First entry:", clt_field(1,1)
       !CALL INFO(SolverName, "Test output start", Level=1)
       !CALL MPI_BARRIER( ELMER_COMM_WORLD, ierr )
-  END IF
-
-  IF (couple_to_icon) THEN
-      CALL INFO(SolverName, 'BEFORE ELMER ICON-O INTERFACE', Level=3)
-      ! Update bmb_flux_field before sending to ICON
-      bmb_fluxVar => VariableGet( Model % Mesh % Variables, "bmb_flux", UnFoundFatal=UnFoundFatal)
-      DO t=1, GetNOFActive(Solver)
-        liquid_ice_sheet_flux_field(t,1) = bmb_fluxVar % Values(bmb_fluxVar % Perm(t))
-      END DO
-      ! couple with ICON-O
-      CALL elmer_icon_interface(is_root_rank)
-      CALL INFO(SolverName, 'AFTER ELMER ICON-O INTERFACE', Level=3)
-      t_oceVar => VariableGet( Mesh % Variables, 'temp_oce' )
-      sal_oceVar => VariableGet( Mesh % Variables, 'sal_oce' )
-      IF ((.NOT.ASSOCIATED(t_oceVar)) .OR. (.NOT.ASSOCIATED(sal_oceVar))) THEN
-        CALL FATAL(SolverName,'Elmer variables not associated')
-      END IF
-      ! write over values for nodes
-      DO i=1, Mesh % NumberOfNodes
-        t_oceVar % Values(t_oceVar % Perm(i)) = t_oce_post_field(i,1)
-        sal_oceVar % Values(sal_oceVar % Perm(i)) = sal_oce_post_field(i,1)
-      END DO
   END IF
 
   CALL INFO(SolverName,'Coupling step done', Level=1)

--- a/elmerice/Solvers/yac2elmer.F90
+++ b/elmerice/Solvers/yac2elmer.F90
@@ -174,7 +174,7 @@ SUBROUTINE YAC2Elmer( Model,Solver,dt,TransientSimulation )
   INTEGER :: i, t, ierr
   INTEGER, POINTER :: t_icePerm(:), smbPerm(:), runoffPerm(:)
   INTEGER, POINTER :: t_ocePerm(:), sal_ocePerm(:)
-  REAL(KIND=dp) :: central_meridian, latitude_of_origin
+  REAL(KIND=dp) :: central_meridian, latitude_of_origin, seconds_per_year
   REAL(KIND=dp) :: expected_central_meridian, expected_latitude_of_origin
   CHARACTER(LEN=16) :: expected_central_meridian_str, expected_latitude_of_origin_str
   LOGICAL :: Parallel, FirstTime=.TRUE., UnFoundFatal=.TRUE.
@@ -354,6 +354,9 @@ SUBROUTINE YAC2Elmer( Model,Solver,dt,TransientSimulation )
   ! Do consistency checks
   central_meridian = ListGetConstReal(GetSimulation(), 'central_meridian', UnFoundFatal=.True.)
   latitude_of_origin = ListGetConstReal(GetSimulation(), 'latitude_of_origin', UnFoundFatal=.True.)
+  seconds_per_year = GetConstReal( Model % Constants, 'seconds_per_year', Found )
+  IF (.NOT. Found) CALL FATAL(SolverName, &
+       'seconds_per_year not found in Constants; should be defined in the Constants section of the sif file')
 
   ! Format expected values as strings
   WRITE(expected_central_meridian_str, '(F6.1)') expected_central_meridian
@@ -482,7 +485,7 @@ SUBROUTINE YAC2Elmer( Model,Solver,dt,TransientSimulation )
       ! Initialize bmb_flux_field for first time step
       bmb_fluxVar => VariableGet( Model % Mesh % Variables, "bmb_flux", UnFoundFatal=UnFoundFatal)
       DO t=1, GetNOFActive(Solver)
-        liquid_ice_sheet_flux_field(t,1) = bmb_fluxVar % Values(bmb_fluxVar % Perm(t))
+        liquid_ice_sheet_flux_field(t,1) = bmb_fluxVar % Values(bmb_fluxVar % Perm(t)) / seconds_per_year
       END DO
     END IF
 
@@ -497,7 +500,7 @@ SUBROUTINE YAC2Elmer( Model,Solver,dt,TransientSimulation )
       ! Update bmb_flux_field before sending to ICON
       bmb_fluxVar => VariableGet( Model % Mesh % Variables, "bmb_flux", UnFoundFatal=UnFoundFatal)
       DO t=1, GetNOFActive(Solver)
-        liquid_ice_sheet_flux_field(t,1) = bmb_fluxVar % Values(bmb_fluxVar % Perm(t))
+        liquid_ice_sheet_flux_field(t,1) = bmb_fluxVar % Values(bmb_fluxVar % Perm(t)) / seconds_per_year
       END DO
       ! Write total liquid ice sheet flux to log
       local_flux_sum = 0.0_dp
@@ -508,7 +511,7 @@ SUBROUTINE YAC2Elmer( Model,Solver,dt,TransientSimulation )
       END DO
       CALL MPI_Allreduce(local_flux_sum, global_flux_sum, 1, MPI_DOUBLE_PRECISION, &
                          MPI_SUM, ParEnv % ActiveComm, ierr)
-      WRITE(Message,'(A,F15.3)') 'Sum of liquid_ice_sheet_flux_field: ', global_flux_sum
+      WRITE(Message,'(A,F15.3,A)') 'Sum of liquid_ice_sheet_flux_field: ', global_flux_sum, ' m^3/s'
       CALL INFO(SolverName, Message, Level=3)
       ! couple with ICON-O
       CALL elmer_icon_interface(is_root_rank)

--- a/elmerice/Solvers/yac2elmer.F90
+++ b/elmerice/Solvers/yac2elmer.F90
@@ -489,15 +489,20 @@ SUBROUTINE YAC2Elmer( Model,Solver,dt,TransientSimulation )
   END IF
 !!!!!!!!!! DO WE HAVE TO INITIALIZE WITH EVERY CALL ? !!!!!!!!!!!!!!
   IF (couple_to_icon) THEN
-      CALL INFO(SolverName, 'BEFORE ELMER ICON-O INTERFACE', Level=3)
+      CALL INFO(SolverName, 'Starting coupling Elmer -> ICON-O', Level=3)
+      CALL INFO(SolverName, 'Getting Elmer liquid and solid flux variables', Level=30)
       ! Update bmb_flux_field before sending to ICON
       bmb_fluxVar => VariableGet( Model % Mesh % Variables, "bmb_flux", UnFoundFatal=UnFoundFatal)
       DO t=1, GetNOFActive(Solver)
         liquid_ice_sheet_flux_field(t,1) = bmb_fluxVar % Values(bmb_fluxVar % Perm(t))
       END DO
+      ! Write total liquid ice sheet flux to log
+      WRITE(Message,'(A,E14.6)') 'Sum of liquid_ice_sheet_flux_field: ', SUM(liquid_ice_sheet_flux_field(:,1))
+      CALL INFO(SolverName, Message, Level=3)
       ! couple with ICON-O
       CALL elmer_icon_interface(is_root_rank)
-      CALL INFO(SolverName, 'AFTER ELMER ICON-O INTERFACE', Level=3)
+      CALL INFO(SolverName, 'Finished coupling Elmer -> ICON-O', Level=3)
+      CALL INFO(SolverName, 'Writing variables from ICON-O into Elmer variables...', Level=30)
       t_oceVar => VariableGet( Mesh % Variables, 'temp_oce' )
       sal_oceVar => VariableGet( Mesh % Variables, 'sal_oce' )
       IF ((.NOT.ASSOCIATED(t_oceVar)) .OR. (.NOT.ASSOCIATED(sal_oceVar))) THEN
@@ -511,16 +516,15 @@ SUBROUTINE YAC2Elmer( Model,Solver,dt,TransientSimulation )
   END IF
 
   IF (couple_to_ebfm) THEN
-      CALL INFO(SolverName, 'BEFORE ELMER EBFM INTERFACE', Level=3)
+      CALL INFO(SolverName, 'Starting coupling Elmer -> EBFM', Level=3)
       ! couple with EBFM
       CALL elmer_ebfm_interface(is_root_rank)
-      CALL INFO(SolverName, 'AFTER ELMER EBFM INTERFACE', Level=3)
-
+      CALL INFO(SolverName, 'Finished coupling Elmer -> EBFM', Level=3)
+      CALL INFO(SolverName, 'Writing variables from EBFM into Elmer variables...', Level=30)
       t_iceVar => VariableGet( Mesh % Variables, 'T_ice' )
       smbVar => VariableGet( Mesh % Variables, 'smb' )
       runoffVar => VariableGet( Mesh % Variables, 'runoff' )
       ZsSol => VariableGet( Model % Mesh % Variables, "Zs" ,UnFoundFatal=UnFoundFatal)
-      CALL INFO(SolverName, 'AFTER GETTING VARIABLES', Level=3)
       IF ((.NOT.ASSOCIATED(t_iceVar)) .OR. (.NOT.ASSOCIATED(smbVar)) .OR. (.NOT.ASSOCIATED(runoffVar))) THEN
         CALL FATAL(SolverName,'Elmer variables not associated')
       END IF
@@ -544,13 +548,13 @@ SUBROUTINE YAC2Elmer( Model,Solver,dt,TransientSimulation )
           'Add  Exported Variable = -elem "runoff"  to the YAC2Elmer solver block in the SIF.')
       END IF
 
-      CALL INFO(SolverName, 'BEFORE WRITING NODAL VALUES', Level=3)
+      CALL INFO(SolverName, 'Writing nodal variables...', Level=30)
        !write over values for nodes
       DO i=1, Mesh % NumberOfNodes
         t_iceVar % Values(t_iceVar % Perm(i)) = t_ice_field(i,1)
         surface_height_field(i,1) = ZsSol % Values(ZsSol % Perm(i))
       END DO
-      CALL INFO(SolverName, 'BEFORE WRITING ELEMENT VALUES', Level=3)
+      CALL INFO(SolverName, 'Writing cell variables....', Level=30)
       ! write over values for elements
       DO t=1, GetNOFActive(Solver)
          smbVar  % Values(smbVar %  Perm(t)) = smb_field(t,1)

--- a/elmerice/Solvers/yac2elmer.F90
+++ b/elmerice/Solvers/yac2elmer.F90
@@ -149,7 +149,7 @@ SUBROUTINE YAC2Elmer( Model,Solver,dt,TransientSimulation )
   USE elmer_ebfm_coupling, ONLY: elmer_ebfm_interface, t_ice_field, smb_field, &
                                  runoff_field, surface_height_field
   USE elmer_icon_coupling, ONLY: elmer_icon_interface, t_oce_post_field, &
-                                 sal_oce_post_field, liquid_flux_field
+                                 sal_oce_post_field, liquid_ice_sheet_flux_field
 
   IMPLICIT NONE
 
@@ -479,9 +479,8 @@ SUBROUTINE YAC2Elmer( Model,Solver,dt,TransientSimulation )
       ! Initialize bmb_flux_field for first time step
       bmb_fluxVar => VariableGet( Model % Mesh % Variables, "bmb_flux", UnFoundFatal=UnFoundFatal)
       DO t=1, GetNOFActive(Solver)
-        liquid_flux_field(t,1) = bmb_fluxVar % Values(bmb_fluxVar % Perm(t))
+        liquid_ice_sheet_flux_field(t,1) = bmb_fluxVar % Values(bmb_fluxVar % Perm(t))
       END DO
->>>>>>> Stashed changes
     END IF
 
     FirstTime = .FALSE.
@@ -547,7 +546,7 @@ SUBROUTINE YAC2Elmer( Model,Solver,dt,TransientSimulation )
       ! Update bmb_flux_field before sending to ICON
       bmb_fluxVar => VariableGet( Model % Mesh % Variables, "bmb_flux", UnFoundFatal=UnFoundFatal)
       DO t=1, GetNOFActive(Solver)
-        liquid_flux_field(t,1) = bmb_fluxVar % Values(bmb_fluxVar % Perm(t))
+        liquid_ice_sheet_flux_field(t,1) = bmb_fluxVar % Values(bmb_fluxVar % Perm(t))
       END DO
       ! couple with ICON-O
       CALL elmer_icon_interface(is_root_rank)

--- a/elmerice/Solvers/yac2elmer.F90
+++ b/elmerice/Solvers/yac2elmer.F90
@@ -152,7 +152,7 @@ SUBROUTINE setup_icon_variables(Model, Solver, Mesh, seconds_per_year, UnFoundFa
   REAL(KIND=dp), INTENT(IN) :: seconds_per_year
   LOGICAL, INTENT(IN) :: UnFoundFatal
 
-  CHARACTER(LEN=1024) :: SolverName='setup_icon_variables'
+  CHARACTER(LEN=1024), PARAMETER :: SolverName='setup_icon_variables'
   INTEGER, POINTER :: t_ocePerm(:), sal_ocePerm(:)
   TYPE(Variable_t), POINTER :: bmb_fluxVar, calving_fluxVar
   INTEGER :: i, t, n
@@ -250,7 +250,7 @@ SUBROUTINE update_and_exchange_icon_variables(Model, Solver, Mesh, seconds_per_y
   REAL(KIND=dp), INTENT(IN) :: seconds_per_year
   LOGICAL, INTENT(IN) :: UnFoundFatal
 
-  CHARACTER(LEN=1024) :: SolverName='update_and_exchange_icon_variables'
+  CHARACTER(LEN=1024), PARAMETER :: SolverName='update_and_exchange_icon_variables'
   TYPE(Variable_t), POINTER :: t_oceVar, sal_oceVar, bmb_fluxVar, calving_fluxVar
   TYPE(Element_t), POINTER :: Element
   REAL(KIND=dp) :: local_liquid_flux_sum, global_liquid_flux_sum
@@ -326,7 +326,7 @@ SUBROUTINE update_and_exchange_ebfm_variables(Model, Solver, Mesh, is_root_rank,
   LOGICAL, INTENT(IN) :: is_root_rank
   LOGICAL, INTENT(IN) :: UnFoundFatal
 
-  CHARACTER(LEN=1024) :: SolverName='update_and_exchange_ebfm_variables'
+  CHARACTER(LEN=1024), PARAMETER :: SolverName='update_and_exchange_ebfm_variables'
   TYPE(Variable_t), POINTER :: t_iceVar, smbVar, runoffVar, ZsSol
   INTEGER :: i, t
 

--- a/elmerice/Utils/ComputeFluxUtils.F90
+++ b/elmerice/Utils/ComputeFluxUtils.F90
@@ -192,7 +192,7 @@
       TYPE(Solver_t) :: Solver
       REAL(KIND=dp), OPTIONAL :: FillValue
 
-      Type(Variable_t), POINTER :: FlowVar,HVar,CFluxVar
+      Type(Variable_t), POINTER :: FlowVar,HVar,CFluxVar,CalvingFluxTot
       TYPE(ValueList_t), POINTER :: BC
       TYPE(GaussIntegrationPoints_t) :: IntegStuff
       TYPE(Element_t), POINTER :: Element,Parent
@@ -231,10 +231,16 @@
       IF (CFluxVar % TYPE /= Variable_on_elements) &
        CALL FATAL(Caller,"calving_front_flux type should be on_elements")
 
+      CFluxVarTot => VariableGet(Solver%Mesh%Variables,'calving_front_flux_total',UnfoundFatal=.TRUE.)
+      IF (CFluxVarTot % TYPE /= Variable_on_elements) &
+       CALL FATAL(Caller,"calving_front_flux_total type should be on_elements")
+
       IF (PRESENT(FillValue)) THEN
         CFluxVar % Values = FillValue
+        CFluxVarTot % Values = FillValue
       ELSE
         CFluxVar % Values = 0._dp
+        CFluxVarTot % Values = 0._dp
       END IF
 
       NofActive = Solver % Mesh % NumberOfBulkElements
@@ -319,8 +325,10 @@
         IF (EIndex > 0) THEN
            IF (VisitedParent(Parent % ElementIndex)) THEN
              CFluxVar % Values ( EIndex ) = CFluxVar % Values ( EIndex ) + CalvingFlux / area
+             CFluxVarTot % Values ( EIndex ) = CFluxVarTot % Values ( EIndex ) + CalvingFlux
            ELSE 
              CFluxVar % Values ( EIndex ) = CalvingFlux / area
+             CFluxVarTot % Values ( EIndex ) = CalvingFlux
              IF (Parent % ElementIndex.GT.NofActive) &
                 CALL FATAL(Caller,"Pb with VisitedParent allocated size")
              VisitedParent(Parent % ElementIndex)=.TRUE.

--- a/elmerice/Utils/ComputeFluxUtils.F90
+++ b/elmerice/Utils/ComputeFluxUtils.F90
@@ -192,7 +192,7 @@
       TYPE(Solver_t) :: Solver
       REAL(KIND=dp), OPTIONAL :: FillValue
 
-      Type(Variable_t), POINTER :: FlowVar,HVar,CFluxVar,CalvingFluxTot
+      Type(Variable_t), POINTER :: FlowVar,HVar,CFluxVar,CFluxVarTot
       TYPE(ValueList_t), POINTER :: BC
       TYPE(GaussIntegrationPoints_t) :: IntegStuff
       TYPE(Element_t), POINTER :: Element,Parent

--- a/elmerice/Utils/ComputeFluxUtils.F90
+++ b/elmerice/Utils/ComputeFluxUtils.F90
@@ -325,10 +325,10 @@
         IF (EIndex > 0) THEN
            IF (VisitedParent(Parent % ElementIndex)) THEN
              CFluxVar % Values ( EIndex ) = CFluxVar % Values ( EIndex ) + CalvingFlux / area
-             CFluxVarTot % Values ( EIndex ) = CFluxVarTot % Values ( EIndex ) + CalvingFlux
+             CFluxVarTot % Values ( EIndex ) = MAX(CFluxVarTot % Values ( EIndex ) + CalvingFlux, 0._dp)
            ELSE 
              CFluxVar % Values ( EIndex ) = CalvingFlux / area
-             CFluxVarTot % Values ( EIndex ) = CalvingFlux
+             CFluxVarTot % Values ( EIndex ) = MAX(CalvingFlux, 0._dp)
              IF (Parent % ElementIndex.GT.NofActive) &
                 CALL FATAL(Caller,"Pb with VisitedParent allocated size")
              VisitedParent(Parent % ElementIndex)=.TRUE.

--- a/fem/src/elmer_coupling.F90
+++ b/fem/src/elmer_coupling.F90
@@ -498,6 +498,13 @@ MODULE elmer_icon_coupling
   ! Buffer for output of creep mapping on internal domain
   DOUBLE PRECISION, PUBLIC, ALLOCATABLE :: sal_oce_post_field(:,:)
 
+  ! Fields Elmer sends to ICON
+
+  INTEGER :: liquid_flux_field_id = -1
+  CHARACTER(LEN=*), PARAMETER :: liquid_flux_field_name = "liquid_flux"
+  INTEGER :: liquid_flux_collection_size = 1
+  DOUBLE PRECISION, PUBLIC, ALLOCATABLE :: liquid_flux_field(:,:)
+
 CONTAINS
 
   SUBROUTINE construct_elmer_icon_coupling( &
@@ -512,12 +519,22 @@ CONTAINS
     CHARACTER(LEN=*), INTENT(IN) :: elmer_comp_name
     CHARACTER(LEN=*), INTENT(IN) :: elmer_grid_name
 
-    INTEGER :: nbr_vertices
+    INTEGER :: nbr_vertices, nbr_cells
 
     REAL(kind=C_DOUBLE), PARAMETER :: nnn_max_search_distance = 1e-5_C_DOUBLE
     REAL(kind=C_DOUBLE), PARAMETER :: nnn_scale = 0.0_C_DOUBLE
 
     nbr_vertices = yac_fget_points_size(corner_point_id)
+    nbr_cells = yac_fget_points_size(cell_point_id)
+
+
+    ! register liquid flux field in YAC
+    CALL yac_fdef_field( &
+      liquid_flux_field_name, comp_id, (/cell_point_id/), 1, liquid_flux_collection_size, &
+      iso8601_timestep, YAC_TIME_UNIT_ISO_FORMAT, liquid_flux_field_id);
+
+    ! allocate and liquid flux field buffer
+    ALLOCATE(liquid_flux_field(nbr_cells, liquid_flux_collection_size))
 
     ! register ocean temperature field in YAC (masked on boundary)
     CALL yac_fdef_field( &

--- a/fem/src/elmer_coupling.F90
+++ b/fem/src/elmer_coupling.F90
@@ -502,12 +502,12 @@ MODULE elmer_icon_coupling
 
   INTEGER :: liquid_ice_sheet_flux_field_id = -1
   CHARACTER(LEN=*), PARAMETER :: liquid_ice_sheet_flux_field_name = "liquid_ice_sheet_flux"
-  INTEGER :: liquid_ice_sheet_flux_collection_size = 1
+  INTEGER, PARAMETER :: liquid_ice_sheet_flux_collection_size = 1
   DOUBLE PRECISION, PUBLIC, ALLOCATABLE :: liquid_ice_sheet_flux_field(:,:)
 
   INTEGER :: solid_ice_sheet_flux_field_id = -1
   CHARACTER(LEN=*), PARAMETER :: solid_ice_sheet_flux_field_name = "solid_ice_sheet_flux"
-  INTEGER :: solid_ice_sheet_flux_collection_size = 1
+  INTEGER, PARAMETER :: solid_ice_sheet_flux_collection_size = 1
   DOUBLE PRECISION, PUBLIC, ALLOCATABLE :: solid_ice_sheet_flux_field(:,:)
 
 CONTAINS
@@ -523,6 +523,10 @@ CONTAINS
     CHARACTER(LEN=*), INTENT(IN) :: boundary_corner_mask_name
     CHARACTER(LEN=*), INTENT(IN) :: elmer_comp_name
     CHARACTER(LEN=*), INTENT(IN) :: elmer_grid_name
+    CHARACTER(LEN=*), PARAMETER :: liquid_ice_sheet_flux_metadata = &
+      'Liquid flux from basal melting under floating ice shelves, in m3/s water equivalent per cell'
+    CHARACTER(LEN=*), PARAMETER :: solid_ice_sheet_flux_metadata = &
+      'Solid flux from iceberg calving, in m3/s ice equivalent per cell'
 
     INTEGER :: nbr_vertices, nbr_cells
 
@@ -533,26 +537,26 @@ CONTAINS
     nbr_cells = yac_fget_points_size(cell_point_id)
 
 
-    ! register liquid flux field in YAC
+    ! register liquid_ice_sheet_flux_field in YAC
     CALL yac_fdef_field( &
       liquid_ice_sheet_flux_field_name, comp_id, (/cell_point_id/), 1, liquid_ice_sheet_flux_collection_size, &
       iso8601_timestep, YAC_TIME_UNIT_ISO_FORMAT, liquid_ice_sheet_flux_field_id);
     CALL yac_fdef_field_metadata( &
       elmer_comp_name, elmer_grid_name, liquid_ice_sheet_flux_field_name, &
-      'Liquid flux from basal melting under floating ice shelves, in m3/s water equivalent per cell');
+      liquid_ice_sheet_flux_metadata);
 
-    ! allocate and liquid flux field buffer
+    ! allocate and liquid_ice_sheet_flux_field buffer
     ALLOCATE(liquid_ice_sheet_flux_field(nbr_cells, liquid_ice_sheet_flux_collection_size))
 
-    ! register solid flux field in YAC
+    ! register solid_ice_sheet_flux_field in YAC
     CALL yac_fdef_field( &
       solid_ice_sheet_flux_field_name, comp_id, (/cell_point_id/), 1, solid_ice_sheet_flux_collection_size, &
       iso8601_timestep, YAC_TIME_UNIT_ISO_FORMAT, solid_ice_sheet_flux_field_id);
 
     CALL yac_fdef_field_metadata( &
       elmer_comp_name, elmer_grid_name, solid_ice_sheet_flux_field_name, &
-      'Solid flux from iceberg calving, in m3/s ice equivalent per cell');
-    ! allocate and solid flux field buffer
+      solid_ice_sheet_flux_metadata);
+    ! allocate and solid_ice_sheet_flux_field buffer
     ALLOCATE(solid_ice_sheet_flux_field(nbr_cells, solid_ice_sheet_flux_collection_size))
 
     ! register ocean temperature field in YAC (masked on boundary)
@@ -674,19 +678,14 @@ CONTAINS
 
       field_role = yac_fget_field_role(elmer_comp_name, elmer_grid_name, field_name)
 
-      WRITE(*,*) 'DEBUG: Field_name: ', field_name, field_role
-
       IF (field_role == YAC_EXCHANGE_TYPE_TARGET) THEN
 
-#if YAC_VERSION_GREATER_EQUAL(3, 6, 0)
+#if !YAC_VERSION_GREATER_EQUAL(3, 6, 0)
+#error "YAC >= 3.6.0 is required"
+#endif
         CALL yac_fget_field_source( &
           elmer_comp_name, elmer_grid_name, field_name, &
           src_comp_name, src_grid_name, src_field_name);
-#else
-        src_comp_name = "icon"
-        src_grid_name = "icon_grid"
-        src_field_name = field_name
-#endif
 
         src_field_timestep = &
           yac_fget_field_timestep( &
@@ -744,7 +743,7 @@ CONTAINS
 
     ! ------------------------------------------------------------------
     ! Exchange: solid_ice_sheet_flux
-    ! Direction: ELMER -> (source) -- Elmer sends the solid (icebergs) ice
+    ! Direction: ELMER -> ICON-O -- Elmer sends the solid (icebergs) ice
     !            sheet mass flux to ICON-O.
     ! ------------------------------------------------------------------
     IF (yac_fget_role_from_field_id(solid_ice_sheet_flux_field_id) == &
@@ -766,13 +765,7 @@ CONTAINS
           (info == YAC_ACTION_PUT_FOR_RESTART) .OR. &
           (info == YAC_ACTION_REDUCTION)) THEN
 
-        ! get data to be sent from elmer
-
         ! execute put operation for solid_ice_sheet_flux field
-        ! * if this is a coupling timestep, this will block until the data has
-        !   been received
-        ! * if this is not a coupling timestep, solid_ice_sheet_flux field buffer
-        !   is left untouched and routine will return immediately
         CALL yac_fput( &
           solid_ice_sheet_flux_field_id, SIZE(solid_ice_sheet_flux_field, 1), &
           SIZE(solid_ice_sheet_flux_field, 2), solid_ice_sheet_flux_field, &
@@ -787,7 +780,7 @@ CONTAINS
 
     ! ------------------------------------------------------------------
     ! Exchange: liquid_ice_sheet_flux
-    ! Direction: ELMER -> (source) -- Elmer sends the liquid (basal melting) ice
+    ! Direction: ELMER -> ICON-O -- Elmer sends the liquid (basal melting) ice
     !            sheet mass flux to ICON-O.
     ! ------------------------------------------------------------------
     IF (yac_fget_role_from_field_id(liquid_ice_sheet_flux_field_id) == &
@@ -809,13 +802,7 @@ CONTAINS
           (info == YAC_ACTION_PUT_FOR_RESTART) .OR. &
           (info == YAC_ACTION_REDUCTION)) THEN
 
-        ! get data to be sent from elmer
-
         ! execute put operation for liquid_ice_sheet_flux field
-        ! * if this is a coupling timestep, this will block until the data has
-        !   been received
-        ! * if this is not a coupling timestep, liquid_ice_sheet_flux field buffer
-        !   is left untouched and routine will return immediately
         CALL yac_fput( &
           liquid_ice_sheet_flux_field_id, SIZE(liquid_ice_sheet_flux_field, 1), &
           SIZE(liquid_ice_sheet_flux_field, 2), liquid_ice_sheet_flux_field, &
@@ -823,8 +810,11 @@ CONTAINS
       ELSE IF (info == YAC_ACTION_NONE) THEN
         CALL yac_fupdate(liquid_ice_sheet_flux_field_id)
       ELSE
-          PRINT *, "ELMER: unexpected action for field: ", TRIM(liquid_ice_sheet_flux_field_name), &
-                   " action: ", TRIM(yac_action_to_string(info))
+          WRITE(*,'(A, A, A, A)') &
+            "ELMER: unexpected action for field: ", &
+            TRIM(liquid_ice_sheet_flux_field_name), &
+            " action: ", &
+            TRIM(yac_action_to_string(info))
       END IF
     END IF
 

--- a/fem/src/elmer_coupling.F90
+++ b/fem/src/elmer_coupling.F90
@@ -659,77 +659,67 @@ CONTAINS
 
   CONTAINS
 
-    SUBROUTINE print_field_info(elmer_comp_name, elmer_grid_name, field_name)
+    SUBROUTINE print_field_info( &
+      elmer_comp_name, elmer_grid_name, elmer_field_name)
+
+#if !YAC_VERSION_GREATER_EQUAL(3, 6, 0)
+#error "YAC >= 3.6.0 is required to call yac_fget_field_source"
+#endif
 
       CHARACTER(LEN=*), INTENT(IN) :: elmer_comp_name
       CHARACTER(LEN=*), INTENT(IN) :: elmer_grid_name
-      CHARACTER(LEN=*), INTENT(IN) :: field_name
+      CHARACTER(LEN=*), INTENT(IN) :: elmer_field_name
 
-      CHARACTER(LEN=:), ALLOCATABLE :: src_comp_name
-      CHARACTER(LEN=:), ALLOCATABLE :: src_grid_name
-      CHARACTER(LEN=:), ALLOCATABLE :: src_field_name
-      CHARACTER(LEN=:), ALLOCATABLE :: src_field_timestep
-      CHARACTER(LEN=:), ALLOCATABLE :: src_field_metadata
-
-      CHARACTER(LEN=:), ALLOCATABLE :: own_field_timestep
-      CHARACTER(LEN=:), ALLOCATABLE :: own_field_metadata
+      CHARACTER(LEN=:), ALLOCATABLE :: print_comp_name
+      CHARACTER(LEN=:), ALLOCATABLE :: print_grid_name
+      CHARACTER(LEN=:), ALLOCATABLE :: print_field_name
+      CHARACTER(LEN=:), ALLOCATABLE :: print_field_timestep
+      CHARACTER(LEN=:), ALLOCATABLE :: print_field_metadata
 
       INTEGER :: field_role
 
-      field_role = yac_fget_field_role(elmer_comp_name, elmer_grid_name, field_name)
+      ! determine role of this field
+      field_role = yac_fget_field_role( &
+        elmer_comp_name, elmer_grid_name, elmer_field_name)
 
-      IF (field_role == YAC_EXCHANGE_TYPE_TARGET) THEN
-
-#if !YAC_VERSION_GREATER_EQUAL(3, 6, 0)
-#error "YAC >= 3.6.0 is required"
-#endif
+      IF (field_role == YAC_EXCHANGE_TYPE_SOURCE) THEN
+        ! elmer owns field
+        print_field_name = elmer_field_name
+        print_grid_name = elmer_grid_name
+        print_comp_name = elmer_comp_name
+      ELSE IF (field_role == YAC_EXCHANGE_TYPE_TARGET) THEN
+        ! other component owns field; need to get comp name etc.
         CALL yac_fget_field_source( &
-          elmer_comp_name, elmer_grid_name, field_name, &
-          src_comp_name, src_grid_name, src_field_name);
-
-        src_field_timestep = &
-          yac_fget_field_timestep( &
-            src_comp_name, src_grid_name, src_field_name)
-
-        IF (yac_ffield_has_metadata( &
-              src_comp_name, src_grid_name, src_field_name)) THEN
-          src_field_metadata = &
-            yac_fget_field_metadata( &
-              src_comp_name, src_grid_name, src_field_name)
-        ELSE
-          src_field_metadata = "N/A"
-        END IF
-
-        PRINT *, "ELMER: field ", field_name, ":"
-        PRINT *, "ELMER:  - source:"
-        PRINT *, "ELMER:    - component: ", src_comp_name
-        PRINT *, "ELMER:    - grid:      ", src_grid_name
-        PRINT *, "ELMER:    - timestep:  ", src_field_timestep
-        PRINT *, "ELMER:    - metadata:  ", src_field_metadata
-
-      ELSE IF (field_role == YAC_EXCHANGE_TYPE_SOURCE) THEN
-
-        own_field_timestep = &
-          yac_fget_field_timestep( &
-            elmer_comp_name, elmer_grid_name, field_name)
-
-        IF (yac_ffield_has_metadata( &
-              elmer_comp_name, elmer_grid_name, field_name)) THEN
-          own_field_metadata = &
-            yac_fget_field_metadata( &
-              elmer_comp_name, elmer_grid_name, field_name)
-        ELSE
-          own_field_metadata = "N/A"
-        END IF
-
-        PRINT *, "ELMER: field ", field_name, ":"
-        PRINT *, "ELMER:  - source: "
-        PRINT *, "ELMER:    - component: ", elmer_comp_name
-        PRINT *, "ELMER:    - grid:      ", elmer_grid_name
-        PRINT *, "ELMER:    - timestep:  ", own_field_timestep
-        PRINT *, "ELMER:    - metadata:  ", own_field_metadata
-
+          elmer_comp_name, elmer_grid_name, elmer_field_name, &
+          print_comp_name, print_grid_name, print_field_name);
+      ELSE
+        PRINT *, "ELMER: field ", elmer_field_name, &
+          " has unexpected role (not connected to any coupling?)"
+        RETURN
       END IF
+
+      ! get timestep for field from YAC
+      print_field_timestep = &
+        yac_fget_field_timestep( &
+          print_comp_name, print_grid_name, print_field_name)
+
+      ! get metadata for field from YAC (metadata lives with whoever owns the field)
+      IF (yac_ffield_has_metadata( &
+            print_comp_name, print_grid_name, print_field_name)) THEN
+        print_field_metadata = &
+          yac_fget_field_metadata( &
+            print_comp_name, print_grid_name, print_field_name)
+      ELSE
+        print_field_metadata = "N/A"
+      END IF
+
+      ! print field info
+      PRINT *, "ELMER: field ", print_field_name, ":"
+      PRINT *, "ELMER:  - source:"
+      PRINT *, "ELMER:    - component: ", print_comp_name
+      PRINT *, "ELMER:    - grid:      ", print_grid_name
+      PRINT *, "ELMER:    - timestep:  ", print_field_timestep
+      PRINT *, "ELMER:    - metadata:  ", print_field_metadata
 
     END SUBROUTINE print_field_info
 
@@ -875,7 +865,7 @@ CONTAINS
     END IF
     ! ------------------------------------------------------------------
     ! Exchange: sal_oce (ocean salinity)
-    ! Direction: (target) ELMER receives ocean salinity from ICON-O. 
+    ! Direction: (target) ELMER receives ocean salinity from ICON-O.
     ! ------------------------------------------------------------------
     ! checks whether the ocean salinity field is defined as a target
     ! in a couple

--- a/fem/src/elmer_coupling.F90
+++ b/fem/src/elmer_coupling.F90
@@ -537,6 +537,9 @@ CONTAINS
     CALL yac_fdef_field( &
       liquid_ice_sheet_flux_field_name, comp_id, (/cell_point_id/), 1, liquid_ice_sheet_flux_collection_size, &
       iso8601_timestep, YAC_TIME_UNIT_ISO_FORMAT, liquid_ice_sheet_flux_field_id);
+    CALL yac_fdef_field_metadata( &
+      elmer_comp_name, elmer_grid_name, liquid_ice_sheet_flux_field_name, &
+      'Liquid flux from basal melting under floating ice shelves, in m3/s water equivalent per cell');
 
     ! allocate and liquid flux field buffer
     ALLOCATE(liquid_ice_sheet_flux_field(nbr_cells, liquid_ice_sheet_flux_collection_size))
@@ -546,6 +549,9 @@ CONTAINS
       solid_ice_sheet_flux_field_name, comp_id, (/cell_point_id/), 1, solid_ice_sheet_flux_collection_size, &
       iso8601_timestep, YAC_TIME_UNIT_ISO_FORMAT, solid_ice_sheet_flux_field_id);
 
+    CALL yac_fdef_field_metadata( &
+      elmer_comp_name, elmer_grid_name, solid_ice_sheet_flux_field_name, &
+      'Solid flux from iceberg calving, in m3/s ice equivalent per cell');
     ! allocate and solid flux field buffer
     ALLOCATE(solid_ice_sheet_flux_field(nbr_cells, solid_ice_sheet_flux_collection_size))
 
@@ -661,11 +667,16 @@ CONTAINS
       CHARACTER(LEN=:), ALLOCATABLE :: src_field_timestep
       CHARACTER(LEN=:), ALLOCATABLE :: src_field_metadata
 
-      WRITE(*,*) 'DEBUG: Field_name: ', field_name, yac_fget_field_role( &
-            elmer_comp_name, elmer_grid_name, field_name)
-      IF (yac_fget_field_role( &
-            elmer_comp_name, elmer_grid_name, field_name) == &
-            YAC_EXCHANGE_TYPE_TARGET) THEN
+      CHARACTER(LEN=:), ALLOCATABLE :: own_field_timestep
+      CHARACTER(LEN=:), ALLOCATABLE :: own_field_metadata
+
+      INTEGER :: field_role
+
+      field_role = yac_fget_field_role(elmer_comp_name, elmer_grid_name, field_name)
+
+      WRITE(*,*) 'DEBUG: Field_name: ', field_name, field_role
+
+      IF (field_role == YAC_EXCHANGE_TYPE_TARGET) THEN
 
 #if YAC_VERSION_GREATER_EQUAL(3, 6, 0)
         CALL yac_fget_field_source( &
@@ -697,9 +708,82 @@ CONTAINS
         PRINT *, "ELMER:    - timestep:  ", src_field_timestep
         PRINT *, "ELMER:    - metadata:  ", src_field_metadata
 
+      ELSE IF (field_role == YAC_EXCHANGE_TYPE_SOURCE) THEN
+
+        own_field_timestep = &
+          yac_fget_field_timestep( &
+            elmer_comp_name, elmer_grid_name, field_name)
+
+        IF (yac_ffield_has_metadata( &
+              elmer_comp_name, elmer_grid_name, field_name)) THEN
+          own_field_metadata = &
+            yac_fget_field_metadata( &
+              elmer_comp_name, elmer_grid_name, field_name)
+        ELSE
+          own_field_metadata = "N/A"
+        END IF
+
+        PRINT *, "ELMER: field ", field_name, ":"
+        PRINT *, "ELMER:  - source: "
+        PRINT *, "ELMER:    - component: ", elmer_comp_name
+        PRINT *, "ELMER:    - grid:      ", elmer_grid_name
+        PRINT *, "ELMER:    - timestep:  ", own_field_timestep
+        PRINT *, "ELMER:    - metadata:  ", own_field_metadata
+
       END IF
 
     END SUBROUTINE print_field_info
+    !SUBROUTINE print_field_info(elmer_comp_name, elmer_grid_name, field_name)
+
+      !CHARACTER(LEN=*), INTENT(IN) :: elmer_comp_name
+      !CHARACTER(LEN=*), INTENT(IN) :: elmer_grid_name
+      !CHARACTER(LEN=*), INTENT(IN) :: field_name
+
+      !CHARACTER(LEN=:), ALLOCATABLE :: src_comp_name
+      !CHARACTER(LEN=:), ALLOCATABLE :: src_grid_name
+      !CHARACTER(LEN=:), ALLOCATABLE :: src_field_name
+      !CHARACTER(LEN=:), ALLOCATABLE :: src_field_timestep
+      !CHARACTER(LEN=:), ALLOCATABLE :: src_field_metadata
+
+      !WRITE(*,*) 'DEBUG: Field_name: ', field_name, yac_fget_field_role( &
+            !elmer_comp_name, elmer_grid_name, field_name)
+      !IF (yac_fget_field_role( &
+            !elmer_comp_name, elmer_grid_name, field_name) == &
+            !YAC_EXCHANGE_TYPE_TARGET) THEN
+
+!#if YAC_VERSION_GREATER_EQUAL(3, 6, 0)
+        !CALL yac_fget_field_source( &
+          !elmer_comp_name, elmer_grid_name, field_name, &
+          !src_comp_name, src_grid_name, src_field_name);
+!#else
+        !src_comp_name = "icon"
+        !src_grid_name = "icon_grid"
+        !src_field_name = field_name
+!#endif
+
+        !src_field_timestep = &
+          !yac_fget_field_timestep( &
+            !src_comp_name, src_grid_name, src_field_name)
+
+        !IF (yac_ffield_has_metadata( &
+              !src_comp_name, src_grid_name, src_field_name)) THEN
+          !src_field_metadata = &
+            !yac_fget_field_metadata( &
+              !src_comp_name, src_grid_name, src_field_name)
+        !ELSE
+          !src_field_metadata = "N/A"
+        !END IF
+
+        !PRINT *, "ELMER: field ", field_name, ":"
+        !PRINT *, "ELMER:  - source:"
+        !PRINT *, "ELMER:    - component: ", src_comp_name
+        !PRINT *, "ELMER:    - grid:      ", src_grid_name
+        !PRINT *, "ELMER:    - timestep:  ", src_field_timestep
+        !PRINT *, "ELMER:    - metadata:  ", src_field_metadata
+
+      !END IF
+
+    !END SUBROUTINE print_field_info
 
   END SUBROUTINE construct_elmer_icon_coupling_post_sync
 

--- a/fem/src/elmer_coupling.F90
+++ b/fem/src/elmer_coupling.F90
@@ -500,10 +500,10 @@ MODULE elmer_icon_coupling
 
   ! Fields Elmer sends to ICON
 
-  INTEGER :: liquid_flux_field_id = -1
-  CHARACTER(LEN=*), PARAMETER :: liquid_flux_field_name = "liquid_flux"
-  INTEGER :: liquid_flux_collection_size = 1
-  DOUBLE PRECISION, PUBLIC, ALLOCATABLE :: liquid_flux_field(:,:)
+  INTEGER :: liquid_ice_sheet_flux_field_id = -1
+  CHARACTER(LEN=*), PARAMETER :: liquid_ice_sheet_flux_field_name = "liquid_ice_sheet_flux"
+  INTEGER :: liquid_ice_sheet_flux_collection_size = 1
+  DOUBLE PRECISION, PUBLIC, ALLOCATABLE :: liquid_ice_sheet_flux_field(:,:)
 
 CONTAINS
 
@@ -530,11 +530,11 @@ CONTAINS
 
     ! register liquid flux field in YAC
     CALL yac_fdef_field( &
-      liquid_flux_field_name, comp_id, (/cell_point_id/), 1, liquid_flux_collection_size, &
-      iso8601_timestep, YAC_TIME_UNIT_ISO_FORMAT, liquid_flux_field_id);
+      liquid_ice_sheet_flux_field_name, comp_id, (/cell_point_id/), 1, liquid_ice_sheet_flux_collection_size, &
+      iso8601_timestep, YAC_TIME_UNIT_ISO_FORMAT, liquid_ice_sheet_flux_field_id);
 
     ! allocate and liquid flux field buffer
-    ALLOCATE(liquid_flux_field(nbr_cells, liquid_flux_collection_size))
+    ALLOCATE(liquid_ice_sheet_flux_field(nbr_cells, liquid_ice_sheet_flux_collection_size))
 
     ! register ocean temperature field in YAC (masked on boundary)
     CALL yac_fdef_field( &
@@ -631,6 +631,9 @@ CONTAINS
 
     CALL print_field_info(elmer_comp_name, elmer_grid_name, temp_oce_field_name)
     CALL print_field_info(elmer_comp_name, elmer_grid_name, sal_oce_field_name)
+    WRITE(*,*) 'DEBUG: Before print_field_info for liquid_ice_sheet_flux'
+    CALL print_field_info(elmer_comp_name, elmer_grid_name, liquid_ice_sheet_flux_field_name)
+    WRITE(*,*) 'DEBUG: After print_field_info for liquid_ice_sheet_flux'
 
   CONTAINS
 
@@ -646,6 +649,8 @@ CONTAINS
       CHARACTER(LEN=:), ALLOCATABLE :: src_field_timestep
       CHARACTER(LEN=:), ALLOCATABLE :: src_field_metadata
 
+      WRITE(*,*) 'DEBUG: Field_name: ', field_name, yac_fget_field_role( &
+            elmer_comp_name, elmer_grid_name, field_name)
       IF (yac_fget_field_role( &
             elmer_comp_name, elmer_grid_name, field_name) == &
             YAC_EXCHANGE_TYPE_TARGET) THEN
@@ -797,6 +802,42 @@ CONTAINS
       ! TODO: ignore info?
 
     END IF
+    ! checks whether the liquid ice sheet flux field is defined as a source
+    ! in a couple
+    IF (yac_fget_role_from_field_id(liquid_ice_sheet_flux_field_id) == &
+        YAC_EXCHANGE_TYPE_SOURCE) THEN
+
+      CALL yac_fget_action(liquid_ice_sheet_flux_field_id, info)
+
+      IF (is_root_rank) THEN
+
+        ! get the action executed by YAC in the next put operation called for
+        ! the liquid_ice_sheet_flux and print out some information
+        PRINT *, "ELMER: call put for field: ", TRIM(liquid_ice_sheet_flux_field_name), &
+                 " datatime: ", TRIM(yac_fget_field_datetime(liquid_ice_sheet_flux_field_id)), &
+                 " action: ", TRIM(yac_action_to_string(info))
+      END IF
+
+      ! if this was a coupling timestep
+      IF ((info == YAC_ACTION_COUPLING) .OR. &
+          (info == YAC_ACTION_PUT_FOR_RESTART) .OR. &
+          (info == YAC_ACTION_REDUCTION)) THEN
+
+        ! get data to be sent from elmer
+
+        ! execute put operation for liquid_ice_sheet_flux field
+        ! * if this is a coupling timestep, this will block until the data has
+        !   been received
+        ! * if this is not a coupling timestep, liquid_ice_sheet_flux field buffer
+        !   is left untouched and routine will return immediately
+        CALL yac_fput( &
+          liquid_ice_sheet_flux_field_id, SIZE(liquid_ice_sheet_flux_field, 1), &
+          SIZE(liquid_ice_sheet_flux_field, 2), liquid_ice_sheet_flux_field, &
+          info, err)
+      ELSE IF (info == YAC_ACTION_NONE) THEN
+        CALL yac_fupdate(liquid_ice_sheet_flux_field_id)
+      END IF
+    END IF
 
   END SUBROUTINE elmer_icon_interface
 
@@ -804,7 +845,8 @@ CONTAINS
 
     ! clean up
     DEALLOCATE(t_oce_pre_field, t_oce_post_field, &
-               sal_oce_pre_field, sal_oce_post_field)
+               sal_oce_pre_field, sal_oce_post_field, &
+               liquid_ice_sheet_flux_field)
 
   END SUBROUTINE destruct_elmer_icon_coupling
 

--- a/fem/src/elmer_coupling.F90
+++ b/fem/src/elmer_coupling.F90
@@ -697,6 +697,44 @@ CONTAINS
 
     INTEGER :: info, err
 
+    IF (yac_fget_role_from_field_id(liquid_ice_sheet_flux_field_id) == &
+        YAC_EXCHANGE_TYPE_SOURCE) THEN
+
+      CALL yac_fget_action(liquid_ice_sheet_flux_field_id, info)
+
+      IF (is_root_rank) THEN
+
+        ! get the action executed by YAC in the next put operation called for
+        ! the liquid_ice_sheet_flux and print out some information
+        PRINT *, "ELMER: call put for field: ", TRIM(liquid_ice_sheet_flux_field_name), &
+                 " datatime: ", TRIM(yac_fget_field_datetime(liquid_ice_sheet_flux_field_id)), &
+                 " action: ", TRIM(yac_action_to_string(info))
+      END IF
+
+      ! if this was a coupling timestep
+      IF ((info == YAC_ACTION_COUPLING) .OR. &
+          (info == YAC_ACTION_PUT_FOR_RESTART) .OR. &
+          (info == YAC_ACTION_REDUCTION)) THEN
+
+        ! get data to be sent from elmer
+
+        ! execute put operation for liquid_ice_sheet_flux field
+        ! * if this is a coupling timestep, this will block until the data has
+        !   been received
+        ! * if this is not a coupling timestep, liquid_ice_sheet_flux field buffer
+        !   is left untouched and routine will return immediately
+        CALL yac_fput( &
+          liquid_ice_sheet_flux_field_id, SIZE(liquid_ice_sheet_flux_field, 1), &
+          SIZE(liquid_ice_sheet_flux_field, 2), liquid_ice_sheet_flux_field, &
+          info, err)
+      ELSE IF (info == YAC_ACTION_NONE) THEN
+        CALL yac_fupdate(liquid_ice_sheet_flux_field_id)
+      ELSE
+          PRINT *, "ELMER: unexpected action for field: ", TRIM(liquid_ice_sheet_flux_field_name), &
+                   " action: ", TRIM(yac_action_to_string(info))
+      END IF
+    END IF
+
     ! checks whether the ocean temperature field is defined as a target
     ! in a couple
     IF (yac_fget_role_from_field_id(t_oce_field_id) == &
@@ -804,40 +842,6 @@ CONTAINS
     END IF
     ! checks whether the liquid ice sheet flux field is defined as a source
     ! in a couple
-    IF (yac_fget_role_from_field_id(liquid_ice_sheet_flux_field_id) == &
-        YAC_EXCHANGE_TYPE_SOURCE) THEN
-
-      CALL yac_fget_action(liquid_ice_sheet_flux_field_id, info)
-
-      IF (is_root_rank) THEN
-
-        ! get the action executed by YAC in the next put operation called for
-        ! the liquid_ice_sheet_flux and print out some information
-        PRINT *, "ELMER: call put for field: ", TRIM(liquid_ice_sheet_flux_field_name), &
-                 " datatime: ", TRIM(yac_fget_field_datetime(liquid_ice_sheet_flux_field_id)), &
-                 " action: ", TRIM(yac_action_to_string(info))
-      END IF
-
-      ! if this was a coupling timestep
-      IF ((info == YAC_ACTION_COUPLING) .OR. &
-          (info == YAC_ACTION_PUT_FOR_RESTART) .OR. &
-          (info == YAC_ACTION_REDUCTION)) THEN
-
-        ! get data to be sent from elmer
-
-        ! execute put operation for liquid_ice_sheet_flux field
-        ! * if this is a coupling timestep, this will block until the data has
-        !   been received
-        ! * if this is not a coupling timestep, liquid_ice_sheet_flux field buffer
-        !   is left untouched and routine will return immediately
-        CALL yac_fput( &
-          liquid_ice_sheet_flux_field_id, SIZE(liquid_ice_sheet_flux_field, 1), &
-          SIZE(liquid_ice_sheet_flux_field, 2), liquid_ice_sheet_flux_field, &
-          info, err)
-      ELSE IF (info == YAC_ACTION_NONE) THEN
-        CALL yac_fupdate(liquid_ice_sheet_flux_field_id)
-      END IF
-    END IF
 
   END SUBROUTINE elmer_icon_interface
 

--- a/fem/src/elmer_coupling.F90
+++ b/fem/src/elmer_coupling.F90
@@ -733,57 +733,6 @@ CONTAINS
       END IF
 
     END SUBROUTINE print_field_info
-    !SUBROUTINE print_field_info(elmer_comp_name, elmer_grid_name, field_name)
-
-      !CHARACTER(LEN=*), INTENT(IN) :: elmer_comp_name
-      !CHARACTER(LEN=*), INTENT(IN) :: elmer_grid_name
-      !CHARACTER(LEN=*), INTENT(IN) :: field_name
-
-      !CHARACTER(LEN=:), ALLOCATABLE :: src_comp_name
-      !CHARACTER(LEN=:), ALLOCATABLE :: src_grid_name
-      !CHARACTER(LEN=:), ALLOCATABLE :: src_field_name
-      !CHARACTER(LEN=:), ALLOCATABLE :: src_field_timestep
-      !CHARACTER(LEN=:), ALLOCATABLE :: src_field_metadata
-
-      !WRITE(*,*) 'DEBUG: Field_name: ', field_name, yac_fget_field_role( &
-            !elmer_comp_name, elmer_grid_name, field_name)
-      !IF (yac_fget_field_role( &
-            !elmer_comp_name, elmer_grid_name, field_name) == &
-            !YAC_EXCHANGE_TYPE_TARGET) THEN
-
-!#if YAC_VERSION_GREATER_EQUAL(3, 6, 0)
-        !CALL yac_fget_field_source( &
-          !elmer_comp_name, elmer_grid_name, field_name, &
-          !src_comp_name, src_grid_name, src_field_name);
-!#else
-        !src_comp_name = "icon"
-        !src_grid_name = "icon_grid"
-        !src_field_name = field_name
-!#endif
-
-        !src_field_timestep = &
-          !yac_fget_field_timestep( &
-            !src_comp_name, src_grid_name, src_field_name)
-
-        !IF (yac_ffield_has_metadata( &
-              !src_comp_name, src_grid_name, src_field_name)) THEN
-          !src_field_metadata = &
-            !yac_fget_field_metadata( &
-              !src_comp_name, src_grid_name, src_field_name)
-        !ELSE
-          !src_field_metadata = "N/A"
-        !END IF
-
-        !PRINT *, "ELMER: field ", field_name, ":"
-        !PRINT *, "ELMER:  - source:"
-        !PRINT *, "ELMER:    - component: ", src_comp_name
-        !PRINT *, "ELMER:    - grid:      ", src_grid_name
-        !PRINT *, "ELMER:    - timestep:  ", src_field_timestep
-        !PRINT *, "ELMER:    - metadata:  ", src_field_metadata
-
-      !END IF
-
-    !END SUBROUTINE print_field_info
 
   END SUBROUTINE construct_elmer_icon_coupling_post_sync
 

--- a/fem/src/elmer_coupling.F90
+++ b/fem/src/elmer_coupling.F90
@@ -118,24 +118,24 @@ MODULE elmer_ebfm_coupling
 
   INTEGER :: t_ice_field_id = -1
   CHARACTER(LEN=*), PARAMETER :: t_ice_field_name = "T_ice"
-  INTEGER :: t_ice_collection_size = 1
+  INTEGER, PARAMETER :: t_ice_collection_size = 1
   DOUBLE PRECISION, PUBLIC, ALLOCATABLE :: t_ice_field(:,:)
 
   INTEGER :: smb_field_id = -1
   CHARACTER(LEN=*), PARAMETER :: smb_field_name = "smb"
-  INTEGER :: smb_collection_size = 1
+  INTEGER, PARAMETER :: smb_collection_size = 1
   DOUBLE PRECISION, PUBLIC, ALLOCATABLE :: smb_field(:,:)
 
   INTEGER :: runoff_field_id = -1
   CHARACTER(LEN=*), PARAMETER :: runoff_field_name = "runoff"
-  INTEGER :: runoff_collection_size = 1
+  INTEGER, PARAMETER :: runoff_collection_size = 1
   DOUBLE PRECISION, PUBLIC, ALLOCATABLE :: runoff_field(:,:)
 
   ! Fields Elmer sends to EBFM
 
   INTEGER :: surface_height_field_id = -1
   CHARACTER(LEN=*), PARAMETER :: surface_height_field_name = "surface_elevation"
-  INTEGER :: surface_height_collection_size = 1
+  INTEGER, PARAMETER :: surface_height_collection_size = 1
   DOUBLE PRECISION, PUBLIC, ALLOCATABLE :: surface_height_field(:,:)
 
 CONTAINS
@@ -468,7 +468,7 @@ MODULE elmer_icon_coupling
   CHARACTER(LEN=*), PARAMETER :: temp_oce_post_field_name = "temp_oce_post"
 
   ! All fields with t_oce prefix use the same collection size.
-  INTEGER :: t_oce_collection_size = 1
+  INTEGER, PARAMETER :: t_oce_collection_size = 1
 
   ! Buffer for receiving `temp_oce` from ICON; used as input for creep mapping
   DOUBLE PRECISION, PUBLIC, ALLOCATABLE :: t_oce_pre_field(:,:)
@@ -489,7 +489,7 @@ MODULE elmer_icon_coupling
   CHARACTER(LEN=*), PARAMETER :: sal_oce_post_field_name = "sal_oce_post"
 
   ! All fields with sal_oce prefix use the same collection size.
-  INTEGER :: sal_oce_collection_size = 1
+  INTEGER, PARAMETER :: sal_oce_collection_size = 1
 
   INTEGER :: interp_stack_config_id = -1
 

--- a/fem/src/elmer_coupling.F90
+++ b/fem/src/elmer_coupling.F90
@@ -505,6 +505,11 @@ MODULE elmer_icon_coupling
   INTEGER :: liquid_ice_sheet_flux_collection_size = 1
   DOUBLE PRECISION, PUBLIC, ALLOCATABLE :: liquid_ice_sheet_flux_field(:,:)
 
+  INTEGER :: solid_ice_sheet_flux_field_id = -1
+  CHARACTER(LEN=*), PARAMETER :: solid_ice_sheet_flux_field_name = "solid_ice_sheet_flux"
+  INTEGER :: solid_ice_sheet_flux_collection_size = 1
+  DOUBLE PRECISION, PUBLIC, ALLOCATABLE :: solid_ice_sheet_flux_field(:,:)
+
 CONTAINS
 
   SUBROUTINE construct_elmer_icon_coupling( &
@@ -535,6 +540,14 @@ CONTAINS
 
     ! allocate and liquid flux field buffer
     ALLOCATE(liquid_ice_sheet_flux_field(nbr_cells, liquid_ice_sheet_flux_collection_size))
+
+    ! register solid flux field in YAC
+    CALL yac_fdef_field( &
+      solid_ice_sheet_flux_field_name, comp_id, (/cell_point_id/), 1, solid_ice_sheet_flux_collection_size, &
+      iso8601_timestep, YAC_TIME_UNIT_ISO_FORMAT, solid_ice_sheet_flux_field_id);
+
+    ! allocate and solid flux field buffer
+    ALLOCATE(solid_ice_sheet_flux_field(nbr_cells, solid_ice_sheet_flux_collection_size))
 
     ! register ocean temperature field in YAC (masked on boundary)
     CALL yac_fdef_field( &
@@ -631,9 +644,8 @@ CONTAINS
 
     CALL print_field_info(elmer_comp_name, elmer_grid_name, temp_oce_field_name)
     CALL print_field_info(elmer_comp_name, elmer_grid_name, sal_oce_field_name)
-    WRITE(*,*) 'DEBUG: Before print_field_info for liquid_ice_sheet_flux'
     CALL print_field_info(elmer_comp_name, elmer_grid_name, liquid_ice_sheet_flux_field_name)
-    WRITE(*,*) 'DEBUG: After print_field_info for liquid_ice_sheet_flux'
+    CALL print_field_info(elmer_comp_name, elmer_grid_name, solid_ice_sheet_flux_field_name)
 
   CONTAINS
 
@@ -697,6 +709,54 @@ CONTAINS
 
     INTEGER :: info, err
 
+    ! ------------------------------------------------------------------
+    ! Exchange: solid_ice_sheet_flux
+    ! Direction: ELMER -> (source) -- Elmer sends the solid (icebergs) ice
+    !            sheet mass flux to ICON-O.
+    ! ------------------------------------------------------------------
+    IF (yac_fget_role_from_field_id(solid_ice_sheet_flux_field_id) == &
+        YAC_EXCHANGE_TYPE_SOURCE) THEN
+
+      CALL yac_fget_action(solid_ice_sheet_flux_field_id, info)
+
+      IF (is_root_rank) THEN
+
+        ! get the action executed by YAC in the next put operation called for
+        ! the solid_ice_sheet_flux and print out some information
+        PRINT *, "ELMER: call put for field: ", TRIM(solid_ice_sheet_flux_field_name), &
+                 " datatime: ", TRIM(yac_fget_field_datetime(solid_ice_sheet_flux_field_id)), &
+                 " action: ", TRIM(yac_action_to_string(info))
+      END IF
+
+      ! if this was a coupling timestep
+      IF ((info == YAC_ACTION_COUPLING) .OR. &
+          (info == YAC_ACTION_PUT_FOR_RESTART) .OR. &
+          (info == YAC_ACTION_REDUCTION)) THEN
+
+        ! get data to be sent from elmer
+
+        ! execute put operation for solid_ice_sheet_flux field
+        ! * if this is a coupling timestep, this will block until the data has
+        !   been received
+        ! * if this is not a coupling timestep, solid_ice_sheet_flux field buffer
+        !   is left untouched and routine will return immediately
+        CALL yac_fput( &
+          solid_ice_sheet_flux_field_id, SIZE(solid_ice_sheet_flux_field, 1), &
+          SIZE(solid_ice_sheet_flux_field, 2), solid_ice_sheet_flux_field, &
+          info, err)
+      ELSE IF (info == YAC_ACTION_NONE) THEN
+        CALL yac_fupdate(solid_ice_sheet_flux_field_id)
+      ELSE
+          PRINT *, "ELMER: unexpected action for field: ", TRIM(solid_ice_sheet_flux_field_name), &
+                   " action: ", TRIM(yac_action_to_string(info))
+      END IF
+    END IF
+
+    ! ------------------------------------------------------------------
+    ! Exchange: liquid_ice_sheet_flux
+    ! Direction: ELMER -> (source) -- Elmer sends the liquid (basal melting) ice
+    !            sheet mass flux to ICON-O.
+    ! ------------------------------------------------------------------
     IF (yac_fget_role_from_field_id(liquid_ice_sheet_flux_field_id) == &
         YAC_EXCHANGE_TYPE_SOURCE) THEN
 
@@ -735,6 +795,10 @@ CONTAINS
       END IF
     END IF
 
+    ! ------------------------------------------------------------------
+    ! Exchange: t_oce (ocean temperature)
+    ! Direction: (target) ELMER receives ocean temperature from ICON-O.
+    ! ------------------------------------------------------------------
     ! checks whether the ocean temperature field is defined as a target
     ! in a couple
     IF (yac_fget_role_from_field_id(t_oce_field_id) == &
@@ -786,7 +850,10 @@ CONTAINS
       ! TODO: ignore info?
 
     END IF
-
+    ! ------------------------------------------------------------------
+    ! Exchange: sal_oce (ocean salinity)
+    ! Direction: (target) ELMER receives ocean salinity from ICON-O. 
+    ! ------------------------------------------------------------------
     ! checks whether the ocean salinity field is defined as a target
     ! in a couple
     IF (yac_fget_role_from_field_id(sal_oce_field_id) == &
@@ -840,8 +907,6 @@ CONTAINS
       ! TODO: ignore info?
 
     END IF
-    ! checks whether the liquid ice sheet flux field is defined as a source
-    ! in a couple
 
   END SUBROUTINE elmer_icon_interface
 
@@ -850,7 +915,7 @@ CONTAINS
     ! clean up
     DEALLOCATE(t_oce_pre_field, t_oce_post_field, &
                sal_oce_pre_field, sal_oce_post_field, &
-               liquid_ice_sheet_flux_field)
+               liquid_ice_sheet_flux_field, solid_ice_sheet_flux_field)
 
   END SUBROUTINE destruct_elmer_icon_coupling
 


### PR DESCRIPTION
This pull request implements the sending of liquid and solid (iceberg) fluxes from Elmer/Ice to ICON-O via YAC. 
The specifics include:
- add required fields to `yac2elmer.f90` and `elmer_coupling.f90`
- compute some integral values for consistency checks across ICON and Elmer
- modify calving flux function, so it computes what we actually need. 
- modify basal melt rate function that it also computes everything in the correct units. Also restrict to only melting and no refreezing for now. 
