### PR TITLE
elmergrid: allow configuring as a standalone CMake project

### DIFF
--- a/elmergrid/CMakeLists.txt
+++ b/elmergrid/CMakeLists.txt
@@ -1,3 +1,37 @@
+# ElmerGrid is configured either as part of the Elmer build, where the top
+# level project supplies the version information, or on its own directly out
+# of this directory.  The block below runs only in the standalone case, so the
+# in-tree build is unaffected.
+#
+# Standalone build:
+#   cmake -S elmergrid -B build-elmergrid && cmake --build build-elmergrid
+IF(CMAKE_SOURCE_DIR STREQUAL CMAKE_CURRENT_SOURCE_DIR)
+  CMAKE_MINIMUM_REQUIRED(VERSION 3.12)
+  PROJECT(ElmerGrid C)
+
+  IF(NOT CMAKE_BUILD_TYPE)
+    SET(CMAKE_BUILD_TYPE "Release" CACHE STRING "Build type" FORCE)
+  ENDIF()
+
+  # The Elmer top level build sets these, and the sources depend on them:
+  # egparallel.c, egnative.c and egextra.c select the one argument form of
+  # mkdir() under MINGW32.  Without the definition the build fails to compile
+  # on a mingw toolchain.  Mirrors CMakeLists.txt in the Elmer root.
+  IF(MINGW)
+    ADD_DEFINITIONS(-DMINGW32)
+  ENDIF()
+  IF(WIN32)
+    ADD_DEFINITIONS(-DWIN32)
+  ENDIF()
+
+  # config.h.cmake normally picks these up from the Elmer top level build.
+  # Only ELMER_FEM_VERSION is set here: fempre.c already handles the case
+  # where the branch is unknown, and prints "Rev: NA, Compiled: NA" then.
+  IF(NOT DEFINED ELMER_FEM_VERSION)
+    SET(ELMER_FEM_VERSION "standalone")
+  ENDIF()
+ENDIF()
+
 CONFIGURE_FILE(config.h.cmake config.h)
 
 ADD_SUBDIRECTORY(src)

--- a/elmergrid/src/CMakeLists.txt
+++ b/elmergrid/src/CMakeLists.txt
@@ -32,14 +32,18 @@ ELSE()
   ADD_SUBDIRECTORY(metis-5.1.0)
 
   # add metis as system include directory
+  # CMAKE_CURRENT_SOURCE_DIR is this directory in both the in-tree and the
+  # standalone build.  The CMAKE_SOURCE_DIR/elmergrid/src spelling that used to
+  # be listed here named the same directory when Elmer is the top level project
+  # and a nonexistent one otherwise.
   TARGET_INCLUDE_DIRECTORIES(ElmerGrid SYSTEM BEFORE PRIVATE
-    ${CMAKE_CURRENT_SOURCE_DIR}/metis-5.1.0/include
-    ${CMAKE_SOURCE_DIR}/elmergrid/src/metis-5.1.0/include)
+    ${CMAKE_CURRENT_SOURCE_DIR}/metis-5.1.0/include)
 ENDIF()
 
+# config.h is generated into the elmergrid binary directory and reached as
+# "../config.h" from the sources here, so this directory is what is needed.
 TARGET_INCLUDE_DIRECTORIES(ElmerGrid PRIVATE
-  ${CMAKE_CURRENT_BINARY_DIR}
-  ${CMAKE_BINARY_DIR}/elmergrid/src)
+  ${CMAKE_CURRENT_BINARY_DIR})
 
 TARGET_COMPILE_DEFINITIONS(ElmerGrid PRIVATE DISABLE_MATC)
 


### PR DESCRIPTION
Closes #891.

`cmake -S elmergrid -B build` does not work at `4f2d7e4b9`, although `ReleaseNotes/release_8.3.txt:270` lists standalone compilation of ElmerGrid as supported. This makes it work. The evidence for each item is in #891.

## What changed

`elmergrid/CMakeLists.txt` — a standalone block guarded on `CMAKE_SOURCE_DIR STREQUAL CMAKE_CURRENT_SOURCE_DIR`, supplying:

- `CMAKE_MINIMUM_REQUIRED(VERSION 3.12)` (matching the Elmer root) and `PROJECT(ElmerGrid C)`
- `-DMINGW32` / `-DWIN32`, mirroring `CMakeLists.txt:724-731`. Without `MINGW32`, `egparallel.c`, `egnative.c` and `egextra.c` take the two-argument `mkdir()` and a mingw build fails to compile.
- a default `ELMER_FEM_VERSION`. Only that one is needed: `fempre.c:84-93` already handles an unknown branch and prints `Rev: NA, Compiled: NA`.
- a default `CMAKE_BUILD_TYPE` of `Release`

`elmergrid/src/CMakeLists.txt` — drops `${CMAKE_SOURCE_DIR}/elmergrid/src/metis-5.1.0/include` and `${CMAKE_BINARY_DIR}/elmergrid/src`. Each sat next to the `CMAKE_CURRENT_SOURCE_DIR` / `CMAKE_CURRENT_BINARY_DIR` entry naming the same directory when Elmer is the top level project, and named a nonexistent directory otherwise.

Net `+30 / −7`. No source file is touched, and there is no change to what the in-tree build compiles or links.

## Behaviour in the existing build

None. The guard is false whenever `elmergrid` is reached through `ADD_SUBDIRECTORY`, so the added block does not execute, and the two removed include paths were duplicates of entries that remain.

## What I verified

MSYS2 UCRT64, gcc 15.2.0, CMake with Ninja, Windows 11.

**Standalone** — `cmake -S elmergrid -B build-eg-standalone -G Ninja` configures, builds 71/71, links `ElmerGrid.exe`, and the binary runs:

```
ElmerGrid mesh conversion and manipulation utility, Welcome!
Version: standalone (Rev: NA, Compiled: NA)
```

**As a subdirectory** — configured from a small parent project that supplies what the Elmer root supplies (`-DMINGW32`, `-DWIN32`, the four `ELMER_FEM_*` variables, `ELMERSOLVER_RPATH_STRING`) and does `ADD_SUBDIRECTORY(elmergrid)`. Builds 71/71 and the binary reports the parent's values:

```
Version: 9.0-intree-check-devel (Rev: deadbeef, Compiled: 2026-08-30)
```

The two version strings differ, which is the point of running both: it shows the guard is false in the subdirectory case rather than merely that both happen to compile.

Before adding the `MINGW32` definition, the standalone build failed at `egparallel.c:3964`, `egnative.c:5531` and `egextra.c:969` with `too many arguments to function 'mkdir'`, so that part of the change is load-bearing rather than defensive.

## What I could not verify

- **Not a full Elmer build, and no `ctest`.** The subdirectory check above is a stand-in for the Elmer root, not the Elmer root itself; it exercises the interface `elmergrid/` actually uses but does not prove the complete build is unaffected. CI covers that.
- **Only mingw-w64 on Windows.** Not built with MSVC, nor on Linux or macOS. The `MINGW32` point is mingw-specific by nature; the rest is platform independent, but I have not shown it elsewhere.

This is also the smallest concrete step toward #202. Happy to reshape it if you would rather the standalone support were expressed differently.
