### PR TITLE
ElmerGUI: Adjust starting processes with Qt6

### DIFF
--- a/ElmerGUI/Application/src/mainwindow.cpp
+++ b/ElmerGUI/Application/src/mainwindow.cpp
@@ -48,6 +48,7 @@
 #include <QStringList>
 #include <QSystemTrayIcon>
 #include <QTimeLine>
+#include <QtGlobal>  /* for QT_VERSION_CHECK with Qt4 or Qt5 */
 #include <QtGui>
 
 #include <fstream>
@@ -5106,7 +5107,11 @@ void MainWindow::showVtkPostSlot() {
 
     logMessage("Executing: " + unifyingCommand);
 
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+    meshUnifier->startCommand(unifyingCommand);
+#else
     meshUnifier->start(unifyingCommand);
+#endif
 
     if (!meshUnifier->waitForStarted()) {
       solverLogWindow->getTextEdit()->append(
@@ -6638,7 +6643,11 @@ void MainWindow::runsolverSlot() {
 
       logMessage("Executing: " + partitioningCommand);
 
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+      meshSplitter->startCommand(partitioningCommand);
+#else
       meshSplitter->start(partitioningCommand);
+#endif
 
       if (!meshSplitter->waitForStarted()) {
         logMessage("Unable to start ElmerGrid for mesh partitioning - aborted");
@@ -6696,7 +6705,7 @@ void MainWindow::meshSplitterFinishedSlot(int exitCode) {
   int nofProcessors = ui.nofProcessorsSpinBox->value();
 
   QString parallelExec = ui.parallelExecLineEdit->text().trimmed();
-#ifdef WIN32
+#if defined (_WIN32)
   parallelExec = "\"" + parallelExec + "\"";
 #endif
 
@@ -6707,7 +6716,11 @@ void MainWindow::meshSplitterFinishedSlot(int exitCode) {
 
   logMessage("Executing: " + parallelCmd);
 
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+  solver->startCommand(parallelCmd);
+#else
   solver->start(parallelCmd);
+#endif
   killsolverAct->setEnabled(true);
 
   if (!solver->waitForStarted()) {
@@ -7075,7 +7088,11 @@ void MainWindow::resultsSlot() {
 
     logMessage("Executing: " + unifyingCommand);
 
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+    meshUnifier->startCommand(unifyingCommand);
+#else
     meshUnifier->start(unifyingCommand);
+#endif
 
     if (!meshUnifier->waitForStarted()) {
       solverLogWindow->getTextEdit()->append(

--- a/ElmerGUI/Application/src/mainwindow.cpp
+++ b/ElmerGUI/Application/src/mainwindow.cpp
@@ -7229,19 +7229,14 @@ void MainWindow::compileSolverSlot() {
     return;
   }
 
+#ifdef _WIN32
+  QString compilerWrapper(QString(qgetenv("ELMER_HOME")) + "\\bin\\elmerf90.exe");
   QStringList args;
-#ifdef WIN32
-  args << "/C";
-  args << "" + QString(qgetenv("ELMER_HOME")) + "\\bin\\elmerf90.bat";
-  QString dllFileName;
-  dllFileName = fileName.left(fileName.lastIndexOf(".")) + ".dll";
   args << "-o";
-  args << dllFileName;
-#endif
+  args << fileName.left(fileName.lastIndexOf(".")) + ".dll";
   args << fileName;
 
-#ifdef WIN32
-  compiler->start("cmd.exe", args);
+  compiler->start(compilerWrapper, args);
 #else
   logMessage("Run->compiler is currently not implemented on this platform");
   return;

--- a/ElmerGUI/Application/src/parallel.cpp
+++ b/ElmerGUI/Application/src/parallel.cpp
@@ -90,7 +90,7 @@ void Parallel::defaultsButtonClicked()
   ui.nofProcessorsSpinBox->setValue(2);
   
 #ifdef WIN32
-  ui.parallelExecLineEdit->setText("mpiexec.exe");
+  ui.parallelExecLineEdit->setText("C:/Program Files/Microsoft MPI/Bin/mpiexec.exe");
   ui.parallelArgsLineEdit->setText("-n %n ElmerSolver_mpi.exe");
 #else
   ui.parallelExecLineEdit->setText("mpirun");


### PR DESCRIPTION
Windows seems to be particular picky when it comes to quotation rules for processes started with `QProcess`.
In particular, it refuses to run an executable if it isn't double-quoted. See: https://www.elmerfem.org/forum/viewtopic.php?p=33284#p33284

I'm suspecting that other platforms don't care as much about that. Additional double-quotes shouldn't hurt there - I guess. But it might make sense if someone could double-check that before merging this.

While at it, I also changed the default value for mpiexec that is used in the GUI on Windows to include the full path for the default installation location of it. That should avoid the need to manually add that path to the environment variable `PATH` and should make it work "out of the box" for the vast majority of GUI users on Windows. (That's by my personal estimate. I don't have any statistics to substantiate that claim. But from my experience, most Windows users just click "Next", "Next", "Next", ... in installers without caring too much what could be changed.)
Please, let me know if you prefer to keep the current setting. I don't have strong feelings either way about that part.
