### PR TITLE
Support relocating the installation prefix on runtime for the compiler wrappers on Windows

### DIFF
--- a/.github/workflows/build-windows-mingw.yaml
+++ b/.github/workflows/build-windows-mingw.yaml
@@ -140,6 +140,7 @@ jobs:
             if [ "${{ matrix.mpi }}" == "with" ]; then
               _extra_config+=("-DBUNDLE_MSMPI_REDIST=ON")
             fi
+            _extra_config+=("-DRELOCATE_PREFIX=ON")
           else
             _extra_config+=("-DCPACK_BUNDLE_EXTRA_WINDOWS_DLLS=OFF")
           fi

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -118,6 +118,9 @@ SET(USE_CONTIGUOUS FALSE CACHE BOOL "Use contiguous attribute")
 
 OPTION(EXTERNAL_METIS "Link to external Metis library" OFF)
 
+# Optionally, relocate the installation prefix based on binary location
+OPTION(RELOCATE_PREFIX "Relocate installation prefix on runtime" OFF)
+
 MARK_AS_ADVANCED(WITH_ELMERPOST)
 
 # if("${CMAKE_VERSION}" VERSION_GREATER 2.8.12)
@@ -766,6 +769,16 @@ ENDIF()
 # IF("${isSystemDir}" STREQUAL "-1")
 #    SET(CMAKE_INSTALL_RPATH "${CMAKE_INSTALL_PREFIX}/lib")
 # ENDIF("${isSystemDir}" STREQUAL "-1")
+
+IF (RELOCATE_PREFIX)
+  # Helper functions for relocating the installation prefix on runtime
+  IF(WIN32)
+    MESSAGE(STATUS "Using runtime relocation")
+    ADD_SUBDIRECTORY(contrib/pathtools)
+  ELSE()
+    MESSAGE(STATUS "Support for runtime relocation is currently Windows-only.")
+  ENDIF()
+ENDIF()
 
 ADD_SUBDIRECTORY(matc)
 

--- a/contrib/pathtools/CMakeLists.txt
+++ b/contrib/pathtools/CMakeLists.txt
@@ -1,0 +1,12 @@
+# The MinGW pathtools have originally been written by Ray Donnelly in 2014
+# under a permissive license.
+# They have been used since in MSYS2 to help with "relocation tasks".
+# They are mainly written for and tested on Windows. They might not work
+# correctly on other platforms.
+
+# Create an object library so the pathtools can be used in different
+# executables or libraries.
+ADD_LIBRARY(pathtools OBJECT "pathtools.c")
+
+TARGET_INCLUDE_DIRECTORIES(pathtools
+  INTERFACE $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>)

