### PR TITLE
elmergrid: add an option to build ElmerGrid with MATC

### DIFF
--- a/elmergrid/src/CMakeLists.txt
+++ b/elmergrid/src/CMakeLists.txt
@@ -41,7 +41,38 @@ TARGET_INCLUDE_DIRECTORIES(ElmerGrid PRIVATE
   ${CMAKE_CURRENT_BINARY_DIR}
   ${CMAKE_BINARY_DIR}/elmergrid/src)
 
-TARGET_COMPILE_DEFINITIONS(ElmerGrid PRIVATE DISABLE_MATC)
+# ---------------------------------------------------------------------------
+# MATC in ElmerGrid
+#
+# ElmerGrid can evaluate MATC expressions in .grd files: egnative.c calls
+# mtc_domath() and mtc_init() under "#if USE_MATC", and egdef.h derives
+# USE_MATC from DISABLE_MATC.  Defining DISABLE_MATC unconditionally, as this
+# file used to, made that unreachable and left no way to ask for it.
+#
+# The option is OFF by default, so nothing changes unless it is asked for.
+# Enabling it needs the matc library, which the Elmer build provides:
+# ADD_SUBDIRECTORY(matc) in the top level CMakeLists.txt is unconditional and
+# runs before this directory.  The TARGET check keeps a standalone ElmerGrid
+# build working, where no such target exists and MATC simply stays off.
+#
+# No header is needed: egnative.c declares both functions itself.
+#
+# See ElmerCSC/elmerfem#899 for what enabling this is ultimately for.
+# ---------------------------------------------------------------------------
+OPTION(ELMERGRID_WITH_MATC "Build ElmerGrid with MATC expression support" OFF)
+
+IF(ELMERGRID_WITH_MATC AND NOT TARGET matc)
+  MESSAGE(WARNING
+    "  [ElmerGrid] ELMERGRID_WITH_MATC is ON but no 'matc' target exists; "
+    "building without MATC.")
+ENDIF()
+
+IF(ELMERGRID_WITH_MATC AND TARGET matc)
+  MESSAGE(STATUS "  [ElmerGrid] MATC:                     ON")
+  TARGET_LINK_LIBRARIES(ElmerGrid PRIVATE matc)
+ELSE()
+  TARGET_COMPILE_DEFINITIONS(ElmerGrid PRIVATE DISABLE_MATC)
+ENDIF()
 
 TARGET_LINK_LIBRARIES(ElmerGrid PRIVATE metis m)
 IF(NOT(WIN32))


### PR DESCRIPTION
Towards #899, and following @richb2k's suggestion in #890 to do the CMake side separately.

This is the ElmerGrid half only, and it does not enable anything by default.

## The problem

ElmerGrid already contains MATC support. `elmergrid/src/egnative.c` calls `mtc_domath()` and `mtc_init()` under `#if USE_MATC`, and `egdef.h` derives `USE_MATC` from `DISABLE_MATC`. But `elmergrid/src/CMakeLists.txt` defined `DISABLE_MATC` unconditionally, so that code was unreachable and there was no way to ask for it. Feeding a `.grd` containing a `$` to a current build gets:

```
a $ found and MATC has not been compiled into ElmerGrid,
either remove the $ or compile ElmerGrid with MATC
```

with no supported way to do what the message suggests.

## What this adds

`ELMERGRID_WITH_MATC`, default `OFF`. When it is `ON`, ElmerGrid links `matc` instead of defining `DISABLE_MATC`.

`ADD_SUBDIRECTORY(matc)` at `CMakeLists.txt:770` is unconditional and runs before `elmergrid` at :828, so the target is always available in an in-tree build. The `TARGET matc` check keeps a standalone ElmerGrid build working: there the target does not exist, MATC stays off, and asking for it produces a warning rather than a configure failure.

No header is needed — `egnative.c` declares both functions itself, so this is only a link and a macro.

## Behaviour

None by default. `ELMERGRID_WITH_MATC` is `OFF`, `DISABLE_MATC` is still defined, and the build is bit for bit what it was.

## What I verified

Built `matc` and `elmergrid` from a small parent project supplying what the Elmer root supplies, with mingw-w64 gcc 15.2 and Ninja, then fed ElmerGrid a `.grd` containing a `$` line. The three states are distinguishable at runtime:

| build | output |
| --- | --- |
| default (`OFF`) | `a $ found and MATC has not been compiled into ElmerGrid` |
| `-DELMERGRID_WITH_MATC=ON` | `a $ found and MATC has been compiled but not activated` |
| `ON`, plus `MATC = True` in the `.grd` | `MATC language activated with 12 digit accuracy` |

Those first two come from the two arms of the same `#if USE_MATC`, so the option demonstrably reaches the compiled binary; the third shows `mtc_init()` running and the expression being accepted rather than rejected.

Configure also reports `[ElmerGrid] MATC: ON` when it is on.

## What this does not do

**It does not address the ElmerGUI half of #899.** ElmerGUI compiles the same sources with `EG_PLUGIN`, and `egdef.h` makes `EG_PLUGIN` force `USE_MATC 0` unconditionally, so MATC cannot reach ElmerGUI's `.grd` reading no matter what is passed. Whether `EG_PLUGIN` should stop implying that, or ElmerGUI should get its own switch, is a design decision I would rather leave to you and @raback than make in a pull request. Details are in my comment on #899.

**It does not enable MATC anywhere.** Per @richb2k's original wording, this is the CMake side working, with turning it on left as a separate step.

**Not built on Linux or macOS**, and no test exercises the `ON` path. The `OFF` default is what CI builds, and that is unchanged.
