### PR TITLE
SaveScalars: Do not assume frequency unit

### DIFF
--- a/fem/src/modules/SaveData/SaveScalars.F90
+++ b/fem/src/modules/SaveData/SaveScalars.F90
@@ -974,7 +974,7 @@ SUBROUTINE SaveScalars( Model,Solver,dt,TransientSimulation )
           END IF 
 
           IF ( SaveEigenFreq ) THEN
-            WRITE( Name, '("eigen: frequency ", I0, " [Hz]")' ) k
+            WRITE( Name, '("eigen: frequency ", I0)' ) k
             IF ( Val >= 0.0 ) THEN
               Val = SQRT(Val) / (2*PI)
             ELSE


### PR DESCRIPTION
Do not assume that the unit of frequency is Hertz