--- a/contrib/pathtools/pathtools.c
+++ b/contrib/pathtools/pathtools.c
@@ -1,0 +1,640 @@
+/*
+      .Some useful path tools.
+        .ASCII only for now.
+   .Written by Ray Donnelly in 2014.
+   .Licensed under CC0 (and anything.
+  .else you need to license it under).
+      .No warranties whatsoever.
+  .email: <mingw.android@gmail.com>.
+ */
+
+#if defined(__APPLE__)
+#include <stdlib.h>
+#else
+#include <malloc.h>
+#endif
+#include <limits.h>
+#include <stdio.h>
+#include <string.h>
+#if defined(__linux__) || defined(__CYGWIN__) || defined(__MSYS__)
+#include <alloca.h>
+#endif
+#include <unistd.h>
+
+/* If you don't define this, then get_executable_path()
+   can only use argv[0] which will often not work well */
+#define IMPLEMENT_SYS_GET_EXECUTABLE_PATH
+
+#if defined(IMPLEMENT_SYS_GET_EXECUTABLE_PATH)
+#if defined(__linux__) || defined(__CYGWIN__) || defined(__MSYS__)
+/* Nothing needed, unistd.h is enough. */
+#elif defined(__APPLE__)
+#include <mach-o/dyld.h>
+#elif defined(_WIN32)
+#define WIN32_MEAN_AND_LEAN
+#include <windows.h>
+#include <psapi.h>
+#endif
+#endif /* defined(IMPLEMENT_SYS_GET_EXECUTABLE_PATH) */
+
+#include "pathtools.h"
+
+static char *
+malloc_copy_string(char const * original)
+{
+  char * result = (char *) malloc (sizeof (char*) * strlen (original)+1);
+  if (result != NULL)
+  {
+    strcpy (result, original);
+  }
+  return result;
+}
+
+void
+sanitise_path(char * path)
+{
+  size_t path_size = strlen (path);
+
+  /* Replace any '\' with '/' */
+  char * path_p = path;
+  while ((path_p = strchr (path_p, '\\')) != NULL)
+  {
+    *path_p = '/';
+  }
+  /* Replace any '//' with '/' */
+  path_p = path + !!*path; /* skip first character, if any, to handle UNC paths correctly */
+  while ((path_p = strstr (path_p, "//")) != NULL)
+  {
+    memmove (path_p, path_p + 1, path_size--);
+  }
+  return;
+}
+
+char *
+get_relative_path(char const * from_in, char const * to_in)
+{
+  size_t from_size = (from_in == NULL) ? 0 : strlen (from_in);
+  size_t to_size = (to_in == NULL) ? 0 : strlen (to_in);
+  size_t max_size = (from_size + to_size) * 2 + 4;
+  char * scratch_space = (char *) alloca (from_size + 1 + to_size + 1 + max_size + max_size);
+  char * from;
+  char * to;
+  char * common_part;
+  char * result;
+  size_t count;
+
+  /* No to, return "./" */
+  if (to_in == NULL)
+  {
+    return malloc_copy_string ("./");
+  }
+
+  /* If alloca failed or no from was given return a copy of to */
+  if (   from_in == NULL
+      || scratch_space == NULL )
+  {
+    return malloc_copy_string (to_in);
+  }
+
+  from = scratch_space;
+  strcpy (from, from_in);
+  to = from + from_size + 1;
+  strcpy (to, to_in);
+  common_part = to + to_size + 1;
+  result = common_part + max_size;
+  simplify_path (from);
+  simplify_path (to);
+
+  result[0] = '\0';
+
+  size_t match_size_dirsep = 0;  /* The match size up to the last /. Always wind back to this - 1 */
+  size_t match_size = 0;         /* The running (and final) match size. */
+  size_t largest_size = (from_size > to_size) ? from_size : to_size;
+  int to_final_is_slash = (to[to_size-1] == '/') ? 1 : 0;
+  char from_c;
+  char to_c;
+  for (match_size = 0; match_size < largest_size; ++match_size)
+  {
+    /* To simplify the logic, always pretend the strings end with '/' */
+    from_c = (match_size < from_size) ? from[match_size] : '/';
+    to_c =   (match_size <   to_size) ?   to[match_size] : '/';
+
+    if (from_c != to_c)
+    {
+      if (from_c != '\0' || to_c != '\0')
+      {
+        match_size = match_size_dirsep;
+      }
+      break;
+    }
+    else if (from_c == '/')
+    {
+      match_size_dirsep = match_size;
+    }
+  }
+  strncpy (common_part, from, match_size);
+  common_part[match_size] = '\0';
+  from += match_size;
+  to += match_size;
+  size_t ndotdots = 0;
+  char const* from_last = from + strlen(from) - 1;
+  while ((from = strchr (from, '/')) && from != from_last)
+  {
+    ++ndotdots;
+    ++from;
+  }
+  for (count = 0; count < ndotdots; ++count)
+  {
+    strcat(result, "../");
+  }
+  if (strlen(to) > 0)
+  {
+    strcat(result, to+1);
+  }
+  /* Make sure that if to ends with '/' result does the same, and
+     vice-versa. */
+  size_t size_result = strlen(result);
+  if ((to_final_is_slash == 1)
+      && (!size_result || result[size_result-1] != '/'))
+  {
+    strcat (result, "/");
+  }
+  else if (!to_final_is_slash
+           && size_result && result[size_result-1] == '/')
+  {
+    result[size_result-1] = '\0';
+  }
+
+  return malloc_copy_string (result);
+}
+
+void
+simplify_path(char * path)
+{
+  ssize_t n_toks = 1; /* in-case we need an empty initial token. */
+  ssize_t i, j;
+  size_t tok_size;
+  size_t in_size = strlen (path);
+  int it_ended_with_a_slash = (path[in_size - 1] == '/') ? 1 : 0;
+  char * result = path;
+  if (path[0] == '/' && path[1] == '/') {
+    /* preserve UNC path */
+    path++;
+    in_size--;
+    result++;
+  }
+  sanitise_path(result);
+  char * result_p = result;
+
+  do
+  {
+    ++n_toks;
+    ++result_p;
+  } while ((result_p = strchr (result_p, '/')) != NULL);
+
+  result_p = result;
+  char const ** toks = (char const **) alloca (sizeof (char const*) * n_toks);
+  n_toks = 0;
+  do
+  {
+    if (result_p > result)
+    {
+      *result_p++ = '\0';
+    }
+    else if (*result_p == '/')
+    {
+      /* A leading / creates an empty initial token. */
+      toks[n_toks++] = result_p;
+      *result_p++ = '\0';
+    }
+    toks[n_toks++] = result_p;
+  } while ((result_p = strchr (result_p, '/')) != NULL);
+
+  /* Remove all non-leading '.' and any '..' we can match
+     with an earlier forward path (i.e. neither '.' nor '..') */
+  for (i = 1; i < n_toks; ++i)
+  {
+    int removals[2] = { -1, -1 };
+    if ( strcmp (toks[i], "." ) == 0)
+    {
+      removals[0] = i;
+    }
+    else if ( strcmp (toks[i], ".." ) == 0)
+    {
+      /* Search backwards for a forward path to collapse.
+         If none are found then the .. also stays. */
+      for (j = i - 1; j > -1; --j)
+      {
+        if ( strcmp (toks[j], "." )
+          && strcmp (toks[j], ".." ) )
+        {
+          removals[0] = j;
+          removals[1] = i;
+          break;
+        }
+      }
+    }
+    for (j = 0; j < 2; ++j)
+    {
+      if (removals[j] >= 0) /* Can become -2 */
+      {
+        --n_toks;
+        memmove (&toks[removals[j]], &toks[removals[j]+1], (n_toks - removals[j])*sizeof (char*));
+        --i;
+        if (!j)
+        {
+          --removals[1];
+        }
+      }
+    }
+  }
+  result_p = result;
+  for (i = 0; i < n_toks; ++i)
+  {
+    tok_size = strlen(toks[i]);
+    memmove (result_p, toks[i], tok_size);
+    result_p += tok_size;
+    if ((!i || tok_size) && ((i < n_toks - 1) || it_ended_with_a_slash == 1))
+    {
+      *result_p = '/';
+      ++result_p;
+    }
+  }
+  *result_p = '\0';
+}
+
+int
+get_executable_path(char const * argv0, char * result, ssize_t max_size)
+{
+  char * system_result = (char *) alloca (max_size);
+  ssize_t system_result_size = -1;
+  ssize_t result_size = -1;
+
+  if (system_result != NULL)
+  {
+#if defined(IMPLEMENT_SYS_GET_EXECUTABLE_PATH)
+#if defined(__linux__) || defined(__CYGWIN__) || defined(__MSYS__)
+    system_result_size = readlink("/proc/self/exe", system_result, max_size);
+#elif defined(__APPLE__)
+    uint32_t bufsize = (uint32_t)max_size;
+    if (_NSGetExecutablePath(system_result, &bufsize) == 0)
+    {
+      system_result_size = (ssize_t)bufsize;
+    }
+#elif defined(_WIN32)
+    unsigned long bufsize = (unsigned long)max_size;
+    system_result_size = GetModuleFileNameA(NULL, system_result, bufsize);
+    if (system_result_size == 0 || system_result_size == (ssize_t)bufsize)
+    {
+      /* Error, possibly not enough space. */
+      system_result_size = -1;
+    }
+    else
+    {
+      /* Early conversion to unix slashes instead of more changes
+         everywhere else .. */
+      char * winslash;
+      system_result[system_result_size] = '\0';
+      while ((winslash = strchr (system_result, '\\')) != NULL)
+      {
+        *winslash = '/';
+      }
+    }
+#else
+#warning "Don't know how to get executable path on this system"
+#endif
+#endif /* defined(IMPLEMENT_SYS_GET_EXECUTABLE_PATH) */
+  }
+  /* Use argv0 as a default in-case of failure */
+  if (system_result_size != -1)
+  {
+    strncpy (result, system_result, system_result_size);
+    result[system_result_size] = '\0';
+  }
+  else
+  {
+    if (argv0 != NULL)
+    {
+      strncpy (result, argv0, max_size);
+      result[max_size-1] = '\0';
+    }
+    else
+    {
+      result[0] = '\0';
+    }
+  }
+  result_size = strlen (result);
+  return result_size;
+}
+
+#if defined(_WIN32)
+int
+get_dll_path(char * result, unsigned long max_size)
+{
+  HMODULE handle;
+  char * p;
+  int ret;
+
+  if (!GetModuleHandleExA(GET_MODULE_HANDLE_EX_FLAG_FROM_ADDRESS |
+      GET_MODULE_HANDLE_EX_FLAG_UNCHANGED_REFCOUNT,
+      (LPCSTR) &get_dll_path, &handle))
+    {
+      return -1;
+    }
+
+  ret = GetModuleFileNameA(handle, result, max_size);
+  if (ret == 0 || ret == (int)max_size)
+    {
+      return -1;
+    }
+
+  /* Early conversion to unix slashes instead of more changes
+     everywhere else .. */
+  result[ret] = '\0';
+  p = result - 1;
+  while ((p = strchr (p + 1, '\\')) != NULL)
+    {
+      *p = '/';
+    }
+
+  return ret;
+}
+#endif
+
+static char const *
+strip_n_prefix_folders(char const * path, size_t n)
+{
+  if (path == NULL)
+  {
+    return NULL;
+  }
+
+  if (path[0] != '/')
+  {
+    return path;
+  }
+
+  char const * last = path;
+  while (n-- && path != NULL)
+  {
+    last = path;
+    path = strchr (path + 1, '/');
+  }
+  return (path == NULL) ? last : path;
+}
+
+void
+strip_n_suffix_folders(char * path, size_t n)
+{
+  if (path == NULL)
+  {
+    return;
+  }
+  while (n--)
+  {
+    if (strrchr (path + 1, '/'))
+    {
+      *strrchr (path + 1, '/') = '\0';
+    }
+    else
+    {
+      return;
+    }
+  }
+  return;
+}
+
+static size_t
+split_path_list(char const * path_list, char split_char, char *** arr)
+{
+  size_t path_count;
+  size_t path_list_size;
+  char const * path_list_p;
+
+  path_list_p = path_list;
+  if (path_list == NULL || path_list[0] == '\0')
+  {
+    return 0;
+  }
+  path_list_size = strlen (path_list);
+
+  path_count = 0;
+  do
+  {
+    ++path_count;
+    ++path_list_p;
+  }
+  while ((path_list_p = strchr (path_list_p, split_char)) != NULL);
+
+  /* allocate everything in one go. */
+  char * all_memory = (char *) malloc (sizeof (char *) * path_count + strlen(path_list) + 1);
+  if (all_memory == NULL)
+    return 0;
+  *arr = (char **)all_memory;
+  all_memory += sizeof (char *) * path_count;
+
+  path_count = 0;
+  path_list_p = path_list;
+  char const * next_path_list_p = 0;
+  do
+  {
+    next_path_list_p = strchr (path_list_p, split_char);
+    if (next_path_list_p != NULL)
+    {
+      ++next_path_list_p;
+    }
+    size_t this_size = (next_path_list_p != NULL)
+                       ? next_path_list_p - path_list_p - 1
+                       : &path_list[path_list_size] - path_list_p;
+    memcpy (all_memory, path_list_p, this_size);
+    all_memory[this_size] = '\0';
+    (*arr)[path_count++] = all_memory;
+    all_memory += this_size + 1;
+  } while ((path_list_p = next_path_list_p) != NULL);
+
+  return path_count;
+}
+
+static char *
+get_relocated_path_list_ref(char const * from, char const * to_path_list, char *ref_path)
+{
+  char * temp;
+  if ((temp = strrchr (ref_path, '/')) != NULL)
+  {
+    temp[1] = '\0';
+  }
+
+  char **arr = NULL;
+  /* Ask Alexey why he added this. Are we not 100% sure
+     that we're dealing with unix paths here? */
+  char split_char = ':';
+  if (strchr (to_path_list, ';'))
+  {
+    split_char = ';';
+  }
+  size_t count = split_path_list (to_path_list, split_char, &arr);
+  int result_size = 1 + (count - 1); /* count - 1 is for ; delim. */
+  size_t ref_path_size = strlen (ref_path);
+  size_t i;
+  /* Space required is:
+     count * (ref_path_size + strlen (rel_to_datadir))
+     rel_to_datadir upper bound is:
+     (count * strlen (from)) + (3 * num_slashes (from))
+     + strlen(arr[i]) + 1.
+     .. pathalogically num_slashes (from) is strlen (from)
+     (from = ////////) */
+  size_t space_required = (count * (ref_path_size + 4 * strlen (from))) + count - 1;
+  for (i = 0; i < count; ++i)
+  {
+    space_required += strlen (arr[i]);
+  }
+  char * scratch = (char *) alloca (space_required);
+  if (scratch == NULL)
+    return NULL;
+  for (i = 0; i < count; ++i)
+  {
+    char * rel_to_datadir = get_relative_path (from, arr[i]);
+    scratch[0] = '\0';
+    arr[i] = scratch;
+    strcat (scratch, ref_path);
+    strcat (scratch, rel_to_datadir);
+    free (rel_to_datadir);
+    simplify_path (arr[i]);
+    size_t arr_i_size = strlen (arr[i]);
+    result_size += arr_i_size;
+    scratch = arr[i] + arr_i_size + 1;
+  }
+  char * result = (char *) malloc (result_size);
+  if (result == NULL)
+  {
+    return NULL;
+  }
+  result[0] = '\0';
+  for (i = 0; i < count; ++i)
+  {
+    strcat (result, arr[i]);
+    if (i != count-1)
+    {
+#if defined(_WIN32)
+      strcat (result, ";");
+#else
+      strcat (result, ":");
+#endif
+    }
+  }
+  free ((void*)arr);
+  return result;
+}
+
+char *
+get_relocated_path_list(char const *from, char const *to_path_list)
+{
+  char exe_path[MAX_PATH];
+  get_executable_path (NULL, &exe_path[0], sizeof (exe_path) / sizeof (exe_path[0]));
+
+  return get_relocated_path_list_ref(from, to_path_list, exe_path);
+}
+
+char *
+get_relocated_path_list_lib(char const *from, char const *to_path_list)
+{
+  char dll_path[PATH_MAX];
+  get_dll_path (&dll_path[0], sizeof(dll_path)/sizeof(dll_path[0]));
+
+  return get_relocated_path_list_ref(from, to_path_list, dll_path);
+}
+
+static char *
+single_path_relocation_ref(const char *from, const char *to, char *ref_path)
+{
+#if defined(__MINGW32__)
+  if (strrchr (ref_path, '/') != NULL)
+  {
+     strrchr (ref_path, '/')[1] = '\0';
+  }
+  char * rel_to_datadir = get_relative_path (from, to);
+  strcat (ref_path, rel_to_datadir);
+  free (rel_to_datadir);
+  simplify_path (&ref_path[0]);
+  return malloc_copy_string(ref_path);
+#else
+  return malloc_copy_string(to);
+#endif
+}
+
+char *
+single_path_relocation(const char *from, const char *to)
+{
+#if defined(__MINGW32__)
+  char exe_path[PATH_MAX];
+  get_executable_path (NULL, &exe_path[0], sizeof(exe_path)/sizeof(exe_path[0]));
+  return single_path_relocation_ref(from, to, exe_path);
+#else
+  return malloc_copy_string(to);
+#endif
+}
+
+char *
+single_path_relocation_lib(const char *from, const char *to)
+{
+#if defined(__MINGW32__)
+  char dll_path[PATH_MAX];
+  get_dll_path (&dll_path[0], sizeof(dll_path)/sizeof(dll_path[0]));
+  return single_path_relocation_ref(from, to, dll_path);
+#else
+  return malloc_copy_string(to);
+#endif
+}
+
+char const *
+msys2_get_relocated_single_path(char const * unix_path)
+{
+  char * unix_part = (char *) strip_n_prefix_folders (unix_path, 1);
+  char win_part[MAX_PATH];
+  get_executable_path (NULL, &win_part[0], MAX_PATH);
+  strip_n_suffix_folders (&win_part[0], 2); /* 2 because the file name is present. */
+  char * new_path = (char *) malloc (strlen (unix_part) + strlen (win_part) + 1);
+  strcpy (new_path, win_part);
+  strcat (new_path, unix_part);
+  return new_path;
+}
+
+char *
+msys2_get_relocated_path_list(char const * paths)
+{
+  char win_part[MAX_PATH];
+  get_executable_path (NULL, &win_part[0], MAX_PATH);
+  strip_n_suffix_folders (&win_part[0], 2); /* 2 because the file name is present. */
+
+  char **arr = NULL;
+
+  size_t count = split_path_list (paths, ':', &arr);
+  int result_size = 1 + (count - 1); /* count - 1 is for ; delim. */
+  size_t i;
+  for (i = 0; i < count; ++i)
+  {
+    arr[i] = (char *) strip_n_prefix_folders (arr[i], 1);
+    result_size += strlen (arr[i]) + strlen (win_part);
+  }
+  char * result = (char *) malloc (result_size);
+  if (result == NULL)
+  {
+    return NULL;
+  }
+  result[0] = '\0';
+  for (i = 0; i < count; ++i)
+  {
+    strcat (result, win_part);
+    strcat (result, arr[i]);
+    if (i != count-1)
+    {
+#if defined(_WIN32)
+      strcat (result, ";");
+#else
+      strcat (result, ":");
+#endif
+    }
+  }
+  free ((void*)arr);
+  return result;
+}

