### PR TITLE
Set Mesh % SingleMesh after AllocateMesh() in LoadMesh2()

### DIFF
--- a/fem/src/MeshLoad.F90
+++ b/fem/src/MeshLoad.F90
@@ -106,6 +106,7 @@ CONTAINS
    END IF
 
    Mesh => AllocateMesh()
+   Mesh % SingleMesh = (.NOT. Parallel) .AND. (ParEnv % PEs > 1)
 
    ! Get sizes of mesh structures for allocation
    !--------------------------------------------------------------------


### PR DESCRIPTION
Fix for **https://github.com/marco-celoria/ElmerIceEnergy/blob/main/scripts/Leonardo_most_recent/run_Elmer_leonardo_N1_n4_c8_ML3_most_recent_39212184.err**

more info: **https://github.com/marco-celoria/ElmerIceEnergy#segmentation-fault-with-elmerfem-most-recent-commit**


If ntasks > 1, in sif we set Mesh = -single "$MESH$", then PrintMeshSize segfaults in MeshIO.F90 because Mesh % SingleMesh is False (its set only after LoadMesh2 finishes, but PrintMeshSize is called inside LoadMesh2). Bug only appears if max output level >= 20.

Fix: set Mesh % SingleMesh after allocating the mesh 