### PR TITLE
ci: build without VtkPost on macos-15-intel (no Homebrew Intel bottle for vtk)

### DIFF
--- a/.github/workflows/build-macos-homebrew.yaml
+++ b/.github/workflows/build-macos-homebrew.yaml
@@ -27,9 +27,17 @@ jobs:
       matrix:
         os: [macos-14]
         blas: [openblas, accelerate]
+        # Homebrew publishes no Intel macOS bottle for vtk: as of vtk 9.7.0 the
+        # bottles are arm64_tahoe, arm64_sequoia, arm64_sonoma, arm64_linux and
+        # x86_64_linux only. "brew install vtk" therefore fails on
+        # macos-15-intel with "vtk: no bottle available!", which fails the whole
+        # dependency step. Building it from source would dominate the job, so
+        # the Intel runner builds without VtkPost instead.
+        vtk: [true]
         include:
           - os: macos-15-intel
             blas: openblas
+            vtk: false
 
     steps:
       - name: get CPU information
@@ -60,7 +68,7 @@ jobs:
             ${{ matrix.blas == 'accelerate' && 'veclibfort' || '' }} \
             open-mpi \
             libomp suitesparse \
-            qwt vtk opencascade expat
+            qwt ${{ matrix.vtk && 'vtk' || '' }} opencascade expat
           echo "HOMEBREW_PREFIX=$(brew --prefix)" >> $GITHUB_ENV
 
       - name: configure
@@ -104,7 +112,7 @@ jobs:
             -DWITH_ELMERGUI=ON \
             -DWITH_QT6=ON \
             -DQWT_INCLUDE_DIR="${HOMEBREW_PREFIX}/opt/qwt/lib/qwt.framework/Headers" \
-            -DWITH_VTK=ON \
+            -DWITH_VTK=${{ matrix.vtk && 'ON' || 'OFF' }} \
             -DEXPAT_INCLUDE_DIR="${HOMEBREW_PREFIX}/opt/expat/include" \
             -DWITH_OCC=ON \
             -DWITH_MATC=ON \

--- a/.github/workflows/build-macos-homebrew.yaml
+++ b/.github/workflows/build-macos-homebrew.yaml
@@ -33,6 +33,11 @@ jobs:
         # macos-15-intel with "vtk: no bottle available!", which fails the whole
         # dependency step. Building it from source would dominate the job, so
         # the Intel runner builds without VtkPost instead.
+        #
+        # This also switches WITH_OCC off, because ElmerGUI/CMakeLists.txt:111
+        # sets WITH_VTK back to TRUE whenever WITH_OCC is on, which makes
+        # FIND_PACKAGE(VTK REQUIRED) at :145 fail even with -DWITH_VTK=OFF.
+        # See #895; if that is changed, the Intel runner can keep OpenCASCADE.
         vtk: [true]
         include:
           - os: macos-15-intel
@@ -114,7 +119,7 @@ jobs:
             -DQWT_INCLUDE_DIR="${HOMEBREW_PREFIX}/opt/qwt/lib/qwt.framework/Headers" \
             -DWITH_VTK=${{ matrix.vtk && 'ON' || 'OFF' }} \
             -DEXPAT_INCLUDE_DIR="${HOMEBREW_PREFIX}/opt/expat/include" \
-            -DWITH_OCC=ON \
+            -DWITH_OCC=${{ matrix.vtk && 'ON' || 'OFF' }} \
             -DWITH_MATC=ON \
             -DWITH_PARAVIEW=ON \
             -DCREATE_PKGCONFIG_FILE=ON \


### PR DESCRIPTION
Closes #893.

The `macos-15-intel` leg of `build-macos-homebrew` currently fails in `install dependencies` on every branch, with:

```
##[error]vtk: no bottle available!
```

Homebrew publishes no Intel macOS bottle for vtk. As of vtk `9.7.0` the bottle tags are `arm64_tahoe`, `arm64_sequoia`, `arm64_sonoma`, `arm64_linux` and `x86_64_linux` — no Intel macOS tag of any kind. The step runs under `bash -e`, so the failed `brew install` aborts it before anything is configured or compiled. The arm64 `macos-14` legs are unaffected because `arm64_sonoma` exists.

## What changed

`vtk` becomes a matrix property, `true` by default and `false` for the Intel runner, driving three places:

- the `brew install` list, via `${{ matrix.vtk && 'vtk' || '' }}`
- `-DWITH_VTK=${{ matrix.vtk && 'ON' || 'OFF' }}`
- `-DWITH_OCC=${{ matrix.vtk && 'ON' || 'OFF' }}`

**On OCC:** disabling VTK alone was not enough, and the first push of this branch proved it — the Intel leg got past `install dependencies` and then failed at `configure`. `ElmerGUI/CMakeLists.txt:111` does `SET(WITH_VTK TRUE)` unconditionally whenever `WITH_OCC` is on, which overrides `-DWITH_VTK=OFF` and lets `FIND_PACKAGE(VTK REQUIRED)` at `:145` run anyway. Filed separately as #895, since fixing it changes what an OpenCASCADE build requires for everyone and is a decision for you rather than something to slip into a CI patch. If #895 is resolved, the `WITH_OCC` half of this change can be reverted and the Intel leg can keep OpenCASCADE.

The two arm64 legs are unchanged and keep building both VtkPost and OpenCASCADE. The Intel leg now gets through dependency install and configure, and exercises the rest of the build — solver, ElmerIce, ElmerGUI with Qt6 and Qwt, MATC, the test suite — instead of dying at `brew install`.

`WITH_VTK` already defaults to `FALSE` in `ElmerGUI/CMakeLists.txt:15`, and `:108-109` sets `WITHOUT_VTKPOST` from it, so VtkPost-less is a configuration the build already supports rather than a new one.

## The trade, and the alternatives

This gives up VtkPost and OpenCASCADE coverage on Intel. I picked it because the alternatives seemed worse, but both are one line away and this is your call:

- `brew install --build-from-source vtk` keeps the coverage but builds VTK on every Intel run, which would dominate the job.
- Dropping the `macos-15-intel` leg entirely loses much more than VtkPost.

Happy to switch to either.

## What I verified

- The workflow file parses, and the matrix expands as intended: `macos-14` × {openblas, accelerate} with `vtk: True`, plus `macos-15-intel` / openblas with `vtk: False`.
- The bottle claim is from `https://formulae.brew.sh/api/formula/vtk.json`, not from the failure log alone.
- That the failure is pre-existing and branch-independent: same job, same step, on `fix/permafrost-hydraulic-reference-state` (run `33298600360`, 07:10 today) and `interfrost-devel` (run `33270077286`, yesterday). Last green runs of this workflow were 2026-08-28.

## What I could not verify

**I have no macOS machine, Intel or otherwise**, so I cannot run this job locally. The CI on this PR is the test, and it has already earned its keep: the first push fixed the dependency install and immediately exposed the `WITH_OCC` problem above, which I had not predicted from reading the CMake.

The Intel leg has not completed a build since 2026-08-28, so **there may be further Intel-specific breakage behind this configure failure too**. I will keep following this run rather than assume the second push is the last one needed.
