### PR TITLE
Report real CPU time and memory on Windows

### DIFF
--- a/fem/src/CPUTime.c
+++ b/fem/src/CPUTime.c
@@ -43,7 +43,9 @@
 #if defined(MINGW32) || defined(WIN32) 
 
 #include <sys/types.h>
-#include <time.h> 
+#include <time.h>
+#include <windows.h>
+#include <psapi.h>
 
 double STDCALLBULL FC_FUNC(realtime,REALTIME) ( )
 {
@@ -52,12 +54,39 @@ double STDCALLBULL FC_FUNC(realtime,REALTIME) ( )
 
 double STDCALLBULL FC_FUNC(cputime,CPUTIME) ( )
 {
-  return clock() / (double)CLOCKS_PER_SEC;
+  /* User CPU time consumed by this process, summed over all its threads --
+     the analogue of getrusage(RUSAGE_SELF).ru_utime used by the POSIX branch
+     below.
+
+     clock() must not be used here.  On Windows it measures elapsed wall time
+     rather than consumed CPU time, so it returns the same value as realtime()
+     above, and every (CPU,REAL) pair Elmer prints becomes two copies of the
+     same number.  That makes a threaded run indistinguishable from a serial
+     one in the solver's own output. */
+  FILETIME created, exited, kernel, user;
+  ULARGE_INTEGER t;
+
+  if ( !GetProcessTimes( GetCurrentProcess(), &created, &exited, &kernel, &user ) )
+    return 0.0;
+
+  t.LowPart  = user.dwLowDateTime;
+  t.HighPart = user.dwHighDateTime;
+
+  /* FILETIME counts 100-nanosecond intervals. */
+  return (double)t.QuadPart * 1.0e-7;
 }
 
 double STDCALLBULL  FC_FUNC(cpumemory,CPUMEMORY) ( )
 {
-  return 0.0;
+  /* Peak working set, the analogue of getrusage(RUSAGE_SELF).ru_maxrss.
+     ru_maxrss is reported in kilobytes, so scale to match: the callers of
+     this function compare the two platforms' numbers. */
+  PROCESS_MEMORY_COUNTERS pmc;
+
+  if ( !GetProcessMemoryInfo( GetCurrentProcess(), &pmc, sizeof(pmc) ) )
+    return 0.0;
+
+  return (double)pmc.PeakWorkingSetSize / 1024.0;
 }
 
 #else


### PR DESCRIPTION
Fixes #887.

On Windows, `cputime()` and `realtime()` in `fem/src/CPUTime.c` had identical bodies — both `clock()/CLOCKS_PER_SEC` — and `cpumemory()` returned a hard-coded `0.0`. Because `clock()` measures elapsed wall time on Windows rather than consumed CPU time, every `(CPU,REAL)` pair Elmer prints contained the same number twice, so a threaded run was indistinguishable from a serial one in the solver's own output. The POSIX branch below already distinguishes them via `getrusage(RUSAGE_SELF)`.

## The change

| | before | after |
|---|---|---|
| `cputime()` | `clock()` — wall time | `GetProcessTimes()` user time, the analogue of `ru_utime`, summed across threads |
| `cpumemory()` | `0.0` | `GetProcessMemoryInfo()` `PeakWorkingSetSize`, the analogue of `ru_maxrss`, in kilobytes |
| `realtime()` | `clock()` | unchanged — already wall time here |

`cpumemory()` is scaled to kilobytes deliberately, to match both `ru_maxrss` and the `"maximum memory usage (kb)"` label `SaveScalars` prints.

**No build change is needed.** On MinGW-w64 the `psapi.h` declaration resolves to `K32GetProcessMemoryInfo` in `kernel32`, which is already linked — I checked this by building rather than assuming, since the alternative would have meant touching the Windows link line.

## Verification

Through `SaveScalars` (`Operator = cpu time / wall time / cpu memory`), same input, same mesh, 112k nodes / 547k tets:

```
before   cpu 10.727 s   real 10.727 s   memory      0 kb
after    cpu 11.375 s   real 11.592 s   memory 373404 kb
```

And the solver banner now tracks threading, where before it read 1.00 at every thread count while wall time fell 4.5×:

| `OMP_NUM_THREADS` | CPU/REAL after the fix |
|---|---|
| 1 | 0.99 |
| 4 | 2.15 |
| 16 | 3.45 |

That matches what Linux already reported for the same case — 1.00 serial, 2.61 at 4 threads — including the important half, that it reads ~1.0 when the run genuinely *is* serial rather than simply always exceeding 1.

`ctest` on MSYS2 UCRT64 with `WITH_OpenMP=TRUE`: **909/912**. The three failures — `EM_port_eigen_3D_prisms`, `JouleHeatToOpenFOAM`, `TemperatureFromOpenFOAM` — are identical to the pre-change baseline on the same machine and are unrelated to this change, which touches no numerics.

## Note

`GetProcessTimes` returns user time only, matching `ru_utime`. Kernel time is available as a separate `FILETIME` if you would rather the two platforms both reported user+system; I kept the narrower definition so the Windows and POSIX numbers mean the same thing. Happy to change it either way.