--- a/contrib/pathtools/pathtools.h
+++ b/contrib/pathtools/pathtools.h
@@ -1,0 +1,65 @@
+/*
+      .Some useful path tools.
+        .ASCII only for now.
+   .Written by Ray Donnelly in 2014.
+   .Licensed under CC0 (and anything.
+  .else you need to license it under).
+      .No warranties whatsoever.
+  .email: <mingw.android@gmail.com>.
+ */
+
+#ifndef PATHTOOLS_H
+#define PATHTOOLS_H
+
+#include <stddef.h>
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* In-place replaces any '\' with '/' and any '//' with '/' */
+void sanitise_path(char * path);
+
+/* Uses a host OS specific function to determine the path of the executable,
+   if IMPLEMENT_SYS_GET_EXECUTABLE_PATH is defined, otherwise uses argv0. */
+int get_executable_path(char const * argv0, char * result, ssize_t max_size);
+
+int get_dll_path(char * result, unsigned long max_size);
+
+/* Where possible, in-place removes occourances of '.' and 'path/..' */
+void simplify_path(char * path);
+
+/* Allocates (via malloc) and returns the path to get from from to to. */
+char * get_relative_path(char const * from, char const * to);
+
+/* NULL terminates path to remove n suffix folders. */
+void strip_n_suffix_folders(char * path, size_t n);
+
+char * get_relocated_path_list(char const * from, char const * to_path_list);
+char * get_relocated_path_list_lib(char const * from, char const * to_path_list);
+
+char * single_path_relocation(const char *from, const char *to);
+char * single_path_relocation_lib(const char *from, const char *to);
+
+/* Allocates (via malloc) and returns a relocated path from a single Unix path.
+   This function makes large assumptions regarding PREFIX and is therefore very
+   much an MSYS2-only function. It operates by removing the first folder of the
+   input and final folder of the program executable then appending the input to
+   that.
+*/
+char const * msys2_get_relocated_single_path(char const * unix_path);
+
+/* Allocates (via malloc) and for each ':' delimited Unix sub-path,  returns the
+   result of applying the procedure detailed for msys2_get_relocated_single_path
+   on that Unix sub-path with the results joined up again with a ';' delimiter.
+   It implements the same logic in msys2_get_relocated_single_path to reduce the
+   the number of mallocs.
+*/
+char * msys2_get_relocated_path_list(char const * paths);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* PATHTOOLS_H */

