### PR TITLE
Cast argv to the CRT's declared type in the Windows compiler/linker wrappers

### DIFF
--- a/fem/src/elmerf90-helper.in.h
+++ b/fem/src/elmerf90-helper.in.h
@@ -143,7 +143,12 @@ static int exec_compiler(const char *fc, const char *who)
 
 #if defined (_WIN32)
     /* Spawn new process and wait for its exit code on Windows. */
-    int status = _spawnvp(P_WAIT, fc, args);
+    /* _spawnvp wants argv as 'const char *const *'; our argv is built
+       as 'char **', and the mismatch warning is elevated to an error
+       by default with GCC 14 or later. Cast at the call site rather
+       than changing argv's type, since push()/args are shared with
+       other array/string logic. */
+    int status = _spawnvp(P_WAIT, fc, (const char * const *)args);
     if (status == -1) {
         int first_errno = errno;
 
@@ -158,7 +163,7 @@ static int exec_compiler(const char *fc, const char *who)
 
             free(args[0]);
             args[0] = strdup(base);
-            status = _spawnvp(P_WAIT, base, args);
+            status = _spawnvp(P_WAIT, base, (const char * const *)args);
             if (status == -1)
                 fprintf(stderr,
                         "%s: could not exec build-time compiler '%s' (%s), "

--- a/fem/src/elmerf90-helper.in.h
+++ b/fem/src/elmerf90-helper.in.h
@@ -4,12 +4,7 @@
  */
 
 #ifdef _WIN32
-#  include <process.h>   /* _execvp */
-   /* _execvp wants argv as 'const char *const *'; our argv is built as
-      'char **', which POSIX execvp() accepts directly but _execvp() does
-      not. Cast explicitly at the call site rather than changing argv's
-      type, since push()/args are shared with other array/string logic. */
-#  define execvp(prog, argv) _execvp((prog), (const char * const *)(argv))
+#  include <process.h>   /* _spawnvp */
 #else
 #  include <unistd.h>    /* execvp */
 #endif


### PR DESCRIPTION
Fixes #866.

`process.h` declares `_spawnvp`'s argv parameter as `const char *const *`, while the wrapper helper builds `args` as `char **`. The `-Wincompatible-pointer-types` warning is elevated to an error by default with GCC 14 or later, so building the wrappers fails on MSYS2 UCRT64 unless the diagnostic is downgraded — which is how CI currently avoids it (`-DCMAKE_C_FLAGS="-Wno-error=incompatible-pointer-types"`, added for Zoltan).

Two commits:

1. Apply the same cast the header's `execvp()` shim used, at both `_spawnvp` call sites. One change covers `elmerf90` and `elmerld`, since both include the helper. No runtime behaviour change — the CRT never writes through argv.
2. Drop the now-unused Windows `execvp` shim (the Windows branch calls `_spawnvp` directly; only the POSIX branch calls `execvp`), keeping `<process.h>` for `_spawnvp`.

Verified on MSYS2 UCRT64 (gcc 16.2.0, mingw-w64 headers 14.0.0.r262): the patched call shape compiles clean with `-Werror=incompatible-pointer-types` forced, at `-std=gnu11`, `gnu17` and `gnu23`.
