### PR TITLE
CI (MinGW): Install nlohmann-json

### DIFF
--- a/.github/workflows/build-windows-mingw.yaml
+++ b/.github/workflows/build-windows-mingw.yaml
@@ -74,7 +74,7 @@ jobs:
             qwt-qt6:p
             vtk:p
             adios2:p
-            anari-sdk:p 
+            anari-sdk:p
             boost:p
             cgns:p
             cli11:p
@@ -85,7 +85,8 @@ jobs:
             gl2ps:p
             liblas:p
             libmariadbclient:p
-            netcdf:p 
+            netcdf:p
+            nlohmann-json:p
             openslide:p
             openvdb:p
             pdal:p


### PR DESCRIPTION
Since recently, VTK from MSYS2 seems to have gotten a new (indirect) dependency. Configuring is failing with errors like the following:
```
CMake Error at D:/a/_temp/msys64/ucrt64/lib/cmake/vtk/VTK-vtk-module-find-packages.cmake:2225 (find_package):
  By not providing "Findnlohmann_json.cmake" in CMAKE_MODULE_PATH this
  project has asked CMake to find a package configuration file provided by
  "nlohmann_json", but CMake did not find one.

  Could not find a package configuration file provided by "nlohmann_json"
  with any of the following names:

    nlohmann_json.cps
    nlohmann_jsonConfig.cmake
    nlohmann_json-config.cmake

  Add the installation prefix of "nlohmann_json" to CMAKE_PREFIX_PATH or set
  "nlohmann_json_DIR" to a directory containing one of the above files.  If
  "nlohmann_json" provides a separate development package or SDK, be sure it
  has been installed.
Call Stack (most recent call first):
  D:/a/_temp/msys64/ucrt64/lib/cmake/vtk/vtk-config.cmake:171 (include)
  ElmerGUI/CMakeLists.txt:145 (FIND_PACKAGE)
```

Install `nlohmann-json` as a new build dependency in the CI.