### PR TITLE
Double-quote all arguments in compiler/linker wrappers on Windows.

### DIFF
--- a/fem/src/elmerf90-helper.in.h
+++ b/fem/src/elmerf90-helper.in.h
@@ -58,7 +58,17 @@ static void push(const char *s)
         fprintf(stderr, "elmerf90: too many arguments\n");
         exit(1);
     }
+
+#if defined (_WIN32)
+    // The spawn* functions on Windows require that their arguments are
+    // surrounded by double-quotes (to deal with spaces in arguments).
+    // See: https://learn.microsoft.com/en-us/cpp/c-runtime-library/spawn-wspawn-functions?view=msvc-170
+    args[nargs] = malloc(strlen(s) + 3);
+    sprintf(args[nargs], "\"%s\"", s);
+    nargs++;
+#else
     args[nargs++] = strdup(s);
+#endif
 }
 
 /* Split a whitespace-separated flag string and push each token. */

--- a/fem/src/elmerf90.c
+++ b/fem/src/elmerf90.c
@@ -142,7 +142,12 @@ int main(int argc, char *argv[])
 
     /* Print the command (matches shell script behaviour) */
     for (int i = 0; i < nargs; i++)
+#if defined (_WIN32)
+        /* The argument list is already double-quoted for Windows. */
+        printf("%s ", args[i]);
+#else
         printf("\"%s\" ", args[i]);
+#endif
     printf("\n");
 
     return exec_compiler(fc, "elmerf90");

--- a/fem/src/elmerld.c
+++ b/fem/src/elmerld.c
@@ -84,10 +84,13 @@ int main(int argc, char *argv[])
 
     /* Print the command (matches shell script behaviour) */
     for (int i = 0; i < nargs; i++)
+#if defined (_WIN32)
+        /* The argument list is already double-quoted for Windows. */
+        printf("%s ", args[i]);
+#else
         printf("\"%s\" ", args[i]);
+#endif
     printf("\n");
 
-    execvp(fc, args);
-    perror("elmerld: exec");
-    return 127;
+    exec_compiler(fc, "elmerld");
 }


### PR DESCRIPTION
Apparently, Windows doesn't know how to deal with arguments in `args` vectors out of the box if they contain spaces.
That quirk is documented behavior:
https://learn.microsoft.com/en-us/cpp/c-runtime-library/spawn-wspawn-functions?view=msvc-170

Manually surround all arguments with double-quotes on Windows to deal with that quirk.

Do not add an additional set of double quotes when echoing the command in the wrappers on Windows.

Additionally, use the `exec_compiler` function that deals - among other things - with these platform specific quirks also in the `elmerld` wrapper.