### PR TITLE
Check out the repository at the given reference for tarball creation

### DIFF
--- a/.github/workflows/create-release-assets.yaml
+++ b/.github/workflows/create-release-assets.yaml
@@ -35,6 +35,7 @@ jobs:
       - name: Checkout repository with submodules
         uses: actions/checkout@v7
         with:
+          ref: ${{ github.event.inputs.ref || github.event.release.tag_name }}
           submodules: recursive
           fetch-depth: 0
 


### PR DESCRIPTION
I forgot to include the reference in the step that checks out the repository. That means that the action always created tarballs for the current head of the default branch. They just had a different name.

To fix that, actually use the given reference when checking out the repository.

I'm sorry for that oversight.