--- a/fem/src/CMakeLists.txt
+++ b/fem/src/CMakeLists.txt
@@ -127,6 +127,8 @@ ELSE()
   SET(HAVE_PARMMG_INT 0)
 ENDIF()
 
+GET_FILENAME_COMPONENT(ELMER_ABS_INSTALL_PREFIX "${CMAKE_INSTALL_PREFIX}" ABSOLUTE)
+
 CONFIGURE_FILE(${CMAKE_CURRENT_SOURCE_DIR}/elmerf90-helper.in.h
   ${CMAKE_CURRENT_BINARY_DIR}/elmerf90-helper.out.h @ONLY)
 FILE(GENERATE
@@ -138,6 +140,12 @@ SET_TARGET_PROPERTIES(elmerf90_bin PROPERTIES OUTPUT_NAME "elmerf90")
 
 ADD_EXECUTABLE(elmerld_bin ${CMAKE_CURRENT_SOURCE_DIR}/elmerld.c)
 SET_TARGET_PROPERTIES(elmerld_bin PROPERTIES OUTPUT_NAME "elmerld")
+
+IF (RELOCATE_PREFIX)
+  # relocate installation prefix using location of executables on the file system
+  TARGET_LINK_LIBRARIES(elmerf90_bin PRIVATE pathtools)
+  TARGET_LINK_LIBRARIES(elmerld_bin PRIVATE pathtools)
+ENDIF()
 
 # Create pkg-config file if requested
 IF(CREATE_PKGCONFIG_FILE)

--- a/fem/src/elmerf90-helper.in.h
+++ b/fem/src/elmerf90-helper.in.h
@@ -21,6 +21,13 @@
 #define ELMERF90_INCLUDE_DIR   "@ELMER_SOLVER_HOME@/include"
 #define ELMERF90_INSTALL_LIB   "@ELMER_INSTALL_LIB_DIR@"
 
+#define ELMERF90_BINDIR "@ELMER_ABS_INSTALL_PREFIX@/bin"
+#cmakedefine RELOCATE_PREFIX
+
+#if defined (RELOCATE_PREFIX)
+#  include "pathtools.h"
+#endif
+
 /* Compile flags are baked in as a single whitespace-separated string and
    split at runtime, matching shell word-splitting behaviour. */
 /* FIXME: Paths with spaces in these flags are not handled correctly. */
@@ -221,6 +228,8 @@ static int exec_compiler(const char *fc, const char *who)
  * If any of the absolute directories cannot be derived from these environment
  * variables, values that are derived from the installation prefix that has been
  * set during configuration are used.
+ * If Elmer was configured with RELOCATE_PREFIX that installation prefix is
+ * relocated using the location of the wrapper executable on the file system.
  *
  * The arguments are allowed to be NULL in which case determination of the
  * respective path is skipped.
@@ -234,7 +243,11 @@ static void get_inc_lib_dirs(char **pincdir, char **plibdir)
         if (env_home && *env_home)
             *pincdir = join(env_home, "/share/elmersolver/include");
         else
+#if defined (RELOCATE_PREFIX)
+            *pincdir = single_path_relocation(ELMERF90_BINDIR, ELMERF90_INCLUDE_DIR);
+#else
             *pincdir = strdup(ELMERF90_INCLUDE_DIR);
+#endif
     }
 
     if (plibdir) {
@@ -244,6 +257,10 @@ static void get_inc_lib_dirs(char **pincdir, char **plibdir)
         else if (env_home && *env_home)
             *plibdir = join(env_home, "/" ELMERF90_INSTALL_LIB);
         else
+#if defined (RELOCATE_PREFIX)
+            *plibdir = single_path_relocation(ELMERF90_BINDIR, ELMERF90_LIBDIR);
+#else
             *plibdir = strdup(ELMERF90_LIBDIR);
+#endif
     }
 }

