### PR TITLE
Return exit code of linker from `elmerld` on Windows.

### DIFF
--- a/fem/src/elmerld.c
+++ b/fem/src/elmerld.c
@@ -101,5 +101,5 @@ int main(int argc, char *argv[])
 #endif
     printf("\n");
 
-    exec_compiler(fc, "elmerld");
+    return exec_compiler(fc, "elmerld");
 }


### PR DESCRIPTION
On Windows, processes cannot be replaced. Instead, `exec_compiler` spawns a child process and waits for it to exit.

In `elmerf90`, the exit code of the spawned child process is returned from the wrapper. Not doing that in `elmerld` was just an oversight.

Fix that oversight by returning the exit code from the child process from `elmerld`, too.

Fixes #916.