### PR TITLE
Elmer/Ice: Fall back to `GetSolverHome` for unset `ELMER_LIB` and `ELMER_HOME`

### DIFF
--- a/elmerice/Solvers/Permafrost/PermafrostMaterials.F90
+++ b/elmerice/Solvers/Permafrost/PermafrostMaterials.F90
@@ -506,6 +506,17 @@ CONTAINS
           END IF
         END IF
         IF (.NOT. fexist) THEN
+          CALL GetSolverHome(MaterialFileName, k)
+          IF ( k > 0 ) THEN
+            MaterialFileName = MaterialFileName(1:k) // '/lib/' // 'permafrostmaterialdb.dat'
+            INQUIRE(FILE=TRIM(MaterialFileName), EXIST=fexist)
+          END IF
+          IF ((.NOT. fexist) .AND. k>0) THEN
+            MaterialFileName = MaterialFileName(1:k) // '/../../' // 'permafrostmaterialdb.dat'
+            INQUIRE(FILE=TRIM(MaterialFileName), EXIST=fexist)
+          END IF
+        END IF
+        IF (.NOT. fexist) THEN
           CALL Fatal('CheckKeyWord', 'permafrostmaterialdb.dat not found')
         END IF
       END IF


### PR DESCRIPTION
Currently, the PermafrostMaterials solver relies on the values of the environment variables `ELMER_LIB` or `ELMER_HOME` to load a database.

Other subroutines (e.g., `CheckKeyWord` in `ModelDescription.F90`) fall back to using `GetSolverHome` if these environment variables are not set.

Do the same in `ReadPermafrostRockMaterial`.

While this is essentially copying existing logic from another source file, I don't know how to test if this actually does what is intended.
Does this look correct to you?
