### PR TITLE
PARPACK: Correctly detect if ARPACK-ng was built without PARPACK.

### DIFF
--- a/cmake/Modules/FindPARPACK.cmake
+++ b/cmake/Modules/FindPARPACK.cmake
@@ -23,7 +23,7 @@ IF(NOT PARPACK_FOUND)
   MESSAGE(STATUS "Finding parpack libraries")
   # Try to find with CMake config file of upstream parpack.
   FIND_PACKAGE(PARPACK CONFIG NAMES arpack arpackng arpack-ng parpack parpackng parpack-ng)
-  IF(PARPACK_FOUND)
+  IF(PARPACK_FOUND AND TARGET parpack)
     GET_TARGET_PROPERTY(PARPACK_INCLUDE_DIR parpack INTERFACE_INCLUDE_DIRECTORIES)
     # Most likely arpack and parpack are packed togeher (like in Arch linux)
     # or they share the same include directory even in splitted packages (parpack-dev depends on arpack-dev)


### PR DESCRIPTION
ARPACK-ng supports building the serial ARPACK library without the parallel PARPACK library.
In either case, it installs CMake config files that identify as "arpackng". Successfully including that package in a downstream project imports an import target with the name `arpack` (for the serial ARPACK library) and, *optionally*, an additional target with the name `parpack` (if it was configured to build the corresponding parallel PARPACK library).

See, e.g.:
https://github.com/opencollab/arpack-ng/blob/92f2e55d33580c0a4cb35fb6c25fd3376b800f80/cmake/arpackng-config.cmake.in#L38-L40

Elmer is (correctly) looking for that "arpackng" CMake config file. If it is found `PARPACK_FOUND` evaluates to a true value even if the `parpack` target was not actually imported.

Adjust the module to make sure that the `parpack` import target exists before attempting to gather properties of it.

This will still lead to an error if the PARPACK dependencies are required but they are not installed. But that error message will be clearer.