--- a/fem/src/elmerf90.c
+++ b/fem/src/elmerf90.c
@@ -66,8 +66,26 @@ int main(int argc, char *argv[])
     char *libdir, *incdir;
     get_inc_lib_dirs(&incdir, &libdir);
 
+    /* Get (absolute) path to Fortran compiler */
     const char *env_fc = getenv("ELMER_Fortran_COMPILER");
-    const char *fc = (env_fc && *env_fc) ? env_fc : ELMERF90_FC;
+    const char *fc;
+    if (env_fc && *env_fc)
+        fc = env_fc;
+    else
+#if defined(RELOCATE_PREFIX)
+    {
+        /* Assume that the Fortran compiler is in the same directory as the
+           compiler wrapper */
+        char *fc_path = strdup(ELMERF90_FC);
+        strip_n_suffix_folders(fc_path, 1);
+        if (strlen(fc_path) > 1)
+            fc = single_path_relocation(fc_path, ELMERF90_FC);
+        else
+            fc = ELMERF90_FC;
+    }
+#else
+        fc = ELMERF90_FC;
+#endif
 
     /* --- Build argv ---------------------------------------------------- */
 

--- a/fem/src/elmerld.c
+++ b/fem/src/elmerld.c
@@ -18,8 +18,26 @@ int main(int argc, char *argv[])
     char *libdir;
     get_inc_lib_dirs(NULL, &libdir);
 
