### PR TITLE
Improve support for `ELMER_LIB` in the compiler wrappers.

### DIFF
--- a/fem/src/elmerf90-helper.in.h
+++ b/fem/src/elmerf90-helper.in.h
@@ -126,6 +126,8 @@ static const char *base_name(const char *p)
  * built libelmersolver. Setting ELMER_Fortran_COMPILER remains the way to be
  * explicit.
  *
+ * Returns the error code of the spawned process on Windows.
+ * On other platforms:
  * Returns only on failure; on success the process has been replaced.
  */
 static int exec_compiler(const char *fc, const char *who)

--- a/fem/src/elmerf90-helper.in.h
+++ b/fem/src/elmerf90-helper.in.h
@@ -198,3 +198,50 @@ static int exec_compiler(const char *fc, const char *who)
     return 127;
 #endif
 }
+
+/*
+ * Get absolute paths to the ElmerSolver modules and the headers.
+ *
+ * If the environment variable ELMER_LIB is set, it is used as the absolute path
+ * to the solver modules. Typically, that is $[prefix]/lib/elmersolver (where
+ * $[prefix] is the installation prefix).
+ *
+ * If the environment variable ELMER_HOME is set, it is used to derive the
+ * absolute path to the directory with the headers (as
+ * ${ELMER_HOME}/share/elmersolver/include).
+ *
+ * If the environment variable ELMER_HOME is set but ELMER_LIB is not set, the
+ * absolute path to the solver modules is derived as
+ * ${ELMER_HOME}/$[ELMERF90_INSTALL_LIB] (where the value of
+ * $[ELMERF90_INSTALL_LIB] can be changed during configuration, but it is
+ * lib/elmersolver by default).
+ *
+ * If any of the absolute directories cannot be derived from these environment
+ * variables, values that are derived from the installation prefix that has been
+ * set during configuration are used.
+ *
+ * The arguments are allowed to be NULL in which case determination of the
+ * respective path is skipped.
+ */
+
+static void get_inc_lib_dirs(char **pincdir, char **plibdir)
+{
+    const char *env_home = getenv("ELMER_HOME");
+
+    if (pincdir) {
+        if (env_home && *env_home)
+            *pincdir = join(env_home, "/share/elmersolver/include");
+        else
+            *pincdir = strdup(ELMERF90_INCLUDE_DIR);
+    }
+
+    if (plibdir) {
+        const char *env_lib = getenv("ELMER_LIB");
+        if (env_lib && *env_lib)
+            *plibdir = strdup(env_lib);
+        else if (env_home && *env_home)
+            *plibdir = join(env_home, "/" ELMERF90_INSTALL_LIB);
+        else
+            *plibdir = strdup(ELMERF90_LIBDIR);
+    }
+}

--- a/fem/src/elmerf90.c
+++ b/fem/src/elmerf90.c
@@ -62,23 +62,11 @@
 
 int main(int argc, char *argv[])
 {
-    const char *env_lib  = getenv("ELMER_LIB");
-    const char *env_home = getenv("ELMER_HOME");
-    const char *env_fc   = getenv("ELMER_Fortran_COMPILER");
-
-    /* Resolve LIBDIR and INCLUDE (mirrors shell-script priority) */
+    /* Get absolute path to headers and solver modules */
     char *libdir, *incdir;
-    if (env_lib && *env_lib) {
-        libdir = strdup(env_lib);
-        incdir = join(env_lib, "/../include");
-    } else if (env_home && *env_home) {
-        libdir = join(env_home, "/" ELMERF90_INSTALL_LIB);
-        incdir = join(env_home, "/share/elmersolver/include");
-    } else {
-        libdir = strdup(ELMERF90_LIBDIR);
-        incdir = strdup(ELMERF90_INCLUDE_DIR);
-    }
+    get_inc_lib_dirs(&incdir, &libdir);
 
+    const char *env_fc = getenv("ELMER_Fortran_COMPILER");
     const char *fc = (env_fc && *env_fc) ? env_fc : ELMERF90_FC;
 
     /* --- Build argv ---------------------------------------------------- */

--- a/fem/src/elmerld.c
+++ b/fem/src/elmerld.c
@@ -14,20 +14,11 @@
 
 int main(int argc, char *argv[])
 {
-    const char *env_lib  = getenv("ELMER_LIB");
-    const char *env_home = getenv("ELMER_HOME");
-    const char *env_fc   = getenv("ELMER_Fortran_COMPILER");
-
-    /* Resolve LIBDIR and INCLUDE (mirrors shell-script priority) */
+    /* Get absolute path to solver modules */
     char *libdir;
-    if (env_lib && *env_lib) {
-        libdir = strdup(env_lib);
-    } else if (env_home && *env_home) {
-        libdir = join(env_home, "/" ELMERF90_INSTALL_LIB);
-    } else {
-        libdir = strdup(ELMERF90_LIBDIR);
-    }
+    get_inc_lib_dirs(NULL, &libdir);
 
+    const char *env_fc = getenv("ELMER_Fortran_COMPILER");
     const char *fc = (env_fc && *env_fc) ? env_fc : ELMERF90_FC;
 
     /* --- Build argv ---------------------------------------------------- */


### PR DESCRIPTION
Currently, the compiler wrappers do not work correctly if the environment variable `ELMER_LIB` is set.

Overhaul the behavior to be able to set `ELMER_LIB` without affecting the absolute path where the headers are searched.

Document the behavior more clearly (in an inline comment in the sources).

@king-aj3: Do the compiler wrappers (especially `elmerf90`) work with this change if `ELMER_LIB` and `ELMER_HOME` are set?
