### PR TITLE
Fix some issues with uploading assets to a release

### DIFF
--- a/.github/workflows/create-release-assets.yaml
+++ b/.github/workflows/create-release-assets.yaml
@@ -67,9 +67,11 @@ jobs:
           path: dist/elmerfem-${{ github.event.inputs.ref || github.event.release.tag_name }}.zip
           archive: false
 
-      # Fail early if workflow_dispatch requests publishing but no release exists
+      # Fail early if workflow_dispatch requests publishing but no release exists for the selected tag
       - name: Ensure release exists when publishing
         if: github.event_name == 'workflow_dispatch' && github.event.inputs.publish_release == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           tag="${{ github.event.inputs.ref }}"
           echo "Checking if release exists for tag '$tag'..."

--- a/.github/workflows/create-release-assets.yaml
+++ b/.github/workflows/create-release-assets.yaml
@@ -69,7 +69,7 @@ jobs:
 
       # Fail early if workflow_dispatch requests publishing but no release exists
       - name: Ensure release exists when publishing
-        if: github.event_name == 'workflow_dispatch' && github.event.inputs.publish_release == true
+        if: github.event_name == 'workflow_dispatch' && github.event.inputs.publish_release == 'true'
         run: |
           tag="${{ github.event.inputs.ref }}"
           echo "Checking if release exists for tag '$tag'..."
@@ -88,7 +88,7 @@ jobs:
       # Upload assets to existing or current release
       # The following steps require that ref is a tag.
       - name: Upload release assets
-        if: github.event_name == 'release' || github.event.inputs.publish_release == true
+        if: github.event_name == 'release' || github.event.inputs.publish_release == 'true'
         uses: softprops/action-gh-release@v3
         with:
           tag_name: ${{ github.event.inputs.ref || github.event.release.tag_name }}

--- a/.github/workflows/create-release-assets.yaml
+++ b/.github/workflows/create-release-assets.yaml
@@ -25,6 +25,13 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - name: Dump inputs
+        run: |
+          echo "Creating tarballs triggered by '${{ github.event_name }}' event"
+          echo "reference (input): ${{ github.event.inputs.ref }}"
+          echo "upload archives (input): ${{ github.event.inputs.publish_release }}"
+          echo "tag name (release): ${{ github.event.release.tag_name }}"
+
       - name: Checkout repository with submodules
         uses: actions/checkout@v7
         with:

--- a/.github/workflows/create-release-assets.yaml
+++ b/.github/workflows/create-release-assets.yaml
@@ -77,7 +77,6 @@ jobs:
           gh api \
             repos/${{ github.repository }}/releases/tags/$tag \
             --silent \
-            --exit-status \
             >/dev/null || {
               echo "::error::No release exists for tag '$tag'."
               exit 1


### PR DESCRIPTION
I didn't think about the option to tag a release in my fork of this repository to be able to test the new workflow there first.
Now that I did that, I found a few more issues with the current workflow.

With the proposed changes, I was able to have the workflow upload the created tarballs to a test release that I created before:
https://github.com/mmuetzel/elmerfem/releases/tag/test-release-1
The corresponding workflow run:
https://github.com/mmuetzel/elmerfem/actions/runs/30338385559

I then created a new test release:
https://github.com/mmuetzel/elmerfem/releases/tag/test-release-2
Publishing triggered the workflow automatically:
https://github.com/mmuetzel/elmerfem/actions/runs/30339172629
And the created tarballs appeared as assets for that release when the run completed.

I hope that will also work in this repository.