### PR TITLE
CI (macos): Switch to newer versions of macOS on Apple Silicon.

### DIFF
--- a/.github/workflows/build-macos-homebrew.yaml
+++ b/.github/workflows/build-macos-homebrew.yaml
@@ -25,24 +25,11 @@ jobs:
       fail-fast: false
 
       matrix:
-        os: [macos-14]
+        os: [macos-26]
         blas: [openblas, accelerate]
-        # Homebrew publishes no Intel macOS bottle for vtk: as of vtk 9.7.0 the
-        # bottles are arm64_tahoe, arm64_sequoia, arm64_sonoma, arm64_linux and
-        # x86_64_linux only. "brew install vtk" therefore fails on
-        # macos-15-intel with "vtk: no bottle available!", which fails the whole
-        # dependency step. Building it from source would dominate the job, so
-        # the Intel runner builds without VtkPost instead.
-        #
-        # This also switches WITH_OCC off, because ElmerGUI/CMakeLists.txt:111
-        # sets WITH_VTK back to TRUE whenever WITH_OCC is on, which makes
-        # FIND_PACKAGE(VTK REQUIRED) at :145 fail even with -DWITH_VTK=OFF.
-        # See #895; if that is changed, the Intel runner can keep OpenCASCADE.
-        vtk: [true]
         include:
-          - os: macos-15-intel
+          - os: macos-15
             blas: openblas
-            vtk: false
 
     steps:
       - name: get CPU information
@@ -73,7 +60,7 @@ jobs:
             ${{ matrix.blas == 'accelerate' && 'veclibfort' || '' }} \
             open-mpi \
             libomp suitesparse \
-            qwt ${{ matrix.vtk && 'vtk' || '' }} opencascade expat
+            qwt vtk opencascade expat
           echo "HOMEBREW_PREFIX=$(brew --prefix)" >> $GITHUB_ENV
 
       - name: configure
@@ -117,9 +104,9 @@ jobs:
             -DWITH_ELMERGUI=ON \
             -DWITH_QT6=ON \
             -DQWT_INCLUDE_DIR="${HOMEBREW_PREFIX}/opt/qwt/lib/qwt.framework/Headers" \
-            -DWITH_VTK=${{ matrix.vtk && 'ON' || 'OFF' }} \
+            -DWITH_VTK=ON \
             -DEXPAT_INCLUDE_DIR="${HOMEBREW_PREFIX}/opt/expat/include" \
-            -DWITH_OCC=${{ matrix.vtk && 'ON' || 'OFF' }} \
+            -DWITH_OCC=ON \
             -DWITH_MATC=ON \
             -DWITH_PARAVIEW=ON \
             -DCREATE_PKGCONFIG_FILE=ON \


### PR DESCRIPTION
Homebrew started (early?) to move support for Intel processors to their "Tier 3".
See: https://docs.brew.sh/Support-Tiers#future-macos-support
The `vtk` package is already no longer available as a binary package for macOS 15 on Intel.

Move the corresponding workflow matrix element to Apple Silicon runners. Also move the remaining workflow matrix elements to an image with a newer version of macOS.

More and more packages for Intel hardware are likely to disappear from Homebrew. So, I think this is a better alternative in the long run to #894.