+    /* Get (absolute) path to Fortran compiler */
     const char *env_fc = getenv("ELMER_Fortran_COMPILER");
-    const char *fc = (env_fc && *env_fc) ? env_fc : ELMERF90_FC;
+    const char *fc;
+    if (env_fc && *env_fc)
+        fc = env_fc;
+    else
+#if defined(RELOCATE_PREFIX)
+    {
+        /* Assume that the Fortran compiler is in the same directory as the
+           compiler wrapper */
+        char *fc_path = strdup(ELMERF90_FC);
+        strip_n_suffix_folders(fc_path, 1);
+        if (strlen(fc_path) > 1)
+            fc = single_path_relocation(fc_path, ELMERF90_FC);
+        else
+            fc = ELMERF90_FC;
+    }
+#else
+        fc = ELMERF90_FC;
+#endif
 
     /* --- Build argv ---------------------------------------------------- */
 


### PR DESCRIPTION
Currently users must set environment variables like `ELMER_HOME` to be able to use Elmer on Windows.

It should be possible to infer that information from the location where executables or libraries are installed.
Do that for the compiler wrappers (as a first step).

If that works out satisfactory, it might be possible to use the same strategy to relocate the installation prefix on runtime also in other places which currently rely on the value of environment variables.
Maybe, it would even be possible to use Elmer without the need to set any environment variable.
